### PR TITLE
ROX-26659: Adding 'active' parameter to alert datastore/searcher

### DIFF
--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -88,7 +88,7 @@ func BenchmarkAlertDatabaseOps(b *testing.B) {
 }
 
 func runSearchAndGroupResults(ctx context.Context, t testing.TB, datastore DataStore, query *v1.Query, expected []*violationsBySeverity) {
-	results, err := datastore.Search(ctx, query)
+	results, err := datastore.Search(ctx, query, true)
 	require.NoError(t, err)
 	require.NotNil(t, results)
 
@@ -109,7 +109,7 @@ func runSearchAndGroupResults(ctx context.Context, t testing.TB, datastore DataS
 }
 
 func runSearch(ctx context.Context, t testing.TB, datastore DataStore, query *v1.Query) {
-	results, err := datastore.Search(ctx, query)
+	results, err := datastore.Search(ctx, query, true)
 	require.NoError(t, err)
 	require.NotNil(t, results)
 }

--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -115,7 +115,7 @@ func runSearch(ctx context.Context, t testing.TB, datastore DataStore, query *v1
 }
 
 func runSearchListAlerts(ctx context.Context, t testing.TB, datastore DataStore, expected []*violationsBySeverity) {
-	results, err := datastore.SearchListAlerts(ctx, pkgSearch.EmptyQuery())
+	results, err := datastore.SearchListAlerts(ctx, pkgSearch.EmptyQuery(), true)
 	require.NoError(t, err)
 	require.NotNil(t, results)
 

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -24,10 +24,8 @@ var (
 //
 //go:generate mockgen-wrapper
 type DataStore interface {
-	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)
-	SearchActive(ctx context.Context, q *v1.Query, excludeResolved bool) ([]searchPkg.Result, error)
-	Count(ctx context.Context, q *v1.Query) (int, error)
-	CountActive(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)
+	Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]searchPkg.Result, error)
+	Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
 	SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error)

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -25,10 +25,12 @@ var (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)
+	SearchActive(ctx context.Context, q *v1.Query, active bool) ([]searchPkg.Result, error)
 	Count(ctx context.Context, q *v1.Query) (int, error)
+	CountActive(ctx context.Context, q *v1.Query, active bool) (int, error)
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
-	SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error)
+	SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error)
 
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
 	WalkByQuery(ctx context.Context, q *v1.Query, db func(d *storage.Alert) error) error

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -25,12 +25,12 @@ var (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)
-	SearchActive(ctx context.Context, q *v1.Query, active bool) ([]searchPkg.Result, error)
+	SearchActive(ctx context.Context, q *v1.Query, excludeResolved bool) ([]searchPkg.Result, error)
 	Count(ctx context.Context, q *v1.Query) (int, error)
-	CountActive(ctx context.Context, q *v1.Query, active bool) (int, error)
+	CountActive(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
-	SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error)
+	SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error)
 
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
 	WalkByQuery(ctx context.Context, q *v1.Query, db func(d *storage.Alert) error) error

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -27,7 +27,7 @@ type DataStore interface {
 	Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]searchPkg.Result, error)
 	Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
-	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
+	SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error)
 	SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error)
 
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -55,19 +55,6 @@ func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query, excludeResolved
 	return ds.searcher.Count(ctx, q, excludeResolved)
 }
 
-// DefaultStateAlertDataStoreImpl will only return unresolved alerts unless Violation State=Resolved is explicitly provided by the query
-type DefaultStateAlertDataStoreImpl struct {
-	DataStore *DataStore
-}
-
-func (ds *DefaultStateAlertDataStoreImpl) Search(ctx context.Context, q *v1.Query) ([]searchCommon.Result, error) {
-	return (*ds.DataStore).Search(ctx, q, true)
-}
-
-func (ds *DefaultStateAlertDataStoreImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
-	return (*ds.DataStore).Count(ctx, q, true)
-}
-
 func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "SearchListAlerts")
 
@@ -318,4 +305,17 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 		})
 	}
 	return pgutils.RetryIfPostgres(ctx, walkFn)
+}
+
+// DefaultStateAlertDataStoreImpl will only return unresolved alerts unless Violation State=Resolved is explicitly provided by the query
+type DefaultStateAlertDataStoreImpl struct {
+	DataStore *DataStore
+}
+
+func (ds *DefaultStateAlertDataStoreImpl) Search(ctx context.Context, q *v1.Query) ([]searchCommon.Result, error) {
+	return (*ds.DataStore).Search(ctx, q, true)
+}
+
+func (ds *DefaultStateAlertDataStoreImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
+	return (*ds.DataStore).Count(ctx, q, true)
 }

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -61,7 +61,7 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 	return ds.searcher.SearchListAlerts(ctx, q, excludeResolved)
 }
 
-// SearchAlerts returns search results for the given request.
+// SearchAlerts returns search results for the given request. This will exclude resolved alerts by default unless Violation State = Resolved is explicitly specified in the query
 func (ds *datastoreImpl) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "SearchAlerts")
 

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -43,22 +43,30 @@ type datastoreImpl struct {
 }
 
 func (ds *datastoreImpl) Search(ctx context.Context, q *v1.Query) ([]searchCommon.Result, error) {
+	return ds.SearchActive(ctx, q, true)
+}
+
+func (ds *datastoreImpl) SearchActive(ctx context.Context, q *v1.Query, active bool) ([]searchCommon.Result, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "Search")
 
-	return ds.searcher.Search(ctx, q)
+	return ds.searcher.Search(ctx, q, active)
 }
 
 // Count returns the number of search results from the query
 func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
-	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "Count")
-
-	return ds.searcher.Count(ctx, q)
+	return ds.CountActive(ctx, q, true)
 }
 
-func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error) {
+func (ds *datastoreImpl) CountActive(ctx context.Context, q *v1.Query, active bool) (int, error) {
+	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "Count")
+
+	return ds.searcher.Count(ctx, q, active)
+}
+
+func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "SearchListAlerts")
 
-	return ds.searcher.SearchListAlerts(ctx, q)
+	return ds.searcher.SearchListAlerts(ctx, q, active)
 }
 
 // SearchAlerts returns search results for the given request.

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -46,10 +46,10 @@ func (ds *datastoreImpl) Search(ctx context.Context, q *v1.Query) ([]searchCommo
 	return ds.SearchActive(ctx, q, true)
 }
 
-func (ds *datastoreImpl) SearchActive(ctx context.Context, q *v1.Query, active bool) ([]searchCommon.Result, error) {
+func (ds *datastoreImpl) SearchActive(ctx context.Context, q *v1.Query, excludeResolved bool) ([]searchCommon.Result, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "Search")
 
-	return ds.searcher.Search(ctx, q, active)
+	return ds.searcher.Search(ctx, q, excludeResolved)
 }
 
 // Count returns the number of search results from the query
@@ -57,16 +57,16 @@ func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	return ds.CountActive(ctx, q, true)
 }
 
-func (ds *datastoreImpl) CountActive(ctx context.Context, q *v1.Query, active bool) (int, error) {
+func (ds *datastoreImpl) CountActive(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "Count")
 
-	return ds.searcher.Count(ctx, q, active)
+	return ds.searcher.Count(ctx, q, excludeResolved)
 }
 
-func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error) {
+func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "SearchListAlerts")
 
-	return ds.searcher.SearchListAlerts(ctx, q, active)
+	return ds.searcher.SearchListAlerts(ctx, q, excludeResolved)
 }
 
 // SearchAlerts returns search results for the given request.

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -55,7 +55,7 @@ func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query, excludeResolved
 	return ds.searcher.Count(ctx, q, excludeResolved)
 }
 
-// DefaultStateAlertDataStoreImpl will always return unresolved alerts unless Violation State=Resolved is explicitly provided by the query
+// DefaultStateAlertDataStoreImpl will only return unresolved alerts unless Violation State=Resolved is explicitly provided by the query
 type DefaultStateAlertDataStoreImpl struct {
 	DataStore *DataStore
 }
@@ -82,10 +82,10 @@ func (ds *datastoreImpl) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.S
 }
 
 // SearchRawAlerts returns search results for the given request in the form of a slice of alerts.
-func (ds *datastoreImpl) SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
+func (ds *datastoreImpl) SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "SearchRawAlerts")
 
-	return ds.searcher.SearchRawAlerts(ctx, q)
+	return ds.searcher.SearchRawAlerts(ctx, q, excludeResolved)
 }
 
 // GetAlert returns an alert by id.

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -55,6 +55,7 @@ func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query, excludeResolved
 	return ds.searcher.Count(ctx, q, excludeResolved)
 }
 
