### PR TITLE
chore(CI): Disable test option for autocomplete search image

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -458,7 +458,8 @@ class SACTest extends BaseSpecification {
         NOACCESSTOKEN            | "Deployment" | 0
         NOACCESSTOKEN            | "Image"      | 0
         "searchDeploymentsToken" | "Deployment" | 1
-        "searchImagesToken"      | "Image"      | 1
+        // ROX-27478 - it's failing since 2024-12-19. Disabled for now. Could be related to: ROX-26729.
+        // "searchImagesToken"      | "Image"      | 1
         "searchNamespacesToken"  | "Namespace"  | 1
     }
 


### PR DESCRIPTION
### Description

Disable flaky test for autocomplete image search variation in SACTest. [ROX-27478](https://issues.redhat.com/browse/ROX-27478)

This test has been flaky since 2024-12-19. Around that time, we have disabled ROX-26729. It could be that they are related.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] disabled e2e tests

#### How I validated my change

Let CI run and check that test is not included anymore.
