### PR TITLE
chore(govulncheck): ignore GO-2022-0635

### DIFF
--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -1,5 +1,8 @@
 {
   "exceptions": {
+    "GO-2022-0635": {
+      "reason": "Unused portion of the SDK"
+    },
     "GO-2022-0646": {
       "reason": "Unused portion of the SDK"
     },


### PR DESCRIPTION
### Description

https://github.com/stackrox/stackrox/pull/13708 found this vulnerability in the AWS SDK. Running govulncheck, it was found this repository is unaffected (does not use any affected functions), so this PR adds it to the ignore list.

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

Added `scan-go-binaries` label to this PR. Expect to not see this vuln mentioned in the report.
