### PR TITLE
ROX-27147: SBOM roxctl support

### DIFF
--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/imageintegration"
+	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/enricher"
@@ -42,7 +43,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: false, ScanResult: enricher.ScanNotDone}, errors.New("Image enrichment failed")).AnyTimes()
 
-		reqBody := &sbomRequestBody{
+		reqBody := &apiparams.SbomRequestBody{
 			ImageName: "test-image",
 			Force:     false,
 		}
@@ -69,7 +70,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: true, ScanResult: enricher.ScanSucceeded}, nil).AnyTimes()
 
-		reqBody := &sbomRequestBody{
+		reqBody := &apiparams.SbomRequestBody{
 			ImageName: "test-image",
 			Force:     false,
 		}

--- a/pkg/apiparams/policy.go
+++ b/pkg/apiparams/policy.go
@@ -4,3 +4,10 @@ package apiparams
 type SaveAsCustomResourcesRequest struct {
 	IDs []string `json:"ids"`
 }
+
+// SbomRequestBody represents the HTTP API request for generating an SBOM from an image scan.
+type SbomRequestBody struct {
+	Cluster   string `json:"cluster"`
+	ImageName string `json:"imageName"`
+	Force     bool   `json:"force"`
+}

--- a/roxctl/image/image.go
+++ b/roxctl/image/image.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/image/check"
+	"github.com/stackrox/rox/roxctl/image/sbom"
 	"github.com/stackrox/rox/roxctl/image/scan"
 )
 
@@ -19,6 +20,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.AddCommand(check.Command(cliEnvironment))
 	c.AddCommand(scan.Command(cliEnvironment))
+	c.AddCommand(sbom.Command(cliEnvironment))
 
 	// This is set very high, because typically the scan will need to be triggered as the image will be new
 	// This means we must let the scanners do their thing otherwise we will miss the scans

