### PR TITLE
ROX-18278: Fix baseline test flake

### DIFF
--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -313,6 +313,7 @@ func (s *serviceImpl) ResolveAlert(ctx context.Context, req *v1.ResolveAlertRequ
 			if err != nil {
 				log.Errorf("Error syncing baseline with cluster %q: %v", alert.GetDeployment().GetClusterId(), err)
 			}
+			log.Infof("Successfully sent process baseline to cluster %q: %s", alert.GetDeployment().GetClusterId(), baseline.GetId())
 		}
 	}
 

--- a/central/processbaseline/service/service_impl.go
+++ b/central/processbaseline/service/service_impl.go
@@ -131,6 +131,7 @@ func (s *serviceImpl) sendBaselineToSensor(pw *storage.ProcessBaseline) {
 	if err != nil {
 		log.Errorf("Error sending process baseline to cluster %q: %v", pw.GetKey().GetClusterId(), err)
 	}
+	log.Infof("Successfully sent process baseline to cluster %q: %s", pw.GetKey().GetClusterId(), pw.GetId())
 }
 
 func (s *serviceImpl) reprocessDeploymentRisks(keys []*storage.ProcessBaselineKey) {

--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -699,8 +699,8 @@ class Enforcement extends BaseSpecification {
         assert  lockProcessBaselines.get(0).getElementsList().
                 find { it.element.processName.equalsIgnoreCase("/usr/sbin/nginx") } != null
 
-        // Waiting for 5 seconds to wait for the baseline to be synced with Sensor.
-        // If this tests flakes again log statements were added to investigate if a
+        // Wait for the baseline to be synced with Sensor.
+        // If this tests flakes again log statements were added in Central and Sensor to investigate if a
         // baseline was synced with sensor at a specific point in time.
         sleep 10000
 

--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -698,6 +698,12 @@ class Enforcement extends BaseSpecification {
         assert lockProcessBaselines.size() ==  1
         assert  lockProcessBaselines.get(0).getElementsList().
                 find { it.element.processName.equalsIgnoreCase("/usr/sbin/nginx") } != null
+
+        // Waiting for 5 seconds to wait for the baseline to be synced with Sensor.
+        // If this tests flakes again log statements were added to investigate if a
+        // baseline was synced with sensor at a specific point in time.
+        sleep 10000
+
         orchestrator.execInContainer(d, "pwd")
         assert waitForViolation(d.name, ALERT_AND_KILL_ENFORCEMENT_BASELINE_PROCESS, WAIT_FOR_VIOLATION_TIMEOUT)
 

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -227,7 +227,7 @@ class ProcessBaselinesTest extends BaseSpecification {
         assert (!StringUtils.isEmpty(lockProcessBaselines.get(0).getElements(0).getElement().processName))
 
         // sleep 5 seconds to allow for propagation to sensor
-        sleep 5000
+        sleep 10000
         orchestrator.execInContainer(deployment, "pwd")
 
         log.info "Locked Process Baseline after pwd: ${lockProcessBaselines}"

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -116,7 +116,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         log.info "Baseline Before after observation: ${baseline}"
 
-        // sleep 10 seconds to allow for propagation to sensor
+        // wait for propagation to sensor
         sleep 10000
         orchestrator.execInContainer(deployment, "pwd")
 
@@ -226,7 +226,7 @@ class ProcessBaselinesTest extends BaseSpecification {
                  lockProcessBaselines(clusterId, deployment, containerName, true)
         assert (!StringUtils.isEmpty(lockProcessBaselines.get(0).getElements(0).getElement().processName))
 
-        // sleep 5 seconds to allow for propagation to sensor
+        // wait for propagation to sensor
         sleep 10000
         orchestrator.execInContainer(deployment, "pwd")
 
@@ -476,7 +476,7 @@ class ProcessBaselinesTest extends BaseSpecification {
 
         log.info "Process Baseline before pwd: ${baselineAfterDelete}"
 
-        // sleep 10 seconds to allow for propagation to sensor
+        // wait for propagation to sensor
         sleep 10000
         orchestrator.execInContainer(deployment, "pwd")
 

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -243,7 +243,7 @@ class ProcessBaselinesTest extends BaseSpecification {
                 alertId = alert.id
                 AlertService.resolveAlert(alertId, addToBaseline)
                 // again, allow the new baseline that contains pwd to propagate
-                sleep 5000
+                sleep 10000
             }
          }
         orchestrator.execInContainer(deployment, "pwd")

--- a/sensor/common/detector/baseline/baseline.go
+++ b/sensor/common/detector/baseline/baseline.go
@@ -52,7 +52,7 @@ func (w *baselineEvaluator) AddBaseline(baseline *storage.ProcessBaseline) {
 		defer w.baselineLock.Unlock()
 
 		delete(w.baselines[baseline.GetKey().GetDeploymentId()], baseline.GetKey().GetContainerName())
-		log.Infof("Deleted baseline %s", baseline.GetId())
+		log.Infof("Deleted process baseline %s", baseline.GetId())
 		return
 	}
 
@@ -75,7 +75,7 @@ func (w *baselineEvaluator) AddBaseline(baseline *storage.ProcessBaseline) {
 	}
 	containerNameMap[baseline.GetKey().GetContainerName()] = baselineSet
 
-	log.Infof("Successfully added baseline %s", baseline.GetId())
+	log.Infof("Successfully added process baseline %s", baseline.GetId())
 }
 
 // IsInBaseline checks if the process indicator is within a locked baseline

--- a/sensor/common/detector/baseline/baseline.go
+++ b/sensor/common/detector/baseline/baseline.go
@@ -2,9 +2,14 @@ package baseline
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/processbaseline"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 // Evaluator encapsulates the interface to the baseline evaluator
@@ -47,6 +52,7 @@ func (w *baselineEvaluator) AddBaseline(baseline *storage.ProcessBaseline) {
 		defer w.baselineLock.Unlock()
 
 		delete(w.baselines[baseline.GetKey().GetDeploymentId()], baseline.GetKey().GetContainerName())
+		log.Infof("Deleted baseline %s", baseline.GetId())
 		return
 	}
 
@@ -68,6 +74,8 @@ func (w *baselineEvaluator) AddBaseline(baseline *storage.ProcessBaseline) {
 		w.baselines[baseline.GetKey().GetDeploymentId()] = containerNameMap
 	}
 	containerNameMap[baseline.GetKey().GetContainerName()] = baselineSet
+
+	log.Infof("Successfully added baseline %s", baseline.GetId())
 }
 
 // IsInBaseline checks if the process indicator is within a locked baseline


### PR DESCRIPTION
### Description

We received a flake for baseline process tests because the baseline was locked, but not synced before we've executed the violating exec into a Pod.

 - Added a sleep to wait for propagation of the baseline to Sensor
 - Added log statements to debug baseline sync flakes easier

If this doesn't fix the flake we must implement an API which can block until the baseline is synced. Related ticket: https://issues.redhat.com/browse/ROX-27486