### PR TITLE
fix(ci): resolve accidental fail-early when collector is not ready yet

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -594,7 +594,7 @@ wait_for_collectors_to_be_operational() {
                 echo "$pod is deemed ready"
             else
                 info "$pod is not ready"
-                kubectl -n "${sensor_namespace}" logs -c collector "$pod"
+                kubectl -n "${sensor_namespace}" logs -c collector "$pod" | true
                 all_ready="false"
                 break
             fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -594,7 +594,7 @@ wait_for_collectors_to_be_operational() {
                 echo "$pod is deemed ready"
             else
                 info "$pod is not ready"
-                kubectl -n "${sensor_namespace}" logs -c collector "$pod" | true
+                kubectl -n "${sensor_namespace}" logs -c collector "$pod" || true
                 all_ready="false"
                 break
             fi


### PR DESCRIPTION
### Description

Looking at the logs of a failed nightly build, I found the following:

> INFO: Fri Jan  3 02:13:00 UTC 2025: Will wait for collectors to reach a ready state in namespace stackrox
daemon set "collector" successfully rolled out
Checking readiness of collector-2mzp4
collector-2mzp4 is deemed ready
Checking readiness of collector-2nz4r
collector-2nz4r is deemed ready
Checking readiness of collector-5trq8
collector-5trq8 is deemed ready
Checking readiness of collector-788b5
collector-788b5 is deemed ready
Checking readiness of collector-7w46c
collector-7w46c is deemed ready
Checking readiness of collector-dlljx
collector-dlljx is deemed ready
Checking readiness of collector-gl5gp
collector-gl5gp is deemed ready
Checking readiness of collector-tjk65
collector-tjk65 is deemed ready
Checking readiness of collector-z7g65
Error from server: Get "https://10.0.49.7:10250/containerLogs/stackrox/collector-z7g65/collector": dial tcp 10.0.49.7:10250: connect: connection refused
INFO: Fri Jan  3 02:13:02 UTC 2025: collector-z7g65 is not ready
Error from server: Get "https://10.0.49.7:10250/containerLogs/stackrox/collector-z7g65/collector": dial tcp 10.0.49.7:10250: connect: connection refused
****
**** 02:13:02: ERROR: test failed [Test failed: exit 1] [QA tests part I]

Following the script from which these logs are generated, we can see we got the first

> Error from server: Get "https://10.0.49.7:10250/containerLogs/stackrox/collector-z7g65/collector": dial tcp 10.0.49.7:10250: connect: connection refused

from

```
if kubectl -n "${sensor_namespace}" logs -c collector "${pod}" | grep "${readiness_indicator}" > /dev/null 2>&1; then
```

and we can see once

> INFO: Fri Jan  3 02:13:02 UTC 2025: collector-z7g65 is not ready

is logged, we then call

```
kubectl -n "${sensor_namespace}" logs -c collector "$pod"
```

which prints a second

> Error from server: Get "https://10.0.49.7:10250/containerLogs/stackrox/collector-z7g65/collector": dial tcp 10.0.49.7:10250: connect: connection refused

and then the script ends.

This is where the problem lies. The "connection refused" caused this line to have a non-zero exit code, which caused the script to end instead of gracefully continuing.

This PR append a `|| true` to the line to ensure this line always has a zero exit code and we may continue the script, as intended.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

Just hoping it causes for fewer test failures...

#### How I validated my change

I didn't. I think this is more of a wait-and-see.