--- a/roxctl/image/sbom/sbom.go
+++ b/roxctl/image/sbom/sbom.go
@@ -77,7 +77,7 @@ func (i *imageSBOMCommand) construct(cobraCmd *cobra.Command) error {
 	// Create the request body.
 	req := struct {
 		Cluster   string `json:"cluster"`
-		ImageName string `json:"image_name"`
+		ImageName string `json:"imageName"`
 		Force     bool   `json:"force"`
 	}{
 		Cluster:   i.cluster,

--- a/roxctl/image/sbom/sbom.go
+++ b/roxctl/image/sbom/sbom.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/apiparams"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
@@ -74,12 +75,8 @@ func (i *imageSBOMCommand) construct(cobraCmd *cobra.Command) error {
 		return errors.Wrap(err, "creating HTTP client")
 	}
 
-	// Create the request body.
-	req := struct {
-		Cluster   string `json:"cluster"`
-		ImageName string `json:"imageName"`
-		Force     bool   `json:"force"`
-	}{
+	// Create the request.
+	req := apiparams.SbomRequestBody{
 		Cluster:   i.cluster,
 		ImageName: i.image,
 		Force:     i.force,

--- a/roxctl/image/sbom/sbom.go
+++ b/roxctl/image/sbom/sbom.go
@@ -1,0 +1,115 @@
+package sbom
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	imageUtils "github.com/stackrox/rox/pkg/images/utils"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	"github.com/stackrox/rox/roxctl/common/util"
+)
+
+const (
+	imageSBOMAPIPath = "/api/v1/images/sbom"
+)
+
+// Command sends a request to Central to generate an SBOM from an image scan.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	imageSBOMCmd := &imageSBOMCommand{env: cliEnvironment}
+
+	c := &cobra.Command{
+		Use:   "sbom",
+		Short: "Generate an SBOM for the specified image.",
+		Long:  "Generate an SBOM for the specified image from an image scan. Optionally, force a rescan of the image. You must have write permissions for the `Image` resource.",
+		RunE: util.RunENoArgs(func(c *cobra.Command) error {
+			if err := imageSBOMCmd.construct(c); err != nil {
+				return err
+			}
+
+			return imageSBOMCmd.GenerateSBOM()
+		}),
+	}
+
+	c.Flags().StringVarP(&imageSBOMCmd.image, "image", "i", "", "Image name and reference. (e.g. nginx:latest or nginx@sha256:...)")
+	c.Flags().BoolVarP(&imageSBOMCmd.force, "force", "f", false, "The --force flag ignores Central's cache for the scan and forces a fresh re-pull from Scanner")
+	c.Flags().StringVar(&imageSBOMCmd.cluster, "cluster", "", "Cluster name or ID to delegate image scan to")
+
+	utils.Must(c.MarkFlagRequired("image"))
+	return c
+}
+
+// imageSBOMCommand holds all configurations and metadata to generate an SBOM.
+type imageSBOMCommand struct {
+	image string
+	force bool
+
+	timeout time.Duration
+	cluster string
+
+	env     environment.Environment
+	client  common.RoxctlHTTPClient
+	reqBody []byte
+}
+
+// construct ensures all flag values are valid and HTTP client/request built.
+func (i *imageSBOMCommand) construct(cmd *cobra.Command) error {
+	var err error
+	i.timeout = flags.Timeout(cmd)
+
+	if err := imageUtils.IsValidImageString(i.image); err != nil {
+		return common.ErrInvalidCommandOption.CausedBy(err)
+	}
+
+	i.client, err = i.env.HTTPClient(i.timeout)
+	if err != nil {
+		return errors.Wrap(err, "creating HTTP client")
+	}
+
+	// Build HTTP request body.
+	req := struct {
+		Cluster   string `json:"cluster"`
+		ImageName string `json:"image_name"`
+		Force     bool   `json:"force"`
+	}{
+		Cluster:   i.cluster,
+		ImageName: i.image,
+		Force:     i.force,
+	}
+
+	i.reqBody, err = json.Marshal(req)
+	if err != nil {
+		return errors.Wrap(err, "creating request body")
+	}
+
+	return nil
+}
+
+func (i *imageSBOMCommand) GenerateSBOM() error {
+	// TODO: Add retries
+	// Send HTTP request and verify response status code.
+	resp, err := i.client.DoReqAndVerifyStatusCode(
+		imageSBOMAPIPath,
+		http.MethodPost,
+		http.StatusOK,
+		bytes.NewReader(i.reqBody),
+	)
+	if err != nil {
+		return errors.Wrap(err, "generating SBOM")
+	}
+
+	// Output the raw SBOM.
+	_, err = io.Copy(i.env.InputOutput().Out(), resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "writing response")
+	}
+
+	return nil
+}

--- a/roxctl/image/sbom/sbom.go
+++ b/roxctl/image/sbom/sbom.go
@@ -27,8 +27,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "sbom",
-		Short: "Generate an SBOM from an image scan.",
-		Long:  "Generate an SBOM from an image scan. Optionally, force a rescan of the image. You must have write permissions for the `Image` resource.",
+		Short: "Generate an SPDX 2.3 SBOM from an image scan.",
+		Long:  "Generate an SPDX 2.3 SBOM from an image scan. You must have write permissions for the `Image` resource.",
 		RunE: util.RunENoArgs(func(c *cobra.Command) error {
 			if err := imageSBOMCmd.construct(c); err != nil {
 				return err
@@ -39,7 +39,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	c.Flags().StringVarP(&imageSBOMCmd.image, "image", "i", "", "Image name and reference. (e.g. nginx:latest or nginx@sha256:...)")
-	c.Flags().BoolVarP(&imageSBOMCmd.force, "force", "f", false, "The --force flag ignores Central's cache for the scan and forces a fresh re-pull from Scanner")
+	c.Flags().BoolVarP(&imageSBOMCmd.force, "force", "f", false, "Bypass Central's cache for the image and force a new pull from the Scanner")
 	c.Flags().StringVar(&imageSBOMCmd.cluster, "cluster", "", "Cluster name or ID to delegate image scan to")
 
 	utils.Must(c.MarkFlagRequired("image"))

--- a/roxctl/image/sbom/sbom_test.go
+++ b/roxctl/image/sbom/sbom_test.go
@@ -51,13 +51,40 @@ func TestConstruct(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid reference")
 	})
 
-	t.Run("http client error", func(t *testing.T) {
+	t.Run("error on invalid image digest algorithm - sha1", func(t *testing.T) {
+		cmd, c := buildCmds(t, env)
+		cmd.image = "registry.invalid/repo@sha1:0"
+		err := cmd.construct(c)
+		assert.ErrorContains(t, err, "invalid reference format")
+	})
+
+	t.Run("error on invalid image digest algorithm - sha257", func(t *testing.T) {
+		cmd, c := buildCmds(t, env)
+		cmd.image = "registry.invalid/repo@sha257:00000000000000000000000000000000000000000000000000000000000000000"
+		err := cmd.construct(c)
+		assert.ErrorContains(t, err, "unsupported digest algorithm")
+	})
+
+	t.Run("no error on valid image digest algorithm - sha256", func(t *testing.T) {
+		cmd, c := buildCmds(t, env)
+		cmd.image = "registry.invalid/repo@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		err := cmd.construct(c)
+		assert.NoError(t, err)
+	})
+
+	t.Run("no error on valid image digest algorithm - sha512", func(t *testing.T) {
+		cmd, c := buildCmds(t, env)
+		cmd.image = "registry.invalid/repo@sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+		err := cmd.construct(c)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error on invalid api endpoint", func(t *testing.T) {
 		t.Setenv("ROX_ENDPOINT", "fake.invalid") // missing port breaks http client
 		cmd, c := buildCmds(t, env)
 		err := cmd.construct(c)
 		assert.ErrorContains(t, err, "HTTP client")
 	})
-
 }
 
 func TestGenerateSBOM(t *testing.T) {

--- a/roxctl/image/sbom/sbom_test.go
+++ b/roxctl/image/sbom/sbom_test.go
@@ -1,0 +1,148 @@
+package sbom
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	roxctlio "github.com/stackrox/rox/roxctl/common/io"
+	"github.com/stackrox/rox/roxctl/common/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test output from central is streamed to stdout as is.
+// Test cli flags are part of http request and flags are recived by server
+
+var (
+	fakeSBOM   = `{"fake":"sbom"}`
+	fakeImgRef = "image.invalid/noexist:latest"
+)
+
+func TestConstruct(t *testing.T) {
+	server := createServer(t, false, false)
+	defer server.Close()
+
+	env, _ := createEnv(t)
+
+	t.Run("success", func(t *testing.T) {
+		cmd, c := buildCmds(t, env)
+		err := cmd.construct(c)
+		assert.NoError(t, err)
+		assert.Contains(t, string(cmd.requestBody), fakeImgRef)
+	})
+
+	t.Run("error on empty image", func(t *testing.T) {
+		cmd, c := buildCmds(t, env)
+		cmd.image = ""
+		err := cmd.construct(c)
+		assert.ErrorContains(t, err, "invalid reference")
+	})
+
+	t.Run("error on invalid image", func(t *testing.T) {
+		cmd, c := buildCmds(t, env)
+		cmd.image = ":@"
+		err := cmd.construct(c)
+		assert.ErrorContains(t, err, "invalid reference")
+	})
+
+	t.Run("http client error", func(t *testing.T) {
+		t.Setenv("ROX_ENDPOINT", "fake.invalid") // missing port breaks http client
+		cmd, c := buildCmds(t, env)
+		err := cmd.construct(c)
+		assert.ErrorContains(t, err, "HTTP client")
+	})
+
+}
+
+func TestGenerateSBOM(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := createServer(t, false, false)
+		defer server.Close()
+
+		env, out := createEnv(t)
+		cmd, c := buildCmds(t, env)
+		require.NoError(t, cmd.construct(c))
+
+		err := cmd.GenerateSBOM()
+		require.NoError(t, err)
+
+		// Output is identical to what server returned.
+		assert.Equal(t, out.String(), fakeSBOM)
+	})
+
+	t.Run("http error from server handled", func(t *testing.T) {
+		server := createServer(t, true, false)
+		defer server.Close()
+
+		env, _ := createEnv(t)
+		cmd, c := buildCmds(t, env)
+		require.NoError(t, cmd.construct(c))
+
+		err := cmd.GenerateSBOM()
+		require.ErrorContains(t, err, "generating SBOM")
+	})
+
+	t.Run("error on text/html response", func(t *testing.T) {
+		server := createServer(t, false, true)
+		defer server.Close()
+
+		env, _ := createEnv(t)
+		cmd, c := buildCmds(t, env)
+		require.NoError(t, cmd.construct(c))
+
+		err := cmd.GenerateSBOM()
+		require.ErrorContains(t, err, "unexpected Content-Type")
+	})
+}
+
+// createServer sets up a test HTTP server.
+func createServer(t *testing.T, retErr bool, htmlResponse bool) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if retErr {
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if htmlResponse {
+			rw.Header().Add("Content-Type", "text/html; charset=utf-8")
+			_, _ = rw.Write([]byte("<html><body>Hello</body></html>"))
+			return
+
+		}
+
+		_, _ = rw.Write([]byte(fakeSBOM))
+	}))
+
+	t.Setenv("ROX_ENDPOINT", server.URL)
+
+	return server
+}
+
+// Creates and returns a test CLI environment and stdout buffer.
+func createEnv(t *testing.T) (environment.Environment, *bytes.Buffer) {
+	testIO, _, out, _ := roxctlio.TestIO()
+	env := environment.NewTestCLIEnvironment(t, testIO, printer.DefaultColorPrinter())
+
+	return env, out
+}
+
+// buildCmds builds the SBOM and Cobra command objects, to be used throughout the
+// various tests.
+func buildCmds(t *testing.T, env environment.Environment) (*imageSBOMCommand, *cobra.Command) {
+	cmd := &imageSBOMCommand{env: env, image: fakeImgRef}
+
+	cobraCmd := &cobra.Command{}
+	flags.AddTimeoutWithDefault(cobraCmd, 10*time.Minute)
+	flags.AddPassword(cobraCmd)
+
+	t.Setenv("ROX_INSECURE_CLIENT", "true")
+	t.Setenv("ROX_CLIENT_MAX_RETRIES", "0")
+
+	return cmd, cobraCmd
+}

--- a/roxctl/image/sbom/sbom_test.go
+++ b/roxctl/image/sbom/sbom_test.go
@@ -16,9 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test output from central is streamed to stdout as is.
-// Test cli flags are part of http request and flags are recived by server
-
 var (
 	fakeSBOM   = `{"fake":"sbom"}`
 	fakeImgRef = "image.invalid/noexist:latest"

--- a/roxctl/image/sbom/sbom_test.go
+++ b/roxctl/image/sbom/sbom_test.go
@@ -120,6 +120,7 @@ func createServer(t *testing.T, retErr bool, htmlResponse bool) *httptest.Server
 	}))
 
 	t.Setenv("ROX_ENDPOINT", server.URL)
