### PR TITLE
ROX-27697: update postgres defaults

### DIFF
--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -57,3 +57,5 @@ log_temp_files = 1024
 # that took longer than 500ms.
 log_autovacuum_min_duration = 500
 autovacuum_max_workers = 5
+autovacuum_vacuum_scale_factor: 0.05
+autovacuum_analyze_scale_factor: 0.02

--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -12,7 +12,7 @@ shared_buffers = 2GB
 work_mem = 40MB
 maintenance_work_mem = 512MB
 effective_cache_size = 4GB
-hashMemMultiplier = 2.0
+hash_mem_multiplier = 2.0
 
 dynamic_shared_memory_type = posix
 max_wal_size = 5GB

--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -1,6 +1,6 @@
 hba_file = '/etc/stackrox.d/config/pg_hba.conf'
 listen_addresses = '*'
-max_connections = 200
+max_connections = 100
 password_encryption = scram-sha-256
 
 ssl = on
@@ -12,6 +12,7 @@ shared_buffers = 2GB
 work_mem = 40MB
 maintenance_work_mem = 512MB
 effective_cache_size = 4GB
+hashMemMultiplier = 2.0
 
 dynamic_shared_memory_type = posix
 max_wal_size = 5GB
@@ -55,3 +56,4 @@ log_temp_files = 1024
 # Autovacuum has to keep up with the data growth. Log any autovacuum activity,
 # that took longer than 500ms.
 log_autovacuum_min_duration = 500
+autovacuum_max_workers = 5

--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -57,5 +57,5 @@ log_temp_files = 1024
 # that took longer than 500ms.
 log_autovacuum_min_duration = 500
 autovacuum_max_workers = 5
-autovacuum_vacuum_scale_factor: 0.05
-autovacuum_analyze_scale_factor: 0.02
+autovacuum_vacuum_scale_factor = 0.05
+autovacuum_analyze_scale_factor = 0.02


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Since #13357 is going to be delayed we are going to make a couple of the updates to default settings now so they are simpler to adjust in the future and so we can have a more accurate detailed document for the users to follow when updating Postgres configuration settings due to updates to resource configurations.

Added the `hash_mem_multiplier` as that may have some use for us to adjust for some queries that spend a lot of time on hash joins.
Added the `autovacuum_max_workers` to make it easier to take advantage of more resources and to help ensure the database is staying in an optimal state by cleaning up dead tuples.
Reverted the `max_connections` to the Postgres default.  Central is the ONLY thing that connects to this database.  As such the default connections should be sufficient and gives us more room to adjust other settings as resource allocations are updated.

A detailed KCS will be written via https://issues.redhat.com/browse/ROX-27698 to take advantage of these values and illustrate how to update them.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI.  
Spun up a cluster and ensured the updated settings existed.

