### PR TITLE
ROX-27617: Add image lineage groovy test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -51,6 +51,8 @@ class ImageScanningTest extends BaseSpecification {
         "us-west1-docker.pkg.dev/acs-san-stackroxci/artifact-registry-test/nginx:1.17"
     static final private String CENTOS_IMAGE = "quay.io/rhacs-eng/qa:centos7-base"
     static final private String CENTOS_ECHO_IMAGE = "quay.io/rhacs-eng/qa:centos7-base-echo"
+    static final private String LINEAGE_IMAGE_A = "quay.io/rhacs-eng/qa:lineage-jdk-17.0.11"
+    static final private String LINEAGE_IMAGE_B = "quay.io/rhacs-eng/qa:lineage-jdk-17.0.13"
 
     // Amount of seconds to sleep to avoid race condition during on-going processing of images.
     static final private int SLEEP_DURING_PROCESSING = isRaceBuild() ? 25000 :
@@ -434,10 +436,11 @@ class ImageScanningTest extends BaseSpecification {
         }
         foundComponent != null
 
-        Vulnerability.EmbeddedVulnerability vuln =
-                foundComponent.vulnsList.find { v -> v.cve == cve }
+        if (cve) {
+            Vulnerability.EmbeddedVulnerability vuln = foundComponent.vulnsList.find { v -> v.cve == cve }
 
-        vuln != null
+            assert vuln != null
+        }
 
         cleanup:
         if (scanner.isTestable()) {
@@ -447,15 +450,17 @@ class ImageScanningTest extends BaseSpecification {
         where:
         "Data inputs are: "
 
-        scanner                          | component      | version            | idx | cve              | image        | registry
-        new StackroxScannerIntegration() | "openssl-libs"        | "1:1.0.2k-12.el7"  | 0   | "RHSA-2019:0483" | RHEL7_IMAGE  | ""
-        new StackroxScannerIntegration() | "openssl-libs"        | "1:1.0.2k-12.el7"  | 0   | "CVE-2018-0735"  | RHEL7_IMAGE  | ""
-        new StackroxScannerIntegration() | "systemd"             | "229-4ubuntu21.29" | 0   | "CVE-2021-33910" | OCI_IMAGE    | ""
-        new StackroxScannerIntegration() | "glibc"               | "2.35-0ubuntu3.1"  | 4   | "CVE-2016-20013" | LIST_IMAGE_OCI_MANIFEST | ""
-        new ClairScannerIntegration()    | "apt"                 | "1.4.8"            | 0   | "CVE-2011-3374"  | NGINX_IMAGE  | ""
-        new ClairScannerIntegration()    | "bash"                | "4.4-5"            | 0   | "CVE-2019-18276" | NGINX_IMAGE  | ""
-        new ClairV4ScannerIntegration()  | "openssl-libs"        | "1:1.1.1-8.el8"    | 0   | "RHSA-2021:1024" | UBI8_0_IMAGE | ""
-        new ClairV4ScannerIntegration()  | "platform-python-pip" | "9.0.3-13.el8"     | 0   | "RHSA-2020:4432" | UBI8_0_IMAGE | ""
+        scanner                          | component                  | version                       | idx | cve              | image           | registry
+        new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "RHSA-2019:0483" | RHEL7_IMAGE     | ""
+        new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "CVE-2018-0735"  | RHEL7_IMAGE     | ""
+        new StackroxScannerIntegration() | "systemd"                  | "229-4ubuntu21.29"            | 0   | "CVE-2021-33910" | OCI_IMAGE       | ""
+        new StackroxScannerIntegration() | "glibc"                    | "2.35-0ubuntu3.1"             | 4   | "CVE-2016-20013" | LIST_IMAGE_OCI_MANIFEST | ""
+        new ClairScannerIntegration()    | "apt"                      | "1.4.8"                       | 0   | "CVE-2011-3374"  | NGINX_IMAGE     | ""
+        new ClairScannerIntegration()    | "bash"                     | "4.4-5"                       | 0   | "CVE-2019-18276" | NGINX_IMAGE     | ""
+        new ClairV4ScannerIntegration()  | "openssl-libs"             | "1:1.1.1-8.el8"               | 0   | "RHSA-2021:1024" | UBI8_0_IMAGE    | ""
+        new ClairV4ScannerIntegration()  | "platform-python-pip"      | "9.0.3-13.el8"                | 0   | "RHSA-2020:4432" | UBI8_0_IMAGE    | ""
+        new StackroxScannerIntegration() | "java-17-openjdk-headless" | "1:17.0.11.0.9-2.el8.x86_64"  | 135 | ""               | LINEAGE_IMAGE_A | ""
+        new StackroxScannerIntegration() | "java-17-openjdk-headless" | "1:17.0.13.0.11-3.el8.x86_64" | 137 | ""               | LINEAGE_IMAGE_B | ""
     }
 
     @Unroll


### PR DESCRIPTION
### Description

Adds groovy tests that validate scanner is properly detecting component + versions in images that have layers in common.

_**Will not be merged until SCANNER_VERSION updated to include a version with the lineage fix.**_ `ImageScanningTest` is expected to fail in the meantime.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

In addition to the tests themselves - manually executed these tests against two clusters, one with the lineage fix and one without - the new test failed for the cluster without the fix, and succeeded in the cluster with the fix. 

```sh
./gradlew test --tests=ImageScanningTest.*"Verify Image Scan Results"*
```