### PR TITLE
ROX-27604: Add support for inactive images in User Workloads view

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -33,8 +33,13 @@ function WorkloadCvesPage({ view }: WorkloadCvePageProps) {
 
     const context = useMemo(() => {
         const pageTitle = 'Workload CVEs'; // TODO Implement throughout in follow up
+        const platformComponentFilters =
+            view === 'platform-workload'
+                ? ['true']
+                : // The '-' filter is used to include inactive images in the "user-workload" view
+                  ['false', '-'];
         const baseSearchFilter = isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
-            ? { 'Platform Component': [String(view === 'platform-workload')] }
+            ? { 'Platform Component': platformComponentFilters }
             : {};
         const getAbsoluteUrl = (subPath: string) =>
             view === 'platform-workload'


### PR DESCRIPTION
### Description

Adds an additional parameter `'-'` to requests on the User workloads page so that the results are a union of entities with "Platform component:false" and "Platform component:NULL". This results in inactive images, such as watched images, being visible in the list.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Add an image to the watch list that is **not** part of an existing deployment.

Before this change, the image will not be included in the User workloads images list:
![image](https://github.com/user-attachments/assets/0c5b42f5-0efd-4b19-902a-2756fb96765d)

After this change, the images list will be updated to include any images that are not part of an existing deployment (e.g. watched images):
![image](https://github.com/user-attachments/assets/e1a29449-ed9a-47b8-90c7-3113ea8a72c5)

