### PR TITLE
ROX-27653: IssueSelfSignedCert expiry 365 days

### DIFF
--- a/pkg/testutils/certs.go
+++ b/pkg/testutils/certs.go
@@ -15,6 +15,10 @@ func IssueSelfSignedCert(t *testing.T, commonName string, dnsNames ...string) tl
 		CN:         commonName,
 		KeyRequest: csr.NewKeyRequest(),
 		Hosts:      dnsNames,
+		CA: &csr.CAConfig{
+			// Must be 398 days or fewer to run on macOS. See https://support.apple.com/en-au/102028 for more information.
+			Expiry: "8760h", // 365 days.
+		},
 	}
 
 	caCert, _, caKey, err := initca.New(&req)


### PR DESCRIPTION
### Description

Apple made the decision to declare any cert which a lifetime of over 398 days as invalid. `IssueSelfSignedCert` creates certs which last 5 years, so this change now switches it to 365 days.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI
