### PR TITLE
ROX-27414: Do not dedupe NodeIndex and NodeInvetory in Central

### DIFF
--- a/central/hash/manager/deduper.go
+++ b/central/hash/manager/deduper.go
@@ -100,6 +100,12 @@ func skipDedupe(msg *central.MsgFromSensor) bool {
 	if eventMsg.Event.GetReprocessDeployment() != nil {
 		return true
 	}
+	if eventMsg.Event.GetIndexReport() != nil {
+		return true
+	}
+	if eventMsg.Event.GetNodeInventory() != nil {
+		return true
+	}
 	return false
 }
 

--- a/central/hash/manager/deduper_test.go
+++ b/central/hash/manager/deduper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	eventPkg "github.com/stackrox/rox/pkg/sensor/event"
 	"github.com/stackrox/rox/pkg/sensor/hash"
@@ -84,6 +85,49 @@ func TestDeduper(t *testing.T) {
 								Resource: &central.SensorEvent_AlertResults{
 									AlertResults: &central.AlertResults{
 										Stage: storage.LifecycleStage_RUNTIME,
+									},
+								},
+							},
+						},
+					},
+					result: true,
+				},
+			},
+		},
+		{
+			testName: "duplicate node indexes should not be deduped",
+			testEvents: []testEvents{
+				{
+					event: &central.MsgFromSensor{
+						Msg: &central.MsgFromSensor_Event{
+							Event: &central.SensorEvent{
+								Id: "1",
+								Resource: &central.SensorEvent_IndexReport{
+									IndexReport: &v4.IndexReport{
+										HashId:   "a",
+										State:    "7",
+										Success:  true,
+										Err:      "",
+										Contents: nil,
+									},
+								},
+							},
+						},
+					},
+					result: true,
+				},
+				{
+					event: &central.MsgFromSensor{
+						Msg: &central.MsgFromSensor_Event{
+							Event: &central.SensorEvent{
+								Id: "1",
+								Resource: &central.SensorEvent_IndexReport{
+									IndexReport: &v4.IndexReport{
+										HashId:   "a",
+										State:    "7",
+										Success:  true,
+										Err:      "",
+										Contents: nil,
 									},
 								},
 							},


### PR DESCRIPTION
### Description

This is a _necessary_ change to fix the issue of NodeIndex messages being deduped, but it may not be the _sufficient_ one. 

The _sufficient_ set of fixes should include also:
- https://github.com/stackrox/stackrox/pull/13605
- https://github.com/stackrox/stackrox/pull/13606
- https://github.com/stackrox/stackrox/pull/13640

See the ticket ROX-27414 for more background information.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- [x] Added test case to the unit test and saw it passing locally
- [x] Manually on a cluster where both node scanning (v2 and v4) run in parallel for some time every 30seconds.

Before that change the Central metrics were like this:

```
rox_central_resource_processed_count{Operation="Unset",Resource="NodeIndex"} 11
rox_central_resource_processed_count{Operation="Unset",Resource="NodeInventory"} 160
```

note that this metric counts the number of objects that reach the dedicated pipeline - here `nodeindex/pipeline.go`.

With that change the metric looks like

```
rox_central_resource_processed_count{Operation="Unset",Resource="NodeIndex"} 123
rox_central_resource_processed_count{Operation="Unset",Resource="NodeInventory"} 124
```