+// DefaultStateAlertDataStoreImpl will always return unresolved alerts unless Violation State=Resolved is explicitly provided by the query
 type DefaultStateAlertDataStoreImpl struct {
 	DataStore *DataStore
 }

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -497,7 +497,7 @@ func (s *alertDatastoreSACTestSuite) TestAlertUnrestrictedSearch() {
 
 func (s *alertDatastoreSACTestSuite) runCountTest(testparams alertSACSearchResult) {
 	ctx := s.testContexts[testparams.scopeKey]
-	resultCount, err := s.datastore.Count(ctx, nil)
+	resultCount, err := s.datastore.Count(ctx, nil, true)
 	s.NoError(err)
 	expectedResultCount := testutils.AggregateCounts(s.T(), testparams.resultCounts)
 	s.Equal(expectedResultCount, resultCount)

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -595,7 +595,7 @@ func countListAlertsResultsPerClusterAndNamespace(results []*storage.ListAlert) 
 
 func (s *alertDatastoreSACTestSuite) runSearchListAlertsTest(testparams alertSACSearchResult) {
 	ctx := s.testContexts[testparams.scopeKey]
-	searchResults, err := s.datastore.SearchListAlerts(ctx, nil)
+	searchResults, err := s.datastore.SearchListAlerts(ctx, nil, true)
 	s.NoError(err)
 	resultsDistribution := countListAlertsResultsPerClusterAndNamespace(searchResults)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testparams.resultCounts, resultsDistribution)
@@ -619,7 +619,7 @@ func (s *alertDatastoreSACTestSuite) TestAlertUnrestrictedSearchListAlerts() {
 
 func (s *alertDatastoreSACTestSuite) runListAlertsTest(testparams alertSACSearchResult) {
 	ctx := s.testContexts[testparams.scopeKey]
-	searchResults, err := s.datastore.SearchListAlerts(ctx, searchPkg.EmptyQuery())
+	searchResults, err := s.datastore.SearchListAlerts(ctx, searchPkg.EmptyQuery(), true)
 	s.NoError(err)
 	resultsDistribution := countListAlertsResultsPerClusterAndNamespace(searchResults)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testparams.resultCounts, resultsDistribution)

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -466,7 +466,7 @@ var alertUnrestrictedSACObjectSearchTestCases = map[string]alertSACSearchResult{
 
 func (s *alertDatastoreSACTestSuite) runSearchTest(testparams alertSACSearchResult) {
 	ctx := s.testContexts[testparams.scopeKey]
-	searchResults, err := s.datastore.Search(ctx, nil)
+	searchResults, err := s.datastore.Search(ctx, nil, true)
 	s.NoError(err)
 	results := make([]sac.NamespaceScopedObject, 0, len(searchResults))
 	for _, r := range searchResults {

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -671,7 +671,7 @@ func countSearchRawAlertsResultsPerClusterAndNamespace(results []*storage.Alert)
 
 func (s *alertDatastoreSACTestSuite) runSearchRawAlertsTest(testparams alertSACSearchResult) {
 	ctx := s.testContexts[testparams.scopeKey]
-	searchResults, err := s.datastore.SearchRawAlerts(ctx, nil)
+	searchResults, err := s.datastore.SearchRawAlerts(ctx, nil, true)
 	s.NoError(err)
 	resultsDistribution := countSearchRawAlertsResultsPerClusterAndNamespace(searchResults)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testparams.resultCounts, resultsDistribution)

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -82,7 +82,7 @@ func (s *alertDataStoreTestSuite) TestSearchRawAlerts() {
 func (s *alertDataStoreTestSuite) TestSearchListAlerts() {
 	s.searcher.EXPECT().SearchListAlerts(s.hasReadCtx, &v1.Query{}).Return(alerttest.NewFakeListAlertSlice(), errFake)
 
-	result, err := s.dataStore.SearchListAlerts(s.hasReadCtx, &v1.Query{})
+	result, err := s.dataStore.SearchListAlerts(s.hasReadCtx, &v1.Query{}, true)
 
 	s.Equal(errFake, err)
 	protoassert.SlicesEqual(s.T(), alerttest.NewFakeListAlertSlice(), result)

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -80,7 +80,7 @@ func (s *alertDataStoreTestSuite) TestSearchRawAlerts() {
 }
 
 func (s *alertDataStoreTestSuite) TestSearchListAlerts() {
-	s.searcher.EXPECT().SearchListAlerts(s.hasReadCtx, &v1.Query{}).Return(alerttest.NewFakeListAlertSlice(), errFake)
+	s.searcher.EXPECT().SearchListAlerts(s.hasReadCtx, &v1.Query{}, true).Return(alerttest.NewFakeListAlertSlice(), errFake)
 
 	result, err := s.dataStore.SearchListAlerts(s.hasReadCtx, &v1.Query{}, true)
 
@@ -90,7 +90,7 @@ func (s *alertDataStoreTestSuite) TestSearchListAlerts() {
 
 func (s *alertDataStoreTestSuite) TestCountAlerts_Success() {
 	expectedQ := search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
-	s.searcher.EXPECT().Count(s.hasReadCtx, expectedQ).Return(1, nil)
+	s.searcher.EXPECT().Count(s.hasReadCtx, expectedQ, true).Return(1, nil)
 
 	result, err := s.dataStore.CountAlerts(s.hasReadCtx)
 
@@ -100,7 +100,7 @@ func (s *alertDataStoreTestSuite) TestCountAlerts_Success() {
 
 func (s *alertDataStoreTestSuite) TestCountAlerts_Error() {
 	expectedQ := search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()
-	s.searcher.EXPECT().Count(s.hasReadCtx, expectedQ).Return(0, errFake)
+	s.searcher.EXPECT().Count(s.hasReadCtx, expectedQ, true).Return(0, errFake)
 
 	_, err := s.dataStore.CountAlerts(s.hasReadCtx)
 

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -71,9 +71,9 @@ func (s *alertDataStoreTestSuite) TestSearchAlerts() {
 }
 
 func (s *alertDataStoreTestSuite) TestSearchRawAlerts() {
-	s.searcher.EXPECT().SearchRawAlerts(s.hasReadCtx, &v1.Query{}).Return([]*storage.Alert{{Id: alerttest.FakeAlertID}}, errFake)
+	s.searcher.EXPECT().SearchRawAlerts(s.hasReadCtx, &v1.Query{}, true).Return([]*storage.Alert{{Id: alerttest.FakeAlertID}}, errFake)
 
-	result, err := s.dataStore.SearchRawAlerts(s.hasReadCtx, &v1.Query{})
+	result, err := s.dataStore.SearchRawAlerts(s.hasReadCtx, &v1.Query{}, true)
 
 	s.Equal(errFake, err)
 	protoassert.SlicesEqual(s.T(), []*storage.Alert{{Id: alerttest.FakeAlertID}}, result)

--- a/central/alert/datastore/internal/search/mocks/searcher.go
+++ b/central/alert/datastore/internal/search/mocks/searcher.go
@@ -44,63 +44,63 @@ func (m *MockSearcher) EXPECT() *MockSearcherMockRecorder {
 }
 
 // Count mocks base method.
-func (m *MockSearcher) Count(ctx context.Context, q *v1.Query) (int, error) {
+func (m *MockSearcher) Count(ctx context.Context, q *v1.Query, active bool) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Count", ctx, q)
+	ret := m.ctrl.Call(m, "Count", ctx, q, active)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Count indicates an expected call of Count.
-func (mr *MockSearcherMockRecorder) Count(ctx, q any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) Count(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockSearcher)(nil).Count), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockSearcher)(nil).Count), ctx, q, active)
 }
 
 // Search mocks base method.
-func (m *MockSearcher) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
+func (m *MockSearcher) Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, q)
+	ret := m.ctrl.Call(m, "Search", ctx, q, active)
 	ret0, _ := ret[0].([]search.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockSearcherMockRecorder) Search(ctx, q any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) Search(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockSearcher)(nil).Search), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockSearcher)(nil).Search), ctx, q, active)
 }
 
 // SearchAlerts mocks base method.
 func (m *MockSearcher) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q)
+	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q, active)
 	ret0, _ := ret[0].([]*v1.SearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchAlerts indicates an expected call of SearchAlerts.
-func (mr *MockSearcherMockRecorder) SearchAlerts(ctx, q any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) SearchAlerts(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchAlerts), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchAlerts), ctx, q, active)
 }
 
 // SearchListAlerts mocks base method.
-func (m *MockSearcher) SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error) {
+func (m *MockSearcher) SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q)
+	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q, active)
 	ret0, _ := ret[0].([]*storage.ListAlert)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchListAlerts indicates an expected call of SearchListAlerts.
-func (mr *MockSearcherMockRecorder) SearchListAlerts(ctx, q any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) SearchListAlerts(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchListAlerts), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchListAlerts), ctx, q, active)
 }
 
 // SearchRawAlerts mocks base method.

--- a/central/alert/datastore/internal/search/mocks/searcher.go
+++ b/central/alert/datastore/internal/search/mocks/searcher.go
@@ -104,16 +104,16 @@ func (mr *MockSearcherMockRecorder) SearchListAlerts(ctx, q, excludeResolved any
 }
 
 // SearchRawAlerts mocks base method.
-func (m *MockSearcher) SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
+func (m *MockSearcher) SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchRawAlerts", ctx, q)
+	ret := m.ctrl.Call(m, "SearchRawAlerts", ctx, q, excludeResolved)
 	ret0, _ := ret[0].([]*storage.Alert)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchRawAlerts indicates an expected call of SearchRawAlerts.
-func (mr *MockSearcherMockRecorder) SearchRawAlerts(ctx, q any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) SearchRawAlerts(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchRawAlerts), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchRawAlerts), ctx, q, excludeResolved)
 }

--- a/central/alert/datastore/internal/search/mocks/searcher.go
+++ b/central/alert/datastore/internal/search/mocks/searcher.go
@@ -76,16 +76,16 @@ func (mr *MockSearcherMockRecorder) Search(ctx, q, active any) *gomock.Call {
 // SearchAlerts mocks base method.
 func (m *MockSearcher) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q, active)
+	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q)
 	ret0, _ := ret[0].([]*v1.SearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchAlerts indicates an expected call of SearchAlerts.
-func (mr *MockSearcherMockRecorder) SearchAlerts(ctx, q, active any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) SearchAlerts(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchAlerts), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchAlerts), ctx, q)
 }
 
 // SearchListAlerts mocks base method.

