### PR TITLE
ROX-23316: check: confirm all components are part of snapshot

### DIFF
--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -475,6 +475,8 @@ spec:
       - RELATED_IMAGE_SCANNER_V4=$(params.scanner-v4-image-catalog-repo)@$(tasks.wait-for-scanner-v4-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_SCANNER_V4_DB=$(params.scanner-v4-db-image-catalog-repo)@$(tasks.wait-for-scanner-v4-db-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_COLLECTOR_SLIM=$(params.collector-slim-image-catalog-repo)@$(tasks.wait-for-collector-slim-image.results.IMAGE_DIGEST)
+      # TODO(ROX-27612): change to RELATED_IMAGE_COLLECTOR and delete RELATED_IMAGE_COLLECTOR_SLIM
+      # once https://github.com/stackrox/stackrox/pull/13350 is merged.
       - RELATED_IMAGE_COLLECTOR_FULL=$(params.collector-full-image-catalog-repo)@$(tasks.wait-for-collector-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_ROXCTL=$(params.roxctl-image-catalog-repo)@$(tasks.wait-for-roxctl-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_CENTRAL_DB=$(params.central-db-image-catalog-repo)@$(tasks.wait-for-central-db-image.results.IMAGE_DIGEST)

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -422,7 +422,7 @@ spec:
     # The timeout must be the same as the pipeline timeout in `collector-slim-retag.yaml`
     timeout: 40m
 
-  - name: wait-for-collector-full-image
+  - name: wait-for-collector-image
     params:
     - name: IMAGE
       value: "$(params.collector-full-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
@@ -475,7 +475,7 @@ spec:
       - RELATED_IMAGE_SCANNER_V4=$(params.scanner-v4-image-catalog-repo)@$(tasks.wait-for-scanner-v4-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_SCANNER_V4_DB=$(params.scanner-v4-db-image-catalog-repo)@$(tasks.wait-for-scanner-v4-db-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_COLLECTOR_SLIM=$(params.collector-slim-image-catalog-repo)@$(tasks.wait-for-collector-slim-image.results.IMAGE_DIGEST)
-      - RELATED_IMAGE_COLLECTOR_FULL=$(params.collector-full-image-catalog-repo)@$(tasks.wait-for-collector-full-image.results.IMAGE_DIGEST)
+      - RELATED_IMAGE_COLLECTOR_FULL=$(params.collector-full-image-catalog-repo)@$(tasks.wait-for-collector-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_ROXCTL=$(params.roxctl-image-catalog-repo)@$(tasks.wait-for-roxctl-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_CENTRAL_DB=$(params.central-db-image-catalog-repo)@$(tasks.wait-for-central-db-image.results.IMAGE_DIGEST)
     - name: SOURCE_ARTIFACT
@@ -686,7 +686,7 @@ spec:
     - rpms-signature-scan
     - sast-snyk-check
     - wait-for-central-db-image
-    - wait-for-collector-full-image
+    - wait-for-collector-image
     - wait-for-collector-slim-image
     - wait-for-main-image
     - wait-for-operator-image
@@ -711,9 +711,9 @@ spec:
           },
           {
             "name": "collector",
-            "containerImage": "$(params.collector-full-image-build-repo)@$(tasks.wait-for-collector-full-image.results.IMAGE_DIGEST)",
-            "repository": "$(tasks.wait-for-collector-full-image.results.GIT_REPO)",
-            "revision": "$(tasks.wait-for-collector-full-image.results.GIT_REF)"
+            "containerImage": "$(params.collector-full-image-build-repo)@$(tasks.wait-for-collector-image.results.IMAGE_DIGEST)",
+            "repository": "$(tasks.wait-for-collector-image.results.GIT_REPO)",
+            "revision": "$(tasks.wait-for-collector-image.results.GIT_REF)"
           },
           {
             "name": "collector-slim",

--- a/scripts/ci/jobs/check-konflux-pipelines.sh
+++ b/scripts/ci/jobs/check-konflux-pipelines.sh
@@ -49,7 +49,7 @@ The actual COMPONENTS contents do not match the expectations.
 To resolve:
 
 1. Open ${pipeline_path} and locate the ${task_name} task
-2. Update the COMPONENTS parameter of this task to include entries for the missing components or remove references to deprecated components. COMPONENTS should include entries for (sorted alphabetically):
+2. Update the COMPONENTS parameter of this task to include entries for the missing components or delete references to removed components. COMPONENTS should include entries for (sorted alphabetically):
 
 ${expected_components}
         "

--- a/scripts/ci/jobs/check-konflux-pipelines.sh
+++ b/scripts/ci/jobs/check-konflux-pipelines.sh
@@ -67,7 +67,7 @@ ensure_create_snapshot_runs_last || { echo "ensure_create_snapshot_runs_last" >>
 check_all_components_part_of_custom_snapshot || { echo "check_all_components_part_of_custom_snapshot" >> "${FAIL_FLAG}"; }
 
 if [[ -s "$FAIL_FLAG" ]]; then
-    echo "ERROR: Some Konflux pipeline consistency checks failed:"
-    cat "$FAIL_FLAG"
+    echo >&2 "ERROR: Some Konflux pipeline consistency checks failed:"
+    cat >&2 "$FAIL_FLAG"
     exit 1
 fi

--- a/scripts/ci/jobs/check-konflux-pipelines.sh
+++ b/scripts/ci/jobs/check-konflux-pipelines.sh
@@ -35,18 +35,6 @@ ${expected_runafter}
 check_all_components_part_of_custom_snapshot() {
     local pipeline_path=".tekton/operator-bundle-pipeline.yaml"
     local task_name="create-acs-style-snapshot"
-    # I realized one other thing.
-    # We check that create-acs-style-snapshot runs last but we don't have a check that all product's Components are passed to the Snapshot.
-    # Imagine when we introduce a new container. We'll add it to Helm charts, we'll add it to the Operator bundle but we may forget to add
-    # it to the Snapshot creation because not many folks besides us three know what Snapshots are and what role they play.
-
-    # I'd suggest to extend check-konflux-pipelines.sh to validate that.
-    # Maybe it's best to do in a follow-up PR/JIRA task to not delay this PR #13577 for even longer.
-    # Besides unwrapping a string from COMPONENTS value (YAML is a superset of JSON so I think yq can parse COMPONENTS raw value),
-    # the tricky thing is what to compare that to.
-    # I suggest that we can compare components names with wait-for-*-image tasks in the pipeline.
-    # The idea is that folks will likely remember to add the new image to the operator-bundle by the time of release and the
-    # check will remind them to include it in the Snapshot too.
 
     actual_components="$(yq '.spec.tasks[] | select(.name == '\"${task_name}\"') | .params[] | select(.name == "COMPONENTS") | .value' "${pipeline_path}" | yq '.[].name' | tr " " "\n" | sort)"
     expected_components_from_images="$(yq '.spec.tasks[] | select(.name == "wait-for-*-image") | .name | sub("(wait-for-|-image)", "")' .tekton/operator-bundle-pipeline.yaml)"

--- a/scripts/ci/jobs/check-konflux-pipelines.sh
+++ b/scripts/ci/jobs/check-konflux-pipelines.sh
@@ -5,11 +5,13 @@
 
 set -euo pipefail
 
+FAIL_FLAG="/tmp/fail"
+
 ensure_create_snapshot_runs_last() {
     local pipeline_path=".tekton/operator-bundle-pipeline.yaml"
     local task_name="create-acs-style-snapshot"
-    expected_runafter="$(yq eval '.spec.tasks[] | select(.name != '\"${task_name}\"') | .name' "${pipeline_path}" | sort)"
-    actual_runafter="$(yq eval '.spec.tasks[] | select(.name == '\"${task_name}\"') | .runAfter[]' "${pipeline_path}")"
+    expected_runafter="$(yq '.spec.tasks[] | select(.name != '\"${task_name}\"') | .name' "${pipeline_path}" | sort)"
+    actual_runafter="$(yq '.spec.tasks[] | select(.name == '\"${task_name}\"') | .runAfter[]' "${pipeline_path}")"
 
     echo "➤ ${pipeline_path} // checking ${task_name}: task's runAfter contents shall match the expected ones (left - expected, right - actual)."
     if ! diff --side-by-side <(echo "${expected_runafter}") <(echo "${actual_runafter}"); then
@@ -24,11 +26,57 @@ To resolve:
 
 ${expected_runafter}
         "
-        exit 1
+        return 1
+    else
+        echo "✓ No diff detected."
+    fi
+}
+
+check_all_components_part_of_custom_snapshot() {
+    local pipeline_path=".tekton/operator-bundle-pipeline.yaml"
+    local task_name="create-acs-style-snapshot"
+    # I realized one other thing.
+    # We check that create-acs-style-snapshot runs last but we don't have a check that all product's Components are passed to the Snapshot.
+    # Imagine when we introduce a new container. We'll add it to Helm charts, we'll add it to the Operator bundle but we may forget to add
+    # it to the Snapshot creation because not many folks besides us three know what Snapshots are and what role they play.
+
+    # I'd suggest to extend check-konflux-pipelines.sh to validate that.
+    # Maybe it's best to do in a follow-up PR/JIRA task to not delay this PR #13577 for even longer.
+    # Besides unwrapping a string from COMPONENTS value (YAML is a superset of JSON so I think yq can parse COMPONENTS raw value),
+    # the tricky thing is what to compare that to.
+    # I suggest that we can compare components names with wait-for-*-image tasks in the pipeline.
+    # The idea is that folks will likely remember to add the new image to the operator-bundle by the time of release and the
+    # check will remind them to include it in the Snapshot too.
+
+    actual_components="$(yq '.spec.tasks[] | select(.name == '\"${task_name}\"') | .params[] | select(.name == "COMPONENTS") | .value' "${pipeline_path}" | yq '.[].name' | tr " " "\n" | sort)"
+    expected_components_from_images="$(yq '.spec.tasks[] | select(.name == "wait-for-*-image") | .name | sub("(wait-for-|-image)", "")' .tekton/operator-bundle-pipeline.yaml)"
+    expected_components=$(echo "${expected_components_from_images} operator-bundle" | tr " " "\n" | sort)
+
+    echo "➤ ${pipeline_path} // checking ${task_name}: COMPONENTS contents shall include all ACS images (left - expected, right - actual)."
+    if ! diff --side-by-side <(echo "${expected_components}") <(echo "${actual_components}"); then
+        echo >&2 -e "
+✗ ERROR:
+
+The actual COMPONENTS contents do not match the expectations.
+To resolve:
+
+1. Open ${pipeline_path} and locate the ${task_name} task
+2. Update the COMPONENTS parameter of this task to include entries for the missing components or remove references to deprecated components. COMPONENTS should include entries for (sorted alphabetically):
+
+${expected_components}
+        "
+        return 1
     else
         echo "✓ No diff detected."
     fi
 }
 
 echo "Ensure consistency of our Konflux pipelines."
-ensure_create_snapshot_runs_last
+ensure_create_snapshot_runs_last || { echo "ensure_create_snapshot_runs_last" >> "${FAIL_FLAG}"; }
+check_all_components_part_of_custom_snapshot || { echo "check_all_components_part_of_custom_snapshot" >> "${FAIL_FLAG}"; }
+
+if [[ -e "$FAIL_FLAG" ]]; then
+    echo "ERROR: Some Konflux pipeline consistency checks failed:"
+    cat "$FAIL_FLAG"
+    exit 1
+fi

--- a/scripts/ci/jobs/check-konflux-pipelines.sh
+++ b/scripts/ci/jobs/check-konflux-pipelines.sh
@@ -36,7 +36,7 @@ check_all_components_part_of_custom_snapshot() {
     local pipeline_path=".tekton/operator-bundle-pipeline.yaml"
     local task_name="create-acs-style-snapshot"
 
-    actual_components="$(yq eval '.spec.tasks[] | select(.name == '\"${task_name}\"') | .params[] | select(.name == "COMPONENTS") | .value' "${pipeline_path}" | yq eval '.[].name' | tr " " "\n" | sort)"
+    actual_components="$(yq eval '.spec.tasks[] | select(.name == '\"${task_name}\"') | .params[] | select(.name == "COMPONENTS") | .value' "${pipeline_path}" | yq eval '.[].name' - | tr " " "\n" | sort)"
     expected_components_from_images="$(yq eval '.spec.tasks[] | select(.name == "wait-for-*-image") | .name | sub("(wait-for-|-image)", "")' .tekton/operator-bundle-pipeline.yaml)"
     expected_components=$(echo "${expected_components_from_images} operator-bundle" | tr " " "\n" | sort)
 

--- a/scripts/ci/jobs/check-konflux-pipelines.sh
+++ b/scripts/ci/jobs/check-konflux-pipelines.sh
@@ -10,8 +10,8 @@ FAIL_FLAG="/tmp/fail"
 ensure_create_snapshot_runs_last() {
     local pipeline_path=".tekton/operator-bundle-pipeline.yaml"
     local task_name="create-acs-style-snapshot"
-    expected_runafter="$(yq '.spec.tasks[] | select(.name != '\"${task_name}\"') | .name' "${pipeline_path}" | sort)"
-    actual_runafter="$(yq '.spec.tasks[] | select(.name == '\"${task_name}\"') | .runAfter[]' "${pipeline_path}")"
+    expected_runafter="$(yq eval '.spec.tasks[] | select(.name != '\"${task_name}\"') | .name' "${pipeline_path}" | sort)"
+    actual_runafter="$(yq eval '.spec.tasks[] | select(.name == '\"${task_name}\"') | .runAfter[]' "${pipeline_path}")"
 
     echo "➤ ${pipeline_path} // checking ${task_name}: task's runAfter contents shall match the expected ones (left - expected, right - actual)."
     if ! diff --side-by-side <(echo "${expected_runafter}") <(echo "${actual_runafter}"); then
@@ -36,8 +36,8 @@ check_all_components_part_of_custom_snapshot() {
     local pipeline_path=".tekton/operator-bundle-pipeline.yaml"
     local task_name="create-acs-style-snapshot"
 
-    actual_components="$(yq '.spec.tasks[] | select(.name == '\"${task_name}\"') | .params[] | select(.name == "COMPONENTS") | .value' "${pipeline_path}" | yq '.[].name' | tr " " "\n" | sort)"
-    expected_components_from_images="$(yq '.spec.tasks[] | select(.name == "wait-for-*-image") | .name | sub("(wait-for-|-image)", "")' .tekton/operator-bundle-pipeline.yaml)"
+    actual_components="$(yq eval '.spec.tasks[] | select(.name == '\"${task_name}\"') | .params[] | select(.name == "COMPONENTS") | .value' "${pipeline_path}" | yq eval '.[].name' | tr " " "\n" | sort)"
+    expected_components_from_images="$(yq eval '.spec.tasks[] | select(.name == "wait-for-*-image") | .name | sub("(wait-for-|-image)", "")' .tekton/operator-bundle-pipeline.yaml)"
     expected_components=$(echo "${expected_components_from_images} operator-bundle" | tr " " "\n" | sort)
 
     echo "➤ ${pipeline_path} // checking ${task_name}: COMPONENTS contents shall include all ACS images (left - expected, right - actual)."


### PR DESCRIPTION
### Description

Follow-up from https://github.com/stackrox/stackrox/pull/13577.
I renamed the `wait-for-collector-image` task to keep it in sync with the component name. 

Discussion point: `RELATED_IMAGE_COLLECTOR_FULL` - should it be renamed to `RELATED_IMAGE_COLLECTOR`?

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request)  is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

* Running the check script locally with invalid changes to the operator-bundle-pipeline, e.g. commenting out `wait-for-...-image`. Also https://github.com/stackrox/stackrox/actions/runs/12671318977/job/35312817486?pr=13748#step:10:39. 

* `operator-bundle-on-push` pipeline starts, so I assume that the renaming was successful.