### PR TITLE
chore(roxctl):  SkipTLSValidation() use flags.booleanFlagOrValue()

### DIFF
--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -110,10 +110,7 @@ func (cmd *centralCertCommand) certs() error {
 }
 
 func skipTLSValidation() bool {
-	if value := flags.SkipTLSValidation(); value != nil {
-		return *value
-	}
-	return false
+	return flags.SkipTLSValidation()
 }
 
 func writeCertPEM(writer io.Writer, cert *x509.Certificate) error {

--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -157,15 +157,8 @@ func UseInsecure() bool {
 
 // SkipTLSValidation returns a bool that indicates the value of the `--insecure-skip-tls-verify` flag, with `nil`
 // indicating that it was left at its default value.
-func SkipTLSValidation() *bool {
-	if !*insecureSkipTLSVerifySet {
-		if env.InsecureClientSkipTLSVerifyEnv.BooleanSetting() == env.InsecureClientSkipTLSVerifyEnv.DefaultBooleanSetting() {
-			return nil
-		}
-		envSetting := env.InsecureClientSkipTLSVerifyEnv.BooleanSetting()
-		return &envSetting
-	}
-	return &insecureSkipTLSVerify
+func SkipTLSValidation() bool {
+	return booleanFlagOrSettingValue(insecureSkipTLSVerify, *insecureSkipTLSVerifySet, env.InsecureClientSkipTLSVerifyEnv)
 }
 
 // CAFile returns the file for custom CA certificates.

--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -54,7 +54,7 @@ func tlsConfigOptsForCentral() (*clientconn.TLSConfigOptions, error) {
 
 	opts := &clientconn.TLSConfigOptions{
 		ServerName:         serverName,
-		InsecureSkipVerify: flags.SkipTLSValidation() != nil && *flags.SkipTLSValidation(),
+		InsecureSkipVerify: flags.SkipTLSValidation(),
 	}
 
 	if !opts.InsecureSkipVerify {


### PR DESCRIPTION
### Description 

The `SkipTLSValidation()` function in `roxctl/common/flags/endpoint.go` currently  returns `nil` whenever the `--insecure-skip-tls-verify` is unset and its corresponding environment variable is not set. Whenever this function does return nil, however, the assumed value for this flag is `false`, which is the flag's default setting. In this change, I simply change `SkipTLSValidation()`'s proprietary implementation to use `flags.booleanFlagOrSettingValue()` function, like the other flag getter functions. 

### Checklist 
- [X] Make `SkipTLSValidation()` implementation consistent with other flag getter functions (return `bool` instead of `*bool`, use `booleanFlagOrSettingValue()`, etc.) in 
   - `flags/endpoint.go`
- [X] Replace corresponding usages of `SkipTLSValidation()` to check for `true` and `false` in 
   - `roxctl/central/cert/cert.go`
   - `roxctl/common/tls.go`


### Testing 
- [X] Flag tests 
- [X] `make tests` 