--- a/central/alert/datastore/internal/search/mocks/searcher.go
+++ b/central/alert/datastore/internal/search/mocks/searcher.go
@@ -44,33 +44,33 @@ func (m *MockSearcher) EXPECT() *MockSearcherMockRecorder {
 }
 
 // Count mocks base method.
-func (m *MockSearcher) Count(ctx context.Context, q *v1.Query, active bool) (int, error) {
+func (m *MockSearcher) Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Count", ctx, q, active)
+	ret := m.ctrl.Call(m, "Count", ctx, q, excludeResolved)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Count indicates an expected call of Count.
-func (mr *MockSearcherMockRecorder) Count(ctx, q, active any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) Count(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockSearcher)(nil).Count), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockSearcher)(nil).Count), ctx, q, excludeResolved)
 }
 
 // Search mocks base method.
-func (m *MockSearcher) Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
+func (m *MockSearcher) Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, q, active)
+	ret := m.ctrl.Call(m, "Search", ctx, q, excludeResolved)
 	ret0, _ := ret[0].([]search.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockSearcherMockRecorder) Search(ctx, q, active any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) Search(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockSearcher)(nil).Search), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockSearcher)(nil).Search), ctx, q, excludeResolved)
 }
 
 // SearchAlerts mocks base method.
@@ -89,18 +89,18 @@ func (mr *MockSearcherMockRecorder) SearchAlerts(ctx, q any) *gomock.Call {
 }
 
 // SearchListAlerts mocks base method.
-func (m *MockSearcher) SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error) {
+func (m *MockSearcher) SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q, active)
+	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q, excludeResolved)
 	ret0, _ := ret[0].([]*storage.ListAlert)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchListAlerts indicates an expected call of SearchListAlerts.
-func (mr *MockSearcherMockRecorder) SearchListAlerts(ctx, q, active any) *gomock.Call {
+func (mr *MockSearcherMockRecorder) SearchListAlerts(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchListAlerts), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockSearcher)(nil).SearchListAlerts), ctx, q, excludeResolved)
 }
 
 // SearchRawAlerts mocks base method.

--- a/central/alert/datastore/internal/search/searcher.go
+++ b/central/alert/datastore/internal/search/searcher.go
@@ -15,9 +15,9 @@ import (
 type Searcher interface {
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
-	SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error)
-	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
-	Count(ctx context.Context, q *v1.Query) (int, error)
+	SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error)
+	Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error)
+	Count(ctx context.Context, q *v1.Query, active bool) (int, error)
 }
 
 // New returns a new instance of Searcher for the given storage.

--- a/central/alert/datastore/internal/search/searcher.go
+++ b/central/alert/datastore/internal/search/searcher.go
@@ -14,7 +14,7 @@ import (
 //go:generate mockgen-wrapper
 type Searcher interface {
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
-	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
+	SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error)
 	SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error)
 	Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error)
 	Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)

--- a/central/alert/datastore/internal/search/searcher.go
+++ b/central/alert/datastore/internal/search/searcher.go
@@ -15,9 +15,9 @@ import (
 type Searcher interface {
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
-	SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error)
-	Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error)
-	Count(ctx context.Context, q *v1.Query, active bool) (int, error)
+	SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error)
+	Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error)
+	Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)
 }
 
 // New returns a new instance of Searcher for the given storage.

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -15,8 +15,8 @@ import (
 // searcherImpl provides an intermediary implementation layer for AlertStorage.
 
 type AlertSearcher interface {
-	Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error)
-	Count(ctx context.Context, q *v1.Query, active bool) (int, error)
+	Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error)
+	Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)
 }
 
 type searcherImpl struct {
@@ -38,8 +38,8 @@ func (ds *searcherImpl) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.Se
 }
 
 // SearchListAlerts retrieves list alerts from the storage
-func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error) {
-	if active {
+func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error) {
+	if excludeResolved {
 		q = applyDefaultState(q)
 	}
 	alerts, err := ds.storage.GetByQuery(ctx, q)
@@ -83,13 +83,13 @@ func (ds *searcherImpl) searchAlerts(ctx context.Context, q *v1.Query) ([]*stora
 }
 
 // Search takes a SearchRequest and finds any matches
-func (ds *searcherImpl) Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
-	return ds.formattedSearcher.Search(ctx, q, active)
+func (ds *searcherImpl) Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error) {
+	return ds.formattedSearcher.Search(ctx, q, excludeResolved)
 }
 
 // Count returns the number of search results from the query
-func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query, active bool) (int, error) {
-	return ds.formattedSearcher.Count(ctx, q, active)
+func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error) {
+	return ds.formattedSearcher.Count(ctx, q, excludeResolved)
 }
 
 // convertAlert returns proto search result from an alert object and the internal search result
@@ -164,15 +164,15 @@ type defaultViolationStateSearcher struct {
 	searcher search.Searcher
 }
 
-func (ds *defaultViolationStateSearcher) Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
-	if active {
+func (ds *defaultViolationStateSearcher) Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error) {
+	if excludeResolved {
 		q = applyDefaultState(q)
 	}
 	return ds.searcher.Search(ctx, q)
 }
 
-func (ds *defaultViolationStateSearcher) Count(ctx context.Context, q *v1.Query, active bool) (int, error) {
-	if active {
+func (ds *defaultViolationStateSearcher) Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error) {
+	if excludeResolved {
 		q = applyDefaultState(q)
 	}
 	return ds.searcher.Count(ctx, q)

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -55,8 +55,8 @@ func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query, exclu
 }
 
 // SearchRawAlerts retrieves Alerts from the storage
-func (ds *searcherImpl) SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
-	alerts, err := ds.searchAlerts(ctx, q)
+func (ds *searcherImpl) SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error) {
+	alerts, err := ds.searchAlerts(ctx, q, excludeResolved)
 	return alerts, err
 }
 
@@ -77,8 +77,10 @@ func (ds *searcherImpl) searchListAlerts(ctx context.Context, q *v1.Query) ([]*s
 	return listAlerts, results, nil
 }
 
-func (ds *searcherImpl) searchAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
-	q = applyDefaultState(q)
+func (ds *searcherImpl) searchAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error) {
+	if excludeResolved {
+		q = applyDefaultState(q)
+	}
 	return ds.storage.GetByQuery(ctx, q)
 }
 

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -12,13 +12,12 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 )
 
-// searcherImpl provides an intermediary implementation layer for AlertStorage.
-
 type AlertSearcher interface {
 	Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error)
 	Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error)
 }
 
+// searcherImpl provides an intermediary implementation layer for AlertStorage.
 type searcherImpl struct {
 	storage           store.Store
 	formattedSearcher AlertSearcher

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -37,7 +37,7 @@ func (ds *searcherImpl) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.Se
 	return protoResults, nil
 }
 
