### PR TITLE
chore(ui): Add link fixes for NS view and VM dashboard image page

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.js
@@ -18,6 +18,7 @@ import CvesByCvssScore from 'Containers/VulnMgmt/widgets/CvesByCvssScore';
 import entityTypes from 'constants/entityTypes';
 import DateTimeField from 'Components/DateTimeField';
 import { entityToColumns } from 'constants/listColumns';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import { entityGridContainerClassName } from '../WorkflowEntityPage';
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
@@ -43,6 +44,8 @@ const emptyImage = {
 };
 
 const VulnMgmtImageOverview = ({ data, entityContext }) => {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isPlatformCveSplitEnabled = isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT');
     // guard against incomplete GraphQL-cached data
     const safeData = { ...emptyImage, ...data };
     const { metadata, scan, topVuln, priority, notes } = safeData;
@@ -171,14 +174,16 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                             isInline
                             title={
                                 <>
-                                    View this image{' '}
+                                    View this image in{' '}
                                     <Button
                                         component={LinkShim}
                                         variant="link"
-                                        href={`${vulnerabilitiesWorkloadCvesPath}${getWorkloadEntityPagePath('Image', data.id)}`}
+                                        href={`${vulnerabilitiesWorkloadCvesPath}/${getWorkloadEntityPagePath('Image', data.id)}`}
                                         isInline
                                     >
-                                        in Workload CVEs
+                                        {isPlatformCveSplitEnabled
+                                            ? 'User Workloads'
+                                            : 'Workload CVEs'}
                                     </Button>{' '}
                                     for a detailed breakdown of detected vulnerabilities
                                 </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { pluralize } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
-import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { getQueryString } from 'utils/queryStringUtils';
 
 export type DeploymentFilterLinkProps = {
     deploymentCount: number;
     namespaceName: string;
     clusterName: string;
+    vulnMgmtBaseUrl: string;
 };
 
-function DeploymentFilterLink({ deploymentCount, namespaceName, clusterName }) {
+function DeploymentFilterLink({ deploymentCount, namespaceName, clusterName, vulnMgmtBaseUrl }) {
     const query = getQueryString({
         vulnerabilityState: 'OBSERVED',
         entityTab: 'Deployment',
@@ -21,9 +21,7 @@ function DeploymentFilterLink({ deploymentCount, namespaceName, clusterName }) {
         },
     });
     return (
-        <Link to={`${vulnerabilitiesWorkloadCvesPath}${query}`}>
-            {pluralize(deploymentCount, 'deployment')}
-        </Link>
+        <Link to={`${vulnMgmtBaseUrl}${query}`}>{pluralize(deploymentCount, 'deployment')}</Link>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -105,7 +105,7 @@ const pollInterval = 30000;
 function NamespaceViewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
-    const { pageTitle, baseSearchFilter } = useWorkloadCveViewContext();
+    const { pageTitle, baseSearchFilter, getAbsoluteUrl } = useWorkloadCveViewContext();
     const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter({
         ...baseSearchFilter,
@@ -272,6 +272,7 @@ function NamespaceViewPage() {
                                                     deploymentCount={deploymentCount}
                                                     namespaceName={name}
                                                     clusterName={clusterName}
+                                                    vulnMgmtBaseUrl={getAbsoluteUrl('')}
                                                 />
                                             </Td>
                                             <Td dataLabel="Labels">


### PR DESCRIPTION
### Description

1. Fixes the broken link in VM 1.0 Dashboard to point to User Workloads (this does not have an answer for if the image belongs to a platform component at this point...)
2. Fixes the deployments link in the Namespace view to keep the user within the correct page

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. Visit VM 1.0 Dashboard -> Image Single
![image](https://github.com/user-attachments/assets/d9e073f7-e47b-438d-82ff-d6dce5b2173c)
![image](https://github.com/user-attachments/assets/f2eff93a-5fbd-410c-b9a8-5a2e9d93db0d)

2. Ensure the NS view deployments link is relative to the top level VM page
![image](https://github.com/user-attachments/assets/42e25905-0ebc-4f53-9b1b-657e94f7bd82)
![image](https://github.com/user-attachments/assets/e62055d1-41be-4d19-920b-3c6e443b7971)
![image](https://github.com/user-attachments/assets/04364a6d-47a4-455d-af68-841819da4c37)
![image](https://github.com/user-attachments/assets/e5f39bb1-bba0-4be8-9691-c7f87ff56c4d)


