### PR TITLE
ROX-27147: Roxctl SBOM HTTP API errors and http client config

### DIFF
--- a/roxctl/central/login/login.go
+++ b/roxctl/central/login/login.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -274,7 +275,8 @@ In case the access token is expired and cannot be refreshed, you have to run "ro
 func (l *loginCommand) verifyLoginAuthProviders() error {
 	// Use the HTTP client with the anonymous auth method to force anonymous access.
 	// Note that this may still be done via HTTP/2 instead of HTTP/1, unless HTTP/1 is forced.
-	httpClient, err := l.env.HTTPClient(30*time.Second, auth.Anonymous())
+	httpClient, err := l.env.HTTPClient(30*time.Second, common.WithAuthMethod(auth.Anonymous()))
+
 	if err != nil {
 		return errors.Wrap(err, "creating HTTP client")
 	}

--- a/roxctl/central/login/login_test.go
+++ b/roxctl/central/login/login_test.go
@@ -182,7 +182,14 @@ func mockEnvWithHTTPClient(t *testing.T) environment.Environment {
 	mockEnv.EXPECT().GRPCConnection(gomock.Any()).AnyTimes().Return(nil, nil)
 	mockEnv.EXPECT().ColorWriter().AnyTimes().Return(env.ColorWriter())
 	mockEnv.EXPECT().HTTPClient(gomock.Any(), gomock.Any()).AnyTimes().Return(
-		common.GetRoxctlHTTPClient(auth.Anonymous(), 30*time.Second, false, true, env.Logger()))
+		common.GetRoxctlHTTPClient(common.NewHttpClientConfig(
+			common.WithAuthMethod(auth.Anonymous()),
+			common.WithTimeout(30*time.Second),
+			common.WithForceHTTP1(false),
+			common.WithUseInsecure(true),
+			common.WithLogger(env.Logger()),
+		)),
+	)
 
 	return mockEnv
 }

--- a/roxctl/central/m2m/exchange/exchange.go
+++ b/roxctl/central/m2m/exchange/exchange.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/jsonutil"
+	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -81,7 +82,7 @@ func (e *exchangeCommand) construct(cmd *cobra.Command) error {
 
 func (e *exchangeCommand) exchange() error {
 	// The exchange API is anonymous, no auth is required.
-	httpClient, err := e.env.HTTPClient(e.timeout, auth.Anonymous())
+	httpClient, err := e.env.HTTPClient(e.timeout, common.WithAuthMethod(auth.Anonymous()))
 	if err != nil {
 		return errors.Wrap(err, "creating HTTP client")
 	}

--- a/roxctl/central/m2m/exchange/exchange_test.go
+++ b/roxctl/central/m2m/exchange/exchange_test.go
@@ -47,7 +47,14 @@ func mockEnvWithHTTPClient(t *testing.T, store *cfgMock.MockStore) environment.E
 	mockEnv.EXPECT().ColorWriter().AnyTimes().Return(env.ColorWriter())
 	mockEnv.EXPECT().ConfigStore().AnyTimes().Return(store, nil)
 	mockEnv.EXPECT().HTTPClient(gomock.Any(), gomock.Any()).AnyTimes().Return(
-		common.GetRoxctlHTTPClient(auth.Anonymous(), 30*time.Second, false, true, env.Logger()))
+		common.GetRoxctlHTTPClient(common.NewHttpClientConfig(
+			common.WithAuthMethod(auth.Anonymous()),
+			common.WithTimeout(30*time.Second),
+			common.WithForceHTTP1(false),
+			common.WithUseInsecure(true),
+			common.WithLogger(env.Logger()),
+		)),
+	)
 
 	return mockEnv
 }

