### PR TITLE
ROX-27200: Support left join in searches

### DIFF
--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package imagecve
 
 import (
@@ -27,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac/testutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
+	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -447,217 +450,217 @@ func (s *ImageCVEViewTestSuite) TestCountBySeverity() {
 
 func (s *ImageCVEViewTestSuite) testCases() []testCase {
 	return []testCase{
-		//{
-		//	desc:        "search all",
-		//	ctx:         context.Background(),
-		//	q:           search.EmptyQuery(),
-		//	matchFilter: matchAllFilter(),
-		//},
-		//{
-		//	desc: "search one cve",
-		//	ctx:  context.Background(),
-		//	q:    search.NewQueryBuilder().AddExactMatches(search.CVE, "CVE-2022-1552").ProtoQuery(),
-		//	matchFilter: matchAllFilter().withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//		return vuln.GetCve() == "CVE-2022-1552"
-		//	}),
-		//},
-		//{
-		//	desc: "search one image",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:latest").ProtoQuery(),
-		//	matchFilter: matchAllFilter().withImageFilter(func(image *storage.Image) bool {
-		//		return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:latest"
-		//	}),
-		//},
-		//{
-		//	desc: "search one cve + one image",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.CVE, "CVE-2022-1552").
-		//		AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withImageFilter(func(image *storage.Image) bool {
-		//			return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
-		//		}).
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetCve() == "CVE-2022-1552"
-		//		}),
-		//},
-		//{
-		//	desc: "search critical severity",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
-		//		}),
-		//},
-		//{
-		//	desc: "search fixable",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddBools(search.Fixable, true).
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetFixedBy() != ""
-		//		}),
-		//},
-		//{
-		//	desc: "search one cve + fixable",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.CVE, "CVE-2015-8704").
-		//		AddBools(search.Fixable, true).
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetCve() == "CVE-2015-8704" && vuln.GetFixedBy() != ""
-		//		}),
-		//},
-		//{
-		//	desc: "search one cve + not fixable",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.CVE, "CVE-2015-8704").
-		//		AddBools(search.Fixable, false).
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetCve() == "CVE-2015-8704" && vuln.GetFixedBy() == ""
-		//		}),
-		//},
-		//{
-		//	desc: "search multiple severities",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.Severity,
-		//			storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String(),
-		//			storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY.String(),
-		//		).
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY ||
-		//				vuln.GetSeverity() == storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY
-		//		}),
-		//},
-		//{
-		//	desc: "search critical severity + one image",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
-		//		AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withImageFilter(func(image *storage.Image) bool {
-		//			return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
-		//		}).
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
-		//		}),
-		//},
-		//{
-		//	desc: "search one operating system",
-		//	ctx:  context.Background(),
-		//	q:    search.NewQueryBuilder().AddExactMatches(search.OperatingSystem, "debian:8").ProtoQuery(),
-		//	matchFilter: matchAllFilter().withImageFilter(func(image *storage.Image) bool {
-		//		return image.GetScan().GetOperatingSystem() == "debian:8"
-		//	}),
-		//},
-		//{
-		//	desc:        "no match",
-		//	ctx:         context.Background(),
-		//	q:           search.NewQueryBuilder().AddExactMatches(search.OperatingSystem, "").ProtoQuery(),
-		//	matchFilter: matchNoneFilter(),
-		//},
-		//{
-		//	desc: "with select",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddSelectFields(search.NewQuerySelect(search.CVE)).
-		//		AddExactMatches(search.OperatingSystem, "").ProtoQuery(),
-		//	expectedErr: "Unexpected select clause in query",
-		//},
-		//{
-		//	desc: "with group by",
-		//	ctx:  context.Background(),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.OperatingSystem, "").
-		//		AddGroupBy(search.CVE).ProtoQuery(),
-		//	expectedErr: "Unexpected group by clause in query",
-		//},
-		//{
-		//	desc:        "search all; skip top cvss; skip images by severity",
-		//	ctx:         context.Background(),
-		//	q:           search.NewQueryBuilder().ProtoQuery(),
-		//	matchFilter: matchAllFilter(),
-		//	readOptions: views.ReadOptions{
-		//		SkipGetImagesBySeverity: true,
-		//		SkipGetTopCVSS:          true,
-		//	},
-		//},
-		//{
-		//	desc: "search one cve w/ image scope",
-		//	ctx: scoped.Context(context.Background(), scoped.Scope{
-		//		ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
-		//		Level: v1.SearchCategory_IMAGES,
-		//	}),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.CVE, "CVE-2022-1552").
-		//		AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withImageFilter(func(image *storage.Image) bool {
-		//			return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
-		//		}).
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetCve() == "CVE-2022-1552"
-		//		}),
-		//},
-		//{
-		//	desc: "search critical severity w/ cve & image scope",
-		//	ctx: scoped.Context(context.Background(), scoped.Scope{
-		//		ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
-		//		Level: v1.SearchCategory_IMAGES,
-		//		Parent: &scoped.Scope{
-		//			ID:    cve.ID("CVE-2022-1552", "debian:8"),
-		//			Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
-		//		},
-		//	}),
-		//	q: search.NewQueryBuilder().
-		//		AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
-		//		ProtoQuery(),
-		//	matchFilter: matchAllFilter().
-		//		withImageFilter(func(image *storage.Image) bool {
-		//			return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian" &&
-		//				image.GetScan().GetOperatingSystem() == "debian:8"
-		//		}).
-		//		withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
-		//			return vuln.GetCve() == "CVE-2022-1552" &&
-		//				vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
-		//		}),
-		//},
-		//{
-		//	desc:           "search all sort by critical severity most first",
-		//	ctx:            context.Background(),
-		//	q:              search.NewQueryBuilder().WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.CriticalSeverityCount).Reversed(true)).AddSortOption(search.NewSortOption(search.CVE))).ProtoQuery(),
-		//	matchFilter:    matchAllFilter(),
-		//	skipCountTests: true,
-		//	testOrder:      true,
-		//	less: func(records []*imageCVECoreResponse) func(i, j int) bool {
-		//		return func(i, j int) bool {
-		//			if records[i].ImagesWithCriticalSeverity == records[j].ImagesWithCriticalSeverity {
-		//				return records[i].CVE <= records[j].CVE
-		//			}
-		//			return records[i].ImagesWithCriticalSeverity > records[j].ImagesWithCriticalSeverity
-		//		}
-		//	},
-		//},
+		{
+			desc:        "search all",
+			ctx:         context.Background(),
+			q:           search.EmptyQuery(),
+			matchFilter: matchAllFilter(),
+		},
+		{
+			desc: "search one cve",
+			ctx:  context.Background(),
+			q:    search.NewQueryBuilder().AddExactMatches(search.CVE, "CVE-2022-1552").ProtoQuery(),
+			matchFilter: matchAllFilter().withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+				return vuln.GetCve() == "CVE-2022-1552"
+			}),
+		},
+		{
+			desc: "search one image",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:latest").ProtoQuery(),
+			matchFilter: matchAllFilter().withImageFilter(func(image *storage.Image) bool {
+				return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:latest"
+			}),
+		},
+		{
+			desc: "search one cve + one image",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.CVE, "CVE-2022-1552").
+				AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withImageFilter(func(image *storage.Image) bool {
+					return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
+				}).
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetCve() == "CVE-2022-1552"
+				}),
+		},
+		{
+			desc: "search critical severity",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
+				}),
+		},
+		{
+			desc: "search fixable",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddBools(search.Fixable, true).
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetFixedBy() != ""
+				}),
+		},
+		{
+			desc: "search one cve + fixable",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.CVE, "CVE-2015-8704").
+				AddBools(search.Fixable, true).
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetCve() == "CVE-2015-8704" && vuln.GetFixedBy() != ""
+				}),
+		},
+		{
+			desc: "search one cve + not fixable",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.CVE, "CVE-2015-8704").
+				AddBools(search.Fixable, false).
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetCve() == "CVE-2015-8704" && vuln.GetFixedBy() == ""
+				}),
+		},
+		{
+			desc: "search multiple severities",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.Severity,
+					storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String(),
+					storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY.String(),
+				).
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY ||
+						vuln.GetSeverity() == storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY
+				}),
+		},
+		{
+			desc: "search critical severity + one image",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
+				AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withImageFilter(func(image *storage.Image) bool {
+					return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
+				}).
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
+				}),
+		},
+		{
+			desc: "search one operating system",
+			ctx:  context.Background(),
+			q:    search.NewQueryBuilder().AddExactMatches(search.OperatingSystem, "debian:8").ProtoQuery(),
+			matchFilter: matchAllFilter().withImageFilter(func(image *storage.Image) bool {
+				return image.GetScan().GetOperatingSystem() == "debian:8"
+			}),
+		},
+		{
+			desc:        "no match",
+			ctx:         context.Background(),
+			q:           search.NewQueryBuilder().AddExactMatches(search.OperatingSystem, "").ProtoQuery(),
+			matchFilter: matchNoneFilter(),
+		},
+		{
+			desc: "with select",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddSelectFields(search.NewQuerySelect(search.CVE)).
+				AddExactMatches(search.OperatingSystem, "").ProtoQuery(),
+			expectedErr: "Unexpected select clause in query",
+		},
+		{
+			desc: "with group by",
+			ctx:  context.Background(),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.OperatingSystem, "").
+				AddGroupBy(search.CVE).ProtoQuery(),
+			expectedErr: "Unexpected group by clause in query",
+		},
+		{
+			desc:        "search all; skip top cvss; skip images by severity",
+			ctx:         context.Background(),
+			q:           search.NewQueryBuilder().ProtoQuery(),
+			matchFilter: matchAllFilter(),
+			readOptions: views.ReadOptions{
+				SkipGetImagesBySeverity: true,
+				SkipGetTopCVSS:          true,
+			},
+		},
+		{
+			desc: "search one cve w/ image scope",
+			ctx: scoped.Context(context.Background(), scoped.Scope{
+				ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
+				Level: v1.SearchCategory_IMAGES,
+			}),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.CVE, "CVE-2022-1552").
+				AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withImageFilter(func(image *storage.Image) bool {
+					return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
+				}).
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetCve() == "CVE-2022-1552"
+				}),
+		},
+		{
+			desc: "search critical severity w/ cve & image scope",
+			ctx: scoped.Context(context.Background(), scoped.Scope{
+				ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
+				Level: v1.SearchCategory_IMAGES,
+				Parent: &scoped.Scope{
+					ID:    cve.ID("CVE-2022-1552", "debian:8"),
+					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
+				},
+			}),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
+				ProtoQuery(),
+			matchFilter: matchAllFilter().
+				withImageFilter(func(image *storage.Image) bool {
+					return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian" &&
+						image.GetScan().GetOperatingSystem() == "debian:8"
+				}).
+				withVulnFilter(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetCve() == "CVE-2022-1552" &&
+						vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
+				}),
+		},
+		{
+			desc:           "search all sort by critical severity most first",
+			ctx:            context.Background(),
+			q:              search.NewQueryBuilder().WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.CriticalSeverityCount).Reversed(true)).AddSortOption(search.NewSortOption(search.CVE))).ProtoQuery(),
+			matchFilter:    matchAllFilter(),
+			skipCountTests: true,
+			testOrder:      true,
+			less: func(records []*imageCVECoreResponse) func(i, j int) bool {
+				return func(i, j int) bool {
+					if records[i].ImagesWithCriticalSeverity == records[j].ImagesWithCriticalSeverity {
+						return records[i].CVE <= records[j].CVE
+					}
+					return records[i].ImagesWithCriticalSeverity > records[j].ImagesWithCriticalSeverity
+				}
+			},
+		},
 		{
 			desc: "search observed CVEs from inactive images and active images in non-platform deployments",
 			ctx:  context.Background(),

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -218,7 +218,7 @@ func TestMultiTableQueries(t *testing.T) {
 				assert.Equal(t, c.expectedWhere, actual.Where)
 				assert.ElementsMatch(t, c.expectedData, actual.Data)
 				var actualJoins []string
-				for _, join := range actual.InnerJoins {
+				for _, join := range actual.Joins {
 					actualJoins = append(actualJoins, join.rightTable)
 				}
 				assert.ElementsMatch(t, c.expectedJoinTables, actualJoins)

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
-	mappings "github.com/stackrox/rox/pkg/search/options/deployments"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -22,7 +20,10 @@ import (
 )
 
 var (
-	deploymentBaseSchema = walker.Walk(reflect.TypeOf((*storage.Deployment)(nil)), "deployments")
+	deploymentBaseSchema = schema.DeploymentsSchema
+	imagesSchema         = schema.ImagesSchema
+	imageCVEsSchema      = schema.ImageCvesSchema
+	_                    = schema.ImageCveEdgesSchema
 )
 
 func TestReplaceVars(t *testing.T) {
@@ -71,20 +72,21 @@ func BenchmarkReplaceVars(b *testing.B) {
 func TestMultiTableQueries(t *testing.T) {
 	t.Parallel()
 
-	deploymentBaseSchema.SetOptionsMap(mappings.OptionsMap)
 	for _, c := range []struct {
 		desc                 string
 		q                    *v1.Query
+		schema               *walker.Schema
 		expectedQueryPortion string
 		expectedFrom         string
 		expectedWhere        string
 		expectedData         []interface{}
-		expectedJoinTables   []string
+		expectedJoinTables   map[string]JoinType
 		expectedError        string
 	}{
 		{
 			desc:          "base schema query",
 			q:             search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema:        deploymentBaseSchema,
 			expectedFrom:  "deployments",
 			expectedWhere: "deployments.Name = $$",
 			expectedData:  []interface{}{"central"},
@@ -92,9 +94,10 @@ func TestMultiTableQueries(t *testing.T) {
 		{
 			desc:               "child schema query",
 			q:                  search.NewQueryBuilder().AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "deployments_containers.Image_Name_FullName = $$",
-			expectedJoinTables: []string{"deployments_containers"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner},
 			expectedData:       []interface{}{"stackrox"},
 		},
 		{
@@ -102,9 +105,10 @@ func TestMultiTableQueries(t *testing.T) {
 			q: search.NewQueryBuilder().
 				AddExactMatches(search.ImageName, "stackrox").
 				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "(deployments.Name = $$ and deployments_containers.Image_Name_FullName = $$)",
-			expectedJoinTables: []string{"deployments_containers"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner},
 			expectedData:       []interface{}{"central", "stackrox"},
 		},
 		{
@@ -113,10 +117,10 @@ func TestMultiTableQueries(t *testing.T) {
 				search.NewQueryBuilder().AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
 				search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
 			),
-
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "(deployments_containers.Image_Name_FullName = $$ or deployments.Name = $$)",
-			expectedJoinTables: []string{"deployments_containers"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner},
 			expectedData:       []interface{}{"central", "stackrox"},
 		},
 		{
@@ -125,10 +129,10 @@ func TestMultiTableQueries(t *testing.T) {
 				search.NewQueryBuilder().AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
 				search.NewQueryBuilder().AddExactMatches(search.PortProtocol, "tcp").ProtoQuery(),
 			),
-
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "(deployments_containers.Image_Name_FullName = $$ and deployments_ports.Protocol = $$)",
-			expectedJoinTables: []string{"deployments_containers", "deployments_ports"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner, "deployments_ports": Inner},
 			expectedData:       []interface{}{"tcp", "stackrox"},
 		},
 		{
@@ -137,9 +141,10 @@ func TestMultiTableQueries(t *testing.T) {
 				search.NewQueryBuilder().AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
 				search.NewQueryBuilder().AddExactMatches(search.PortProtocol, "tcp").ProtoQuery(),
 			),
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "(deployments_containers.Image_Name_FullName = $$ or deployments_ports.Protocol = $$)",
-			expectedJoinTables: []string{"deployments_containers", "deployments_ports"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner, "deployments_ports": Inner},
 			expectedData:       []interface{}{"tcp", "stackrox"},
 		},
 		{
@@ -148,22 +153,25 @@ func TestMultiTableQueries(t *testing.T) {
 				search.NewQueryBuilder().AddBools(search.Privileged, true).ProtoQuery(),
 				search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
 			),
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "(deployments_containers.SecurityContext_Privileged = $$ or deployments.Name = $$)",
-			expectedJoinTables: []string{"deployments_containers"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner},
 			expectedData:       []interface{}{"central", "true"},
 		},
 		{
 			desc:               "negated child schema query",
 			q:                  search.NewQueryBuilder().AddStrings(search.ImageName, "!central").ProtoQuery(),
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "NOT (deployments_containers.Image_Name_FullName ilike $$)",
-			expectedJoinTables: []string{"deployments_containers"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner},
 			expectedData:       []interface{}{"central%"},
 		},
 		{
 			desc:          "nil query",
 			q:             nil,
+			schema:        deploymentBaseSchema,
 			expectedFrom:  "deployments",
 			expectedWhere: "",
 			expectedData:  []interface{}{},
@@ -174,6 +182,7 @@ func TestMultiTableQueries(t *testing.T) {
 				search.NewQueryBuilder().AddDocIDs("123").ProtoQuery(),
 				search.MatchNoneQuery(),
 			),
+			schema:        deploymentBaseSchema,
 			expectedFrom:  "deployments",
 			expectedWhere: "(deployments.Id = ANY($$::uuid[]) and false)",
 			expectedData:  []interface{}{[]string{"123"}},
@@ -183,9 +192,10 @@ func TestMultiTableQueries(t *testing.T) {
 			q: search.NewQueryBuilder().
 				AddExactMatches(search.ImageName, "stackrox").
 				AddExactMatches(search.DeploymentID, uuid.NewDummy().String()).ProtoQuery(),
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "(deployments.Id = $$ and deployments_containers.Image_Name_FullName = $$)",
-			expectedJoinTables: []string{"deployments_containers"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner},
 			expectedData:       []interface{}{uuid.NewDummy(), "stackrox"},
 		},
 		{
@@ -193,6 +203,7 @@ func TestMultiTableQueries(t *testing.T) {
 			q: search.NewQueryBuilder().
 				AddExactMatches(search.ImageName, "stackrox").
 				AddExactMatches(search.DeploymentID, "not a uuid").ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedError: `uuid: incorrect UUID length 10 in string "not a uuid"
         	            	value "not a uuid" in search query must be valid UUID`,
 		},
@@ -202,14 +213,34 @@ func TestMultiTableQueries(t *testing.T) {
 				[]search.FieldLabel{search.ImageName, search.EnvironmentKey},
 				[]string{search.WildcardString, search.WildcardString}).
 				ProtoQuery(),
+			schema:             deploymentBaseSchema,
 			expectedFrom:       "deployments",
 			expectedWhere:      "(deployments_containers.Image_Name_FullName is not null and deployments_containers_envs.Key is not null)",
-			expectedJoinTables: []string{"deployments_containers", "deployments_containers_envs"},
+			expectedJoinTables: map[string]JoinType{"deployments_containers": Inner, "deployments_containers_envs": Inner},
+		},
+		{
+			desc: "search active and inactive images with observed CVEs in non-platform deployments",
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).
+				AddStrings(search.PlatformComponent, "false", "-").
+				ProtoQuery(),
+			schema:        imagesSchema,
+			expectedFrom:  "images",
+			expectedWhere: "((deployments.PlatformComponent = $$ or deployments.PlatformComponent is null) and (image_cve_edges.State = $$))",
+			expectedJoinTables: map[string]JoinType{
+				"image_component_edges":     Inner,
+				"image_component_cve_edges": Inner,
+				"image_cves":                Inner,
+				"image_cve_edges":           Inner,
+				"deployments_containers":    Left,
+				"deployments":               Left,
+			},
+			expectedData: []interface{}{"false", "0"},
 		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
 			ctx := sac.WithAllAccess(context.Background())
-			actual, err := standardizeQueryAndPopulatePath(ctx, c.q, deploymentBaseSchema, SEARCH)
+			actual, err := standardizeQueryAndPopulatePath(ctx, c.q, c.schema, SEARCH)
 			if c.expectedError != "" {
 				assert.Error(t, err, c.expectedError)
 			} else {
@@ -217,11 +248,15 @@ func TestMultiTableQueries(t *testing.T) {
 				assert.Equal(t, c.expectedFrom, actual.From)
 				assert.Equal(t, c.expectedWhere, actual.Where)
 				assert.ElementsMatch(t, c.expectedData, actual.Data)
-				var actualJoins []string
-				for _, join := range actual.Joins {
-					actualJoins = append(actualJoins, join.rightTable)
+
+				var actualJoins map[string]JoinType
+				if len(actual.Joins) > 0 {
+					actualJoins = make(map[string]JoinType)
+					for _, join := range actual.Joins {
+						actualJoins[join.rightTable] = join.joinType
+					}
 				}
-				assert.ElementsMatch(t, c.expectedJoinTables, actualJoins)
+				assert.Equal(t, c.expectedJoinTables, actualJoins)
 			}
 		})
 	}
@@ -234,6 +269,7 @@ func TestSelectQueries(t *testing.T) {
 		desc          string
 		ctx           context.Context
 		q             *v1.Query
+		schema        *walker.Schema
 		expectedError string
 		expectedQuery string
 	}{
@@ -241,12 +277,14 @@ func TestSelectQueries(t *testing.T) {
 			desc: "base schema; no select",
 			q: search.NewQueryBuilder().
 				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema:        deploymentBaseSchema,
 			expectedError: "select portion of the query cannot be empty",
 		},
 		{
 			desc: "base schema; select",
 			q: search.NewQueryBuilder().
 				AddSelectFields(search.NewQuerySelect(search.DeploymentName)).ProtoQuery(),
+			schema:        deploymentBaseSchema,
 			expectedQuery: "select deployments.Name as deployment from deployments",
 		},
 		{
@@ -254,6 +292,7 @@ func TestSelectQueries(t *testing.T) {
 			q: search.NewQueryBuilder().
 				AddSelectFields(search.NewQuerySelect(search.DeploymentName)).
 				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema:        deploymentBaseSchema,
 			expectedQuery: "select deployments.Name as deployment from deployments where deployments.Name = $1",
 		},
 		{
@@ -264,6 +303,7 @@ func TestSelectQueries(t *testing.T) {
 					search.NewQuerySelect(search.ImageName),
 				).
 				AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedQuery: "select deployments_containers.SecurityContext_Privileged as privileged, " +
 				"deployments_containers.Image_Name_FullName as image " +
 				"from deployments inner join deployments_containers " +
@@ -279,6 +319,7 @@ func TestSelectQueries(t *testing.T) {
 				).
 				AddExactMatches(search.ImageName, "stackrox").
 				AddGroupBy(search.Cluster, search.Namespace).ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedQuery: "select jsonb_agg(deployments_containers.SecurityContext_Privileged) as privileged, " +
 				"jsonb_agg(deployments_containers.Image_Name_FullName) as image, " +
 				"deployments.ClusterName as cluster, deployments.Namespace as namespace " +
@@ -294,6 +335,7 @@ func TestSelectQueries(t *testing.T) {
 					search.NewQuerySelect(search.DeploymentName),
 					search.NewQuerySelect(search.ImageName),
 				).ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedQuery: "select deployments.Name as deployment, deployments_containers.Image_Name_FullName as image " +
 				"from deployments inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id",
 		},
@@ -306,6 +348,7 @@ func TestSelectQueries(t *testing.T) {
 				).
 				AddExactMatches(search.ImageName, "stackrox").
 				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedQuery: "select deployments.Name as deployment, deployments_containers.Image_Name_FullName as image " +
 				"from deployments inner join deployments_containers " +
 				"on deployments.Id = deployments_containers.deployments_Id " +
@@ -317,6 +360,7 @@ func TestSelectQueries(t *testing.T) {
 				AddSelectFields(
 					search.NewQuerySelect(search.DeploymentName).AggrFunc(aggregatefunc.Count).Distinct(),
 				).ProtoQuery(),
+			schema:        deploymentBaseSchema,
 			expectedQuery: "select count(distinct(deployments.Name)) as deployment_count from deployments",
 		},
 		{
@@ -327,14 +371,16 @@ func TestSelectQueries(t *testing.T) {
 				).
 				AddExactMatches(search.ImageName, "stackrox").
 				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedQuery: "select count(distinct(deployments.Name)) as deployment_count " +
 				"from deployments inner join deployments_containers " +
 				"on deployments.Id = deployments_containers.deployments_Id " +
 				"where (deployments.Name = $1 and deployments_containers.Image_Name_FullName = $2)",
 		},
 		{
-			desc: "nil query",
-			q:    nil,
+			desc:   "nil query",
+			q:      nil,
+			schema: deploymentBaseSchema,
 		},
 		{
 			desc: "base schema; select w/ conjunction",
@@ -348,6 +394,7 @@ func TestSelectQueries(t *testing.T) {
 				q.Selects = []*v1.QuerySelect{search.NewQuerySelect(search.DeploymentName).Proto()}
 				return q
 			}(),
+			schema:        deploymentBaseSchema,
 			expectedQuery: "select deployments.Name as deployment from deployments where (deployments.Name = $1 and deployments.Namespace = $2)",
 		},
 		{
@@ -359,6 +406,7 @@ func TestSelectQueries(t *testing.T) {
 			q: search.NewQueryBuilder().
 				AddSelectFields(search.NewQuerySelect(search.DeploymentName)).
 				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedQuery: "select deployments.Name as deployment from deployments " +
 				"inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id " +
 				"where (deployments.Name = $1 and deployments_containers.Image_Id = $2)",
@@ -376,8 +424,33 @@ func TestSelectQueries(t *testing.T) {
 			q: search.NewQueryBuilder().
 				AddSelectFields(search.NewQuerySelect(search.DeploymentName)).
 				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema: deploymentBaseSchema,
 			expectedQuery: "select deployments.Name as deployment from deployments " +
 				"where (deployments.Name = $1 and (deployments.NamespaceId = $2 and deployments.ClusterId = $3))",
+		},
+		{
+			desc: "select query with filters that will add left joins to the query",
+			q: search.NewQueryBuilder().
+				AddSelectFields(
+					search.NewQuerySelect(search.CVE),
+					search.NewQuerySelect(search.CVEID).Distinct(),
+					search.NewQuerySelect(search.CVSS).AggrFunc(aggregatefunc.Max),
+					search.NewQuerySelect(search.ImageSHA).AggrFunc(aggregatefunc.Count).Distinct(),
+				).
+				AddExactMatches(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).
+				AddStrings(search.PlatformComponent, "true", "-").
+				ProtoQuery(),
+			schema: imageCVEsSchema,
+			expectedQuery: "select image_cves.CveBaseInfo_Cve as cve, " +
+				"distinct(image_cves.Id) as cve_id, max(image_cves.Cvss) as cvss_max, " +
+				"count(distinct(images.Id)) as image_sha_count " +
+				"from image_cves " +
+				"inner join image_component_cve_edges on image_cves.Id = image_component_cve_edges.ImageCveId " +
+				"inner join image_component_edges on image_component_cve_edges.ImageComponentId = image_component_edges.ImageComponentId " +
+				"inner join images on image_component_edges.ImageId = images.Id left join deployments_containers on images.Id = deployments_containers.Image_Id " +
+				"left join deployments on deployments_containers.deployments_Id = deployments.Id " +
+				"inner join image_cve_edges on(image_component_edges.ImageId = image_cve_edges.ImageId and image_cves.Id = image_cve_edges.ImageCveId) " +
+				"where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and (image_cve_edges.State = $2))",
 		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
@@ -386,7 +459,7 @@ func TestSelectQueries(t *testing.T) {
 				ctx = context.Background()
 			}
 
-			actualQ, err := standardizeSelectQueryAndPopulatePath(ctx, c.q, schema.DeploymentsSchema, SELECT)
+			actualQ, err := standardizeSelectQueryAndPopulatePath(ctx, c.q, c.schema, SELECT)
 			if c.expectedError != "" {
 				assert.Error(t, err, c.expectedError)
 				return

--- a/pkg/search/postgres/joins_test.go
+++ b/pkg/search/postgres/joins_test.go
@@ -192,20 +192,20 @@ func TestRemoveUnnecessaryRelations(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			innerTestRecord.Root.removeUnnecessaryRelations(innerTestRecord.ReachableFields)
 
-			expectedInnerJoins := innerTestRecord.ExpectedRoot.toInnerJoins()
-			innerJoins := innerTestRecord.Root.toInnerJoins()
+			expectedJoins := innerTestRecord.ExpectedRoot.toJoins()
+			joins := innerTestRecord.Root.toJoins()
 
 			// We have to sort before using comparison. Children in joinTreeNode
 			// is map where pointers are keys and because of that order changes.
 			// It's sufficient to sort by joined tables.
-			sort.SliceStable(expectedInnerJoins, func(i, j int) bool {
-				return expectedInnerJoins[i].rightTable+expectedInnerJoins[i].leftTable < expectedInnerJoins[j].rightTable+expectedInnerJoins[j].leftTable
+			sort.SliceStable(expectedJoins, func(i, j int) bool {
+				return expectedJoins[i].rightTable+expectedJoins[i].leftTable < expectedJoins[j].rightTable+expectedJoins[j].leftTable
 			})
-			sort.SliceStable(innerJoins, func(i, j int) bool {
-				return innerJoins[i].rightTable+innerJoins[i].leftTable < innerJoins[j].rightTable+innerJoins[j].leftTable
+			sort.SliceStable(joins, func(i, j int) bool {
+				return joins[i].rightTable+joins[i].leftTable < joins[j].rightTable+joins[j].leftTable
 			})
 
-			assert.EqualValues(t, expectedInnerJoins, innerJoins)
+			assert.EqualValues(t, expectedJoins, joins)
 		})
 	}
 }

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -82,23 +82,23 @@ func standardizeSelectQueryAndPopulatePath(ctx context.Context, q *v1.Query, sch
 	}
 
 	standardizeFieldNamesInQuery(q)
-	innerJoins, dbFields := getJoinsAndFields(schema, q)
+	joins, dbFields := getJoinsAndFields(schema, q)
 	if len(q.GetSelects()) == 0 && q.GetQuery() == nil {
 		return nil, nil
 	}
 
 	if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
-		innerJoins, err = handleImageCveEdgesTableInJoins(schema, innerJoins)
+		joins, err = handleImageCveEdgesTableInJoins(schema, joins)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	parsedQuery := &query{
-		Schema:     schema,
-		QueryType:  queryType,
-		From:       schema.Table,
-		InnerJoins: innerJoins,
+		Schema:    schema,
+		QueryType: queryType,
+		From:      schema.Table,
+		Joins:     joins,
 	}
 
 	if err = populateSelect(parsedQuery, schema, q.GetSelects(), dbFields, nowForQuery); err != nil {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR adds support for left join for search queries. The `RawQuery` syntax exposed in APIs supports `-` as a null check character. For single table queries (no joins) with `Field : -` already translate to `select * from table where field is NULL` but this was not supported when the field is in a table that is related to the root table via a joins because that would require left joins. After this PR queries with `Field : -` will translate to `select * from table1 left join table2 on table1.key1=table2.key2 where table2.field is NULL`.

Note that this PR does not add left join support to select queries. That will be done in a followup task. Current implementation will satisfy the requirement of showing inactive images with non-platform workloads.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
![4B4132F7-FA06-47DF-AEA8-04C1D1727E41](https://github.com/user-attachments/assets/4906737d-68c1-4bb5-934c-8f5d234ca6e3)
