### PR TITLE
chore(ui): Replace apostrophe for contraction or possession

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -638,7 +638,7 @@ function AuthProviderForm({
                             <Alert
                                 isInline
                                 variant="info"
-                                title="Note: the claim mappings are used to map claims returned in underlying identity provider's token to ACS token."
+                                title="Note: the claim mappings are used to map claims returned in underlying identity provider’s token to ACS token."
                                 component="p"
                             >
                                 <p>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -62,7 +62,7 @@ function ClusterDeployment({
                             legacy-installed Secured Clusters to work.
                         </Text>
                         <Switch
-                            label="Configured for upgrades: Secured Clusters can be upgraded to match Central's version."
+                            label="Configured for upgrades: Secured Clusters can be upgraded to match Central’s version."
                             labelOff="Not configured for upgrades: Attempts to upgrade Secured Clusters will fail."
                             onChange={toggleSA}
                             isChecked={createUpgraderSA}

--- a/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
@@ -18,7 +18,7 @@ function ShowAdministrationUsage(): ReactElement {
             </Button>
             <Modal
                 title="Administration usage"
-                description="The page shows the collected administration usage data: number of secured Kubernetes nodes and CPU units. The current usage is computed from the latest metrics received from sensors, and there can be a delay of about 5 minutes. The maximum usage is aggregated hourly and only includes clusters that are still connected. The date range is inclusive and depends on the user's timezone. Data shown is not sent to Red Hat or displayed as Prometheus metrics."
+                description="The page shows the collected administration usage data: number of secured Kubernetes nodes and CPU units. The current usage is computed from the latest metrics received from sensors, and there can be a delay of about 5 minutes. The maximum usage is aggregated hourly and only includes clusters that are still connected. The date range is inclusive and depends on the user’s timezone. Data shown is not sent to Red Hat or displayed as Prometheus metrics."
                 isOpen={isModalOpen}
                 variant="large"
                 onClose={closeModal}

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -13,7 +13,7 @@ function ContainerConfiguration({ deployment }: ContainerConfigurationProps): Re
 
     if (deployment === null) {
         content =
-            "Container configurations are unavailable because the alert's deployment no longer exists.";
+            'Container configurations are unavailable because the alert’s deployment no longer exists.';
     } else if (deployment.containers.length !== 0) {
         content = deployment.containers.map((container, i) => (
             <React.Fragment key={container.id}>

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
@@ -13,7 +13,7 @@ function PortConfiguration({ deployment }: PortConfigurationProps): ReactElement
 
     if (deployment === null) {
         content =
-            "Port configurations are unavailable because the alert's deployment no longer exists.";
+            'Port configurations are unavailable because the alert’s deployment no longer exists.';
     } else if (deployment.ports.length !== 0) {
         content = deployment.ports.map((port, i) => {
             /* eslint-disable react/no-array-index-key */

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
@@ -13,7 +13,7 @@ function SecurityContext({ deployment }: SecurityContextProps): ReactElement {
 
     if (deployment === null) {
         content =
-            "Security context is unavailable because the alert's deployment no longer exists.";
+            'Security context is unavailable because the alert’s deployment no longer exists.';
     } else {
         const securityContextContainers =
             deployment?.containers?.filter(

--- a/ui/apps/platform/src/messages/vulnMgmt.messages.ts
+++ b/ui/apps/platform/src/messages/vulnMgmt.messages.ts
@@ -10,11 +10,11 @@ export const imageScanMessages = {
     },
     missingScanData: {
         header: 'Failed to get the base OS information.',
-        body: "The integrated scanner can't find the OS, or the base OS is unidentifiable.",
+        body: 'The integrated scanner can’t find the OS, or the base OS is unidentifiable.',
     },
     osUnavailable: {
         header: 'The scanner doesn’t provide OS information.',
-        body: "The integrated scanner can't find the OS, or the base OS is unidentifiable.",
+        body: 'The integrated scanner can’t find the OS, or the base OS is unidentifiable.',
     },
     languageCvesUnavailable: {
         header: 'Unable to retrieve Language CVE data; only OS CVE data available',


### PR DESCRIPTION
### Description

Outside of policyCriteriaDescriptors which are replaced in #13642

### Problem

Quote in string is an edge case (especially for fixer) in first draft of lint rule in #13364

Also, IBM Style recommends typographical quote marks.

### Analysis

Although that was for double quote, start with single quote (especially because full stack developers use template literal).

Temporary lint rule reported:
* 2 occurrences of **contraction**
    The integrated scanner can't find the OS
    Ironically, the original text had correct punctuation, but a recent change apparently retyped the entire sentence :(
* 6 occurrences of **possession**, for example
    because the alert's deployment no longer exists

https://www.patternfly.org/ux-writing/writing-for-all-audiences/#writing-for-all-abilities
> Use common contractions (for example, "it’s” and "you’re") in areas that sound most natural to you. Contractions help make your UI more accessible, and they’re great for maintaining a casual voice and tone.

Although **possession** might bend or even break usage rules, rewrite is outside the scope.

### Solution

1. Replace Unicode 0027 **apostrophe** with Unicode 2019 **right single quotation mark** character.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4614590 - 4614590
        total 50 = 11608554 - 11608504
    * `ls -al build/static/js/*.js | wc`
        files 0 = 176 - 176
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/access-control/auth-providers?action=create&type=oidc
 
    * Before changes, `AuthProviderForm` renders Unicode 0027 **apostrophe**.
        ![AuthProviderForm_0027](https://github.com/user-attachments/assets/06cd994c-3a80-42d8-b072-ec0ba9404026)

    * After changes, `AuthProviderForm` renders Unicode 2019 **right single quotation mark**.
        ![AuthProviderForm_2019](https://github.com/user-attachments/assets/4a420c95-4e09-455f-b2d4-db2d228fe95b)

2. Visit /main/clusters/new enter name and then click **Next**

    * Before changes, `ClusterDeployment` renders Unicode 0027 **apostrophe**.
        ![ClusterDeployment_0027](https://github.com/user-attachments/assets/2a5c1ae7-cc75-41f6-baf5-9504b2d764d6)

    * After changes, `ClusterDeployment` renders Unicode 2019 **right single quotation mark**.
        ![ClusterDeployment_2019](https://github.com/user-attachments/assets/aadfa76e-b9cd-4e25-92c8-46bfec13834f)

3. Visit https://localhost:3000/main/system-health and then click **Show administration usage**

    * Before changes, `ShowAdministrationUsage` renders Unicode 0027 **apostrophe**.
        ![ShowAdministrationUsage_0027](https://github.com/user-attachments/assets/e5bd31af-7e9d-4e65-96e4-6853adbc0879)

    * After changes, `ShowAdministrationUsage` renders Unicode 2019 **right single quotation mark**.
        ![ShowAdministrationUsage_2019](https://github.com/user-attachments/assets/258a1aa4-6c37-4a8b-a7a1-2db82bf61d50)

4. Visit /main/vulnerability-management/images and click an image that has a warning alert for **No CVEs**.

    Temporarily edit vulnMgmt.messages.ts file to display `missingScanData` message in place of `osCvesUnavailable` message.

    * Before changes, `imageScanMessages` has Unicode 0027 **apostrophe**.
        ![imageScanMessages_0027](https://github.com/user-attachments/assets/5ed0a8d2-9f64-4b44-9b84-884d5c5a11bf)

    * After changes, `imageScanMessages` has Unicode 2019 **right single quotation mark**.
        ![imageScanMessages_2019](https://github.com/user-attachments/assets/ca5807e1-bfb1-4bf8-99de-918df6b6da2b)