--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -82,7 +82,7 @@ func GetRoxctlHTTPClient(config *HttpClientConfig) (RoxctlHTTPClient, error) {
 	// Silence the default log output of the HTTP retry client to not pollute output.
 	retryClient.Logger = nil
 
-	if config.DisableBackoff {
+	if !config.RetryExponentialBackoff {
 		// Disable the exponential backoff, in some scenarios the backoff makes roxctl appear
 		// stuck (partially due to the logger being disabled).
 		retryClient.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration { return min }

--- a/roxctl/common/client_options.go
+++ b/roxctl/common/client_options.go
@@ -1,0 +1,107 @@
+package common
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/roxctl/common/auth"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	"github.com/stackrox/rox/roxctl/common/logger"
+)
+
+// HttpClientOption encodes behavior of a HTTP client.
+type HttpClientOption func(*HttpClientConfig)
+
+// HttpClientConfig is used for configuring the abstracted HTTP client.
+type HttpClientConfig struct {
+	AuthMethod            auth.Method
+	DisableBackoff        bool
+	ForceHTTP1            bool
+	Logger                logger.Logger
+	RetryCount            int
+	RetryDelay            time.Duration
+	ReturnRespBodyOnError bool
+	Timeout               time.Duration
+	UseInsecure           bool
+}
+
+// NewHttpClientConfig returns a default config modified by options.
+func NewHttpClientConfig(options ...HttpClientOption) *HttpClientConfig {
+	opts := &HttpClientConfig{
+		ForceHTTP1:  flags.ForceHTTP1(),
+		UseInsecure: flags.UseInsecure(),
+		RetryCount:  env.ClientMaxRetries.IntegerSetting(),
+		RetryDelay:  10 * time.Second,
+	}
+
+	for _, optFunc := range options {
+		optFunc(opts)
+	}
+
+	return opts
+}
+
+// WithAuthMethod sets the auth method to use for the HTTP client.
+func WithAuthMethod(am auth.Method) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.AuthMethod = am
+	}
+}
+
+// WithDisableBackoff disables exponential backoff.
+func WithDisableBackoff(disable bool) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.DisableBackoff = disable
+	}
+}
+
+// WithForceHTTP1 sets if the client should only use HTTP1.
+func WithForceHTTP1(force bool) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.ForceHTTP1 = force
+	}
+}
+
+// WithLogger sets the logger the client should use.
+func WithLogger(log logger.Logger) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.Logger = log
+	}
+}
+
+// WithRetryCount sets the number of retry attempts on request failure.
+func WithRetryCount(retryCount int) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.RetryCount = retryCount
+	}
+}
+
+// WithRetryDelay sets the time to wait between retry attempts.
+func WithRetryDelay(d time.Duration) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.RetryDelay = d
+	}
+}
+
+// WithReturnErrorResponseBody when true indicates that on error the response body
+// should be returned. By default the response body is empty with no messaging
+// to indicate what the error is or why it occurred.
+func WithReturnErrorResponseBody(returnErrRespBody bool) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.ReturnRespBodyOnError = returnErrRespBody
+	}
+}
+
+// WithTimeout the timeout to use for the http request.
+func WithTimeout(timeout time.Duration) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.Timeout = timeout
+	}
+}
+
+// WithUseInsecure sets if HTTP1 should be forced.
+func WithUseInsecure(force bool) HttpClientOption {
+	return func(hco *HttpClientConfig) {
+		hco.ForceHTTP1 = force
+	}
+}

