### PR TITLE
ROX-26026: Introduce `registry` to Scanner build matrix 

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -39,7 +39,7 @@ jobs:
         matrix='{
           "pre_build_scanner_go_binary": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"] },
           "build_and_push_scanner": { },
-          "push_scanner_manifests": { "name":["default"] }
+          "push_scanner_manifests": { "name":["default"], "registry":[] }
         }'
 
         if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
@@ -61,6 +61,9 @@ jobs:
         fi
 
         matrix="$(jq '.build_and_push_scanner = .pre_build_scanner_go_binary' <<< "$matrix")"
+        matrix="$(jq '.build_and_push_scanner.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
+
+        matrix="$(jq '.push_scanner_manifests.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
 
         echo "Job matrix after conditionals:"
         jq <<< "$matrix"
@@ -246,7 +249,7 @@ jobs:
         github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       run: |
         source ./scripts/ci/lib.sh
-        push_scanner_image_set ${{ matrix.goarch }}
+        push_scanner_image_set "${{ matrix.registry }}" "${{ matrix.goarch }}"
 
   push-scanner-manifests:
     needs:
@@ -305,7 +308,7 @@ jobs:
           architectures="amd64"
         fi
 
-        push_scanner_image_manifest_lists "$architectures"
+        push_scanner_image_manifest_lists "${{ matrix.registry }}" "$architectures"
 
   scan-images-with-roxctl:
     if: github.event_name == 'push' ||

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -39,7 +39,8 @@ jobs:
         matrix='{
           "pre_build_scanner_go_binary": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"] },
           "build_and_push_scanner": { },
-          "push_scanner_manifests": { "name":["default"], "registry":[] }
+          "push_scanner_manifests": { "name":["default"], "registry":[] },
+          "scan_images_with_roxctl": { "image":["scanner-v4", "scanner-v4-db"], "registry":[] }
         }'
 
         if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
@@ -64,6 +65,8 @@ jobs:
         matrix="$(jq '.build_and_push_scanner.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
 
         matrix="$(jq '.push_scanner_manifests.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
+
+        matrix="$(jq '.scan_images_with_roxctl.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
 
         echo "Job matrix after conditionals:"
         jq <<< "$matrix"
@@ -314,6 +317,7 @@ jobs:
     if: github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'scan-images-with-roxctl')
     needs:
+    - define-scanner-job-matrix
     - build-and-push-scanner
     - push-scanner-manifests
     name: Check images for vulnerabilities
@@ -324,12 +328,7 @@ jobs:
       security-events: write
     strategy:
       fail-fast: false
-      matrix:
-        image:
-          [
-            "scanner-v4",
-            "scanner-v4-db",
-          ]
+      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).scan_images_with_roxctl }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -358,7 +357,7 @@ jobs:
       run: |
         release_tag="$(make --quiet --no-print-directory tag)"
         roxctl image scan --retries=10 --retry-delay=15 --force --severity=IMPORTANT,CRITICAL --output=sarif \
-          --image="quay.io/stackrox-io/${{ matrix.image }}:${release_tag}" \
+          --image="${{ matrix.registry }}/${{ matrix.image }}:${release_tag}" \
           | tee results.sarif
 
     # TODO: re-enable roxctl scan results upload once quota issue has been resolved

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -356,11 +356,10 @@ jobs:
 
     - name: Scan images for vulnerabilities
       run: |
-        release_tag=$(make tag)
+        release_tag="$(make --quiet --no-print-directory tag)"
         roxctl image scan --retries=10 --retry-delay=15 --force --severity=IMPORTANT,CRITICAL --output=sarif \
-          --image="quay.io/rhacs-eng/${{ matrix.image }}:${release_tag}" \
-          > results.sarif
-        cat results.sarif
+          --image="quay.io/stackrox-io/${{ matrix.image }}:${release_tag}" \
+          | tee results.sarif
 
     # TODO: re-enable roxctl scan results upload once quota issue has been resolved
     # - name: Upload roxctl scan results to GitHub Security tab

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -39,7 +39,7 @@ jobs:
         matrix='{
           "pre_build_scanner_go_binary": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"] },
           "build_and_push_scanner": { },
-          "push_manifests": { "name":["default"] }
+          "push_scanner_manifests": { "name":["default"] }
         }'
 
         if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
@@ -50,14 +50,14 @@ jobs:
         if ! is_tagged; then
           if ! is_in_PR_context || pr_has_label ci-build-prerelease; then
             matrix="$(jq '.pre_build_scanner_go_binary.name += ["prerelease"]' <<< "$matrix")"
