### PR TITLE
ROX-27674: Create rc.0 tags for patch releases

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -149,14 +149,16 @@ jobs:
         run: |
           git config user.name "${{github.event.sender.login}}"
           git config user.email noreply@github.com
-      - name: Create and annotate branch ${{needs.variables.outputs.branch}}
+      - name: Create release branch ${{needs.variables.outputs.branch}}
         if: steps.check-existing.outputs.branch-exists == 'false'
         run: |
           git switch --create "${{needs.variables.outputs.branch}}"
           git commit --allow-empty --message \
             "Empty commit to diverge ${{needs.variables.outputs.release}} from ${{env.main_branch}}"
+      - name: Tag release branch with rc.0 ${{needs.variables.outputs.branch}}
+        run: |
           git tag --annotate --message "Upstream automation" \
-            "${{needs.variables.outputs.release}}.0-rc.0" HEAD
+            "${{needs.variables.outputs.release}}.${{needs.variables.outputs.patch}}-rc.0" HEAD
       - name: Update the changelog
         if: steps.check-existing.outputs.branch-exists == 'false'
         run: |


### PR DESCRIPTION
### Description

Scanner Vulnerability Updater needs to determine an initial tag to generate vulnerabilities while the final release tags (both patch and non-patch) are not not tagged yet. Currently this is true for non-patch releases, but it fails on patch releases because we only get RC tags after the first RC is cut. We can ignore such scenarios and workaround it, but I feel, conceptually, creating rc.0's makes sense.

#### More Context on Scanner Vulnerability Updater

The updater relies [on `RELEASE_VERSION`](https://github.com/stackrox/stackrox/blob/master/scanner/updater/version/RELEASE_VERSION) to determine which releases it should create bundles for. Previously, we would create bundles for each release specified. Today, we create one bundle per "vulnerability schema", which has a internal version and it is currently at v2. For offline bundles (yes, they are different from online), we still create one bundle per release, but the contents are the same when the schema is the same, essentially.

Details on how it works are here: https://github.com/stackrox/stackrox/blob/master/scanner/decisions/0011-separate-versioning-for-vuln-bundles.md

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [X] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

Some caveats: I don't know if there is any additional automated tests I can use to validate this, happy to execute them if your point me out to the right direction.

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I didn't execute the workflow.

I did try to validate the change conceptually. I looked at https://github.com/stackrox/stackrox/blob/release-rc0/.github/workflows/variables.yml#L82, determined that calls to that action are made with [A.B.C[-N] formats and X.Y.Z versions for both patch and non-patch](https://github.com/stackrox/stackrox/blob/release-rc0/.github/workflows/start-release.yml#L98), and deduced that if I always create the rc.0 tag regardless of the branch existing or not, I should be good.

Not sure if I should support re-running this, as in, check if the tag already exists before creating it. Let me know, and I update.

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