+	t.Setenv("ROX_API_TOKEN", "fake")
 
 	return server
 }

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -131,7 +131,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	objectPrinterFactory.AddFlags(c)
 
 	c.Flags().StringVarP(&imageScanCmd.image, "image", "i", "", "Image name and reference. (e.g. nginx:latest or nginx@sha256:...)")
-	c.Flags().BoolVarP(&imageScanCmd.force, "force", "f", false, "The --force flag ignores Central's cache for the scan and forces a fresh re-pull from Scanner")
+	c.Flags().BoolVarP(&imageScanCmd.force, "force", "f", false, "Bypass Central's cache for the image and force a new pull from the Scanner")
 	c.Flags().BoolVarP(&imageScanCmd.includeSnoozed, "include-snoozed", "a", false, "The --include-snoozed flag returns both snoozed and unsnoozed CVEs if set")
 	c.Flags().IntVarP(&imageScanCmd.retryDelay, "retry-delay", "d", 3, "Set time to wait between retries in seconds")
 	c.Flags().IntVarP(&imageScanCmd.retryCount, "retries", "r", 3, "Number of retries before exiting as error")


### PR DESCRIPTION
### Description

Adds the `roxctl image sbom` command to support the SBOM generation effort. The parameters largely mirror those of `roxctl image scan`.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change
Unit tests + manual tests shown below.