-            matrix="$(jq '.push_manifests.name += ["prerelease"]' <<< "$matrix")"
+            matrix="$(jq '.push_scanner_manifests.name += ["prerelease"]' <<< "$matrix")"
           fi
         fi
 
         # Conditionally add a -race debug build (binaries built with -race)
         if ! is_in_PR_context || pr_has_label ci-build-race-condition-debug; then
           matrix="$(jq '.pre_build_scanner_go_binary.name += ["race-condition-debug"]' <<< "$matrix")"
-          matrix="$(jq '.push_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
+          matrix="$(jq '.push_scanner_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
         fi
 
         matrix="$(jq '.build_and_push_scanner = .pre_build_scanner_go_binary' <<< "$matrix")"
@@ -259,7 +259,7 @@ jobs:
       # default
       # prerelease
       # race-condition-debug
-      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_manifests }}
+      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_scanner_manifests }}
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
       env:

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -13,6 +13,12 @@ on:
     - reopened
     - synchronize
 
+defaults:
+  run:
+    # This enables `-o pipefail` for all jobs as compared to when shell isn't set.
+    # See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+    shell: bash
+
 jobs:
   define-scanner-job-matrix:
     outputs:

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -296,7 +296,8 @@ jobs:
         push_scanner_image_manifest_lists "$architectures"
 
   scan-images-with-roxctl:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'scan-images-with-roxctl')
     needs:
     - build-and-push-scanner
     - push-scanner-manifests

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -36,25 +36,31 @@ jobs:
         source './scripts/ci/lib.sh'
 
         # If goarch is updated, be sure to update architectures in "push-scanner-manifests" below.
-        matrix='{ "build_and_push": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"] }, "push_manifests": { "name":["default"] } }'
+        matrix='{
+          "pre_build_scanner_go_binary": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"] },
+          "build_and_push_scanner": { },
+          "push_manifests": { "name":["default"] }
+        }'
 
         if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
-          matrix="$(jq '.build_and_push.goarch += ["ppc64le", "s390x"]' <<< "$matrix")"
+          matrix="$(jq '.pre_build_scanner_go_binary.goarch += ["ppc64le", "s390x"]' <<< "$matrix")"
         fi;
 
         # Conditionally add a prerelease build (binaries built with GOTAGS=release)
         if ! is_tagged; then
           if ! is_in_PR_context || pr_has_label ci-build-prerelease; then
-            matrix="$(jq '.build_and_push.name += ["prerelease"]' <<< "$matrix")"
+            matrix="$(jq '.pre_build_scanner_go_binary.name += ["prerelease"]' <<< "$matrix")"
             matrix="$(jq '.push_manifests.name += ["prerelease"]' <<< "$matrix")"
           fi
         fi
 
         # Conditionally add a -race debug build (binaries built with -race)
         if ! is_in_PR_context || pr_has_label ci-build-race-condition-debug; then
-          matrix="$(jq '.build_and_push.name += ["race-condition-debug"]' <<< "$matrix")"
+          matrix="$(jq '.pre_build_scanner_go_binary.name += ["race-condition-debug"]' <<< "$matrix")"
           matrix="$(jq '.push_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
         fi
+
+        matrix="$(jq '.build_and_push_scanner = .pre_build_scanner_go_binary' <<< "$matrix")"
 
         echo "Job matrix after conditionals:"
         jq <<< "$matrix"
@@ -70,7 +76,7 @@ jobs:
       # default              - built with environment defaults (see handle-tagged-build & env.mk)
       # prerelease           - built with GOTAGS=release
       # race-condition-debug - built with -race
-      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
+      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).pre_build_scanner_go_binary }}
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
     steps:
@@ -181,7 +187,7 @@ jobs:
       # default              - built with environment defaults (see handle-tagged-build & env.mk)
       # prerelease           - built with GOTAGS=release
       # race-condition-debug - built with -race
-      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push }}
+      matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push_scanner }}
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.4
       env:

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -39,8 +39,8 @@ jobs:
         matrix='{
           "pre_build_scanner_go_binary": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"] },
           "build_and_push_scanner": { },
-          "push_scanner_manifests": { "name":["default"], "registry":[] },
-          "scan_images_with_roxctl": { "image":["scanner-v4", "scanner-v4-db"], "registry":[] }
+          "push_scanner_manifests": { "name":["default"], "registry":["quay.io/stackrox-io", "quay.io/rhacs-eng"] },
+          "scan_images_with_roxctl": { "image":["scanner-v4", "scanner-v4-db"], "registry":["quay.io/stackrox-io", "quay.io/rhacs-eng"] }
         }'
 
         if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
@@ -62,11 +62,7 @@ jobs:
         fi
 
         matrix="$(jq '.build_and_push_scanner = .pre_build_scanner_go_binary' <<< "$matrix")"
