### PR TITLE
fix(CI): retry scanner images builds

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -240,7 +240,7 @@ jobs:
       run: echo "BUILD_TAG=$(make -C scanner --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"
 
     - name: Build Scanner and ScannerDB images
-      run: make -C scanner GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} images
+      run: scripts/lib.sh retry 6 true make -C scanner GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} images
 
     - name: Push Scanner and ScannerDB images
       # Skip for external contributions.


### PR DESCRIPTION
### Description

This PR fixes problem with scanner images that fails due to:
```
ERROR: failed to solve: registry.access.redhat.com/ubi8-minimal:latest: failed to resolve source metadata for registry.access.redhat.com/ubi8-minimal:latest: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry.access.redhat.com/v2/ubi8-minimal/manifests/sha256:cf095e5668919ba1b4ace3888107684ad9d587b1830d3eb56973e6a54f456e67: 502 Bad Gateway
```
This is related to:
- #10209
- https://github.com/stackrox/stackrox/pull/8844
---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI

https://github.com/stackrox/stackrox/actions/runs/12807954997/job/35709990370?pr=13841#step:13:1
