### PR TITLE
chore: Kill `Java` mentions from Konflux pipelines

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -81,10 +81,6 @@ spec:
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: "false"
-    description: Java build
-    name: java
-    type: string
   - description: Image tag expiration time, time values could be something like
       1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
@@ -123,9 +119,6 @@ spec:
   - description: ""
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
-  - description: ""
-    name: JAVA_COMMUNITY_DEPENDENCIES
-    value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
 
   workspaces:
   - name: git-auth

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -81,10 +81,6 @@ spec:
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: "false"
-    description: Java build
-    name: java
-    type: string
   - description: Image tag expiration time, time values could be something like
       1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
@@ -119,9 +115,6 @@ spec:
   - description: ""
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
-  - description: ""
-    name: JAVA_COMMUNITY_DEPENDENCIES
-    value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -81,10 +81,6 @@ spec:
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: "false"
-    description: Java build
-    name: java
-    type: string
   - description: Image tag expiration time, time values could be something like
       1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
@@ -227,9 +223,6 @@ spec:
   - description: ""
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
-  - description: ""
-    name: JAVA_COMMUNITY_DEPENDENCIES
-    value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
   - description: ""
     name: SNAPSHOT_NAME
     value: $(tasks.create-acs-style-snapshot.results.SNAPSHOT_NAME)

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -81,10 +81,6 @@ spec:
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
     type: string
-  - default: "false"
-    description: Java build
-    name: java
-    type: string
   - description: Image tag expiration time, time values could be something like
       1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
@@ -119,9 +115,6 @@ spec:
   - description: ""
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
-  - description: ""
-    name: JAVA_COMMUNITY_DEPENDENCIES
-    value: $(tasks.build-container-amd64.results.JAVA_COMMUNITY_DEPENDENCIES)
 
   workspaces:
   - name: git-auth


### PR DESCRIPTION
### Description

There are build failures in buildah task updates.

> Failed to resolve pipeline result reference for "scanner-db-on-push-7ls5b" with error %!w(*fmt.wrapError=&{invalid pipeline result "JAVA_COMMUNITY_DEPENDENCIES": "JAVA_COMMUNITY_DEPENDENCIES" is not a named result returned by pipeline task "build-container-amd64" 0xc16b452d00}) 

E.g. see https://github.com/stackrox/scanner/pull/1745/checks?check_run_id=35291959937

That's because the corresponding java things were removed from the new version of the tasks.
- https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.3/MIGRATION.md
- https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-remote-oci-ta/0.3/MIGRATION.md

Here I searched for "java" (case insensitive) in the `.tekton/` directory and removed what I found.
This should hopefully make builds in the task updates feel better.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No change.

#### How I validated my change

We don't use Java in container builds so checking only the status of Konflux pipelines is sufficient.