### PR TITLE
test: stop using pipe listener for tls manager test

### DIFF
--- a/pkg/netutil/pipeconn/pipe_listener.go
+++ b/pkg/netutil/pipeconn/pipe_listener.go
@@ -39,6 +39,8 @@ type pipeListener struct {
 
 // NewPipeListener returns a net.Listener that accepts connections which are local pipe connections (i.e., via
 // net.Pipe()). It also returns a function that implements a context-aware dial.
+// Note: due to lack of buffering, this mechanism might be inappropriate for some protocols, such as TLS.
+// See https://github.com/golang/go/issues/71269#issuecomment-2592638836
 func NewPipeListener() (net.Listener, DialContextFunc) {
 	lis := &pipeListener{
 		closed:       concurrency.NewSignal(),


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

`crypto/mtls` code in go 1.23 [does not work with unbuffered connections](https://github.com/golang/go/issues/71269 provided by the pipe listener package. In fact, it is [not guaranteed to work in any version](https://github.com/golang/go/issues/24198#issuecomment-376914471).

Let's use plan TCP for this, there is no measurable slowdown.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

```
go test -v -timeout 10s -count 1 github.com/stackrox/rox/central/tlsconfig -run TestManager/TestNoExtraCertIssuedInStackRoxNamespace
```
with 1.22 1.23 and 1.24rc1 Go versions.