### PR TITLE
feat(helm): support admission control failurePolicy configuration

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -113,6 +113,7 @@ admissionControl:
   hostAliases: null # [dict]
   priorityClassName: null # string
   namespaceSelector: null # dict
+  failurePolicy: null # string
 collector:
   forceCollectionMethod: null # bool
   collectionMethod: null # string

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -76,6 +76,7 @@ admissionControl:
     timeout: 10
     enforceOnUpdates: false
   replicas: 3
+  failurePolicy: Ignore
 
   affinity:
     nodeAffinity:

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -235,7 +235,7 @@ webhooks:
           - kube-public
           - istio-system
       {{- end }}
-    failurePolicy: Ignore
+    failurePolicy: {{ ._rox.admissionControl.failurePolicy }}
     clientConfig:
       caBundle: {{ required "The 'ca.cert' config option MUST be set to StackRox's Service CA certificate in order for the admission controller to be usable" ._rox.ca._cert | b64enc }}
       service:
@@ -261,7 +261,7 @@ webhooks:
           - pods
           - pods/exec
           - pods/portforward
-    failurePolicy: Ignore
+    failurePolicy: {{ ._rox.admissionControl.failurePolicy }}
     clientConfig:
       caBundle: {{ required "The 'ca.cert' config option MUST be set to StackRox's Service CA certificate in order for the admission controller to be usable" ._rox.ca._cert | b64enc }}
       service:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -307,6 +307,10 @@
 #    cert: null
 #    key: null
 #
+#  # Failure Policy from the admission configuration
+#  # Available values: Ignore|Fail
+#  failurePolicy: Ignore
+#
 ## Collector specific configuration.
 #collector:
 #

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -161,3 +161,21 @@ tests:
                 - istio-system
       expect: |
         .validatingwebhookconfigurations[].webhooks[].namespaceSelector.matchExpressions | assertThat(length == 2)
+
+- name: "Admission Controller Failure Policy"
+  tests:
+    - name: "default failure policy ignore"
+      values:
+        admissionControl:
+          listenOnCreates: true
+          listenOnEvents: false
+      expect: |
+        .validatingwebhookconfigurations[].webhooks[].failurePolicy | assertThat(. == "Ignore")
+    - name: "override failurePolicy to fail"
+      values:
+        admissionControl:
+          listenOnCreates: true
+          listenOnEvents: false
+          failurePolicy: "Fail"
+      expect: |
+        .validatingwebhookconfigurations[].webhooks[].failurePolicy | assertThat(. == "Fail")


### PR DESCRIPTION
### Description

Add support to define which failurePolicy the admission controller can apply. 
FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.

### User-facing documentation

- [X] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [X] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [X] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [X] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Added unit test for current config and custom configuration.
