### PR TITLE
ROX-27276: violations platform components links

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -2,6 +2,11 @@ import React, { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
 
 import { Deployment } from 'types/deployment.proto';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import {
+    vulnerabilitiesPlatformWorkloadCvesPath,
+    vulnerabilitiesWorkloadCvesPath,
+} from 'routePaths';
 import ContainerConfigurationDescriptionList from './ContainerConfigurationDescriptionList';
 
 export type ContainerConfigurationProps = {
@@ -9,6 +14,16 @@ export type ContainerConfigurationProps = {
 };
 
 function ContainerConfiguration({ deployment }: ContainerConfigurationProps): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+
+    const hasPlatformWorkloadCveLink =
+        isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT') &&
+        deployment &&
+        deployment.platformComponent;
+    const vulnMgmtBasePath = hasPlatformWorkloadCveLink
+        ? vulnerabilitiesPlatformWorkloadCvesPath
+        : vulnerabilitiesWorkloadCvesPath;
+
     let content: JSX.Element[] | string = 'None';
 
     if (deployment === null) {
@@ -18,7 +33,11 @@ function ContainerConfiguration({ deployment }: ContainerConfigurationProps): Re
         content = deployment.containers.map((container, i) => (
             <React.Fragment key={container.id}>
                 <Title headingLevel="h4" className="pf-v5-u-mb-md">{`containers[${i}]`}</Title>
-                <ContainerConfigurationDescriptionList key={container.id} container={container} />
+                <ContainerConfigurationDescriptionList
+                    key={container.id}
+                    container={container}
+                    vulnMgmtBasePath={vulnMgmtBasePath}
+                />
             </React.Fragment>
         ));
     }

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
@@ -24,16 +24,18 @@ function MultilineDescription({ descArr }) {
 
 type ContainerConfigurationDescriptionListProps = {
     container: Container;
+    vulnMgmtBasePath: string;
 };
 
 function ContainerConfigurationDescriptionList({
     container,
+    vulnMgmtBasePath,
 }: ContainerConfigurationDescriptionListProps): ReactElement {
     const { resources, volumes, secrets, config, image } = container;
     const { command, args } = config || {};
     return (
         <DescriptionList isCompact isHorizontal>
-            <ContainerImage image={image} />
+            <ContainerImage image={image} vulnMgmtBasePath={vulnMgmtBasePath} />
             <DescriptionListItem
                 term="Commands"
                 desc={command?.length > 0 ? <MultilineDescription descArr={command} /> : 'None'}

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 
-import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
-
 import DescriptionListItem from 'Components/DescriptionListItem';
 
 type ContainerImageProps = {
@@ -16,10 +14,11 @@ type ContainerImageProps = {
         notPullable: boolean;
         id: string;
     };
+    vulnMgmtBasePath: string;
 };
 
-function ContainerImage({ image }: ContainerImageProps): ReactElement {
-    const imageDetailsPageURL = `${vulnerabilitiesWorkloadCvesPath}/images/${image.id}`;
+function ContainerImage({ image, vulnMgmtBasePath }: ContainerImageProps): ReactElement {
+    const imageDetailsPageURL = `${vulnMgmtBasePath}/images/${image.id}`;
 
     if (image.id === '' || image.notPullable) {
         const unavailableText = image.notPullable

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -5,7 +5,11 @@ import { DescriptionList } from '@patternfly/react-core';
 
 import dateTimeFormat from 'constants/dateTimeFormat';
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { vulnManagementPath } from 'routePaths';
+import {
+    vulnerabilitiesPlatformWorkloadCvesPath,
+    vulnerabilitiesWorkloadCvesPath,
+} from 'routePaths';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { AlertDeployment } from 'types/alert.proto';
 import { Deployment } from 'types/deployment.proto';
 
@@ -20,12 +24,23 @@ function DeploymentOverview({
     alertDeployment,
     deployment,
 }: DeploymentOverviewProps): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const hasPlatformWorkloadCveLink =
+        isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT') &&
+        deployment &&
+        deployment.platformComponent;
     return (
         <DescriptionList isCompact isHorizontal>
             <DescriptionListItem
                 term="Deployment ID"
                 desc={
-                    <Link to={`${vulnManagementPath}/deployment/${alertDeployment.id}`}>
+                    <Link
+                        to={
+                            hasPlatformWorkloadCveLink
+                                ? `${vulnerabilitiesPlatformWorkloadCvesPath}/deployments/${alertDeployment.id}`
+                                : `${vulnerabilitiesWorkloadCvesPath}/deployments/${alertDeployment.id}`
+                        }
+                    >
                         {alertDeployment.id}
                     </Link>
                 }

--- a/ui/apps/platform/src/types/deployment.proto.ts
+++ b/ui/apps/platform/src/types/deployment.proto.ts
@@ -45,6 +45,7 @@ export type Deployment = {
     ports: PortConfig[];
     stateTimestamp: string; // int64
     riskScore: number; // float
+    platformComponent: boolean;
 };
 
 export type Container = {


### PR DESCRIPTION
### Description

Updates links on the Violations detail pane for deployments to point to the appropriate User or Platform component page when the platform component workload cve split is enabled.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit a Violation for a deployment in user-space and test the deployment and image links on the Details->Deployment tab.
![image](https://github.com/user-attachments/assets/7073fc4a-bbdf-4be5-b881-85a562d1513f)
![image](https://github.com/user-attachments/assets/6287ed46-8cb9-4e19-8954-11911b13cdca)
![image](https://github.com/user-attachments/assets/1955155f-3b3d-4e0f-8038-9a6afc34187b)

Repeat for a Violation on a platform component deployment.
![image](https://github.com/user-attachments/assets/9e9e6339-7226-4f24-81d6-a0aec4a66e49)
![image](https://github.com/user-attachments/assets/030d3ebf-a28b-438c-b28c-8b047ec0d758)
![image](https://github.com/user-attachments/assets/fd75546a-ea9e-47c7-a144-fa47d6d02d2f)

