### PR TITLE
chore: limit k8s updates to patch only

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -62,6 +62,8 @@ updates:
       - dependency-name: "github.com/quay/claircore"
     groups:
       k8s.io:
+        update-types:
+          - "patch"
         patterns:
           - "k8s.io/*"
 


### PR DESCRIPTION
### Description

k8s minor updates usually updates Go version. Since we do not follow the latest go version in our project we cannot update k8s and we should do it manually.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