-        matrix="$(jq '.build_and_push_scanner.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
-
-        matrix="$(jq '.push_scanner_manifests.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
-
-        matrix="$(jq '.scan_images_with_roxctl.registry = ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
+        matrix="$(jq '.build_and_push_scanner.registry = .push_scanner_manifests.registry' <<< "$matrix")"
 
         echo "Job matrix after conditionals:"
         jq <<< "$matrix"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -318,7 +318,7 @@ push_scanner_image_manifest_lists() {
     info "Pushing scanner-v4 and scanner-v4-db images as manifest lists"
 
     if [[ "$#" -ne 2 ]]; then
-        die "missing arg. usage: push_scanner_image_manifest_lists <resgistry> <architectures (CSV)>"
+        die "missing arg. usage: push_scanner_image_manifest_lists <registry> <architectures (CSV)>"
     fi
 
     local registry="$1"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -317,33 +317,32 @@ push_main_image_set() {
 push_scanner_image_manifest_lists() {
     info "Pushing scanner-v4 and scanner-v4-db images as manifest lists"
 
-    if [[ "$#" -ne 1 ]]; then
-        die "missing arg. usage: push_scanner_image_manifest_lists <architectures (CSV)>"
+    if [[ "$#" -ne 2 ]]; then
+        die "missing arg. usage: push_scanner_image_manifest_lists <resgistry> <architectures (CSV)>"
     fi
 
-    local architectures="$1"
+    local registry="$1"
+    local architectures="$2"
     local scanner_image_set=("scanner-v4" "scanner-v4-db")
-    local registries=("quay.io/rhacs-eng" "quay.io/stackrox-io")
 
     local tag
     tag="$(make --quiet --no-print-directory -C scanner tag)"
-    for registry in "${registries[@]}"; do
-        registry_rw_login "$registry"
-        for image in "${scanner_image_set[@]}"; do
-            retry 5 true \
-              "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:${tag}" "$architectures" | cat
-        done
+    registry_rw_login "$registry"
+    for image in "${scanner_image_set[@]}"; do
+        retry 5 true \
+          "$SCRIPTS_ROOT/scripts/ci/push-as-multiarch-manifest-list.sh" "${registry}/${image}:${tag}" "$architectures" | cat
     done
 }
 
 push_scanner_image_set() {
     info "Pushing scanner-v4 and scanner-v4-db images"
 
-    if [[ "$#" -ne 1 ]]; then
-        die "missing arg. usage: push_scanner_image_set <arch>"
+    if [[ "$#" -ne 2 ]]; then
+        die "missing arg. usage: push_scanner_image_set <registry> <arch>"
     fi
 
-    local arch="$1"
+    local registry="$1"
+    local arch="$2"
 
     local scanner_image_set=("scanner-v4" "scanner-v4-db")
 
@@ -367,16 +366,13 @@ push_scanner_image_set() {
         done
     }
 
-    local registries=("quay.io/rhacs-eng" "quay.io/stackrox-io")
-
     local tag
     tag="$(make --quiet --no-print-directory -C scanner tag)"
-    for registry in "${registries[@]}"; do
-        registry_rw_login "$registry"
 
-        _tag_scanner_image_set "$tag" "$registry" "$tag-$arch"
-        _push_scanner_image_set "$registry" "$tag-$arch"
-    done
+    registry_rw_login "$registry"
+
+    _tag_scanner_image_set "$tag" "$registry" "$tag-$arch"
+    _push_scanner_image_set "$registry" "$tag-$arch"
 }
 
 registry_rw_login() {


### PR DESCRIPTION
### Description

Similar to https://github.com/stackrox/stackrox/pull/13694 the goal here is to make it possible to disable pushes to `quay.io/rhacs-eng/` for release builds (which will be driven by Konflux).
Unlike https://github.com/stackrox/stackrox/pull/13694 where the `.github/workflows/build.yaml` workflow is defined through branding, the `.github/workflows/scanner-build.yaml` doesn't have a notion of branding and so I felt introducing one would be too artificial given that the Scanner V4 doesn't have any conditional on the branding. Therefore, I introduce the "registry" `quay.io/stackrox-io`/`quay.io/rhacs-eng` as the matrix parameter.

This change can be reviewed by commits or in its eventual state.

Request for reviewers: an extra dimension for `build-and-push-scanner` and `push-scanner-manifests` will lead to a double execution of some steps which means more GitHub minutes. Given that these will run in parallel, that we don't pay for these minutes, and that these jobs seem to be quick enough (~5 minutes), I hope the impact is ok to take. Please take a critical look let know if you won't be ok with that.

Also note that this change will require adjusting required jobs for PR since the one set up earlier for Scanner isn't valid anymore. The effect is that everyone will have to rebase their PRs. That's ok we did such things before.
![image](https://github.com/user-attachments/assets/7f430dcd-73d9-42ee-8072-4c8a0988147d)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No contributions to the automated testing.

#### How I validated my change

- Checked GHA graph and logs that builds are still happening.
- Added more labels on the PR to give a chance for anything build-related to blow up.