### PR TITLE
ROX-27647: Split exception management CVE table into tabs

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
@@ -50,7 +50,7 @@ describe('Exception Management Request Details Page', () => {
         );
         cy.get('div.pf-v5-c-alert.pf-m-warning').should(
             'contain',
-            'You are viewing a canceled request. If this cancelation was not intended, please submit a new request'
+            'You are viewing a canceled request. If this cancellation was not intended, please submit a new request'
         );
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, ReactNode } from 'react';
 import {
     Alert,
     AlertActionCloseButton,
@@ -87,6 +87,20 @@ export function getCVEsForUpdatedRequest(exception: VulnerabilityException): str
 
 const tabContentId = 'ExceptionRequestDetails';
 const cveTableTabContentId = 'ExceptionRequestCveTable';
+
+function CveTableTabWrapper({
+    children,
+    isPlatformCveSplitEnabled,
+}: {
+    children: ReactNode;
+    isPlatformCveSplitEnabled: boolean;
+}) {
+    if (!isPlatformCveSplitEnabled) {
+        return children;
+    }
+
+    return <TabContent id={cveTableTabContentId}>{children}</TabContent>;
+}
 
 function ExceptionRequestDetailsPage() {
     const { requestId } = useParams();
@@ -208,7 +222,6 @@ function ExceptionRequestDetailsPage() {
         isPlatformCveSplitEnabled && activeCveTableTabKey === 'PLATFORM_COMPONENTS'
             ? vulnerabilitiesPlatformWorkloadCvesPath
             : vulnerabilitiesWorkloadCvesPath;
-
     return (
         <>
             <PageTitle title="Exception Management - Request Details" />
@@ -295,26 +308,27 @@ function ExceptionRequestDetailsPage() {
                         />
                     </PageSection>
                     <PageSection className="pf-v5-u-pt-0">
-                        <Tabs
-                            activeKey={activeCveTableTabKey}
-                            onSelect={handleCveTableTabClick}
-                            isBox
-                            aria-label="Exception request CVEs split by affected image scope"
-                            role="region"
-                            className={isPlatformCveSplitEnabled ? '' : 'pf-v5-u-display-none'}
-                        >
-                            <Tab
-                                eventKey={'USER_WORKLOADS'}
-                                title={<TabTitleText>User workloads</TabTitleText>}
-                                tabContentId={cveTableTabContentId}
-                            />
-                            <Tab
-                                eventKey={'PLATFORM_COMPONENTS'}
-                                title={<TabTitleText>Platform components</TabTitleText>}
-                                tabContentId={cveTableTabContentId}
-                            />
-                        </Tabs>
-                        <TabContent id={cveTableTabContentId}>
+                        {isPlatformCveSplitEnabled && (
+                            <Tabs
+                                activeKey={activeCveTableTabKey}
+                                onSelect={handleCveTableTabClick}
+                                isBox
+                                aria-label="Exception request CVEs split by affected image scope"
+                                role="region"
+                            >
+                                <Tab
+                                    eventKey={'USER_WORKLOADS'}
+                                    title={<TabTitleText>User workloads</TabTitleText>}
+                                    tabContentId={cveTableTabContentId}
+                                />
+                                <Tab
+                                    eventKey={'PLATFORM_COMPONENTS'}
+                                    title={<TabTitleText>Platform components</TabTitleText>}
+                                    tabContentId={cveTableTabContentId}
+                                />
+                            </Tabs>
+                        )}
+                        <CveTableTabWrapper isPlatformCveSplitEnabled={isPlatformCveSplitEnabled}>
                             <RequestCVEsTable
                                 searchFilter={searchFilter}
                                 vulnMgmtBaseUrl={vulnMgmtBaseUrl}
@@ -322,7 +336,7 @@ function ExceptionRequestDetailsPage() {
                                 expandedRowSet={expandedRowSet}
                                 vulnerabilityState={vulnerabilityState}
                             />
-                        </TabContent>
+                        </CveTableTabWrapper>
                     </PageSection>
                 </TabContent>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -214,7 +214,7 @@ function ExceptionRequestDetailsPage() {
     };
 
     if (isPlatformCveSplitEnabled) {
-        searchFilter['Platform component'] =
+        searchFilter['Platform Component'] =
             activeCveTableTabKey === 'USER_WORKLOADS' ? ['false', '-'] : ['true'];
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -14,20 +14,17 @@ import { useQuery } from '@apollo/client';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 
-import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { SetResult } from 'hooks/useSet';
-import useURLPagination from 'hooks/useURLPagination';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
-import {
-    VulnerabilityExceptionScope,
-    VulnerabilityState,
-} from 'services/VulnerabilityExceptionService';
+import { VulnerabilityState } from 'services/VulnerabilityExceptionService';
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { getTableUIState } from 'utils/getTableUIState';
+import { SearchFilter } from 'types/search';
 import {
     aggregateByCVSS,
     aggregateByCreatedTime,
@@ -43,38 +40,32 @@ import {
     cveListQuery,
 } from '../../WorkloadCves/Tables/WorkloadCVEOverviewTable';
 import { VulnerabilitySeverityLabel } from '../../types';
-import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 
-import { getImageScopeSearchValue } from '../utils';
-
 type RequestCVEsTableProps = {
-    cves: string[];
-    scope: VulnerabilityExceptionScope;
+    searchFilter: SearchFilter;
+    vulnMgmtBaseUrl: string;
+    pagination: UseURLPaginationResult;
     expandedRowSet: SetResult<string>;
     vulnerabilityState: VulnerabilityState;
 };
 
 function RequestCVEsTable({
-    cves,
-    scope,
+    searchFilter,
+    vulnMgmtBaseUrl,
+    pagination,
     expandedRowSet,
     vulnerabilityState,
 }: RequestCVEsTableProps) {
-    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const { page, perPage, setPage, setPerPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
         sortFields: getWorkloadSortFields('CVE'),
         defaultSortOption: getDefaultWorkloadSortOption('CVE'),
         onSort: () => setPage(1),
     });
 
-    const queryObject = {
-        CVE: cves.join(','),
-        Image: getImageScopeSearchValue(scope),
-    };
-
-    const query = getRequestQueryStringForSearchFilter(queryObject);
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
 
     const {
         error,
@@ -97,7 +88,7 @@ function RequestCVEsTable({
     const colSpan = 6;
 
     return (
-        <PageSection variant="light">
+        <PageSection variant="light" className="pf-v5-u-pt-0">
             <Flex direction={{ default: 'column' }}>
                 <Toolbar>
                     <ToolbarContent className="pf-v5-u-justify-content-space-between">
@@ -184,11 +175,11 @@ function RequestCVEsTable({
 
                                 const cveURLQueryOptions = {
                                     s: {
-                                        IMAGE: queryObject.Image,
+                                        IMAGE: searchFilter.Image,
                                     },
                                 };
 
-                                const cveURL = `${vulnerabilitiesWorkloadCvesPath}/${getWorkloadEntityPagePath(
+                                const cveURL = `${vulnMgmtBaseUrl}/${getWorkloadEntityPagePath(
                                     'CVE',
                                     cve,
                                     vulnerabilityState,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -76,6 +76,7 @@ function RequestCVEsTable({
             query,
             pagination: getPaginationParams({ page, perPage, sortOption }),
         },
+        fetchPolicy: 'no-cache',
     });
 
     const tableState = getTableUIState({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
@@ -56,6 +56,7 @@ function useRequestCVEsDetails(exception: VulnerabilityException): UseAffectedIm
             variables: {
                 query,
             },
+            fetchPolicy: 'no-cache',
         }
     );
 


### PR DESCRIPTION
### Description

Divides the CVE table in Exception Management into two tabs, with each tab contextual to either user workloads or platform components.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Create a Vulnerability Exception and visit the detail page. By default, the "user workloads" tab is selected. CVEs in this section should show counts for images specific to user workloads and the link in the table should navigate to the correct VM section.
![image](https://github.com/user-attachments/assets/547f11b0-12cd-46e6-b27f-49859b6b625e)
![image](https://github.com/user-attachments/assets/11484b08-e971-4975-bbff-ee1cf45977af)


Switch to the "platform components" tab and ensure the displayed CVEs match the counts for only platform components, and link to the correct VM section.
![image](https://github.com/user-attachments/assets/c67b0080-ab0f-4c03-af69-a1cec6bcd070)
![image](https://github.com/user-attachments/assets/57d6a010-61e9-4dfb-a009-20c0500f31b5)