-// SearchListAlerts retrieves list alerts from the storage
+// SearchListAlerts retrieves list alerts from the storage, passing excludeResolved = true will exclude resolved alerts unless the query has explicitly added Violation State = Resolved to the filter
 func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error) {
 	if excludeResolved {
 		q = applyDefaultState(q)

--- a/central/alert/datastore/internal/search/searcher_postgres_test.go
+++ b/central/alert/datastore/internal/search/searcher_postgres_test.go
@@ -152,9 +152,9 @@ func (s *AlertsSearchSuite) TestCountResolved() {
 	}
 	results, err := s.searcher.Count(ctx, search.EmptyQuery(), false)
 	s.NoError(err)
-	s.Equal(results, 4)
+	s.Equal(4, results)
 
 	results, err = s.searcher.Count(ctx, search.EmptyQuery(), true)
 	s.NoError(err)
-	s.Equal(results, 2)
+	s.Equal(2, results)
 }

--- a/central/alert/datastore/internal/search/searcher_postgres_test.go
+++ b/central/alert/datastore/internal/search/searcher_postgres_test.go
@@ -115,10 +115,12 @@ func (s *AlertsSearchSuite) TestSearchResolved() {
 	}
 	results, err := s.searcher.Search(ctx, &v1.Query{}, false)
 	s.NoError(err)
+	// check that the result is in the allAlertIds map, then set the value to false, indicating it has already been found
 	for _, result := range results {
-		s.Equal(allAlertIds[result.ID], true)
+		s.True(allAlertIds[result.ID])
 		allAlertIds[result.ID] = false
 	}
+	// check that all ids were found
 	for entry := range allAlertIds {
 		s.False(allAlertIds[entry])
 	}

--- a/central/alert/datastore/internal/search/searcher_postgres_test.go
+++ b/central/alert/datastore/internal/search/searcher_postgres_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stackrox/rox/central/alert/datastore/internal/store"
 	"github.com/stackrox/rox/central/alert/datastore/internal/store/postgres"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
@@ -113,7 +112,7 @@ func (s *AlertsSearchSuite) TestSearchResolved() {
 		s.NoError(err)
 		protoassert.Equal(s.T(), alert, foundAlert)
 	}
-	results, err := s.searcher.Search(ctx, &v1.Query{}, false)
+	results, err := s.searcher.Search(ctx, search.EmptyQuery(), false)
 	s.NoError(err)
 	// check that the result is in the allAlertIds map, then set the value to false, indicating it has already been found
 	for _, result := range results {
@@ -124,7 +123,7 @@ func (s *AlertsSearchSuite) TestSearchResolved() {
 	for entry := range allAlertIds {
 		s.False(allAlertIds[entry])
 	}
-	results, err = s.searcher.Search(ctx, &v1.Query{}, true)
+	results, err = s.searcher.Search(ctx, search.EmptyQuery(), true)
 	s.NoError(err)
 	for _, result := range results {
 		s.True(unresolvedAlertIds[result.ID])
@@ -151,11 +150,11 @@ func (s *AlertsSearchSuite) TestCountResolved() {
 		s.NoError(err)
 		protoassert.Equal(s.T(), alert, foundAlert)
 	}
-	results, err := s.searcher.Count(ctx, &v1.Query{}, false)
+	results, err := s.searcher.Count(ctx, search.EmptyQuery(), false)
 	s.NoError(err)
 	s.Equal(results, 4)
 
-	results, err = s.searcher.Count(ctx, &v1.Query{}, true)
+	results, err = s.searcher.Count(ctx, search.EmptyQuery(), true)
 	s.NoError(err)
 	s.Equal(results, 2)
 }

--- a/central/alert/datastore/internal/search/searcher_postgres_test.go
+++ b/central/alert/datastore/internal/search/searcher_postgres_test.go
@@ -61,7 +61,7 @@ func (s *AlertsSearchSuite) TestSearch() {
 	protoassert.Equal(s.T(), alert, foundAlert)
 
 	// Common alert searches
-	results, err := s.searcher.Search(ctx, search.NewQueryBuilder().AddExactMatches(search.DeploymentID, alert.GetDeployment().GetId()).ProtoQuery())
+	results, err := s.searcher.Search(ctx, search.NewQueryBuilder().AddExactMatches(search.DeploymentID, alert.GetDeployment().GetId()).ProtoQuery(), true)
 	s.NoError(err)
 	s.Len(results, 1)
 
@@ -70,7 +70,7 @@ func (s *AlertsSearchSuite) TestSearch() {
 		AddExactMatches(search.PolicyID, alert.GetPolicy().GetId()).
 		AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String()).
 		ProtoQuery()
-	results, err = s.searcher.Search(ctx, q)
+	results, err = s.searcher.Search(ctx, q, true)
 	s.NoError(err)
 	s.Len(results, 1)
 
@@ -78,14 +78,14 @@ func (s *AlertsSearchSuite) TestSearch() {
 		AddBools(search.PlatformComponent, false).
 		AddExactMatches(search.EntityType, storage.Alert_DEPLOYMENT.String()).
 		ProtoQuery()
-	results, err = s.searcher.Search(ctx, q)
+	results, err = s.searcher.Search(ctx, q, true)
 	s.NoError(err)
 	s.Len(results, 1)
 
 	q = search.NewQueryBuilder().
 		AddBools(search.PlatformComponent, true).
 		ProtoQuery()
-	results, err = s.searcher.Search(ctx, q)
+	results, err = s.searcher.Search(ctx, q, true)
 	s.NoError(err)
 	s.Len(results, 0)
 }

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -44,18 +44,18 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 }
 
 // Count mocks base method.
-func (m *MockDataStore) Count(ctx context.Context, q *v1.Query) (int, error) {
+func (m *MockDataStore) Count(ctx context.Context, q *v1.Query, active bool) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Count", ctx, q)
+	ret := m.ctrl.Call(m, "Count", ctx, q, active)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Count indicates an expected call of Count.
-func (mr *MockDataStoreMockRecorder) Count(ctx, q any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Count(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockDataStore)(nil).Count), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockDataStore)(nil).Count), ctx, q, active)
 }
 
 // CountAlerts mocks base method.
@@ -163,48 +163,48 @@ func (mr *MockDataStoreMockRecorder) PruneAlerts(ctx any, ids ...any) *gomock.Ca
 }
 
 // Search mocks base method.
-func (m *MockDataStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
+func (m *MockDataStore) Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, q)
+	ret := m.ctrl.Call(m, "Search", ctx, q, active)
 	ret0, _ := ret[0].([]search.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockDataStoreMockRecorder) Search(ctx, q any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Search(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q, active)
 }
 
 // SearchAlerts mocks base method.
 func (m *MockDataStore) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q)
+	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q, active)
 	ret0, _ := ret[0].([]*v1.SearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchAlerts indicates an expected call of SearchAlerts.
-func (mr *MockDataStoreMockRecorder) SearchAlerts(ctx, q any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) SearchAlerts(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchAlerts), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchAlerts), ctx, q, active)
 }
 
 // SearchListAlerts mocks base method.
-func (m *MockDataStore) SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error) {
+func (m *MockDataStore) SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q)
+	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q, active)
 	ret0, _ := ret[0].([]*storage.ListAlert)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchListAlerts indicates an expected call of SearchListAlerts.
-func (mr *MockDataStoreMockRecorder) SearchListAlerts(ctx, q any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) SearchListAlerts(ctx, q, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchListAlerts), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchListAlerts), ctx, q, active)
 }
 
 // SearchRawAlerts mocks base method.

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -44,18 +44,33 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 }
 
 // Count mocks base method.
-func (m *MockDataStore) Count(ctx context.Context, q *v1.Query, active bool) (int, error) {
+func (m *MockDataStore) Count(ctx context.Context, q *v1.Query) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Count", ctx, q, active)
+	ret := m.ctrl.Call(m, "Count", ctx, q)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Count indicates an expected call of Count.
-func (mr *MockDataStoreMockRecorder) Count(ctx, q, active any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockDataStore)(nil).Count), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockDataStore)(nil).Count), ctx, q)
+}
+
+// CountActive mocks base method.
+func (m *MockDataStore) CountActive(ctx context.Context, q *v1.Query, active bool) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountActive", ctx, q, active)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountActive indicates an expected call of CountActive.
+func (mr *MockDataStoreMockRecorder) CountActive(ctx, q, active any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActive", reflect.TypeOf((*MockDataStore)(nil).CountActive), ctx, q, active)
 }
 
 // CountAlerts mocks base method.
@@ -163,33 +178,48 @@ func (mr *MockDataStoreMockRecorder) PruneAlerts(ctx any, ids ...any) *gomock.Ca
 }
 
 // Search mocks base method.
-func (m *MockDataStore) Search(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
+func (m *MockDataStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, q, active)
+	ret := m.ctrl.Call(m, "Search", ctx, q)
 	ret0, _ := ret[0].([]search.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockDataStoreMockRecorder) Search(ctx, q, active any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Search(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q)
+}
+
+// SearchActive mocks base method.
+func (m *MockDataStore) SearchActive(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchActive", ctx, q, active)
+	ret0, _ := ret[0].([]search.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchActive indicates an expected call of SearchActive.
+func (mr *MockDataStoreMockRecorder) SearchActive(ctx, q, active any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchActive", reflect.TypeOf((*MockDataStore)(nil).SearchActive), ctx, q, active)
 }
 
 // SearchAlerts mocks base method.
 func (m *MockDataStore) SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q, active)
+	ret := m.ctrl.Call(m, "SearchAlerts", ctx, q)
 	ret0, _ := ret[0].([]*v1.SearchResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchAlerts indicates an expected call of SearchAlerts.
-func (mr *MockDataStoreMockRecorder) SearchAlerts(ctx, q, active any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) SearchAlerts(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchAlerts), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchAlerts), ctx, q)
 }
 
 // SearchListAlerts mocks base method.

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -44,33 +44,18 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 }
 
 // Count mocks base method.
-func (m *MockDataStore) Count(ctx context.Context, q *v1.Query) (int, error) {
+func (m *MockDataStore) Count(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Count", ctx, q)
+	ret := m.ctrl.Call(m, "Count", ctx, q, excludeResolved)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Count indicates an expected call of Count.
-func (mr *MockDataStoreMockRecorder) Count(ctx, q any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Count(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockDataStore)(nil).Count), ctx, q)
-}
-
-// CountActive mocks base method.
-func (m *MockDataStore) CountActive(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountActive", ctx, q, excludeResolved)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CountActive indicates an expected call of CountActive.
-func (mr *MockDataStoreMockRecorder) CountActive(ctx, q, excludeResolved any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActive", reflect.TypeOf((*MockDataStore)(nil).CountActive), ctx, q, excludeResolved)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockDataStore)(nil).Count), ctx, q, excludeResolved)
 }
 
 // CountAlerts mocks base method.
@@ -178,33 +163,18 @@ func (mr *MockDataStoreMockRecorder) PruneAlerts(ctx any, ids ...any) *gomock.Ca
 }
 
 // Search mocks base method.
