### PR TITLE
ROX-27596: enables storage of external ips by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-25638: Introduce configurable log rotation. `ROX_LOGGING_MAX_ROTATION_FILES` and `ROX_LOGGING_MAX_SIZE_MB` variables allow for configuring the number and the size of a central log rotation file.
 - ROX-14332: Automatic service certificate renewal for Secured Clusters installed using Helm or operator.
 - Scanner V4 adds supports for openSUSE Leap 15.5 and 15.6
+- ROX-27596: ROX_EXTERNAL_IPS feature flag enabled by default. Note: Collector will still need to be configured for external IPs for this to have an effect.
 
 ### Removed Features
 

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -61,6 +61,8 @@ func (suite *FlowStoreUpdaterTestSuite) TearDownTest() {
 }
 
 func (suite *FlowStoreUpdaterTestSuite) TestUpdateNoExternalIPs() {
+	suite.T().Setenv(features.ExternalIPs.EnvVar(), "false")
+
 	firstTimestamp := time.Now()
 	storedFlows := []*storage.NetworkFlow{
 		{

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -103,7 +103,7 @@ var (
 	SensorPullSecretsByName = registerFeature("Sensor will capture pull secrets by name and registry host instead of just registry host", "ROX_SENSOR_PULL_SECRETS_BY_NAME", enabled)
 
 	// ExternalIPs enables storing detailed discovered external IPs
-	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS")
+	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS", enabled)
 
 	// NetworkGraphExternalIPs enables displaying external (discovered) entities in the network graph
 	NetworkGraphExternalIPs = registerFeature("Enables display of external IPs in the network graph UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")


### PR DESCRIPTION
### Description

Reverses existing ROX_EXTERNAL_IPS feature flag, which controls storage of discovered network entities, making it enabled by default.

This means that control over the feature is moved to Collector (via runtime configuration) but storage can be disabled at Central level if required.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
~- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

~- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag~
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

~- [ ] added unit tests~
~- [ ] added e2e tests~
~- [ ] added regression tests~
~- [ ] added compatibility tests~
~- [ ] modified existing tests~

Trivial change, existing testing should be enough.

#### How I validated my change

CI should be enough.
