### PR TITLE
chore(govulncheck): ignore GO-2024-3105,GO-2024-3106,GO-2024-3107

### DIFF
--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -2,6 +2,15 @@
   "exceptions": {
     "GO-2022-0646": {
       "reason": "Unused portion of the SDK"
+    },
+    "GO-2024-3105": {
+      "reason": "Requires Go 1.22.7 or 1.23.1"
+    },
+    "GO-2024-3106": {
+      "reason": "Requires Go 1.22.7 or 1.23.1"
+    },
+    "GO-2024-3107": {
+      "reason": "Requires Go 1.22.7 or 1.23.1"
     }
   }
 }


### PR DESCRIPTION
### Description

CI flagged GO-2024-3105, GO-2024-3106, and GO-2024-3107, which does affect upstream binaries. Ignore it for now, as there is nothing we can do without bumping our upstream version of Go (from 1.22.5 to 1.22.7 or 1.23.1).

Downstream is unaffected, as it's using 1.22.9.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No

#### How I validated my change

Added `scan-go-binaries` to this PR. I expect this to come back clean.