-func (m *MockDataStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
+func (m *MockDataStore) Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, q)
+	ret := m.ctrl.Call(m, "Search", ctx, q, excludeResolved)
 	ret0, _ := ret[0].([]search.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockDataStoreMockRecorder) Search(ctx, q any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Search(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q)
-}
-
-// SearchActive mocks base method.
-func (m *MockDataStore) SearchActive(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchActive", ctx, q, excludeResolved)
-	ret0, _ := ret[0].([]search.Result)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SearchActive indicates an expected call of SearchActive.
-func (mr *MockDataStoreMockRecorder) SearchActive(ctx, q, excludeResolved any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchActive", reflect.TypeOf((*MockDataStore)(nil).SearchActive), ctx, q, excludeResolved)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockDataStore)(nil).Search), ctx, q, excludeResolved)
 }
 
 // SearchAlerts mocks base method.

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -59,18 +59,18 @@ func (mr *MockDataStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // CountActive mocks base method.
-func (m *MockDataStore) CountActive(ctx context.Context, q *v1.Query, active bool) (int, error) {
+func (m *MockDataStore) CountActive(ctx context.Context, q *v1.Query, excludeResolved bool) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountActive", ctx, q, active)
+	ret := m.ctrl.Call(m, "CountActive", ctx, q, excludeResolved)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CountActive indicates an expected call of CountActive.
-func (mr *MockDataStoreMockRecorder) CountActive(ctx, q, active any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) CountActive(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActive", reflect.TypeOf((*MockDataStore)(nil).CountActive), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActive", reflect.TypeOf((*MockDataStore)(nil).CountActive), ctx, q, excludeResolved)
 }
 
 // CountAlerts mocks base method.
@@ -193,18 +193,18 @@ func (mr *MockDataStoreMockRecorder) Search(ctx, q any) *gomock.Call {
 }
 
 // SearchActive mocks base method.
-func (m *MockDataStore) SearchActive(ctx context.Context, q *v1.Query, active bool) ([]search.Result, error) {
+func (m *MockDataStore) SearchActive(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchActive", ctx, q, active)
+	ret := m.ctrl.Call(m, "SearchActive", ctx, q, excludeResolved)
 	ret0, _ := ret[0].([]search.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchActive indicates an expected call of SearchActive.
-func (mr *MockDataStoreMockRecorder) SearchActive(ctx, q, active any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) SearchActive(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchActive", reflect.TypeOf((*MockDataStore)(nil).SearchActive), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchActive", reflect.TypeOf((*MockDataStore)(nil).SearchActive), ctx, q, excludeResolved)
 }
 
 // SearchAlerts mocks base method.
@@ -223,18 +223,18 @@ func (mr *MockDataStoreMockRecorder) SearchAlerts(ctx, q any) *gomock.Call {
 }
 
 // SearchListAlerts mocks base method.
-func (m *MockDataStore) SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error) {
+func (m *MockDataStore) SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q, active)
+	ret := m.ctrl.Call(m, "SearchListAlerts", ctx, q, excludeResolved)
 	ret0, _ := ret[0].([]*storage.ListAlert)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchListAlerts indicates an expected call of SearchListAlerts.
-func (mr *MockDataStoreMockRecorder) SearchListAlerts(ctx, q, active any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) SearchListAlerts(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchListAlerts), ctx, q, active)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchListAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchListAlerts), ctx, q, excludeResolved)
 }
 
 // SearchRawAlerts mocks base method.

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -208,18 +208,18 @@ func (mr *MockDataStoreMockRecorder) SearchListAlerts(ctx, q, excludeResolved an
 }
 
 // SearchRawAlerts mocks base method.
-func (m *MockDataStore) SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
+func (m *MockDataStore) SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchRawAlerts", ctx, q)
+	ret := m.ctrl.Call(m, "SearchRawAlerts", ctx, q, excludeResolved)
 	ret0, _ := ret[0].([]*storage.Alert)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchRawAlerts indicates an expected call of SearchRawAlerts.
-func (mr *MockDataStoreMockRecorder) SearchRawAlerts(ctx, q any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) SearchRawAlerts(ctx, q, excludeResolved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchRawAlerts), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawAlerts", reflect.TypeOf((*MockDataStore)(nil).SearchRawAlerts), ctx, q, excludeResolved)
 }
 
 // UpsertAlert mocks base method.

--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -336,7 +336,7 @@ func (s *serviceImpl) ResolveAlerts(ctx context.Context, req *v1.ResolveAlertsRe
 	}
 	runtimeQuery := search.NewQueryBuilder().AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).ProtoQuery()
 	cq := search.ConjunctionQuery(query, runtimeQuery)
