### PR TITLE
fix(ui): Update naming and nav for platform components

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -108,12 +108,6 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
               },
               {
                   type: 'link',
-                  content: 'Kubernetes Components',
-                  path: vulnerabilitiesPlatformCvesPath,
-                  routeKey: 'vulnerabilities/platform-cves',
-              },
-              {
-                  type: 'link',
                   content: 'Nodes',
                   path: vulnerabilitiesNodeCvesPath,
                   routeKey: 'vulnerabilities/node-cves',
@@ -145,6 +139,14 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                   routeKey: 'vulnerability-management',
                   isActive: (pathname) =>
                       Boolean(matchPath(pathname, { vulnManagementPath, exact: true })),
+              },
+              {
+                  type: 'link',
+                  content: (
+                      <NavigationContent variant="Deprecated">Platform CVEs</NavigationContent>
+                  ),
+                  path: vulnerabilitiesPlatformCvesPath,
+                  routeKey: 'vulnerabilities/platform-cves',
               },
           ]
         : [

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -165,7 +165,7 @@ function NodeCvesOverviewPage() {
             >
                 <Flex alignItems={{ default: 'alignItemsCenter' }} className="pf-v5-u-flex-grow-1">
                     <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
-                        <Title headingLevel="h1">Node CVEs</Title>
+                        <Title headingLevel="h1">Nodes</Title>
                         <FlexItem>Prioritize and manage scanned CVEs across nodes</FlexItem>
                     </Flex>
                     <FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -32,7 +32,7 @@ function WorkloadCvesPage({ view }: WorkloadCvePageProps) {
     const hasReadAccessForNamespaces = hasReadAccess('Namespace');
 
     const context = useMemo(() => {
-        const pageTitle = 'Workload CVEs'; // TODO Implement throughout in follow up
+        const pageTitle = view === 'platform-workload' ? 'Platform components' : 'User workloads';
         const platformComponentFilters =
             view === 'platform-workload'
                 ? ['true']


### PR DESCRIPTION
### Description

Cleans up the naming for the Workload CVE split as discussed at the sync.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

View the left navigation when the feature flag is on. "Kubernetes components" returns as "Platform CVEs", and is moved to the bottom with a (Deprecated) label.

Page `<h1>` headers reflect the current context:
![image](https://github.com/user-attachments/assets/a12dc22d-caee-495f-ab54-b56cb4fb0672)
![image](https://github.com/user-attachments/assets/8cf5092d-5754-4e95-ba90-6610560e4795)
![image](https://github.com/user-attachments/assets/091070a8-e9d7-4610-9026-2cd02a69c858)

Breadcrumb links reflect the current context:
![image](https://github.com/user-attachments/assets/dd156839-b385-4843-b0b2-d0793691f7fe)
![image](https://github.com/user-attachments/assets/21073ee1-daa5-46c2-b2ee-6c40e0319372)


