### PR TITLE
ROX-27347: Fix for new rep job failing because previous rep is in a p…

### DIFF
--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -195,9 +195,7 @@ func (s *scheduler) runSingleReport(req *reportGen.ReportRequest) {
 	defer s.readyForReports.Signal()
 	defer s.concurrencySema.Release(1)
 	defer s.removeFromRunningReportConfigs(req.ReportSnapshot.GetReportConfigurationId())
-	//for testing only
-	log.Infof("sleep for 2 mins to test Vuln reporting")
-	time.Sleep(2 * time.Minute)
+
 	s.reportGenerator.ProcessReportRequest(req)
 }
 
@@ -328,7 +326,6 @@ func (s *scheduler) queuePendingReports() {
 	}
 
 	for _, snap := range pendingReports {
-		log.Infof("pending job is %s", pendingReports)
 		_, found, err := s.reportConfigDatastore.GetReportConfiguration(scheduledCtx, snap.GetReportConfigurationId())
 		if err != nil {
 			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)
@@ -406,25 +403,21 @@ func findAndRemoveFromQueue(reportRequestsQueue *list.List, pred func(req *repor
 func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *storage.ReportSnapshot, reSubmission bool) (string, error) {
 	s.dbLock.Lock()
 	defer s.dbLock.Unlock()
-	log.Infof("rep snapshot validated is %s", snapshot)
-
-	if snapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_ON_DEMAND {
-		userHasAnotherReport, err := s.doesUserHavePendingReport(snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId())
-		if err != nil {
-			return "", err
-		}
-		if userHasAnotherReport {
-			return "", errors.Wrapf(errox.AlreadyExists, "User already has a report running for config ID '%s'",
-				snapshot.GetReportConfigurationId())
-		}
-	}
-
 	var err error
 	if !reSubmission {
-		log.Info("job is not resubmitted")
+		if snapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_ON_DEMAND {
+			userHasAnotherReport, err := s.doesUserHavePendingReport(snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId())
+			if err != nil {
+				return "", err
+			}
+			if userHasAnotherReport {
+				return "", errors.Wrapf(errox.AlreadyExists, "User already has a report running for config ID '%s'",
+					snapshot.GetReportConfigurationId())
+			}
+		}
+
 		snapshot.ReportId, err = s.reportSnapshotStore.AddReportSnapshot(ctx, snapshot)
 	} else {
-		log.Info("job is resubmitted")
 		err = s.reportSnapshotStore.UpdateReportSnapshot(ctx, snapshot)
 	}
 

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -195,6 +195,7 @@ func (s *scheduler) runSingleReport(req *reportGen.ReportRequest) {
 	defer s.readyForReports.Signal()
 	defer s.concurrencySema.Release(1)
 	defer s.removeFromRunningReportConfigs(req.ReportSnapshot.GetReportConfigurationId())
+
 	//for testing only
 	time.Sleep(2 * time.Minute)
 	s.reportGenerator.ProcessReportRequest(req)
@@ -405,19 +406,19 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 	s.dbLock.Lock()
 	defer s.dbLock.Unlock()
 
+	if snapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_ON_DEMAND {
+		userHasAnotherReport, err := s.doesUserHavePendingReport(snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId())
+		if err != nil {
+			return "", err
+		}
+		if userHasAnotherReport {
+			return "", errors.Wrapf(errox.AlreadyExists, "User already has a report running for config ID '%s'",
+				snapshot.GetReportConfigurationId())
+		}
+	}
+
 	var err error
 	if !reSubmission {
-		if snapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_ON_DEMAND {
-			userHasAnotherReport, err := s.doesUserHavePendingReport(snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId())
-			if err != nil {
-				return "", err
-			}
-			if userHasAnotherReport {
-				return "", errors.Wrapf(errox.AlreadyExists, "User already has a report running for config ID '%s'",
-					snapshot.GetReportConfigurationId())
-			}
-		}
-
 		snapshot.ReportId, err = s.reportSnapshotStore.AddReportSnapshot(ctx, snapshot)
 	} else {
 		err = s.reportSnapshotStore.UpdateReportSnapshot(ctx, snapshot)


### PR DESCRIPTION
This PR addresses the issue where the vulnerability report job remains in a waiting state for an extended period after a central restart.
Root Cause: Upon a central restart, pending reports are re-queued. The scheduler includes a validation check to ensure that no report snapshot exists for the same user with the same configuration. However, since the snapshot from the previous report job persists, this check fails, preventing the report job from being re-queued, leaving it stuck in the waiting state.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality
To test this change:
1. added 2 minute sleep in run report logic to give time to restart central
2. deploy acs with the fix. start a new job for a report config 
3. set a env variable in central pod to restart the pod
4. verified that after restart the job completes

Upgrade scenario:
1. upgrade acs with a job in waiting state to image with the fix 
2. job in waiting state completes
- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