-	alerts, err := s.dataStore.SearchRawAlerts(ctx, cq)
+	alerts, err := s.dataStore.SearchRawAlerts(ctx, cq, true)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -158,7 +158,7 @@ func (s *serviceImpl) CountAlerts(ctx context.Context, request *v1.RawQuery) (*v
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 
-	count, err := s.dataStore.Count(ctx, parsedQuery)
+	count, err := s.dataStore.Count(ctx, parsedQuery, true)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (s *serviceImpl) GetAlertsCounts(ctx context.Context, request *v1.GetAlerts
 		requestQ = search.ConjunctionQuery(requestQ, conjunct)
 	}
 
-	alerts, err := s.dataStore.Search(ctx, requestQ)
+	alerts, err := s.dataStore.Search(ctx, requestQ, true)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +440,7 @@ func (s *serviceImpl) DeleteAlerts(ctx context.Context, request *v1.DeleteAlerts
 		return nil, errors.Wrapf(errox.InvalidArgs, "please specify Violation State:%s in the query to confirm deletion", storage.ViolationState_RESOLVED.String())
 	}
 
-	results, err := s.dataStore.Search(ctx, query)
+	results, err := s.dataStore.Search(ctx, query, true)
 	if err != nil {
 		return nil, err
 	}

--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -143,7 +143,7 @@ func (s *serviceImpl) ListAlerts(ctx context.Context, request *v1.ListAlertsRequ
 	if err != nil {
 		return nil, err
 	}
-	alerts, err := s.dataStore.SearchListAlerts(ctx, q)
+	alerts, err := s.dataStore.SearchListAlerts(ctx, q, true)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (s *serviceImpl) GetAlertsGroup(ctx context.Context, request *v1.ListAlerts
 	if err != nil {
 		return nil, err
 	}
-	alerts, err := s.dataStore.SearchListAlerts(ctx, q)
+	alerts, err := s.dataStore.SearchListAlerts(ctx, q, true)
 	if err != nil {
 		log.Error(err)
 		return nil, err
@@ -263,7 +263,7 @@ func (s *serviceImpl) GetAlertTimeseries(ctx context.Context, req *v1.ListAlerts
 		return nil, err
 	}
 
-	alerts, err := s.dataStore.SearchListAlerts(ctx, q)
+	alerts, err := s.dataStore.SearchListAlerts(ctx, q, true)
 	if err != nil {
 		return nil, err
 	}

--- a/central/alert/service/service_test.go
+++ b/central/alert/service/service_test.go
@@ -666,7 +666,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCluster() {
 
 func (s *getAlertsCountsTests) testGetAlertCounts(fakeSearchResultsSlice []search.Result, groupBy v1.GetAlertsCountsRequest_RequestGroup, expected *v1.GetAlertsCountsResponse) {
 	fakeContext := context.Background()
-	s.datastoreMock.EXPECT().Search(fakeContext, gomock.Any()).Return(fakeSearchResultsSlice, nil)
+	s.datastoreMock.EXPECT().Search(fakeContext, gomock.Any(), true).Return(fakeSearchResultsSlice, nil)
 
 	result, err := s.service.GetAlertsCounts(fakeContext, &v1.GetAlertsCountsRequest{Request: &v1.ListAlertsRequest{
 		Query: "",

--- a/central/alert/service/service_test.go
+++ b/central/alert/service/service_test.go
@@ -170,7 +170,7 @@ func (s *listAlertsTests) TestListAlerts() {
 	}
 	fakeContext := context.Background()
 
-	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, fakeQueryProto).Return(s.fakeListAlertSlice, nil)
+	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, fakeQueryProto, true).Return(s.fakeListAlertSlice, nil)
 	result, err := s.service.ListAlerts(fakeContext, &v1.ListAlertsRequest{
 		Query: fakeQuery.Query(),
 	})
@@ -189,7 +189,7 @@ func (s *listAlertsTests) TestListAlertsWhenTheDataLayerFails() {
 			paginated.GetViolationTimeSortOption(),
 		},
 	}
-	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery).Return(nil, errFake)
+	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(nil, errFake)
 
 	result, err := s.service.ListAlerts(fakeContext, &v1.ListAlertsRequest{
 		Query: "",
@@ -348,7 +348,7 @@ func (s *getAlertsGroupsTests) testGetAlertsGroupFor(fakeListAlertSlice []*stora
 	protoQuery.Pagination = &v1.QueryPagination{
 		Limit: math.MaxInt32,
 	}
-	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery).Return(fakeListAlertSlice, nil)
+	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(fakeListAlertSlice, nil)
 
 	result, err := s.service.GetAlertsGroup(fakeContext, &v1.ListAlertsRequest{
 		Query: "",
@@ -364,7 +364,7 @@ func (s *getAlertsGroupsTests) TestGetAlertsGroupWhenTheDataAccessLayerFails() {
 	protoQuery.Pagination = &v1.QueryPagination{
 		Limit: math.MaxInt32,
 	}
-	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery).Return(nil, errFake)
+	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(nil, errFake)
 
 	result, err := s.service.GetAlertsGroup(fakeContext, &v1.ListAlertsRequest{
 		Query: "",
@@ -864,7 +864,7 @@ func (s *getAlertTimeseriesTests) TestGetAlertTimeseries() {
 	}
 	fakeContext := context.Background()
 	protoQuery := search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
-	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery).Return(alerts, nil)
+	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(alerts, nil)
 
 	result, err := s.service.GetAlertTimeseries(fakeContext, &v1.ListAlertsRequest{
 		Query: "",
@@ -877,7 +877,7 @@ func (s *getAlertTimeseriesTests) TestGetAlertTimeseries() {
 func (s *getAlertTimeseriesTests) TestGetAlertTimeseriesWhenTheDataAccessLayerFails() {
 	fakeContext := context.Background()
 	protoQuery := search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
-	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery).Return(nil, errFake)
+	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(nil, errFake)
 
 	result, err := s.service.GetAlertTimeseries(fakeContext, &v1.ListAlertsRequest{
 		Query: "",

--- a/central/alert/service/service_test.go
+++ b/central/alert/service/service_test.go
@@ -734,7 +734,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 	}
 
 	fakeContext := context.Background()
-	s.datastoreMock.EXPECT().Search(fakeContext, gomock.Any()).Return(fakeSearchResultsSlice, nil)
+	s.datastoreMock.EXPECT().Search(fakeContext, gomock.Any(), true).Return(fakeSearchResultsSlice, nil)
 
 	result, err := s.service.GetAlertsCounts(fakeContext, &v1.GetAlertsCountsRequest{Request: &v1.ListAlertsRequest{
 		Query: "",
@@ -746,7 +746,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 
 func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheDataAccessLayerFails() {
 	fakeContext := context.Background()
-	s.datastoreMock.EXPECT().Search(fakeContext, gomock.Any()).Return(nil, errFake)
+	s.datastoreMock.EXPECT().Search(fakeContext, gomock.Any(), true).Return(nil, errFake)
 
 	result, err := s.service.GetAlertsCounts(fakeContext, &v1.GetAlertsCountsRequest{Request: &v1.ListAlertsRequest{
 		Query: "",
@@ -974,7 +974,7 @@ func (s *baseSuite) TestDeleteAlerts() {
 		Limit: math.MaxInt32,
 	}
 
-	s.datastoreMock.EXPECT().Search(context.Background(), expectedQuery).Return([]search.Result{}, nil)
+	s.datastoreMock.EXPECT().Search(context.Background(), expectedQuery, true).Return([]search.Result{}, nil)
 
 	_, err := s.service.DeleteAlerts(context.Background(), &v1.DeleteAlertsRequest{
 		Query: &v1.RawQuery{

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -753,7 +753,7 @@ func (ds *datastoreImpl) getAlerts(ctx context.Context, deploymentID string) ([]
 	q := pkgSearch.NewQueryBuilder().
 		AddExactMatches(pkgSearch.ViolationState, storage.ViolationState_ACTIVE.String()).
 		AddExactMatches(pkgSearch.DeploymentID, deploymentID).ProtoQuery()
-	return ds.alertDataStore.SearchRawAlerts(ctx, q)
+	return ds.alertDataStore.SearchRawAlerts(ctx, q, true)
 }
 
 func (ds *datastoreImpl) markAlertsStale(ctx context.Context, alerts []*storage.Alert) error {

--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -294,7 +294,7 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 		search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery(),
 	)
 	alertQuery.Pagination = infPagination
-	r.unresolvedAlerts, err = f.alertStore.SearchListAlerts(ctx, alertQuery)
+	r.unresolvedAlerts, err = f.alertStore.SearchListAlerts(ctx, alertQuery, true)
 	if err != nil {
 		return err
 	}

--- a/central/detection/alertmanager/alert_manager_impl.go
+++ b/central/detection/alertmanager/alert_manager_impl.go
@@ -139,7 +139,7 @@ func (d *alertManagerImpl) shouldDebounceNotification(ctx context.Context, alert
 		AddExactMatches(search.PolicyID, alert.GetPolicy().GetId()).
 		AddExactMatches(search.ViolationState, storage.ViolationState_RESOLVED.String()).
 		ProtoQuery()
-	resolvedAlerts, err := d.alerts.SearchRawAlerts(ctx, q)
+	resolvedAlerts, err := d.alerts.SearchRawAlerts(ctx, q, true)
 	if err != nil {
 		log.Errorf("Error fetching formerly resolved alerts for alert %s: %v", alert.GetId(), err)
 		return false
@@ -318,7 +318,7 @@ func (d *alertManagerImpl) mergeManyAlerts(
 	for _, filter := range oldAlertFilters {
 		filter.apply(qb)
 	}
-	previousAlerts, err := d.alerts.SearchRawAlerts(ctx, qb.ProtoQuery())
+	previousAlerts, err := d.alerts.SearchRawAlerts(ctx, qb.ProtoQuery(), true)
 	if err != nil {
 		err = errors.Wrapf(err, "couldn't load previous alerts (query was %s)", qb.Query())
 		return

--- a/central/detection/alertmanager/alert_manager_impl.go
+++ b/central/detection/alertmanager/alert_manager_impl.go
@@ -139,7 +139,7 @@ func (d *alertManagerImpl) shouldDebounceNotification(ctx context.Context, alert
 		AddExactMatches(search.PolicyID, alert.GetPolicy().GetId()).
 		AddExactMatches(search.ViolationState, storage.ViolationState_RESOLVED.String()).
 		ProtoQuery()
-	resolvedAlerts, err := d.alerts.SearchRawAlerts(ctx, q, true)
+	resolvedAlerts, err := d.alerts.SearchRawAlerts(ctx, q, false)
 	if err != nil {
 		log.Errorf("Error fetching formerly resolved alerts for alert %s: %v", alert.GetId(), err)
 		return false

--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -186,11 +186,11 @@ func (suite *AlertManagerTestSuite) TestNotifyAndUpdateBatch() {
 	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx,
 		testutils.PredMatcher("query for dep 1", func(q *v1.Query) bool {
 			return strings.Contains(protocompat.MarshalTextString(q), "Dep1")
-		})).Return([]*storage.Alert{resolvedAlerts[0]}, nil)
+		}), true).Return([]*storage.Alert{resolvedAlerts[0]}, nil)
 	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx,
 		testutils.PredMatcher("query for dep 2", func(q *v1.Query) bool {
 			return strings.Contains(protocompat.MarshalTextString(q), "Dep2")
-		})).Return([]*storage.Alert{resolvedAlerts[1]}, nil)
+		}), true).Return([]*storage.Alert{resolvedAlerts[1]}, nil)
 
 	// Only the first alert will get notified
 	suite.notifierMock.EXPECT().ProcessAlert(suite.ctx, alerts[0])
@@ -202,7 +202,7 @@ func (suite *AlertManagerTestSuite) TestNotifyAndUpdateBatch() {
 }
 
 func (suite *AlertManagerTestSuite) TestGetAlertsByPolicy() {
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, testutils.PredMatcher("query for violation state, policy", queryHasFields(search.ViolationState, search.PolicyID))).Return(([]*storage.Alert)(nil), nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, testutils.PredMatcher("query for violation state, policy", queryHasFields(search.ViolationState, search.PolicyID)), true).Return(([]*storage.Alert)(nil), nil)
 
 	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, nil, WithPolicyID("pid"))
 	suite.False(modified.Cardinality() > 0)
@@ -210,7 +210,7 @@ func (suite *AlertManagerTestSuite) TestGetAlertsByPolicy() {
 }
 
 func (suite *AlertManagerTestSuite) TestGetAlertsByDeployment() {
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, testutils.PredMatcher("query for violation state, deployment", queryHasFields(search.ViolationState, search.DeploymentID))).Return(([]*storage.Alert)(nil), nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, testutils.PredMatcher("query for violation state, deployment", queryHasFields(search.ViolationState, search.DeploymentID)), true).Return(([]*storage.Alert)(nil), nil)
 
 	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, nil, WithDeploymentID("did", false))
 	suite.False(modified.Cardinality() > 0)
@@ -219,7 +219,7 @@ func (suite *AlertManagerTestSuite) TestGetAlertsByDeployment() {
 
 func (suite *AlertManagerTestSuite) TestGetAlertsByClusterAndResource() {
 	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx,
-		testutils.PredMatcher("query for violation state, cluster id and resource type", queryHasFields(search.ViolationState, search.ClusterID, search.ResourceType)),
+		testutils.PredMatcher("query for violation state, cluster id and resource type", queryHasFields(search.ViolationState, search.ClusterID, search.ResourceType)), true,
 	).Return(([]*storage.Alert)(nil), nil)
 
 	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, nil, WithLifecycleStage(storage.LifecycleStage_RUNTIME), WithClusterID("cid"), WithNamespace("nn"), WithResource("rn", storage.Alert_Resource_SECRETS))
@@ -230,7 +230,7 @@ func (suite *AlertManagerTestSuite) TestGetAlertsByClusterAndResource() {
 func (suite *AlertManagerTestSuite) TestOnUpdatesWhenAlertsDoNotChange() {
 	alerts := getAlerts()
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 	// No updates should be attempted
 
 	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, alerts)
@@ -245,7 +245,7 @@ func (suite *AlertManagerTestSuite) TestMarksOldAlertsResolved() {
 
 	// Unchanged alerts should not be updated.
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 	// We should get a notification for the new alert.
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), alerts[0]).Return()
 
@@ -265,7 +265,7 @@ func (suite *AlertManagerTestSuite) TestSendsNotificationsForNewAlerts() {
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), alerts[0]).Return()
 
 	// Make one of the alerts not appear in the previous alerts.
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts[1:], nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts[1:], nil)
 
 	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, alerts)
 	suite.True(modified.Cardinality() > 0)
@@ -282,7 +282,7 @@ func (suite *AlertManagerTestSuite) TestNewResourceAlertIsAdded() {
 	// We should get a notification for the new alert.
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -309,7 +309,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlerts() {
 	// Updated alert should notify
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -336,7 +336,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsNoNotify() {
 
 	// Updated alert should not notify
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -364,7 +364,7 @@ func (suite *AlertManagerTestSuite) TestMergeMultipleResourceAlerts() {
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert2).Return()
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -397,7 +397,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsKeepsNewViolationsIfM
 		suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
 	}
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -428,7 +428,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsKeepsNewViolationsIfM
 
 	// Updated alert should not notify
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -458,7 +458,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsOnlyKeepsMaxViolation
 	// Updated alert should notify if set to
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -488,7 +488,7 @@ func (suite *AlertManagerTestSuite) TestMergeResourceAlertsOnlyKeepsMaxViolation
 
 	// Updated alert should not notify
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Add all the policies from the old alerts so that they aren't marked as stale
 	for _, a := range alerts {
@@ -511,7 +511,7 @@ func (suite *AlertManagerTestSuite) TestOldResourceAlertAreMarkedAsResolvedWhenP
 	// We should get a notifications for new alert
 	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), newAlert).Return()
 
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any()).Return(alerts, nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), true).Return(alerts, nil)
 
 	// Don't add any policies to simulate policies being deleted
 	suite.runtimeDetectorMock.EXPECT().PolicySet().Return(suite.policySet).AnyTimes()

--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -186,11 +186,11 @@ func (suite *AlertManagerTestSuite) TestNotifyAndUpdateBatch() {
 	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx,
 		testutils.PredMatcher("query for dep 1", func(q *v1.Query) bool {
 			return strings.Contains(protocompat.MarshalTextString(q), "Dep1")
-		}), true).Return([]*storage.Alert{resolvedAlerts[0]}, nil)
+		}), false).Return([]*storage.Alert{resolvedAlerts[0]}, nil)
 	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx,
 		testutils.PredMatcher("query for dep 2", func(q *v1.Query) bool {
 			return strings.Contains(protocompat.MarshalTextString(q), "Dep2")
-		}), true).Return([]*storage.Alert{resolvedAlerts[1]}, nil)
+		}), false).Return([]*storage.Alert{resolvedAlerts[1]}, nil)
 
 	// Only the first alert will get notified
 	suite.notifierMock.EXPECT().ProcessAlert(suite.ctx, alerts[0])

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -252,7 +252,7 @@ func (resolver *clusterResolver) FailingPolicyCounter(ctx context.Context, args 
 		return nil, err
 	}
 
-	alerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q)
+	alerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q, true)
 	if err != nil {
 		return nil, nil
 	}
@@ -897,7 +897,7 @@ func (resolver *clusterResolver) getActiveDeployAlerts(ctx context.Context, q *v
 		search.ConjunctionQuery(q,
 			search.NewQueryBuilder().AddExactMatches(search.ClusterID, cluster.GetId()).
 				AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).
-				AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery()))
+				AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery()), true)
 }
 
 func (resolver *clusterResolver) Risk(ctx context.Context) (*riskResolver, error) {

--- a/central/graphql/resolvers/deploymentevents.go
+++ b/central/graphql/resolvers/deploymentevents.go
@@ -352,7 +352,7 @@ func (resolver *Resolver) getPolicyViolationEvents(ctx context.Context, query *v
 	}
 
 	query = paginated.FillDefaultSortOption(query, paginated.GetViolationTimeSortOption())
-	alerts, err := resolver.ViolationsDataStore.SearchRawAlerts(ctx, query)
+	alerts, err := resolver.ViolationsDataStore.SearchRawAlerts(ctx, query, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving alerts from search")
 	}

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -373,7 +373,7 @@ func (resolver *deploymentResolver) FailingPolicyCounter(ctx context.Context, ar
 		return nil, err
 	}
 
-	alerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q)
+	alerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q, true)
 	if err != nil {
 		return nil, nil
 	}

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -193,7 +193,7 @@ func (resolver *deploymentResolver) DeployAlertCount(ctx context.Context, args R
 		return 0, err
 	}
 
-	count, err := resolver.root.ViolationsDataStore.Count(ctx, q)
+	count, err := resolver.root.ViolationsDataStore.Count(ctx, q, true)
 	if err != nil {
 		return 0, err
 	}
@@ -326,7 +326,7 @@ func (resolver *deploymentResolver) FailingPolicyCount(ctx context.Context, args
 	if err != nil {
 		return 0, err
 	}
-	count, err := resolver.root.ViolationsDataStore.Count(ctx, query)
+	count, err := resolver.root.ViolationsDataStore.Count(ctx, query, true)
 	if err != nil {
 		return 0, nil
 	}
@@ -349,7 +349,7 @@ func (resolver *deploymentResolver) FailingRuntimePolicyCount(ctx context.Contex
 	}
 	query = search.ConjunctionQuery(query,
 		search.NewQueryBuilder().AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).ProtoQuery())
-	count, err := resolver.root.ViolationsDataStore.Count(ctx, query)
+	count, err := resolver.root.ViolationsDataStore.Count(ctx, query, true)
 	if err != nil {
 		return 0, err
 	}
@@ -671,7 +671,7 @@ func (resolver *deploymentResolver) unresolvedAlertsExists(ctx context.Context, 
 		return false, err
 	}
 	q.Pagination = &v1.QueryPagination{Limit: 1}
-	results, err := resolver.root.ViolationsDataStore.Search(ctx, q)
+	results, err := resolver.root.ViolationsDataStore.Search(ctx, q, true)
 	if err != nil {
 		return false, err
 	}

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -173,7 +173,7 @@ func (resolver *deploymentResolver) DeployAlerts(ctx context.Context, args Pagin
 
 	nested = paginated.FillDefaultSortOption(nested, paginated.GetViolationTimeSortOption())
 	return resolver.root.wrapAlerts(
-		resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, nested))
+		resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, nested, true))
 }
 
 func (resolver *deploymentResolver) DeployAlertCount(ctx context.Context, args RawQuery) (int32, error) {
@@ -285,7 +285,7 @@ func (resolver *deploymentResolver) FailingPolicies(ctx context.Context, args Pa
 	q.Pagination = &v1.QueryPagination{SortOptions: pagination.GetSortOptions()}
 
 	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
-	alerts, err := resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, q)
+	alerts, err := resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, q, true)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -396,7 +396,7 @@ func (resolver *namespaceResolver) FailingPolicyCounter(ctx context.Context, arg
 		return nil, err
 	}
 
