### PR TITLE
chore: remove legacy auth for SAC

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -70,11 +70,11 @@ var (
 			"/v1.ImageService/EnrichLocalImageInternal",
 			"/v1.ImageService/UpdateLocalScanStatusInternal",
 		},
-		user.With(permissions.Modify(permissions.WithLegacyAuthForSAC(resources.Image, true))): {
+		user.With(permissions.Modify(resources.Image)): {
 			"/v1.ImageService/DeleteImages",
 			"/v1.ImageService/ScanImage",
 		},
-		user.With(permissions.View(permissions.WithLegacyAuthForSAC(resources.Image, true))): {
+		user.With(permissions.View(resources.Image)): {
 			"/v1.ImageService/InvalidateScanAndRegistryCaches",
 		},
 		user.With(permissions.View(resources.WatchedImage)): {

--- a/central/main.go
+++ b/central/main.go
@@ -749,7 +749,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		},
 		{
 			Route:         "/api/v1/images/sbom",
-			Authorizer:    user.With(permissions.Modify(permissions.WithLegacyAuthForSAC(resources.Image, true))),
+			Authorizer:    user.With(permissions.Modify(resources.Image)),
 			ServerHandler: imageService.SBOMHandler(imageintegration.Set(), enrichment.ImageEnricherSingleton(), sachelper.NewClusterSacHelper(clusterDataStore.Singleton())),
 			Compression:   true,
 		},

--- a/pkg/auth/permissions/resource.go
+++ b/pkg/auth/permissions/resource.go
@@ -30,12 +30,6 @@ type ResourceMetadata struct {
 	// access to the old Resource is allowed OR to the ReplacingResource.
 	ReplacingResource *ResourceMetadata
 	Scope             ResourceScope
-	// legacyAuthForSAC is a tri-state bool determining whether legacy auth for SAC is forced on or off. If false,
-	// no legacy auth for SAC is performed (only affects globally-scoped resources). If true, legacy auth for SAC
-	// (at the global scope) is performed even for non-globally scoped resources. If `nil`, the default behavior is used
-	// (i.e., performing legacy auth for globally-scoped resources, and not performing it for resources with cluster
-	// or namespace scopes).
-	legacyAuthForSAC *bool
 }
 
 // GetResource returns the resource for this metadata object.
@@ -75,13 +69,6 @@ func (m ResourceMetadata) String() string {
 type ResourceHandle interface {
 	GetResource() Resource
 	GetReplacingResource() *Resource
-}
-
-// WithLegacyAuthForSAC returns a resource metadata that instructs the legacy auth handler to either force or force
-// skip legacy auth for SAC.
-func WithLegacyAuthForSAC(md ResourceMetadata, use bool) ResourceMetadata {
-	md.legacyAuthForSAC = &use
-	return md
 }
 
 // IsPermittedBy returns whether the ResourceMetadata is contained within the map

--- a/pkg/sac/resources/list.go
+++ b/pkg/sac/resources/list.go
@@ -211,9 +211,7 @@ func AllResourcesViewPermissions() []permissions.ResourceWithAccess {
 	result := make([]permissions.ResourceWithAccess, len(metadatas))
 	for i, metadata := range metadatas {
 		result[i] = permissions.ResourceWithAccess{
-			// We want to ensure access to *all* resources, so when using SAC, always perform legacy auth (= enforcement
-			// at the global scope) even for cluster- or namespace-scoped resources.
-			Resource: permissions.WithLegacyAuthForSAC(metadata, true),
+			Resource: metadata,
 			Access:   storage.Access_READ_ACCESS,
 		}
 	}
@@ -226,9 +224,7 @@ func AllResourcesModifyPermissions() []permissions.ResourceWithAccess {
 	result := make([]permissions.ResourceWithAccess, len(metadatas))
 	for i, metadata := range metadatas {
 		result[i] = permissions.ResourceWithAccess{
-			// We want to ensure access to *all* resources, so when using SAC, always perform legacy auth (= enforcement
-			// at the global scope) even for cluster- or namespace-scoped resources.
-			Resource: permissions.WithLegacyAuthForSAC(metadata, true),
+			Resource: metadata,
 			Access:   storage.Access_READ_WRITE_ACCESS,
 		}
 	}


### PR DESCRIPTION
### Description

`WithLegacyAuthForSAC` sets a field that is write only and there is no place that reads it. It's safe to remove it as it's effectively no-op.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
