### PR TITLE
ROX-27688: Use single-line JSON in generic notifier

### DIFF
--- a/central/notifiers/generic/generic.go
+++ b/central/notifiers/generic/generic.go
@@ -21,13 +21,13 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	"github.com/stackrox/rox/pkg/utils"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -179,7 +179,10 @@ func (g *generic) Test(ctx context.Context) *notifiers.NotifierError {
 }
 
 func (g *generic) constructJSON(message protocompat.Message, msgKey string) (io.Reader, error) {
-	msgStr := protojson.MarshalOptions{}.Format(message)
+	msgStr, err := jsonutil.MarshalToCompactString(message)
+	if err != nil {
+		return nil, err
+	}
 
 	var strJSON string
 	// No extra fields append so that the payload is something like {"alert": {...}}

--- a/central/notifiers/generic/generic.go
+++ b/central/notifiers/generic/generic.go
@@ -179,7 +179,7 @@ func (g *generic) Test(ctx context.Context) *notifiers.NotifierError {
 }
 
 func (g *generic) constructJSON(message protocompat.Message, msgKey string) (io.Reader, error) {
-	msgStr := protojson.Format(message)
+	msgStr := protojson.MarshalOptions{}.Format(message)
 
 	var strJSON string
 	// No extra fields append so that the payload is something like {"alert": {...}}


### PR DESCRIPTION
### Description

#### Problem
ACSCS uses Vector to send audit logs to cloudwatch. Vector service on production has error logs about not able to parse JSON.

#### Root cause
Regression after the [protobuf upgrade](https://github.com/stackrox/stackrox/pull/10951). Vector [doesn't support multiline strings](https://github.com/vectordotdev/vector/issues/4952) in requests, and we changed the format with the upgrade:

Before:
```
new(jsonpb.Marshaler).MarshalToString(message)
```
Now:
```
msgStr := protojson.Format(message)
```
From the doc:
```
// Format formats the message as a multiline string.
// This function is only intended for human consumption and ignores errors.
// Do not depend on the output being stable. Its output will change across
// different builds of your program, even when using the same version of the
// protobuf module.
```
### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested in ACSCS integration 