-	alerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q)
+	alerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q, true)
 	if err != nil {
 		return nil, nil
 	}
@@ -453,11 +453,10 @@ func (resolver *namespaceResolver) PolicyStatusOnly(ctx context.Context, args Ra
 	q.Pagination = &v1.QueryPagination{
 		Limit: 1,
 	}
-	results, err := resolver.root.ViolationsDataStore.Search(ctx,
-		search.ConjunctionQuery(q,
-			search.NewQueryBuilder().AddExactMatches(search.ClusterID, resolver.data.GetMetadata().GetClusterId()).
-				AddExactMatches(search.Namespace, resolver.data.GetMetadata().GetName()).
-				AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()))
+	results, err := resolver.root.ViolationsDataStore.Search(ctx, search.ConjunctionQuery(q,
+		search.NewQueryBuilder().AddExactMatches(search.ClusterID, resolver.data.GetMetadata().GetClusterId()).
+			AddExactMatches(search.Namespace, resolver.data.GetMetadata().GetName()).
+			AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()))
 	if err != nil {
 		return "", err
 	}
@@ -481,7 +480,7 @@ func (resolver *namespaceResolver) getActiveDeployAlerts(ctx context.Context, q 
 			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery())
 	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 
-	return resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q)
+	return resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q, true)
 }
 
 func (resolver *namespaceResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -456,7 +456,7 @@ func (resolver *namespaceResolver) PolicyStatusOnly(ctx context.Context, args Ra
 	results, err := resolver.root.ViolationsDataStore.Search(ctx, search.ConjunctionQuery(q,
 		search.NewQueryBuilder().AddExactMatches(search.ClusterID, resolver.data.GetMetadata().GetClusterId()).
 			AddExactMatches(search.Namespace, resolver.data.GetMetadata().GetName()).
-			AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()))
+			AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery()), true)
 	if err != nil {
 		return "", err
 	}

--- a/central/graphql/resolvers/policies.go
+++ b/central/graphql/resolvers/policies.go
@@ -185,7 +185,7 @@ func (resolver *policyResolver) failingDeployments(ctx context.Context, q *v1.Qu
 		search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery())
 
 	alertsQuery = paginated.FillDefaultSortOption(alertsQuery, paginated.GetViolationTimeSortOption())
