### PR TITLE
fix(scanner): Fix -ldflags in scanner's Makefile

### DIFF
--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -59,8 +59,7 @@ GOOS := $(HOST_OS)
 GO_BUILD_FLAGS = CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH)
 GO_BUILD_CMD   = $(GO_BUILD_FLAGS) go build \
                    -trimpath \
-                   -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=$(TAG)" \
-                   -ldflags="-X github.com/stackrox/rox/scanner/internal/version.VulnerabilityVersion=$(SCANNER_VULNERABILITY_VERSION)" \
+                   -ldflags="-X github.com/stackrox/rox/scanner/internal/version.Version=$(TAG) -X github.com/stackrox/rox/scanner/internal/version.VulnerabilityVersion=$(SCANNER_VULNERABILITY_VERSION)" \
                    -tags=$(GOTAGS) \
                    $(RACE_FLAG)
 GO_TEST_CMD    = $(GO_BUILD_FLAGS) go test

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -59,7 +59,13 @@ func init() {
 
 func main() {
 	configPath := flag.String("conf", "", "Path to scanner's configuration file.")
+	printVersion := flag.Bool("version", false,
+		"Print the build version tag and the vulnerability schema version, then exit.")
 	flag.Parse()
+	if *printVersion {
+		fmt.Println(version.Version, version.VulnerabilityVersion)
+		os.Exit(0)
+	}
 	cfg, err := config.Read(*configPath)
 	if err != nil {
 		golog.Fatalf("failed to load configuration %q: %v", *configPath, err)


### PR DESCRIPTION
### Description

Properly set the `version` variable by passing the proper `-ldflag` to `go build`.

Before it was setting `-ldflags` twice when building scanner, the second flag overwrote the first, leading to empty `version=""` in the scanner binary, but not affecting the vulnerability version.

Added a `-version` to print the version, for convenience.

### User-facing documentation

- [X] CHANGELOG is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [X] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Run before the fix:

```
$ ./bin/scanner 2>/dev/null| grep 'version":"' 
{"level":"info","host":"...":"main","version":"","build_flavor":"development","time":"2025-01-07T13:20:59-08:00","message":"starting scanner"}
pkg/metrics: 2025/01/07 13:20:59.882686 throttle.go:90: Info: gathering CPU throttle metrics from sys/fs/cgroup/cpu.stat
^C
$
```

After:

```
./bin/scanner 2>/dev/null -version                                                                                                        
4.7.x-368-g5aff1fa886
```