### PR TITLE
ROX-27300: fix a flake in the `pkg/logger` unit test

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -975,4 +975,5 @@ func waitForTerminationSignal() {
 		osutils.Restart()
 	}
 	log.Info("Central terminated")
+	log.InnerLogger.Sync()
 }

--- a/central/main.go
+++ b/central/main.go
@@ -269,6 +269,8 @@ func runSafeMode() {
 }
 
 func main() {
+	defer utils.IgnoreError(log.InnerLogger.Sync)
+
 	premain.StartMain()
 
 	conf := config.GetConfig()
@@ -975,5 +977,4 @@ func waitForTerminationSignal() {
 		osutils.Restart()
 	}
 	log.Info("Central terminated")
-	log.InnerLogger.Sync()
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -137,8 +138,7 @@ func Test_withRotatingCore(t *testing.T) {
 		}
 		assert.NoError(t, logger.Sync())
 		_, err := os.Stat(oldestRoll)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), oldestRoll+": no such file or directory", oldestRoll)
+		require.ErrorIs(t, err, fs.ErrNotExist)
 		t.Run("ensure there are still only 2 files", func(t *testing.T) {
 			found := 0
 			err = ForEachRotation(logname1, func(_ string) error {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Lubmerjack logger, the log rotation wrapper we use, removes the old log files asynchronously.
The test was flaking because it didn't wait for this to happen.

This PR adds a retry loop with a sleep to ensure the file is deleted by the lumberjack goroutine.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

```console
sh$ go test -count=1000 -run ^Test_withRotatingCore
PASS
ok  	github.com/stackrox/rox/pkg/logging	68.894s
```