-	listAlerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, alertsQuery)
+	listAlerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, alertsQuery, true)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/policies.go
+++ b/central/graphql/resolvers/policies.go
@@ -245,7 +245,7 @@ func (resolver *policyResolver) FailingDeploymentCount(ctx context.Context, args
 
 	q = search.ConjunctionQuery(q, resolver.getPolicyQuery(),
 		search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery())
-	count, err := resolver.root.ViolationsDataStore.Count(ctx, q)
+	count, err := resolver.root.ViolationsDataStore.Count(ctx, q, true)
 	if err != nil {
 		return 0, err
 	}

--- a/central/graphql/resolvers/search.go
+++ b/central/graphql/resolvers/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 
+	alertDataStore "github.com/stackrox/rox/central/alert/datastore"
 	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
 	"github.com/stackrox/rox/central/graphql/resolvers/searchers"
 	"github.com/stackrox/rox/central/rbac/service"
@@ -122,7 +123,7 @@ func (r RawQuery) IsEmpty() bool {
 
 func (resolver *Resolver) getAutoCompleteSearchers() map[v1.SearchCategory]search.Searcher {
 	searchers := map[v1.SearchCategory]search.Searcher{
-		v1.SearchCategory_ALERTS:                  resolver.ViolationsDataStore,
+		v1.SearchCategory_ALERTS:                  &alertDataStore.DefaultStateAlertDataStoreImpl{DataStore: &resolver.ViolationsDataStore},
 		v1.SearchCategory_CLUSTERS:                resolver.ClusterDataStore,
 		v1.SearchCategory_DEPLOYMENTS:             resolver.DeploymentDataStore,
 		v1.SearchCategory_IMAGES:                  resolver.ImageDataStore,

--- a/central/graphql/resolvers/violations.go
+++ b/central/graphql/resolvers/violations.go
@@ -38,7 +38,7 @@ func (resolver *Resolver) Violations(ctx context.Context, args PaginatedQuery) (
 
 	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 	return resolver.wrapListAlerts(
-		resolver.ViolationsDataStore.SearchListAlerts(ctx, q))
+		resolver.ViolationsDataStore.SearchListAlerts(ctx, q, true))
 }
 
 // ViolationCount returns count of all violations, or those that match the requested query

--- a/central/graphql/resolvers/violations.go
+++ b/central/graphql/resolvers/violations.go
@@ -51,7 +51,7 @@ func (resolver *Resolver) ViolationCount(ctx context.Context, args RawQuery) (in
 	if err != nil {
 		return 0, err
 	}
-	count, err := resolver.ViolationsDataStore.Count(ctx, q)
+	count, err := resolver.ViolationsDataStore.Count(ctx, q, true)
 	if err != nil {
 		return 0, err
 	}
@@ -125,6 +125,6 @@ func anyActiveDeployAlerts(ctx context.Context, root *Resolver, q *v1.Query) (bo
 		Limit: 1,
 	}
 
-	results, err := root.ViolationsDataStore.Search(ctx, q)
+	results, err := root.ViolationsDataStore.Search(ctx, q, true)
 	return len(results) != 0, err
 }

--- a/central/graphql/resolvers/violations.go
+++ b/central/graphql/resolvers/violations.go
@@ -100,7 +100,7 @@ func getLatestViolationTime(ctx context.Context, root *Resolver, q *v1.Query) (*
 		Offset: 0,
 	}
 
-	alerts, err := root.ViolationsDataStore.SearchRawAlerts(ctx, q)
+	alerts, err := root.ViolationsDataStore.SearchRawAlerts(ctx, q, true)
 	if err != nil || len(alerts) == 0 || alerts[0] == nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/vul_mgmt_widgets.go
+++ b/central/graphql/resolvers/vul_mgmt_widgets.go
@@ -101,7 +101,7 @@ func deploymentsWithMostSevereViolations(ctx context.Context, resolver *Resolver
 	}
 
 	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
-	alerts, err := resolver.ViolationsDataStore.SearchListAlerts(ctx, q)
+	alerts, err := resolver.ViolationsDataStore.SearchListAlerts(ctx, q, true)
 	if err != nil {
 		return nil, err
 	}

--- a/central/platform/reprocessor/reprocessor_impl_test.go
+++ b/central/platform/reprocessor/reprocessor_impl_test.go
@@ -83,7 +83,7 @@ func (s *platformReprocessorImplTestSuite) TestRunReprocessing() {
 }
 
 func (s *platformReprocessorImplTestSuite) TestStartAndStop() {
-	s.alertDatastore.EXPECT().Count(gomock.Any(), gomock.Any()).Return(6, nil).AnyTimes()
+	s.alertDatastore.EXPECT().Count(gomock.Any(), gomock.Any(), true).Return(6, nil).AnyTimes()
 	s.deploymentDatastore.EXPECT().Count(gomock.Any(), gomock.Any()).Return(4, nil).AnyTimes()
 
 	alerts := testAlerts()

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1146,7 +1146,7 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			gc.collectAlerts(privateConfig)
 
 			// Grab the actual remaining alerts and make sure they match the alerts expected to be remaining
-			remainingAlerts, err := alerts.SearchListAlerts(ctx, getAllAlerts())
+			remainingAlerts, err := alerts.SearchListAlerts(ctx, getAllAlerts(), true)
 			require.NoError(t, err)
 
 			log.Infof("Remaining alerts: %v", remainingAlerts)

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1146,7 +1146,7 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			gc.collectAlerts(privateConfig)
 
 			// Grab the actual remaining alerts and make sure they match the alerts expected to be remaining
-			remainingAlerts, err := alerts.SearchListAlerts(ctx, getAllAlerts(), true)
+			remainingAlerts, err := alerts.SearchListAlerts(ctx, getAllAlerts(), false)
 			require.NoError(t, err)
 
 			log.Infof("Remaining alerts: %v", remainingAlerts)

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1133,7 +1133,7 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			for _, deployment := range c.deployments {
 				require.NoError(t, deployments.UpsertDeployment(ctx, deployment))
 			}
-			all, err := alerts.Search(ctx, getAllAlerts())
+			all, err := alerts.Search(ctx, getAllAlerts(), true)
 			if err != nil {
 				t.Error(err)
 			}

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -351,7 +351,7 @@ func (s *PruningTestSuite) generateClusterDataStructures() (configDatastore.Data
 	namespaceDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).AnyTimes().Return([]search.Result{}, nil)
 	podDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 	imageIntegrationDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
-	alertDataStore.EXPECT().SearchRawAlerts(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
+	alertDataStore.EXPECT().SearchRawAlerts(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 	notifierMock.EXPECT().ProcessAlert(gomock.Any(), gomock.Any()).AnyTimes().Return()
 	podDataStore.EXPECT().RemovePod(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	imageIntegrationDataStore.EXPECT().RemoveImageIntegration(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1133,7 +1133,7 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			for _, deployment := range c.deployments {
 				require.NoError(t, deployments.UpsertDeployment(ctx, deployment))
 			}
-			all, err := alerts.Search(ctx, getAllAlerts(), true)
+			all, err := alerts.Search(ctx, getAllAlerts(), false)
 			if err != nil {
 				t.Error(err)
 			}

--- a/central/risk/getters/alert.go
+++ b/central/risk/getters/alert.go
@@ -9,5 +9,5 @@ import (
 
 // AlertSearcher provides the required access to alerts for risk scoring.
 type AlertSearcher interface {
-	SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error)
+	SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error)
 }

--- a/central/risk/getters/alert.go
+++ b/central/risk/getters/alert.go
@@ -9,5 +9,5 @@ import (
 
 // AlertSearcher provides the required access to alerts for risk scoring.
 type AlertSearcher interface {
-	SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error)
+	SearchListAlerts(ctx context.Context, q *v1.Query, active bool) ([]*storage.ListAlert, error)
 }

--- a/central/risk/getters/alert_mock.go
+++ b/central/risk/getters/alert_mock.go
@@ -15,7 +15,7 @@ type MockAlertsSearcher struct {
 }
 
 // SearchListAlerts implements the AlertsSearcher interface
-func (m MockAlertsSearcher) SearchListAlerts(_ context.Context, q *v1.Query) (alerts []*storage.ListAlert, err error) {
+func (m MockAlertsSearcher) SearchListAlerts(_ context.Context, q *v1.Query, _ bool) (alerts []*storage.ListAlert, err error) {
 	state := storage.ViolationState_ACTIVE.String()
 	search.ApplyFnToAllBaseQueries(q, func(bq *v1.BaseQuery) {
 		mfQ, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)

--- a/central/risk/multipliers/deployment/violations.go
+++ b/central/risk/multipliers/deployment/violations.go
@@ -46,7 +46,7 @@ func NewViolations(searcher getters.AlertSearcher) *ViolationsMultiplier {
 func (v *ViolationsMultiplier) Score(ctx context.Context, deployment *storage.Deployment, _ map[string][]*storage.Risk_Result) *storage.Risk_Result {
 	qb := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deployment.GetId()).AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String())
 
-	alerts, err := v.searcher.SearchListAlerts(ctx, qb.ProtoQuery())
+	alerts, err := v.searcher.SearchListAlerts(ctx, qb.ProtoQuery(), true)
 	if err != nil {
 		log.Errorf("Couldn't get risk violations for %s: %s", deployment.GetId(), err)
 		return nil

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -93,7 +93,7 @@ func (s *serviceImpl) getSearchFuncs() map[v1.SearchCategory]SearchFunc {
 
 func (s *serviceImpl) getAutocompleteSearchers() map[v1.SearchCategory]search.Searcher {
 	searchers := map[v1.SearchCategory]search.Searcher{
-		v1.SearchCategory_ALERTS:             s.alerts,
+		v1.SearchCategory_ALERTS:             &alertDataStore.DefaultStateAlertDataStoreImpl{DataStore: &s.alerts},
 		v1.SearchCategory_DEPLOYMENTS:        s.deployments,
 		v1.SearchCategory_IMAGES:             s.images,
 		v1.SearchCategory_POLICIES:           s.policies,

--- a/central/splunk/violations.go
+++ b/central/splunk/violations.go
@@ -192,7 +192,7 @@ func queryAlerts(ctx context.Context, alertDS datastore.DataStore, checkpoint sp
 		}},
 	}
 
-	return alertDS.SearchRawAlerts(ctx, pq)
+	return alertDS.SearchRawAlerts(ctx, pq, true)
 }
 
 func extractViolations(alert *storage.Alert, fromTime time.Time, toTime time.Time) ([]*integrations.SplunkViolation, error) {


### PR DESCRIPTION
### Description
Added a parameter to the searcher and datastore methods that utilize the `applyDefaultState` method to make it more concise to service-level calls to the datastore that certain violations will be automatically filtered by the datastore if that parameter is passed to it.

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- Tested the violations dashboard, seems to be functioning as expected, showing only the violations that are active