Setup:
```
$ export ROX_ENDPOINT=...
$ export ROX_API_TOKEN=...

$ make cli_darwin-arm64
$ alias roxctl=bin/darwin_arm64/roxctl
```
Help info:
```
$ roxctl image -h | grep -i sbom
  sbom        Generate an SBOM from an image scan.
```
```
$ roxctl image sbom -h
Generate an SPDX 2.3 SBOM from an image scan. You must have write permissions for the `Image` resource.

Usage:
  bin/darwin_arm64/roxctl image sbom [flags]

Flags:
      --cluster string   Cluster name or ID to delegate image scan to
  -f, --force            Bypass Central's cache for the image and force a new pull from the Scanner (default false)
  -i, --image string     Image name and reference. (e.g. nginx:latest or nginx@sha256:...)
...
```
No flags:
```
$ roxctl image sbom
ERROR:	required flag(s) "image" not set
```
Invalid flag:
```
$ roxctl image sbom --image ":@"
ERROR:	invalid command option: image: invalid reference format
```
Executing against Central 4.6.1 that has not implemented SBOMs:
```
$ roxctl image sbom --image "quay.io/rhacs-eng/main:4.6.1"
ERROR:	unexpected Content-Type "text/html; charset=utf-8" from Central, confirm Central version supports SBOM generation
```
Repeating using Central version that has the SBOM endpoint implemented:
```
$ oc set image deploy/central *=quay.io/rhacs-eng/main:4.7.x-354-gc29cd156b3
$ roxctl image sbom --image "quay.io/rhacs-eng/main:4.6.1"
ERROR:	generating SBOM: expected status code 200, but received 501. Response Body: {"code":12,"message":"SBOM feature is not enabled"}
```
Enabling the feature and retrying (success - the output is static as the back-end is not yet fully implemented):
```
$ oc set env deploy/central ROX_SBOM_GENERATION=true
$ roxctl image sbom --image "quay.io/rhacs-eng/main:4.6.1"
{"SPDXID":"SPDXRef-DOCUMENT","creationInfo":{"created":"2023-08-30T04:40:16Z","creators":["Organization: NA Org","Tool:  N/A - PoC"]},"spdxVersion":"SPDX-2.3"}

$ roxctl image sbom --image "quay.io/rhacs-eng/main:4.6.1" | jq
{
  "SPDXID": "SPDXRef-DOCUMENT",
  "creationInfo": {
    "created": "2023-08-30T04:40:16Z",
    "creators": [
      "Organization: NA Org",
      "Tool:  N/A - PoC"
    ]
  },
  "spdxVersion": "SPDX-2.3"
}
```
Also note when there are non-501 errors the CLI appears to hang and doesn't return the 'actual' error:
```
$ roxctl image sbom --image "quay.io/rhacs-eng/main:noexist"
$ time roxctl image sbom --image "quay.io/rhacs-eng/main:noexist"
ERROR:	generating SBOM: error when doing http request: POST https://<ip>:443/api/v1/images/sbom giving up after 4 attempt(s)

real	1m7.767s
user	0m0.078s
sys	0m0.031s
```
The length of time it takes is due to the HTTP client's retry logic + backoff, and there is currently no mechanism provided by the HTTP client abstraction to print the response body (error message). Will address this in https://github.com/stackrox/stackrox/pull/13741:

```
$ export ROX_CLIENT_MAX_RETRIES=0
$ time roxctl image sbom --image "quay.io/rhacs-eng/main:noexist"
ERROR:	generating SBOM: error when doing http request: POST https://<ip>:443/api/v1/images/sbom giving up after 1 attempt(s)

real	0m7.055s
user	0m0.063s
sys	0m0.032s
```

Can see the individual attempts + backoff when temporarily enabling logging for the underlying retryclient implementation by commenting out the below line:

https://github.com/stackrox/stackrox/blob/201a5b79b781b4ff323bde0de99e0d7884ff92f4/roxctl/common/client.go#L84

Result: 
```
$ unset ROX_CLIENT_MAX_RETRIES
$ roxctl image sbom --image "quay.io/rhacs-eng/main:noexist"
2025/01/07 19:13:47 [DEBUG] POST https://<ip>:443/api/v1/images/sbom
2025/01/07 19:13:49 [DEBUG] POST https://<ip>:443/api/v1/images/sbom (status: 500): retrying in 10s (3 left)
2025/01/07 19:14:02 [DEBUG] POST https://<ip>:443/api/v1/images/sbom (status: 500): retrying in 20s (2 left)
2025/01/07 19:14:26 [DEBUG] POST https://<ip>:443/api/v1/images/sbom (status: 500): retrying in 30s (1 left)
ERROR:	generating SBOM: error when doing http request: POST https://<ip>:443/api/v1/images/sbom giving up after 4 attempt(s)
```

Note the error from Central is still not logged (will be addressed in https://github.com/stackrox/stackrox/pull/13741).