--- a/roxctl/common/client_options.go
+++ b/roxctl/common/client_options.go
@@ -14,24 +14,25 @@ type HttpClientOption func(*HttpClientConfig)
 
 // HttpClientConfig is used for configuring the abstracted HTTP client.
 type HttpClientConfig struct {
-	AuthMethod            auth.Method
-	DisableBackoff        bool
-	ForceHTTP1            bool
-	Logger                logger.Logger
-	RetryCount            int
-	RetryDelay            time.Duration
-	ReturnRespBodyOnError bool
-	Timeout               time.Duration
-	UseInsecure           bool
+	AuthMethod              auth.Method
+	ForceHTTP1              bool
+	Logger                  logger.Logger
+	RetryExponentialBackoff bool
+	RetryCount              int
+	RetryDelay              time.Duration
+	ReturnRespBodyOnError   bool
+	Timeout                 time.Duration
+	UseInsecure             bool
 }
 
 // NewHttpClientConfig returns a default config modified by options.
 func NewHttpClientConfig(options ...HttpClientOption) *HttpClientConfig {
 	opts := &HttpClientConfig{
-		ForceHTTP1:  flags.ForceHTTP1(),
-		UseInsecure: flags.UseInsecure(),
-		RetryCount:  env.ClientMaxRetries.IntegerSetting(),
-		RetryDelay:  10 * time.Second,
+		ForceHTTP1:              flags.ForceHTTP1(),
+		UseInsecure:             flags.UseInsecure(),
+		RetryCount:              env.ClientMaxRetries.IntegerSetting(),
+		RetryDelay:              10 * time.Second,
+		RetryExponentialBackoff: true,
 	}
 
 	for _, optFunc := range options {
@@ -48,10 +49,10 @@ func WithAuthMethod(am auth.Method) HttpClientOption {
 	}
 }
 
-// WithDisableBackoff disables exponential backoff.
-func WithDisableBackoff(disable bool) HttpClientOption {
+// WithRetryExponentialBackoff disables/enables exponential backoff.
+func WithRetryExponentialBackoff(value bool) HttpClientOption {
 	return func(hco *HttpClientConfig) {
-		hco.DisableBackoff = disable
+		hco.RetryExponentialBackoff = value
 	}
 }
 

--- a/roxctl/common/client_options.go
+++ b/roxctl/common/client_options.go
@@ -100,8 +100,8 @@ func WithTimeout(timeout time.Duration) HttpClientOption {
 }
 
 // WithUseInsecure sets if HTTP1 should be forced.
-func WithUseInsecure(force bool) HttpClientOption {
+func WithUseInsecure(useInsecure bool) HttpClientOption {
 	return func(hco *HttpClientConfig) {
-		hco.ForceHTTP1 = force
+		hco.UseInsecure = useInsecure
 	}
 }

--- a/roxctl/common/client_options_test.go
+++ b/roxctl/common/client_options_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/roxctl/common/auth"
+	roxctlio "github.com/stackrox/rox/roxctl/common/io"
+	"github.com/stackrox/rox/roxctl/common/logger"
+	"github.com/stackrox/rox/roxctl/common/printer"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFunctionalOptions verifies that each option
+// modifies the expected property of the config.
+func TestFunctionalOptions(t *testing.T) {
+	cfg := &HttpClientConfig{}
+
+	assert.Zero(t, cfg.AuthMethod)
+	WithAuthMethod(auth.Anonymous())(cfg)
+	assert.NotZero(t, cfg.AuthMethod)
+
+	assert.Zero(t, cfg.DisableBackoff)
+	WithDisableBackoff(true)(cfg)
+	assert.NotZero(t, cfg.DisableBackoff)
+
+	assert.Zero(t, cfg.ForceHTTP1)
+	WithForceHTTP1(true)(cfg)
+	assert.NotZero(t, cfg.ForceHTTP1)
+
+	assert.Zero(t, cfg.Logger)
+	WithLogger(logger.NewLogger(roxctlio.DefaultIO(), printer.DefaultColorPrinter()))(cfg)
+	assert.NotZero(t, cfg.Logger)
+
+	assert.Zero(t, cfg.RetryCount)
+	WithRetryCount(1)(cfg)
+	assert.NotZero(t, cfg.RetryCount)
+
+	assert.Zero(t, cfg.RetryDelay)
+	WithRetryDelay(1 * time.Second)(cfg)
+	assert.NotZero(t, cfg.RetryDelay)
+
+	assert.Zero(t, cfg.ReturnRespBodyOnError)
+	WithReturnErrorResponseBody(true)(cfg)
+	assert.NotZero(t, cfg.ReturnRespBodyOnError)
+
+	assert.Zero(t, cfg.Timeout)
+	WithTimeout(1 * time.Second)(cfg)
+	assert.NotZero(t, cfg.Timeout)
+
+	assert.Zero(t, cfg.UseInsecure)
+	WithUseInsecure(true)(cfg)
+	assert.NotZero(t, cfg.UseInsecure)
+}

--- a/roxctl/common/client_options_test.go
+++ b/roxctl/common/client_options_test.go
@@ -20,9 +20,9 @@ func TestFunctionalOptions(t *testing.T) {
 	WithAuthMethod(auth.Anonymous())(cfg)
 	assert.NotZero(t, cfg.AuthMethod)
 
-	assert.Zero(t, cfg.DisableBackoff)
-	WithDisableBackoff(true)(cfg)
-	assert.NotZero(t, cfg.DisableBackoff)
+	assert.Zero(t, cfg.RetryExponentialBackoff)
+	WithRetryExponentialBackoff(true)(cfg)
+	assert.NotZero(t, cfg.RetryExponentialBackoff)
 
 	assert.Zero(t, cfg.ForceHTTP1)
 	WithForceHTTP1(true)(cfg)

--- a/roxctl/common/environment/auth_config.go
+++ b/roxctl/common/environment/auth_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/client/authn/tokenbased"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
 	"google.golang.org/grpc/credentials"
@@ -95,7 +96,7 @@ Still, trying to authenticate with the given token. In case there's any issues, 
 }
 
 func (c configMethod) refreshAccessToken(url string, accessConfig *config.CentralAccessConfig) error {
-	client, err := c.env.HTTPClient(time.Minute, auth.Anonymous())
+	client, err := c.env.HTTPClient(time.Minute, common.WithAuthMethod(auth.Anonymous()))
 	if err != nil {
 		return errors.Wrap(err, "obtaining client for token refresh")
 	}

--- a/roxctl/common/environment/auth_config_test.go
+++ b/roxctl/common/environment/auth_config_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/roxctl/common"
-	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
 	configMock "github.com/stackrox/rox/roxctl/common/config/mocks"
 	roxctlIO "github.com/stackrox/rox/roxctl/common/io"
@@ -204,7 +203,7 @@ type mockEnvironment struct {
 	Environment
 }
 
-func (m *mockEnvironment) HTTPClient(_ time.Duration, _ ...auth.Method) (common.RoxctlHTTPClient, error) {
+func (m *mockEnvironment) HTTPClient(_ time.Duration, _ ...common.HttpClientOption) (common.RoxctlHTTPClient, error) {
 	if m.fail {
 		return nil, errClient
 	}

--- a/roxctl/common/environment/environment.go
+++ b/roxctl/common/environment/environment.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/roxctl/common"
-	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/config"
 	io2 "github.com/stackrox/rox/roxctl/common/io"
 	"github.com/stackrox/rox/roxctl/common/logger"
@@ -17,7 +16,7 @@ import (
 //go:generate mockgen-wrapper
 type Environment interface {
 	// HTTPClient returns a interfaces.RoxctlHTTPClient
-	HTTPClient(timeout time.Duration, method ...auth.Method) (common.RoxctlHTTPClient, error)
+	HTTPClient(timeout time.Duration, options ...common.HttpClientOption) (common.RoxctlHTTPClient, error)
 
 	// GRPCConnection returns an authenticated grpc.ClientConn
 	GRPCConnection(connectionOpts ...common.GRPCOption) (*grpc.ClientConn, error)

--- a/roxctl/common/environment/mocks/environment.go
+++ b/roxctl/common/environment/mocks/environment.go
@@ -15,7 +15,6 @@ import (
 	time "time"
 
 	common "github.com/stackrox/rox/roxctl/common"
-	auth "github.com/stackrox/rox/roxctl/common/auth"
 	config "github.com/stackrox/rox/roxctl/common/config"
 	io "github.com/stackrox/rox/roxctl/common/io"
 	logger "github.com/stackrox/rox/roxctl/common/logger"
@@ -112,10 +111,10 @@ func (mr *MockEnvironmentMockRecorder) GRPCConnection(connectionOpts ...any) *go
 }
 
 // HTTPClient mocks base method.
-func (m *MockEnvironment) HTTPClient(timeout time.Duration, method ...auth.Method) (common.RoxctlHTTPClient, error) {
+func (m *MockEnvironment) HTTPClient(timeout time.Duration, options ...common.HttpClientOption) (common.RoxctlHTTPClient, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{timeout}
-	for _, a := range method {
+	for _, a := range options {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "HTTPClient", varargs...)
@@ -125,9 +124,9 @@ func (m *MockEnvironment) HTTPClient(timeout time.Duration, method ...auth.Metho
 }
 
 // HTTPClient indicates an expected call of HTTPClient.
-func (mr *MockEnvironmentMockRecorder) HTTPClient(timeout any, method ...any) *gomock.Call {
+func (mr *MockEnvironmentMockRecorder) HTTPClient(timeout any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{timeout}, method...)
+	varargs := append([]any{timeout}, options...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HTTPClient", reflect.TypeOf((*MockEnvironment)(nil).HTTPClient), varargs...)
 }
 

--- a/roxctl/image/sbom/sbom.go
+++ b/roxctl/image/sbom/sbom.go
@@ -78,7 +78,7 @@ func (i *imageSBOMCommand) construct(cobraCmd *cobra.Command) error {
 	i.client, err = i.env.HTTPClient(
 		flags.Timeout(cobraCmd),
 		// Disable exponential backoff so that roxctl does not appear stuck.
-		common.WithDisableBackoff(true),
+		common.WithRetryExponentialBackoff(false),
 		// Ensure error response is made available for troubleshooting failures.
 		common.WithReturnErrorResponseBody(true),
 		common.WithRetryDelay(time.Duration(i.retryDelay)*time.Second),

--- a/roxctl/image/sbom/sbom_test.go
+++ b/roxctl/image/sbom/sbom_test.go
@@ -130,7 +130,7 @@ func createServer(t *testing.T, retErr bool, htmlResponse bool) *httptest.Server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if retErr {
 			rw.WriteHeader(http.StatusInternalServerError)
-			rw.Write([]byte(`{"code":13,"message":"Error From Request Body"}`))
+			_, _ = rw.Write([]byte(`{"code":13,"message":"Error From Request Body"}`))
 			return
 		}
 

--- a/roxctl/image/sbom/sbom_test.go
+++ b/roxctl/image/sbom/sbom_test.go
@@ -109,7 +109,7 @@ func TestGenerateSBOM(t *testing.T) {
 		require.NoError(t, cmd.construct(c))
 
 		err := cmd.GenerateSBOM()
-		require.ErrorContains(t, err, "generating SBOM")
+		require.ErrorContains(t, err, "Error From Request Body")
 	})
 
 	t.Run("error on text/html response", func(t *testing.T) {
@@ -130,6 +130,7 @@ func createServer(t *testing.T, retErr bool, htmlResponse bool) *httptest.Server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if retErr {
 			rw.WriteHeader(http.StatusInternalServerError)
+			rw.Write([]byte(`{"code":13,"message":"Error From Request Body"}`))
 			return
 		}
 


### PR DESCRIPTION
### Description

Stacked on top of: 

- https://github.com/stackrox/stackrox/pull/13706

This PR modifies the [roxctl HTTP client abstraction](https://github.com/stackrox/stackrox/blob/1ae035a0c21d156e9689c7e429eae2e35c4d63ca/roxctl/common/environment/environment.go#L20) to allow for it to be configured - to an extent mimicking the [GRPCConnection equivalent](https://github.com/stackrox/stackrox/blob/9ad6937ece0b12b180466bb4d899af8e2af95f31/roxctl/common/environment/environment.go#L22).

The motivation for this change was so that errors can be surfaced via the new `roxctl image sbom` and behavior (retries, delays, backoffs, etc.) made configurable to align with `roxctl image scan` (which uses the GRPC client)

The new configuration allows for: 
- HTTP API errors to be surfaced (currently suppressed)
- Optionally disabling exponential backoff
  - Logging is disabled for the HTTP client (do not know history as to why), so there is no indication that retries are happening or exponential backoff is occuring, making roxctl appear 'hung' when errors occur.
- Modifying previously hardcoded values (such as retry delay) as needed.

The changes were made such that existing command behaviors should not have been affected.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Relying on existing tests + the SBOM tests were modified to inspect the response body + manual testing:

Setup:
```
$ export ROX_ENDPOINT=...
$ export ROX_API_TOKEN=...

$ make cli_darwin-arm64
$ alias roxctl=bin/darwin_arm64/roxctl
```

Before this PR - attempts to call the API with a known bad image took a long time and did not provide a meaningful error:
```
$ time roxctl image sbom --image "quay.io/rhacs-eng/main:noexist"
ERROR:	generating SBOM: error when doing http request: POST https://<ip>:443/api/v1/images/sbom giving up after 4 attempt(s)

real	1m4.611s
user	0m0.063s
sys	0m0.024s
```

Using this PR notice a more meaningful error is returned and in a shorter timeframe:
```
$ time roxctl image sbom --image "quay.io/rhacs-eng/main:noexist"
ERROR:	generating SBOM: expected status code 200, but received 500. Response Body: {"code":13,"message":"generating SBOM: image enrichment error: error getting metadata for image: quay.io/rhacs-eng/main:noexist error: getting metadata from registry: \"Autogenerated https://quay.io for cluster remote\": failed to get the manifest digest: Head \"https://quay.io/v2/rhacs-eng/main/manifests/noexist\": http: non-successful response (status=404 body=\"\")"}

real	0m15.424s
user	0m0.062s
sys	0m0.058s
```

Additionally, the command now allows for controlling the # of retries and delay to put in on par with `roxctl image scan`:

```
$ time roxctl image sbom --image "quay.io/rhacs-eng/main:noexist" --retries=0
ERROR:	generating SBOM: expected status code 200, but received 500. Response Body: {"code":13,"message":"generating SBOM: image enrichment error: error getting metadata for image: quay.io/rhacs-eng/main:noexist error: getting metadata from registry: \"Autogenerated https://quay.io for cluster remote\": failed to get the manifest digest: Head \"https://quay.io/v2/rhacs-eng/main/manifests/noexist\": http: non-successful response (status=404 body=\"\")"}

real	0m0.729s
user	0m0.062s
sys	0m0.028s
```
```
$ time roxctl image sbom --image "quay.io/rhacs-eng/main:noexist" --retries=2 --retry-delay=1
ERROR:	generating SBOM: expected status code 200, but received 500. Response Body: {"code":13,"message":"generating SBOM: image enrichment error: error getting metadata for image: quay.io/rhacs-eng/main:noexist error: getting metadata from registry: \"Autogenerated https://quay.io for cluster remote\": failed to get the manifest digest: Head \"https://quay.io/v2/rhacs-eng/main/manifests/noexist\": http: non-successful response (status=404 body=\"\")"}

real	0m5.761s
user	0m0.064s
sys	0m0.028s
```