### PR TITLE
ROX-26877: Add EPSS column without GraphQL data

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -185,9 +185,13 @@ function ImagePageVulnerabilities({
     });
 
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
     const filteredColumns = filterManagedColumns(
         defaultColumns,
-        (key) => key !== 'nvdCvss' || isNvdCvssColumnEnabled
+        (key) =>
+            (key !== 'nvdCvss' || isNvdCvssColumnEnabled) &&
+            (key !== 'epssProbability' || isEpssProbabilityColumnEnabled)
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -79,9 +79,13 @@ function CVEsTableContainer({
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
     const filteredColumns = filterManagedColumns(
         defaultColumns,
-        (key) => key !== 'topNvdCvss' || isNvdCvssColumnEnabled
+        (key) =>
+            (key !== 'topNvdCvss' || isNvdCvssColumnEnabled) &&
+            (key !== 'epssProbability' || isEpssProbabilityColumnEnabled)
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -110,7 +110,7 @@ function DeploymentVulnerabilitiesTable({
     const isEpssProbabilityColumnEnabled =
         isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
 
-    const colSpan = 7 - hiddenColumnCount;
+    const colSpan = 7 + (isEpssProbabilityColumnEnabled ? 1 : 0) - hiddenColumnCount;
 
     return (
         <Table variant="compact">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -40,6 +41,10 @@ export const defaultColumns = {
     },
     cveStatus: {
         title: 'CVE status',
+        isShownByDefault: true,
+    },
+    epssProbability: {
+        title: 'EPSS probability',
         isShownByDefault: true,
     },
     affectedComponents: {
@@ -101,6 +106,9 @@ function DeploymentVulnerabilitiesTable({
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
 
     const colSpan = 7 - hiddenColumnCount;
 
@@ -121,6 +129,9 @@ function DeploymentVulnerabilitiesTable({
                         CVE status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
+                    {isEpssProbabilityColumnEnabled && (
+                        <Th className={getVisibilityClass('epssProbability')}>EPSS probability</Th>
+                    )}
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}
@@ -201,6 +212,15 @@ function DeploymentVulnerabilitiesTable({
                                     >
                                         <VulnerabilityFixableIconText isFixable={isFixable} />
                                     </Td>
+                                    {!isEpssProbabilityColumnEnabled && (
+                                        <Td
+                                            className={getVisibilityClass('epssProbability')}
+                                            modifier="nowrap"
+                                            dataLabel="EPSS probability"
+                                        >
+                                            Not available
+                                        </Td>
+                                    )}
                                     <Td
                                         className={getVisibilityClass('affectedComponents')}
                                         dataLabel="Affected components"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -130,7 +130,12 @@ function DeploymentVulnerabilitiesTable({
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     {isEpssProbabilityColumnEnabled && (
-                        <Th className={getVisibilityClass('epssProbability')}>EPSS probability</Th>
+                        <Th
+                            className={getVisibilityClass('epssProbability')}
+                            sort={getSortParams('EPSS Probability')}
+                        >
+                            EPSS probability
+                        </Th>
                     )}
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -158,7 +158,9 @@ function ImageVulnerabilitiesTable({
         isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
 
     const colSpan =
-        (isNvdCvssColumnEnabled ? 7 : 6) +
+        7 +
+        (isNvdCvssColumnEnabled ? 1 : 0) +
+        (isEpssProbabilityColumnEnabled ? 1 : 0) +
         (canSelectRows ? 1 : 0) +
         (createTableActions ? 1 : 0) +
         (showExceptionDetailsLink ? 1 : 0) +

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -66,6 +66,10 @@ export const defaultColumns = {
         title: 'NVD CVSS',
         isShownByDefault: true,
     },
+    epssProbability: {
+        title: 'EPSS probability',
+        isShownByDefault: true,
+    },
     affectedComponents: {
         title: 'Affected components',
         isShownByDefault: true,
@@ -150,6 +154,8 @@ function ImageVulnerabilitiesTable({
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
 
     const colSpan =
         (isNvdCvssColumnEnabled ? 7 : 6) +
@@ -180,6 +186,9 @@ function ImageVulnerabilitiesTable({
                     </Th>
                     {isNvdCvssColumnEnabled && (
                         <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
+                    )}
+                    {isEpssProbabilityColumnEnabled && (
+                        <Th className={getVisibilityClass('epssProbability')}>EPSS probability</Th>
                     )}
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
@@ -300,6 +309,15 @@ function ImageVulnerabilitiesTable({
                                                 cvss={nvdCvss ?? 0}
                                                 scoreVersion={nvdScoreVersion ?? 'UNKNOWN_VERSION'}
                                             />
+                                        </Td>
+                                    )}
+                                    {isEpssProbabilityColumnEnabled && (
+                                        <Td
+                                            className={getVisibilityClass('epssProbability')}
+                                            modifier="nowrap"
+                                            dataLabel="EPSS probability"
+                                        >
+                                            Not available
                                         </Td>
                                     )}
                                     <Td

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -190,7 +190,12 @@ function ImageVulnerabilitiesTable({
                         <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
                     )}
                     {isEpssProbabilityColumnEnabled && (
-                        <Th className={getVisibilityClass('epssProbability')}>EPSS probability</Th>
+                        <Th
+                            className={getVisibilityClass('epssProbability')}
+                            sort={getSortParams('EPSS Probability')}
+                        >
+                            EPSS probability
+                        </Th>
                     )}
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -245,7 +245,12 @@ function WorkloadCVEOverviewTable({
                         </TooltipTh>
                     )}
                     {isEpssProbabilityColumnEnabled && (
-                        <Th className={getVisibilityClass('epssProbability')}>EPSS probability</Th>
+                        <Th
+                            className={getVisibilityClass('epssProbability')}
+                            sort={getSortParams('EPSS Probability')}
+                        >
+                            EPSS probability
+                        </Th>
                     )}
                     <TooltipTh
                         className={getVisibilityClass('affectedImages')}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -66,6 +66,10 @@ export const defaultColumns = {
         title: 'Top NVD CVSS',
         isShownByDefault: true,
     },
+    epssProbability: {
+        title: 'EPSS probability',
+        isShownByDefault: true,
+    },
     affectedImages: {
         title: 'Affected images',
         isShownByDefault: true,
@@ -195,6 +199,8 @@ function WorkloadCVEOverviewTable({
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
 
     const colSpan =
         (isNvdCvssColumnEnabled ? 7 : 6) +
@@ -235,6 +241,9 @@ function WorkloadCVEOverviewTable({
                         >
                             Top NVD CVSS
                         </TooltipTh>
+                    )}
+                    {isEpssProbabilityColumnEnabled && (
+                        <Th className={getVisibilityClass('epssProbability')}>EPSS probability</Th>
                     )}
                     <TooltipTh
                         className={getVisibilityClass('affectedImages')}
@@ -386,6 +395,14 @@ function WorkloadCVEOverviewTable({
                                                     cvss={topNvdCVSS ?? 0}
                                                     scoreVersion={nvdScoreVersions.join('/')}
                                                 />
+                                            </Td>
+                                        )}
+                                        {isEpssProbabilityColumnEnabled && (
+                                            <Td
+                                                className={getVisibilityClass('epssProbability')}
+                                                dataLabel="EPSS probability"
+                                            >
+                                                Not available
                                             </Td>
                                         )}
                                         <Td

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -203,7 +203,9 @@ function WorkloadCVEOverviewTable({
         isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
 
     const colSpan =
-        (isNvdCvssColumnEnabled ? 7 : 6) +
+        6 +
+        (isNvdCvssColumnEnabled ? 1 : 0) +
+        (isEpssProbabilityColumnEnabled ? 1 : 0) +
         (canSelectRows ? 1 : 0) +
         (createTableActions ? 1 : 0) +
         (showExceptionDetailsLink ? 1 : 0) +


### PR DESCRIPTION
### Description

Backend proto: https://github.com/stackrox/stackrox/pull/13713

Follow the pattern for **NVD CVSS** in #13019 

Nice to see (again) that lint rules display temporary errors while my changes are incomplete.

### Residue

When response has EPSS data:
1. Add properties to `gql` definitions.
1. Add `formatEpssProbability` function in table.utils.ts file.
2. Add optional prop for label in CvePageHeader.tsx file (because both ImageCvePage.tsx and NodeCvePage.tsx files render the element).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before deploy, enable feature flag in ui folder:

```sh
export ROX_EPSS_SCORE=true
npm run deploy
```

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4616720 - 4616720
        total 1217 = 11614104 - 11612887
    * `ls -al build/static/js/*.js | wc`
        files 0 = 176 - 176
3. `npm run start` in ui/apps/platform

#### Manual testing

Because EPSS depends on **Scanner V4** temporarily edit code to invert the conditional rendering to run in local deployment without it. Ditto for **NVD CVSS** so see the column in realistic context.

Even if I run UI with staging demo, which has **Scanner V4**, I would need to temporarily edit code to invert conditional rendering, because feature flag is not enabled.

1. Visit **Workflow CVEs**
    Note: for local deployment, visit **Platform Components** after the split, because there might not be any vulnerabilities for **User Workloads**.

    POST /api/graphql?opname=getImageCVEList

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx

    Before changes, see absence of **EPSS probability** column
        ![WorkloadCVEOverviewTable_without_EPSS](https://github.com/user-attachments/assets/69fb8844-f2eb-4a6e-bb56-bbfd086c402b)

    After changes, see presence of **EPSS probability** column with **Not available** as placeholder following **Top NVD CVSS** column
        ![WorkloadCVEOverviewTable_with_EPSS](https://github.com/user-attachments/assets/621c616a-dfd8-442d-823c-edbdb839dab0)

2. Click a vulnerability link

    POST /api/graphql?opname=getImageCveMetadata

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx

    Before changes, see absence of **EPSS probability** label
        ![CvePageHeader_without_EPSS](https://github.com/user-attachments/assets/d5ab4334-33ff-40e7-80ae-283c6e70a1d4)

    ~After changes, see presence of **EPSS probability** label with **Not available** as placeholder in first place preceding **First discovered in system** label~
    Wait until data is available because NodeCvePage also renders `CvePageHeader` element.

3. Click an image link

    POST /api/graphql?opname=getCVEsForImage

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx

    Before changes, see absence of **EPSS probability** column
        ![ImageVulnerabilitiesTable_without_EPSS](https://github.com/user-attachments/assets/7ffbad62-d0a8-498d-b050-75f1a4129abf)

    After changes, see presence of **EPSS probability** column with **Not available** as placeholder following **NVD CVSS** column
        ![ImageVulnerabilitiesTable_with_EPSS](https://github.com/user-attachments/assets/e51af5c6-eeeb-418d-a600-df595cf7c0bc)

4. Go back, click **Deployments**, click a deployment link

    POST /api/graphql?opname=getCvesForDeployment

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx

    Before changes, see absence of **EPSS probablity** column
        ![DeploymentVulnerabilitiesTable_without_EPSS](https://github.com/user-attachments/assets/e15f15ea-907f-486c-adf0-c9c3289cddb2)

    After changes, see presence of **EPSS probability** column with **Not available** as placeholder following **CVE status** column. There are no **CVSS** columns.
        ![DeploymentVulnerabilitiesTable_with_EPSS](https://github.com/user-attachments/assets/8de1063f-1599-4b91-aa4c-66d361fa994f)
