### PR TITLE
ROX-27392: workload CVE dynamic base url

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -3,6 +3,7 @@ import pluralize from 'pluralize';
 import cloneDeep from 'lodash/cloneDeep';
 import { Alert, Button } from '@patternfly/react-core';
 
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import CollapsibleSection from 'Components/CollapsibleSection';
 import Metadata from 'Components/Metadata';
@@ -174,7 +175,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                                     <Button
                                         component={LinkShim}
                                         variant="link"
-                                        href={getWorkloadEntityPagePath('Image', data.id)}
+                                        href={`${vulnerabilitiesWorkloadCvesPath}${getWorkloadEntityPagePath('Image', data.id)}`}
                                         isInline
                                     >
                                         in Workload CVEs

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -14,6 +14,7 @@ import { useQuery } from '@apollo/client';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { SetResult } from 'hooks/useSet';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
@@ -186,12 +187,13 @@ function RequestCVEsTable({
                                         IMAGE: queryObject.Image,
                                     },
                                 };
-                                const cveURL = getWorkloadEntityPagePath(
+
+                                const cveURL = `${vulnerabilitiesWorkloadCvesPath}/${getWorkloadEntityPagePath(
                                     'CVE',
                                     cve,
                                     vulnerabilityState,
                                     cveURLQueryOptions
-                                );
+                                )}`;
 
                                 return (
                                     <Tbody key={cve} isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -42,10 +42,10 @@ const deploymentMetadataQuery = gql`
 
 function DeploymentPage() {
     const { deploymentId } = useParams() as { deploymentId: string };
-    const { createUrl, pageTitle } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl, pageTitle } = useWorkloadCveViewContext();
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
 
-    const workloadCveOverviewDeploymentsPath = createUrl(
+    const workloadCveOverviewDeploymentsPath = getAbsoluteUrl(
         getOverviewPagePath('Workload', {
             vulnerabilityState: 'OBSERVED',
             entityTab: 'Deployment',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -31,11 +31,6 @@ import DeploymentPageVulnerabilities from './DeploymentPageVulnerabilities';
 import DeploymentPageDetails from './DeploymentPageDetails';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
-const workloadCveOverviewDeploymentsPath = getOverviewPagePath('Workload', {
-    vulnerabilityState: 'OBSERVED',
-    entityTab: 'Deployment',
-});
-
 const deploymentMetadataQuery = gql`
     ${deploymentMetadataFragment}
     query getDeploymentMetadata($id: ID!) {
@@ -47,8 +42,15 @@ const deploymentMetadataQuery = gql`
 
 function DeploymentPage() {
     const { deploymentId } = useParams() as { deploymentId: string };
-    const { pageTitle } = useWorkloadCveViewContext();
+    const { createUrl, pageTitle } = useWorkloadCveViewContext();
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
+
+    const workloadCveOverviewDeploymentsPath = createUrl(
+        getOverviewPagePath('Workload', {
+            vulnerabilityState: 'OBSERVED',
+            entityTab: 'Deployment',
+        })
+    );
 
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -8,6 +8,7 @@ import DateDistance from 'Components/DateDistance';
 import EmptyTableResults from '../components/EmptyTableResults';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export type DeploymentResources = {
     deploymentCount: number;
@@ -39,6 +40,7 @@ export type DeploymentResourceTableProps = {
 };
 
 function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTableProps) {
+    const { createUrl } = useWorkloadCveViewContext();
     const vulnerabilityState = useVulnerabilityState();
     return (
         <Table borders={false} variant="compact">
@@ -62,10 +64,12 @@ function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTabl
                         <Tr>
                             <Td dataLabel="Name">
                                 <Link
-                                    to={getWorkloadEntityPagePath(
-                                        'Deployment',
-                                        id,
-                                        vulnerabilityState
+                                    to={createUrl(
+                                        getWorkloadEntityPagePath(
+                                            'Deployment',
+                                            id,
+                                            vulnerabilityState
+                                        )
                                     )}
                                 >
                                     {name}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -40,7 +40,7 @@ export type DeploymentResourceTableProps = {
 };
 
 function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTableProps) {
-    const { createUrl } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl } = useWorkloadCveViewContext();
     const vulnerabilityState = useVulnerabilityState();
     return (
         <Table borders={false} variant="compact">
@@ -64,7 +64,7 @@ function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTabl
                         <Tr>
                             <Td dataLabel="Name">
                                 <Link
-                                    to={createUrl(
+                                    to={getAbsoluteUrl(
                                         getWorkloadEntityPagePath(
                                             'Deployment',
                                             id,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -47,11 +47,6 @@ import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getImageBaseNameDisplay } from '../utils/images';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
-const workloadCveOverviewImagePath = getOverviewPagePath('Workload', {
-    vulnerabilityState: 'OBSERVED',
-    entityTab: 'Image',
-});
-
 export const imageDetailsQuery = gql`
     ${imageDetailsFragment}
     query getImageDetails($id: ID!) {
@@ -74,7 +69,7 @@ function ScannerV4RequiredTooltip({ children }: { children: ReactElement }) {
 
 function ImagePage() {
     const { imageId } = useParams();
-    const { pageTitle } = useWorkloadCveViewContext();
+    const { createUrl, pageTitle } = useWorkloadCveViewContext();
     const { data, error } = useQuery<
         {
             image: {
@@ -109,6 +104,13 @@ function ImagePage() {
             ? `${imageName.registry}/${getImageBaseNameDisplay(imageData.id, imageName)}`
             : 'NAME UNKNOWN';
     const scanMessage = getImageScanMessage(imageData?.notes || [], imageData?.scanNotes || []);
+
+    const workloadCveOverviewImagePath = createUrl(
+        getOverviewPagePath('Workload', {
+            vulnerabilityState: 'OBSERVED',
+            entityTab: 'Image',
+        })
+    );
 
     let mainContent: ReactNode | null = null;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -69,7 +69,7 @@ function ScannerV4RequiredTooltip({ children }: { children: ReactElement }) {
 
 function ImagePage() {
     const { imageId } = useParams();
-    const { createUrl, pageTitle } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl, pageTitle } = useWorkloadCveViewContext();
     const { data, error } = useQuery<
         {
             image: {
@@ -105,7 +105,7 @@ function ImagePage() {
             : 'NAME UNKNOWN';
     const scanMessage = getImageScanMessage(imageData?.notes || [], imageData?.scanNotes || []);
 
-    const workloadCveOverviewImagePath = createUrl(
+    const workloadCveOverviewImagePath = getAbsoluteUrl(
         getOverviewPagePath('Workload', {
             vulnerabilityState: 'OBSERVED',
             entityTab: 'Image',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -93,11 +93,6 @@ import VulnerabilityStateTabs, {
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
-const workloadCveOverviewCvePath = getOverviewPagePath('Workload', {
-    vulnerabilityState: 'OBSERVED',
-    entityTab: 'CVE',
-});
-
 export const imageCveMetadataQuery = gql`
     query getImageCveMetadata($cve: String!) {
         imageCVE(cve: $cve) {
@@ -212,7 +207,7 @@ function ImageCvePage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const { pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
+    const { createUrl, pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const urlParams = useParams();
@@ -368,6 +363,13 @@ function ImageCvePage() {
             />
         );
     }
+
+    const workloadCveOverviewCvePath = createUrl(
+        getOverviewPagePath('Workload', {
+            vulnerabilityState: 'OBSERVED',
+            entityTab: 'CVE',
+        })
+    );
 
     const cveName = metadataRequest.data?.imageCVE?.cve;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -207,7 +207,7 @@ function ImageCvePage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const { createUrl, pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl, pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const urlParams = useParams();
@@ -364,7 +364,7 @@ function ImageCvePage() {
         );
     }
 
-    const workloadCveOverviewCvePath = createUrl(
+    const workloadCveOverviewCvePath = getAbsoluteUrl(
         getOverviewPagePath('Workload', {
             vulnerabilityState: 'OBSERVED',
             entityTab: 'CVE',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -28,7 +28,6 @@ import useAnalytics, {
 } from 'hooks/useAnalytics';
 import useLocalStorage from 'hooks/useLocalStorage';
 import { SearchFilter } from 'types/search';
-import { vulnerabilityNamespaceViewPath } from 'routePaths';
 import {
     getDefaultWorkloadSortOption,
     getDefaultZeroCveSortOption,
@@ -172,7 +171,7 @@ function WorkloadCvesOverviewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const { pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
+    const { createUrl, pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter: setURLSearchFilter } = useURLSearch();
@@ -462,7 +461,7 @@ function WorkloadCvesOverviewPage() {
                                                 {hasReadAccessForNamespaces && (
                                                     <Button
                                                         variant="secondary"
-                                                        href={vulnerabilityNamespaceViewPath}
+                                                        href={createUrl('namespace-view')}
                                                         component={LinkShim}
                                                     >
                                                         Prioritize by namespace view

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -72,6 +72,7 @@ import {
     parseQuerySearchFilter,
     getVulnStateScopedQueryString,
     getZeroCveScopedQueryString,
+    getNamespaceViewPagePath,
 } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
@@ -171,7 +172,7 @@ function WorkloadCvesOverviewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const { createUrl, pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl, pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter: setURLSearchFilter } = useURLSearch();
@@ -461,7 +462,9 @@ function WorkloadCvesOverviewPage() {
                                                 {hasReadAccessForNamespaces && (
                                                     <Button
                                                         variant="secondary"
-                                                        href={createUrl('namespace-view')}
+                                                        href={getAbsoluteUrl(
+                                                            getNamespaceViewPagePath()
+                                                        )}
                                                         component={LinkShim}
                                                     >
                                                         Prioritize by namespace view

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -108,7 +108,7 @@ function AffectedDeploymentsTable({
     onClearFilters,
     tableConfig,
 }: AffectedDeploymentsTableProps) {
-    const { createUrl } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
@@ -182,7 +182,7 @@ function AffectedDeploymentsTable({
                                             spaceItems={{ default: 'spaceItemsNone' }}
                                         >
                                             <Link
-                                                to={createUrl(
+                                                to={getAbsoluteUrl(
                                                     getWorkloadEntityPagePath(
                                                         'Deployment',
                                                         id,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -26,6 +26,7 @@ import DeploymentComponentVulnerabilitiesTable, {
 } from './DeploymentComponentVulnerabilitiesTable';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { VulnerabilitySeverityLabel } from '../../types';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const tableId = 'WorkloadCvesAffectedDeploymentsTable';
 export const defaultColumns = {
@@ -107,6 +108,7 @@ function AffectedDeploymentsTable({
     onClearFilters,
     tableConfig,
 }: AffectedDeploymentsTableProps) {
+    const { createUrl } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
@@ -180,10 +182,12 @@ function AffectedDeploymentsTable({
                                             spaceItems={{ default: 'spaceItemsNone' }}
                                         >
                                             <Link
-                                                to={getWorkloadEntityPagePath(
-                                                    'Deployment',
-                                                    id,
-                                                    vulnerabilityState
+                                                to={createUrl(
+                                                    getWorkloadEntityPagePath(
+                                                        'Deployment',
+                                                        id,
+                                                        vulnerabilityState
+                                                    )
                                                 )}
                                             >
                                                 <Truncate position="middle" content={name} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -108,7 +108,7 @@ function DeploymentOverviewTable({
     onClearFilters,
     columnVisibilityState,
 }: DeploymentOverviewTableProps) {
-    const { createUrl } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl } = useWorkloadCveViewContext();
     const vulnerabilityState = useVulnerabilityState();
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
     const hiddenColumnCount = getHiddenColumnCount(columnVisibilityState);
@@ -179,7 +179,7 @@ function DeploymentOverviewTable({
                                 <Tr>
                                     <Td dataLabel="Deployment">
                                         <Link
-                                            to={createUrl(
+                                            to={getAbsoluteUrl(
                                                 getWorkloadEntityPagePath(
                                                     'Deployment',
                                                     id,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -20,6 +20,7 @@ import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { VulnerabilitySeverityLabel } from '../../types';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const tableId = 'WorkloadCvesDeploymentOverviewTable';
 
@@ -107,6 +108,7 @@ function DeploymentOverviewTable({
     onClearFilters,
     columnVisibilityState,
 }: DeploymentOverviewTableProps) {
+    const { createUrl } = useWorkloadCveViewContext();
     const vulnerabilityState = useVulnerabilityState();
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
     const hiddenColumnCount = getHiddenColumnCount(columnVisibilityState);
@@ -177,10 +179,12 @@ function DeploymentOverviewTable({
                                 <Tr>
                                     <Td dataLabel="Deployment">
                                         <Link
-                                            to={getWorkloadEntityPagePath(
-                                                'Deployment',
-                                                id,
-                                                vulnerabilityState
+                                            to={createUrl(
+                                                getWorkloadEntityPagePath(
+                                                    'Deployment',
+                                                    id,
+                                                    vulnerabilityState
+                                                )
                                             )}
                                         >
                                             <Truncate position="middle" content={name} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -97,7 +97,7 @@ function DeploymentVulnerabilitiesTable({
     onClearFilters,
     tableConfig,
 }: DeploymentVulnerabilitiesTableProps) {
-    const { createUrl } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
@@ -168,7 +168,7 @@ function DeploymentVulnerabilitiesTable({
                                             vulnerabilityState={vulnerabilityState}
                                         >
                                             <Link
-                                                to={createUrl(
+                                                to={getAbsoluteUrl(
                                                     getWorkloadEntityPagePath(
                                                         'CVE',
                                                         cve,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -26,6 +26,7 @@ import DeploymentComponentVulnerabilitiesTable, {
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import { FormattedDeploymentVulnerability } from './table.utils';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const tableId = 'WorkloadCvesDeploymentVulnerabilitiesTable';
 export const defaultColumns = {
@@ -96,6 +97,7 @@ function DeploymentVulnerabilitiesTable({
     onClearFilters,
     tableConfig,
 }: DeploymentVulnerabilitiesTableProps) {
+    const { createUrl } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
@@ -166,10 +168,12 @@ function DeploymentVulnerabilitiesTable({
                                             vulnerabilityState={vulnerabilityState}
                                         >
                                             <Link
-                                                to={getWorkloadEntityPagePath(
-                                                    'CVE',
-                                                    cve,
-                                                    vulnerabilityState
+                                                to={createUrl(
+                                                    getWorkloadEntityPagePath(
+                                                        'CVE',
+                                                        cve,
+                                                        vulnerabilityState
+                                                    )
                                                 )}
                                             >
                                                 {cve}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -46,6 +46,7 @@ import CVESelectionTd from '../../components/CVESelectionTd';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const tableId = 'WorkloadCvesImageVulnerabilitiesTable';
 export const defaultColumns = {
@@ -141,6 +142,7 @@ function ImageVulnerabilitiesTable({
     onClearFilters,
     tableConfig,
 }: ImageVulnerabilitiesTableProps) {
+    const { createUrl } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
@@ -251,10 +253,12 @@ function ImageVulnerabilitiesTable({
                                             vulnerabilityState={vulnerabilityState}
                                         >
                                             <Link
-                                                to={getWorkloadEntityPagePath(
-                                                    'CVE',
-                                                    cve,
-                                                    vulnerabilityState
+                                                to={createUrl(
+                                                    getWorkloadEntityPagePath(
+                                                        'CVE',
+                                                        cve,
+                                                        vulnerabilityState
+                                                    )
                                                 )}
                                             >
                                                 {cve}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -142,7 +142,7 @@ function ImageVulnerabilitiesTable({
     onClearFilters,
     tableConfig,
 }: ImageVulnerabilitiesTableProps) {
-    const { createUrl } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
@@ -253,7 +253,7 @@ function ImageVulnerabilitiesTable({
                                             vulnerabilityState={vulnerabilityState}
                                         >
                                             <Link
-                                                to={createUrl(
+                                                to={getAbsoluteUrl(
                                                     getWorkloadEntityPagePath(
                                                         'CVE',
                                                         cve,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -187,7 +187,7 @@ function WorkloadCVEOverviewTable({
     onClearFilters,
     columnVisibilityState,
 }: WorkloadCVEOverviewTableProps) {
-    const { createUrl } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl } = useWorkloadCveViewContext();
     const expandedRowSet = useSet<string>();
     const showExceptionDetailsLink = vulnerabilityState !== 'OBSERVED';
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
@@ -340,7 +340,7 @@ function WorkloadCVEOverviewTable({
                                                 vulnerabilityState={vulnerabilityState}
                                             >
                                                 <Link
-                                                    to={createUrl(
+                                                    to={getAbsoluteUrl(
                                                         getWorkloadEntityPagePath(
                                                             'CVE',
                                                             cve,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -50,6 +50,7 @@ import CVESelectionTd from '../../components/CVESelectionTd';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const tableId = 'WorkloadCveOverviewTable';
 export const defaultColumns = {
@@ -186,6 +187,7 @@ function WorkloadCVEOverviewTable({
     onClearFilters,
     columnVisibilityState,
 }: WorkloadCVEOverviewTableProps) {
+    const { createUrl } = useWorkloadCveViewContext();
     const expandedRowSet = useSet<string>();
     const showExceptionDetailsLink = vulnerabilityState !== 'OBSERVED';
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
@@ -338,10 +340,12 @@ function WorkloadCVEOverviewTable({
                                                 vulnerabilityState={vulnerabilityState}
                                             >
                                                 <Link
-                                                    to={getWorkloadEntityPagePath(
-                                                        'CVE',
-                                                        cve,
-                                                        vulnerabilityState
+                                                    to={createUrl(
+                                                        getWorkloadEntityPagePath(
+                                                            'CVE',
+                                                            cve,
+                                                            vulnerabilityState
+                                                        )
                                                     )}
                                                 >
                                                     {cve}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 import { QuerySearchFilter } from '../types';
 
 export type WorkloadCveView = {
-    createUrl: (path: string) => string;
+    getAbsoluteUrl: (path: string) => string;
     baseSearchFilter: QuerySearchFilter;
     pageTitle: string;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -37,7 +37,7 @@ function WorkloadCvesPage({ view }: WorkloadCvePageProps) {
         const baseSearchFilter = isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
             ? { 'Platform Component': [String(view === 'platform-workload')] }
             : {};
-        const createUrl = (path) => `${vulnerabilitiesWorkloadCvesPath}${path}`; // TODO Implement throughout in follow up
+        const createUrl = (path: string) => `${vulnerabilitiesWorkloadCvesPath}/${path}`;
 
         return { pageTitle, baseSearchFilter, createUrl };
     }, [view, isFeatureFlagEnabled]);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -37,9 +37,9 @@ function WorkloadCvesPage({ view }: WorkloadCvePageProps) {
         const baseSearchFilter = isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
             ? { 'Platform Component': [String(view === 'platform-workload')] }
             : {};
-        const createUrl = (path: string) => `${vulnerabilitiesWorkloadCvesPath}/${path}`;
+        const getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesWorkloadCvesPath}/${subPath}`;
 
-        return { pageTitle, baseSearchFilter, createUrl };
+        return { pageTitle, baseSearchFilter, getAbsoluteUrl };
     }, [view, isFeatureFlagEnabled]);
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
@@ -19,7 +19,7 @@ export type ImageNameLinkProps = {
 };
 
 function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
-    const { createUrl } = useWorkloadCveViewContext();
+    const { getAbsoluteUrl } = useWorkloadCveViewContext();
     const vulnerabilityState = useVulnerabilityState();
     const [copyIconTooltip, setCopyIconTooltip] = useState('Copy image name');
 
@@ -43,7 +43,9 @@ function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
             spaceItems={{ default: 'spaceItemsNone' }}
         >
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
-                <Link to={createUrl(getWorkloadEntityPagePath('Image', id, vulnerabilityState))}>
+                <Link
+                    to={getAbsoluteUrl(getWorkloadEntityPagePath('Image', id, vulnerabilityState))}
+                >
                     <Truncate position="middle" content={baseName} />
                 </Link>{' '}
                 <span className="pf-v5-u-color-200 pf-v5-u-font-size-sm">in {registry}</span>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
@@ -6,6 +6,7 @@ import { OutlinedCopyIcon } from '@patternfly/react-icons';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import { getImageBaseNameDisplay } from '../utils/images';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
+import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export type ImageNameLinkProps = {
     name: {
@@ -18,6 +19,7 @@ export type ImageNameLinkProps = {
 };
 
 function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
+    const { createUrl } = useWorkloadCveViewContext();
     const vulnerabilityState = useVulnerabilityState();
     const [copyIconTooltip, setCopyIconTooltip] = useState('Copy image name');
 
@@ -41,7 +43,7 @@ function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
             spaceItems={{ default: 'spaceItemsNone' }}
         >
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
-                <Link to={getWorkloadEntityPagePath('Image', id, vulnerabilityState)}>
+                <Link to={createUrl(getWorkloadEntityPagePath('Image', id, vulnerabilityState))}>
                     <Truncate position="middle" content={baseName} />
                 </Link>{' '}
                 <span className="pf-v5-u-color-200 pf-v5-u-font-size-sm">in {registry}</span>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.test.ts
@@ -4,18 +4,16 @@ import {
     getWorkloadEntityPagePath,
 } from './searchUtils';
 
-const workloadUrlBase = '/main/vulnerabilities/workload-cves';
-
 describe('getWorkloadEntityPagePath', () => {
     it('should return the correct path for CVE entity', () => {
         expect(getWorkloadEntityPagePath('CVE', 'CVE-123-456', 'OBSERVED')).toEqual(
-            `${workloadUrlBase}/cves/CVE-123-456?vulnerabilityState=OBSERVED`
+            `cves/CVE-123-456?vulnerabilityState=OBSERVED`
         );
         expect(getWorkloadEntityPagePath('CVE', 'CVE-123-456', 'DEFERRED')).toEqual(
-            `${workloadUrlBase}/cves/CVE-123-456?vulnerabilityState=DEFERRED`
+            `cves/CVE-123-456?vulnerabilityState=DEFERRED`
         );
         expect(getWorkloadEntityPagePath('CVE', 'CVE-123-456', 'FALSE_POSITIVE')).toEqual(
-            `${workloadUrlBase}/cves/CVE-123-456?vulnerabilityState=FALSE_POSITIVE`
+            `cves/CVE-123-456?vulnerabilityState=FALSE_POSITIVE`
         );
 
         expect(
@@ -23,19 +21,19 @@ describe('getWorkloadEntityPagePath', () => {
                 s: { SEVERITY: ['CRITICAL', 'IMPORTANT'], FIXABLE: [], NAMESPACE: ['stackrox'] },
             })
         ).toEqual(
-            `${workloadUrlBase}/cves/CVE-123-456?s[SEVERITY][0]=CRITICAL&s[SEVERITY][1]=IMPORTANT&s[NAMESPACE][0]=stackrox&vulnerabilityState=OBSERVED`
+            `cves/CVE-123-456?s[SEVERITY][0]=CRITICAL&s[SEVERITY][1]=IMPORTANT&s[NAMESPACE][0]=stackrox&vulnerabilityState=OBSERVED`
         );
     });
 
     it('should return the correct path for Image entity', () => {
         expect(getWorkloadEntityPagePath('Image', 'sha256:123-456', 'OBSERVED')).toEqual(
-            `${workloadUrlBase}/images/sha256:123-456?vulnerabilityState=OBSERVED`
+            `images/sha256:123-456?vulnerabilityState=OBSERVED`
         );
         expect(getWorkloadEntityPagePath('Image', 'sha256:123-456', 'DEFERRED')).toEqual(
-            `${workloadUrlBase}/images/sha256:123-456?vulnerabilityState=DEFERRED`
+            `images/sha256:123-456?vulnerabilityState=DEFERRED`
         );
         expect(getWorkloadEntityPagePath('Image', 'sha256:123-456', 'FALSE_POSITIVE')).toEqual(
-            `${workloadUrlBase}/images/sha256:123-456?vulnerabilityState=FALSE_POSITIVE`
+            `images/sha256:123-456?vulnerabilityState=FALSE_POSITIVE`
         );
 
         expect(
@@ -43,29 +41,27 @@ describe('getWorkloadEntityPagePath', () => {
                 s: { SEVERITY: ['CRITICAL', 'IMPORTANT'], FIXABLE: [], NAMESPACE: ['stackrox'] },
             })
         ).toEqual(
-            `${workloadUrlBase}/images/sha256:123-456?s[SEVERITY][0]=CRITICAL&s[SEVERITY][1]=IMPORTANT&s[NAMESPACE][0]=stackrox&vulnerabilityState=OBSERVED`
+            `images/sha256:123-456?s[SEVERITY][0]=CRITICAL&s[SEVERITY][1]=IMPORTANT&s[NAMESPACE][0]=stackrox&vulnerabilityState=OBSERVED`
         );
     });
 
     it('should return the correct path for Deployment entity', () => {
         expect(getWorkloadEntityPagePath('Deployment', 'deployment-123-456', 'OBSERVED')).toEqual(
-            `${workloadUrlBase}/deployments/deployment-123-456?vulnerabilityState=OBSERVED`
+            `deployments/deployment-123-456?vulnerabilityState=OBSERVED`
         );
         expect(getWorkloadEntityPagePath('Deployment', 'deployment-123-456', 'DEFERRED')).toEqual(
-            `${workloadUrlBase}/deployments/deployment-123-456?vulnerabilityState=DEFERRED`
+            `deployments/deployment-123-456?vulnerabilityState=DEFERRED`
         );
         expect(
             getWorkloadEntityPagePath('Deployment', 'deployment-123-456', 'FALSE_POSITIVE')
-        ).toEqual(
-            `${workloadUrlBase}/deployments/deployment-123-456?vulnerabilityState=FALSE_POSITIVE`
-        );
+        ).toEqual(`deployments/deployment-123-456?vulnerabilityState=FALSE_POSITIVE`);
 
         expect(
             getWorkloadEntityPagePath('Deployment', 'deployment-123-456', 'OBSERVED', {
                 s: { SEVERITY: ['CRITICAL', 'IMPORTANT'], FIXABLE: [], NAMESPACE: ['stackrox'] },
             })
         ).toEqual(
-            `${workloadUrlBase}/deployments/deployment-123-456?s[SEVERITY][0]=CRITICAL&s[SEVERITY][1]=IMPORTANT&s[NAMESPACE][0]=stackrox&vulnerabilityState=OBSERVED`
+            `deployments/deployment-123-456?s[SEVERITY][0]=CRITICAL&s[SEVERITY][1]=IMPORTANT&s[NAMESPACE][0]=stackrox&vulnerabilityState=OBSERVED`
         );
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -39,6 +39,10 @@ const baseUrlForCveMap = {
     Platform: vulnerabilitiesPlatformCvesPath,
 } as const;
 
+export function getNamespaceViewPagePath(): string {
+    return 'namespace-view';
+}
+
 export function getOverviewPagePath(
     cveBase: 'Workload' | 'Node' | 'Platform',
     pageSearch: OverviewPageSearch

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -1,11 +1,7 @@
 import qs from 'qs';
 import { cloneDeep } from 'lodash';
 
-import {
-    vulnerabilitiesNodeCvesPath,
-    vulnerabilitiesPlatformCvesPath,
-    vulnerabilitiesWorkloadCvesPath,
-} from 'routePaths';
+import { vulnerabilitiesNodeCvesPath, vulnerabilitiesPlatformCvesPath } from 'routePaths';
 import {
     VulnerabilitySeverity,
     VulnerabilityState,
@@ -38,7 +34,7 @@ export type OverviewPageSearch = {
 );
 
 const baseUrlForCveMap = {
-    Workload: vulnerabilitiesWorkloadCvesPath,
+    Workload: '', // base URL provided by calling context
     Node: vulnerabilitiesNodeCvesPath,
     Platform: vulnerabilitiesPlatformCvesPath,
 } as const;
@@ -59,11 +55,11 @@ export function getWorkloadEntityPagePath(
     const queryString = getQueryString({ ...queryOptions, vulnerabilityState });
     switch (workloadCveEntity) {
         case 'CVE':
-            return `${vulnerabilitiesWorkloadCvesPath}/cves/${id}${queryString}`;
+            return `cves/${id}${queryString}`;
         case 'Image':
-            return `${vulnerabilitiesWorkloadCvesPath}/images/${id}${queryString}`;
+            return `images/${id}${queryString}`;
         case 'Deployment':
-            return `${vulnerabilitiesWorkloadCvesPath}/deployments/${id}${queryString}`;
+            return `deployments/${id}${queryString}`;
         default:
             return ensureExhaustive(workloadCveEntity);
     }


### PR DESCRIPTION
### Description

Allows dynamically configuring the base URL when linking to Workload CVE pages in order to support "user" and "platform" views of this page.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Existing CI tests.

Manual testing of links in the following locations:
- Overview page CVE link
- Overview page Image link
- Overview page Deployment link
- Overview page Namespace view button
- Namespace view deployment link
- CVE page Image link
- CVE page Deployment link
- CVE page Image link in nested Deployment table
- CVE page breadcrumb link
- Image page CVE link
- Image page Deployment link via Resources tab
- Image page breadcrumb link
- Deployment page CVE link
- Deployment page Image link in nested CVE table
- Deployment page Image link via Resources tab
- Deployment page breadcrumb link
- Exception Management CVE link (hard coded to workload-cves)
- VM 1.0 dashboard link (hard coded to workload-cves)
