### PR TITLE
feat(ui): Minor tweaks to SBOM API and UI

### DIFF
--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/images/integration"
+	"github.com/stackrox/rox/pkg/zip"
 	"google.golang.org/grpc/codes"
 )
 
@@ -76,7 +77,7 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tell the browser this is a download.
-	w.Header().Add("Content-Disposition", "attachment; sbom.json")
+	w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=%s.%s", zip.GetSafeFilename(params.ImageName), "json"))
 	w.Header().Add("Content-Type", "application/json")
 	w.Header().Add("Content-Length", fmt.Sprint(len(bytes)))
 	_, _ = w.Write(bytes)

--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -21,7 +21,7 @@ import (
 
 type sbomRequestBody struct {
 	Cluster   string `json:"cluster"`
-	ImageName string `json:"image_name"`
+	ImageName string `json:"imageName"`
 	Force     bool   `json:"force"`
 }
 

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -91,7 +91,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 	t.Run("invalid json body", func(t *testing.T) {
 		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
 		t.Setenv(features.ScannerV4.EnvVar(), "true")
-		invalidJson := `{"cluster": "test-cluster", "image_name": "test-image", "force": true,`
+		invalidJson := `{"cluster": "test-cluster", "imageName": "test-image", "force": true,`
 		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewBufferString(invalidJson))
 		recorder := httptest.NewRecorder()
 
@@ -140,7 +140,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
 		t.Setenv(features.ScannerV4.EnvVar(), "true")
 		t.Setenv(env.SBOMGenerationMaxReqSizeBytes.EnvVar(), "2")
-		largeRequestBody := []byte(`{"cluster": "test-cluster", "image_name": "test-image", "force": true}`)
+		largeRequestBody := []byte(`{"cluster": "test-cluster", "imageName": "test-image", "force": true}`)
 		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(largeRequestBody))
 		recorder := httptest.NewRecorder()
 

--- a/ui/apps/platform/src/Components/ReportJob/ReportJobsTable.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/ReportJobsTable.tsx
@@ -19,6 +19,7 @@ import ReportJobStatus from 'Containers/Vulnerabilities/VulnerablityReporting/Vi
 import { GetSortParams } from 'hooks/useURLSort';
 import { TableUIState } from 'utils/getTableUIState';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { sanitizeFilename } from 'utils/fileUtils';
 
 export type ReportJobsTableProps<T> = {
     tableState: TableUIState<T>;
@@ -30,12 +31,10 @@ export type ReportJobsTableProps<T> = {
     renderExpandableRowContent: (snapshot: T) => React.ReactNode;
 };
 
-const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
-
 const onDownload = (snapshot: Snapshot, jobId: string, configName: string) => () => {
     const { completedAt } = snapshot.reportStatus;
     const filename = `${configName}-${completedAt}`;
-    const sanitizedFilename = filename.replaceAll(filenameSanitizerRegex, '_');
+    const sanitizedFilename = sanitizeFilename(filename);
     return saveFile({
         method: 'get',
         url: `/v2/compliance/scan/configurations/reports/download?id=${jobId}`,

--- a/ui/apps/platform/src/Components/ReportJob/utils.ts
+++ b/ui/apps/platform/src/Components/ReportJob/utils.ts
@@ -1,4 +1,5 @@
 import { saveFile } from 'services/DownloadService';
+import { sanitizeFilename } from 'utils/fileUtils';
 import { JobContextTab, jobContextTabs } from './types';
 
 export function ensureJobContextTab(value: unknown): JobContextTab {
@@ -8,11 +9,9 @@ export function ensureJobContextTab(value: unknown): JobContextTab {
     return 'CONFIGURATION_DETAILS';
 }
 
-const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
-
 export function onDownloadReport({ reportJobId, name, completedAt, baseDownloadURL }) {
     const filename = `${name}-${completedAt}`;
-    const sanitizedFilename = filename.replaceAll(filenameSanitizerRegex, '_');
+    const sanitizedFilename = sanitizeFilename(filename);
     return saveFile({
         method: 'get',
         url: `${baseDownloadURL}?id=${reportJobId}`,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -31,6 +31,7 @@ import { ExclamationCircleIcon, FilterIcon } from '@patternfly/react-icons';
 
 import { ReportConfiguration } from 'services/ReportsService.types';
 import { getDateTime } from 'utils/dateUtils';
+import { sanitizeFilename } from 'utils/fileUtils';
 import { getReportFormValuesFromConfiguration } from 'Containers/Vulnerabilities/VulnerablityReporting/utils';
 import useSet from 'hooks/useSet';
 import useURLPagination from 'hooks/useURLPagination';
@@ -65,8 +66,6 @@ const sortOptions = {
     sortFields: ['Report Completion Time'],
     defaultSortOption: { field: 'Report Completion Time', direction: 'desc' } as const,
 };
-
-const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
 
 const headingLevel = 'h2';
 
@@ -263,10 +262,7 @@ function ReportJobs({ reportId }: RunHistoryProps) {
                         function onDownload() {
                             const { completedAt } = reportStatus;
                             const filename = `${name}-${completedAt}`;
-                            const sanitizedFilename = filename.replaceAll(
-                                filenameSanitizerRegex,
-                                '_'
-                            );
+                            const sanitizedFilename = sanitizeFilename(filename);
                             return saveFile({
                                 method: 'get',
                                 url: `/api/reports/jobs/download?id=${reportJobId}`,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -9,9 +9,11 @@ import {
     Flex,
     Modal,
     Text,
+    Title,
 } from '@patternfly/react-core';
 import Raven from 'raven-js';
 
+import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useAnalytics, { IMAGE_SBOM_GENERATED } from 'hooks/useAnalytics';
 import useRestMutation from 'hooks/useRestMutation';
@@ -38,8 +40,17 @@ function GenerateSbomModal(props: GenerateSbomModalProps) {
         <Modal
             isOpen
             onClose={onClose}
-            title="Generate Software Bill of Materials (SBOM)"
             variant="medium"
+            header={
+                <Flex
+                    className="pf-v5-u-mr-md"
+                    justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                >
+                    <Title headingLevel="h1">Generate Software Bill of Materials (SBOM)</Title>
+                    <TechPreviewLabel />
+                </Flex>
+            }
             actions={[
                 <Button
                     key="generate-sbom-action"

--- a/ui/apps/platform/src/services/DownloadService.js
+++ b/ui/apps/platform/src/services/DownloadService.js
@@ -1,4 +1,6 @@
 import FileSaver from 'file-saver';
+import { parseAxiosResponseAttachment } from 'utils/fileUtils';
+
 import axios from './instance';
 
 /**
@@ -17,17 +19,12 @@ export function saveFile({ method, url, data, name = '', timeout = 0 }) {
     return axios(options)
         .then((response) => {
             if (response.data) {
-                const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-                const matches = filenameRegex.exec(response.headers['content-disposition']);
-
-                const file = new Blob([response.data], {
-                    type: response.headers['content-type'],
-                });
+                const { file, filename } = parseAxiosResponseAttachment(response);
 
                 if (name && typeof name === 'string') {
                     FileSaver.saveAs(file, name);
-                } else if (matches !== null && matches[1]) {
-                    FileSaver.saveAs(file, matches[1].replace(/['"]/g, ''));
+                } else if (filename) {
+                    FileSaver.saveAs(file, filename);
                 } else {
                     throw new Error('Unable to extract file name');
                 }

--- a/ui/apps/platform/src/services/ImageSbomService.ts
+++ b/ui/apps/platform/src/services/ImageSbomService.ts
@@ -9,6 +9,7 @@ export function generateAndSaveSbom({ imageName }: { imageName: string }): Promi
         url: '/api/v1/images/sbom',
         data: { imageName },
         timeout: 0,
+        responseType: 'arraybuffer',
     }).then((response) => {
         const { file, filename } = parseAxiosResponseAttachment(response);
         FileSaver.saveAs(file, filename);

--- a/ui/apps/platform/src/services/ImageSbomService.ts
+++ b/ui/apps/platform/src/services/ImageSbomService.ts
@@ -1,5 +1,5 @@
 import FileSaver from 'file-saver';
-import { sanitizeFilename } from 'utils/fileUtils';
+import { parseAxiosResponseAttachment } from 'utils/fileUtils';
 
 import axios from './instance';
 
@@ -10,11 +10,7 @@ export function generateAndSaveSbom({ imageName }: { imageName: string }): Promi
         data: { imageName },
         timeout: 0,
     }).then((response) => {
-        const fileName = sanitizeFilename(`${imageName}.sbom`);
-        const file = new Blob([response.data], {
-            type: response.headers['content-type'],
-        });
-
-        FileSaver.saveAs(file, fileName);
+        const { file, filename } = parseAxiosResponseAttachment(response);
+        FileSaver.saveAs(file, filename);
     });
 }

--- a/ui/apps/platform/src/services/ImageSbomService.ts
+++ b/ui/apps/platform/src/services/ImageSbomService.ts
@@ -1,9 +1,20 @@
-import { saveFile } from './DownloadService';
+import FileSaver from 'file-saver';
+import { sanitizeFilename } from 'utils/fileUtils';
+
+import axios from './instance';
 
 export function generateAndSaveSbom({ imageName }: { imageName: string }): Promise<void> {
-    return saveFile({
-        method: 'post',
+    return axios({
+        method: 'POST',
         url: '/api/v1/images/sbom',
         data: { imageName },
+        timeout: 0,
+    }).then((response) => {
+        const fileName = sanitizeFilename(`${imageName}.sbom`);
+        const file = new Blob([response.data], {
+            type: response.headers['content-type'],
+        });
+
+        FileSaver.saveAs(file, fileName);
     });
 }

--- a/ui/apps/platform/src/utils/fileUtils.ts
+++ b/ui/apps/platform/src/utils/fileUtils.ts
@@ -1,0 +1,5 @@
+const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
+
+export function sanitizeFilename(filename: string, replacementChar: string = '_') {
+    return filename.replaceAll(filenameSanitizerRegex, replacementChar);
+}

--- a/ui/apps/platform/src/utils/fileUtils.ts
+++ b/ui/apps/platform/src/utils/fileUtils.ts
@@ -1,5 +1,19 @@
+import { AxiosResponse } from 'axios';
+
 const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
 
 export function sanitizeFilename(filename: string, replacementChar: string = '_') {
     return filename.replaceAll(filenameSanitizerRegex, replacementChar);
+}
+
+const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+
+export function parseAxiosResponseAttachment(response: AxiosResponse): {
+    file: Blob;
+    filename: string | null;
+} {
+    const matches = filenameRegex.exec(response.headers['content-disposition'] ?? '');
+    const filename = matches && matches[1] ? matches[1] : null;
+    const file = new Blob([response.data], { type: response.headers['content-type'] });
+    return { file, filename };
 }


### PR DESCRIPTION
### Description

A few minor changes to SBOM Generation:

1. Update the API to allow the UI to pass `imageName` instead of `image_name` as the parameter
2. Add a `TechPreview` label to the modal header
3. Move away from the DownloadService's `saveFile` function due to incorrect assumptions on the response data that do not hold for the SBOM API

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Go to VM -> open the Generate SBOM modal:
![image](https://github.com/user-attachments/assets/1b1dea31-06fe-451e-961f-89fd447e8b15)

Submit the request and see that the request is submitted, but fails with an error. The UI correctly parses and displays the error. (In this case, Scanner V4 is not installed correctly even though it is enabled).
![image](https://github.com/user-attachments/assets/28fe1a05-001d-456b-86ec-c20218b5749d)

Compare to an older central build, that errors due to not providing `image_name` as the parameter.
![image](https://github.com/user-attachments/assets/09b2ce7a-e7ff-4965-8436-50cc0a01f7b0)

