### PR TITLE
ROX-24530: let Konflux images expire after 13w

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -35,8 +35,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    # TODO(ROX-24530): return expiration for non-released images to 13w
-    value: '52w'
+    value: '13w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/central-db
   - name: path-context

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -35,8 +35,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    # TODO(ROX-24530): return expiration for non-released images to 13w
-    value: '52w'
+    value: '13w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/main
   - name: path-context

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -35,8 +35,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    # TODO(ROX-24530): return expiration for non-released images to 13w
-    value: '52w'
+    value: '13w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/stackrox-operator
   - name: path-context

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -34,9 +34,8 @@ spec:
     value: operator/konflux.bundle.Dockerfile
   - name: git-url
     value: '{{source_url}}'
-  # TODO(ROX-24530): return expiration for non-released images to 13w
   - name: image-expires-after
-    value: '52w'
+    value: '13w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/stackrox-operator-bundle
   - name: revision

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -35,8 +35,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    # TODO(ROX-24530): return expiration for non-released images to 13w
-    value: '52w'
+    value: '13w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/roxctl
   - name: path-context

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -35,8 +35,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    # TODO(ROX-24530): return expiration for non-released images to 13w
-    value: '52w'
+    value: '13w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/scanner-v4
   - name: path-context

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -35,8 +35,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    # TODO(ROX-24530): return expiration for non-released images to 13w
-    value: '52w'
+    value: '13w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/scanner-v4-db
   - name: path-context


### PR DESCRIPTION
### Description

Context: https://issues.redhat.com/browse/ROX-24530

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. Finding [central-db image built on Konflux](https://console.redhat.com/application-pipeline/ns/rh-acs-tenant/pipelinerun/central-db-on-push-kslg7): `quay.io/rhacs-eng/central-db:4.7.x-385-g4ddf2f0459-fast`
2. `docker create --name expiration-check quay.io/rhacs-eng/central-db:4.7.x-385-g4ddf2f0459-fast`
3. `docker inspect expiration-check | jq -r '.[0].Config.Labels["quay.expires-after"]'` -> `13w`

