### PR TITLE
ROX-27279: Disable SBOM Generation UI when image has scan notes

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -31,7 +31,9 @@ import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 import useURLPagination from 'hooks/useURLPagination';
 
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
-import GenerateSbomModal from '../../components/GenerateSbomModal';
+import GenerateSbomModal, {
+    getSbomGenerationStatusMessage,
+} from '../../components/GenerateSbomModal';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import useHasGenerateSbomAbility from '../../hooks/useHasGenerateSBOMAbility';
@@ -63,8 +65,17 @@ export const imageDetailsQuery = gql`
     }
 `;
 
-function ScannerV4RequiredTooltip({ children }: { children: ReactElement }) {
-    return <Tooltip content="SBOM generation requires Scanner V4">{children}</Tooltip>;
+function GenerateSbomButtonTooltip({
+    children,
+    message,
+}: {
+    children: ReactElement;
+    message?: string;
+}) {
+    if (!message) {
+        return children;
+    }
+    return <Tooltip content={message}>{children}</Tooltip>;
 }
 
 function ImagePage() {
@@ -104,6 +115,7 @@ function ImagePage() {
             ? `${imageName.registry}/${getImageBaseNameDisplay(imageData.id, imageName)}`
             : 'NAME UNKNOWN';
     const scanMessage = getImageScanMessage(imageData?.notes || [], imageData?.scanNotes || []);
+    const hasScanMessage = !isEmpty(scanMessage);
 
     const workloadCveOverviewImagePath = getAbsoluteUrl(
         getOverviewPagePath('Workload', {
@@ -128,7 +140,6 @@ function ImagePage() {
             </PageSection>
         );
     } else {
-        const SbomButtonWrapper = isScannerV4Enabled ? React.Fragment : ScannerV4RequiredTooltip;
         const sha = imageData?.id;
         mainContent = (
             <>
@@ -158,17 +169,24 @@ function ImagePage() {
                                 </Flex>
                                 {hasGenerateSbomAbility && (
                                     <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-                                        <SbomButtonWrapper>
+                                        <GenerateSbomButtonTooltip
+                                            message={getSbomGenerationStatusMessage({
+                                                isScannerV4Enabled,
+                                                hasScanMessage,
+                                            })}
+                                        >
                                             <Button
                                                 variant="secondary"
                                                 onClick={() => {
                                                     setSbomTargetImage(imageData.name?.fullName);
                                                 }}
-                                                isAriaDisabled={!isScannerV4Enabled}
+                                                isAriaDisabled={
+                                                    !isScannerV4Enabled || hasScanMessage
+                                                }
                                             >
                                                 Generate SBOM
                                             </Button>
-                                        </SbomButtonWrapper>
+                                        </GenerateSbomButtonTooltip>
                                         {sbomTargetImage && (
                                             <GenerateSbomModal
                                                 onClose={() => setSbomTargetImage(undefined)}
@@ -178,7 +196,7 @@ function ImagePage() {
                                     </FlexItem>
                                 )}
                             </Flex>
-                            {!isEmpty(scanMessage) && (
+                            {hasScanMessage && (
                                 <Alert
                                     className="pf-v5-u-w-100"
                                     variant="warning"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -65,7 +65,7 @@ export const imageDetailsQuery = gql`
     }
 `;
 
-function GenerateSbomButtonTooltip({
+function OptionalSbomButtonTooltip({
     children,
     message,
 }: {
@@ -169,7 +169,7 @@ function ImagePage() {
                                 </Flex>
                                 {hasGenerateSbomAbility && (
                                     <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-                                        <GenerateSbomButtonTooltip
+                                        <OptionalSbomButtonTooltip
                                             message={getSbomGenerationStatusMessage({
                                                 isScannerV4Enabled,
                                                 hasScanMessage,
@@ -186,7 +186,7 @@ function ImagePage() {
                                             >
                                                 Generate SBOM
                                             </Button>
-                                        </GenerateSbomButtonTooltip>
+                                        </OptionalSbomButtonTooltip>
                                         {sbomTargetImage && (
                                             <GenerateSbomModal
                                                 onClose={() => setSbomTargetImage(undefined)}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabelLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabelLayout.tsx
@@ -1,27 +1,16 @@
 import React from 'react';
 import { Button, Flex, FlexItem, Label, Popover } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import isEmpty from 'lodash/isEmpty';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 
-import getImageScanMessage from '../utils/getImageScanMessage';
+import { ScanMessage } from 'messages/vulnMgmt.messages';
 
 export type ImageScanningIncompleteLabelProps = {
-    imageNotes: string[];
-    scanNotes: string[];
+    scanMessage: ScanMessage;
 };
 
-function ImageScanningIncompleteLabel({
-    imageNotes,
-    scanNotes,
-}: ImageScanningIncompleteLabelProps) {
-    const scanMessage = getImageScanMessage(imageNotes, scanNotes);
-
-    if (isEmpty(scanMessage)) {
-        return null;
-    }
-
+function ImageScanningIncompleteLabel({ scanMessage }: ImageScanningIncompleteLabelProps) {
     return (
         <>
             <Popover

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -17,6 +17,24 @@ import useAnalytics, { IMAGE_SBOM_GENERATED } from 'hooks/useAnalytics';
 import useRestMutation from 'hooks/useRestMutation';
 import { generateAndSaveSbom } from 'services/ImageSbomService';
 
+export function getSbomGenerationStatusMessage({
+    isScannerV4Enabled,
+    hasScanMessage,
+}: {
+    isScannerV4Enabled: boolean;
+    hasScanMessage: boolean;
+}): string | undefined {
+    if (!isScannerV4Enabled) {
+        return 'SBOM generation requires Scanner V4';
+    }
+
+    if (hasScanMessage) {
+        return 'SBOM generation is unavailable due to incomplete scan data';
+    }
+
+    return undefined;
+}
+
 export type GenerateSbomModalProps = {
     onClose: () => void;
     imageName: string;


### PR DESCRIPTION
### Description

If image or scan notes are present, disable SBOM Generation in the UI.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit an image with displayed scan notes and attempt to generate SBOM:
![image](https://github.com/user-attachments/assets/3688d0e7-447d-434f-8220-c4e16438584e)
![image](https://github.com/user-attachments/assets/d124ab3f-b00e-4131-aec3-12de7dab48b6)

Successfully scanned images are unaffected:
![image](https://github.com/user-attachments/assets/450314fa-8a1c-446a-b93c-90e7b7da11d6)
![image](https://github.com/user-attachments/assets/cc6a62b4-4dff-4132-aa3f-a16d4ac3cbfe)

