### PR TITLE
ROX-26026: Matrixize more jobs in `.github/workflow/build.yaml`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -746,7 +746,8 @@ jobs:
         directory: 'junit-reports'
 
   scan-images-with-roxctl:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'scan-images-with-roxctl')
     needs:
       - define-job-matrix
       - build-and-push-main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,12 @@ on:
     - reopened
     - synchronize
 
+defaults:
+  run:
+    # This enables `-o pipefail` for all jobs as compared to when shell isn't set.
+    # See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+    shell: bash
+
 jobs:
   define-job-matrix:
     outputs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,13 @@ jobs:
         run: |
           source './scripts/ci/lib.sh'
 
-          matrix='{ "pre_build_go_binaries": { "name":[], "arch":[] }, "build_and_push_main": { "name":[], "arch":[] }, "push_main_multiarch_manifests": { "name":[] } }'
+          matrix='{
+            "pre_build_go_binaries": { "name":[], "arch":[] },
+            "build_and_push_main": { "name":[], "arch":[] },
+            "push_main_multiarch_manifests": { "name":[] },
+            "build_and_push_operator": { "name":[] },
+            "scan_images_with_roxctl": { "name":[], "image":[], "exclude":[] }
+          }'
 
           # The base matrix
           matrix="$(jq '.pre_build_go_binaries.name += ["default"]' <<< "$matrix")"
@@ -38,6 +44,13 @@ jobs:
           matrix="$(jq '.build_and_push_main.arch += ["amd64", "arm64"]' <<< "$matrix")"
 
           matrix="$(jq '.push_main_multiarch_manifests.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+
+          matrix="$(jq '.build_and_push_operator.name += ["RHACS_BRANDING"]' <<< "$matrix")"
+
+          matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.scan_images_with_roxctl.image += ["central-db", "collector", "collector-slim", "main", "roxctl", "scanner", "scanner-db", "scanner-db-slim", "scanner-slim", "stackrox-operator"]' <<< "$matrix")"
+          # TODO(ROX-27191): remove the exclusion once there's a community operator.
+          matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
 
           if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
             matrix="$(jq '.pre_build_go_binaries.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
@@ -592,6 +605,8 @@ jobs:
 
   build-and-push-operator:
     runs-on: ubuntu-latest
+    needs:
+      - define-job-matrix
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.4
       env:
@@ -599,10 +614,9 @@ jobs:
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
         QUAY_RHACS_ENG_BEARER_TOKEN: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
     strategy:
-      matrix:
-        branding: [ RHACS_BRANDING ]
+      matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).build_and_push_operator }}
     env:
-      ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
+      ROX_PRODUCT_BRANDING: ${{ matrix.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -728,6 +742,7 @@ jobs:
   scan-images-with-roxctl:
     if: github.event_name == 'push'
     needs:
+      - define-job-matrix
       - build-and-push-main
       - build-and-push-operator
       - push-main-manifests
@@ -739,20 +754,7 @@ jobs:
       security-events: write
     strategy:
       fail-fast: false
-      matrix:
-        image:
-          [
-            "central-db",
-            "collector",
-            "collector-slim",
-            "main",
-            "roxctl",
-            "scanner",
-            "scanner-db",
-            "scanner-db-slim",
-            "scanner-slim",
-            "stackrox-operator",
-          ]
+      matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).scan_images_with_roxctl }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -779,14 +781,16 @@ jobs:
 
       - name: Scan images for vulnerabilities
         run: |
-          release_tag=$(make tag)
-          if [[ ${{ matrix.image }} =~ "operator" ]]; then
-            release_tag=$(make -C operator --silent tag)
+          release_tag="$(make --quiet --no-print-directory tag)"
+          if [[ "${{ matrix.image }}" =~ "operator" ]]; then
+            release_tag="$(make -C operator --quiet --no-print-directory tag)"
           fi
+
+          registry="$(./scripts/ci/lib.sh registry_from_branding "${{ matrix.name }}")"
+
           roxctl image scan --retries=10 --retry-delay=15 --force --severity=CRITICAL,IMPORTANT --output=sarif \
-            --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
-            > results.sarif
-          cat results.sarif
+            --image="${registry}/${{ matrix.image }}:${release_tag}" \
+            | tee results.sarif
 
       # TODO: re-enable roxctl scan results upload once quota issue has been resolved
       # - name: Upload roxctl scan results to GitHub Security tab


### PR DESCRIPTION
### Description

For release builds we need to disable GHA builds which push into `quay.io/rhacs-eng/` and use Konflux for that instead.
This change allows more easily conditionally disable GHA builds by suppressing `RHACS_BRANDING` from the matrix in the `define-job-matrix` job.

Extracted from https://github.com/stackrox/stackrox/pull/13422 and refined.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No change to automated tests.

#### How I validated my change

- Looked at the Build workflow and checked that it seems to work as before.
- Added extra labels on this PR to give a chance for anything build-related to blow up.