### PR TITLE
ROX-27232: chore: bump Slack action

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -198,37 +198,40 @@ jobs:
 
       - name: Post to Slack about picked cherries
         if: failure() && steps.cherry-pick.outputs.bad-cherries != ''
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Couldn't close upstream milestone ${{needs.variables.outputs.milestone}} on <${{github.server_url}}/${{github.repository}}|${{github.repository}}>. See workflow run <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}> for details.",
-
-              "blocks": [
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":${{ fromJSON('["desert", "red_circle"]')[github.event.inputs.dry-run != 'true'] }}:
-            *Couldn't close upstream milestone ${{needs.variables.outputs.milestone}} on <${{github.server_url}}/${{github.repository}}|${{github.repository}}>.*" }},
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            "*Couldn't cherry-pick the following PRs
-            to the release branch:*\n\n${{steps.cherry-pick.outputs.bad-cherries}}" }},
-
-            { "type": "divider" },
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":arrow_right: *Please assist the PR assignees in merging their changes to `${{needs.variables.outputs.branch}}` branch
-            and then re-run failed jobs of the <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|workflow run>.*" }},
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ">
-            Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
-            Milestone: <${{github.event.milestone.html_url}}|${{needs.variables.outputs.milestone}}>\n>
-            Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
-            ]}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "Couldn't close upstream milestone ${{needs.variables.outputs.milestone}} on <${{github.server_url}}/${{github.repository}}|${{github.repository}}>. See workflow run <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}> for details."
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :${{ fromJSON('["desert", "red_circle"]')[github.event.inputs.dry-run != 'true'] }}:
+                    *Couldn't close upstream milestone ${{needs.variables.outputs.milestone}} on <${{github.server_url}}/${{github.repository}}|${{github.repository}}>.*
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *Couldn't cherry-pick the following PRs to the release branch:*
+                    ${{steps.cherry-pick.outputs.bad-cherries}}
+              - type: "divider"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :arrow_right: *Please assist the PR assignees in merging their changes to `${{needs.variables.outputs.branch}}` branch
+                    and then re-run failed jobs of the <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|workflow run>.*
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    > Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>
+                    > Milestone: <${{github.event.milestone.html_url}}|${{needs.variables.outputs.milestone}}>
+                    > Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>
 
       - name: Tag release branch with "${{needs.variables.outputs.milestone}}"
         id: tag
@@ -276,30 +279,25 @@ jobs:
       - run: |
           echo "Created GitHub pre-release [${{needs.variables.outputs.milestone}}](${{steps.pre-release.outputs.url}})" >> "$GITHUB_STEP_SUMMARY"
       - name: Post to Slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Upstream release candidate <${{steps.pre-release.outputs.url}}|${{needs.variables.outputs.milestone}}> of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub",
-
-              "blocks": [
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}:
-            *Upstream release candidate <${{steps.pre-release.outputs.url}}|${{needs.variables.outputs.milestone}}>
-            of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub*" }},
-
-            { "type": "divider" },
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":arrow_right: Once all checks pass and you're ready for release,
-            run the <${{ github.server_url }}/${{ github.repository }}/actions/workflows/finish-release.yml|Finish Release>
-            workflow and delete the `${{ needs.variables.outputs.next-milestone }}`
-            milestone to avoid confusion." }}
-            ]}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "Upstream release candidate <${{steps.pre-release.outputs.url}}|${{needs.variables.outputs.milestone}}> of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}: *Upstream release candidate <${{steps.pre-release.outputs.url}}|${{needs.variables.outputs.milestone}}> of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub*
+              - type: "divider"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :arrow_right: Once all checks pass and you're ready for release, run the <${{ github.server_url }}/${{ github.repository }}/actions/workflows/finish-release.yml|Finish Release> workflow and delete the `${{ needs.variables.outputs.next-milestone }}` milestone to avoid confusion.
 
   clusters:
     name: Setup demo clusters

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -139,29 +139,30 @@ jobs:
           fi
 
       - name: Post to Slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Release <${{ steps.release.outputs.url }} | ${{ inputs.version }}> has been published. Consult the tracker for next steps.",
-
-              "blocks": [
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}:
-            *Release <${{ steps.release.outputs.url }} | ${{ inputs.version }}> of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub.*" }},
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":arrow_right: Tell the downstream release engineer to trigger the downstream release,
-            and once the downstream release is complete, merge the PR created by CI in
-            <https://github.com/stackrox/release-artifacts/pulls|stackrox/release-artifacts>
-            repository." }},
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":arrow_right: Check the status of the upstream CI for the tag in <https://prow.ci.openshift.org/?repo=stackrox%2Fstackrox&job=*release-${{ needs.variables.outputs.release }}*|Openshift CI> and follow up on any failures." }}
-            ]}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "Release <${{ steps.release.outputs.url }} | ${{ inputs.version }}> has been published. Consult the tracker for next steps."
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}: *Release <${{ steps.release.outputs.url }} | ${{ inputs.version }}> of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub.*
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :arrow_right: Tell the downstream release engineer to trigger the downstream release.
+                    Once the downstream release is complete, merge the PR created by CI in <https://github.com/stackrox/release-artifacts/pulls|stackrox/release-artifacts> repository.
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :arrow_right: Check the status of the upstream CI for the tag in <https://prow.ci.openshift.org/?repo=stackrox%2Fstackrox&job=*release-${{ needs.variables.outputs.release }}*|Openshift CI> and follow up on any failures."
 
   update-infra-demo-version:
     name: Update infra demo default versions

--- a/.github/workflows/notify-milestone-change.yml
+++ b/.github/workflows/notify-milestone-change.yml
@@ -66,36 +66,24 @@ jobs:
             fi
 
       - name: Send Slack notification
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "${{ steps.context.outputs.pr-info }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.context.outputs.pr-info }}"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.context.outputs.call-to-action }}"
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ steps.context.outputs.jira-info}}"
-                  }
-                }
-              ]
-            }
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "${{ steps.context.outputs.pr-info }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.context.outputs.pr-info }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.context.outputs.call-to-action }}"
+              - type: "divider"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.context.outputs.jira-info}}"

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -334,67 +334,67 @@ jobs:
     name: Notify everybody
     needs: [variables, properties, branch, milestone]
     runs-on: ubuntu-latest
-    env:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - name: Post to Slack (normal release)
         if: needs.variables.outputs.patch == 0
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Upstream release ${{needs.variables.outputs.named-release-patch}} has been triggered. Consult the tracker for next steps.",
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "Upstream release ${{needs.variables.outputs.named-release-patch}} has been triggered. Consult the tracker for next steps."
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}: *Upstream release ${{needs.variables.outputs.named-release-patch}} has been triggered on <${{github.server_url}}/${{github.repository}}|${{github.repository}}> by ${{ github.event.sender.login }}.*
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    Branch `${{needs.variables.outputs.branch}}` and milestone `${{needs.variables.outputs.next-milestone}}` have been created.
 
-              "blocks": [
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}:
-            *Upstream release ${{needs.variables.outputs.named-release-patch}}
-            has been triggered on <${{github.server_url}}/${{github.repository}}|${{github.repository}}> by ${{ github.event.sender.login }}.*" }},
+                    PRs merged to the ${{env.main_branch}} branch and assigned to RC milestones will be cherry-picked when closing the respective milestones.
+                    For the urgent fixes that must go exclusively to this release open PRs to the `${{needs.variables.outputs.branch}}` branch.
+              - type: "divider"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    > Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>
+                    > Release: ${{needs.variables.outputs.named-release-patch}}
+                    > Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>
 
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            "Branch `${{needs.variables.outputs.branch}}`
-            and milestone `${{needs.variables.outputs.next-milestone}}`
-            have been created.\n\nPRs merged to the ${{env.main_branch}} branch
-            and assigned to RC milestones will be cherry-picked when closing the respective milestones.
-            For the urgent fixes that must go exclusively to this release
-            open PRs to the `${{needs.variables.outputs.branch}}` branch." }},
-
-            { "type": "divider" },
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ">
-            Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
-            Release: ${{needs.variables.outputs.named-release-patch}}\n>
-            Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
-            ]}
       - name: Post to Slack (patch release)
         if: needs.variables.outputs.patch != 0
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Upstream patch release ${{needs.variables.outputs.named-release-patch}} has been triggered. Consult the tracker for next steps.",
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "Upstream patch release ${{needs.variables.outputs.named-release-patch}} has been triggered. Consult the tracker for next steps."
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}: *Upstream patch release ${{needs.variables.outputs.named-release-patch}} has been triggered on <${{github.server_url}}/${{github.repository}}|${{github.repository}}> by ${{ github.event.sender.login }}.*
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    Milestone `${{needs.variables.outputs.next-milestone}}` has been created.
 
-              "blocks": [
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}:
-            *Upstream patch release ${{needs.variables.outputs.named-release-patch}}
-            has been triggered on <${{github.server_url}}/${{github.repository}}|${{github.repository}}> by ${{ github.event.sender.login }}.*" }},
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            "Milestone `${{needs.variables.outputs.next-milestone}}`
-            has been created.\n\nPRs merged to the ${{env.main_branch}} branch
-            and assigned to RC milestones will be cherry-picked when closing the respective milestones.
-            For the urgent fixes that must go exclusively to this release
-            open PRs to the `${{needs.variables.outputs.branch}}` branch." }},
-
-            { "type": "divider" },
-
-            { "type": "section", "text": { "type": "mrkdwn", "text":
-            ">
-            Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
-            Release: ${{needs.variables.outputs.named-release-patch}}\n>
-            Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
-            ]}
+                    PRs merged to the ${{env.main_branch}} branch and assigned to RC milestones will be cherry-picked when closing the respective milestones.
+                    For the urgent fixes that must go exclusively to this release open PRs to the `${{needs.variables.outputs.branch}}` branch.
+              - type: "divider"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    > Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>
+                    > Release: ${{needs.variables.outputs.named-release-patch}}
+                    > Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -111,35 +111,26 @@ jobs:
             "${{inputs.previous-version}}" \
             "${{inputs.milestone}}"
       - name: Post to Slack about cluster creation
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Upgrade clusters have been prepared for ${{ inputs.milestone }} milestone. Consult the upgrade test documentation for next steps.",
-
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":${{ fromJSON('["desert", "tada"]')[github.event.inputs.dry-run != 'true'] }}: *Upgrade clusters have been prepared for ${{ inputs.milestone }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}> by ${{ github.event.sender.login }}.*"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":arrow_right: Setup your local access to Central by running in your clone of `${{ github.repository }}`:\n```./scripts/release-tools/upgrade-cluster-client.sh ${{ inputs.milestone }}```"
-                  }
-                }
-              ]
-            }
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "Upgrade clusters have been prepared for ${{ inputs.milestone }} milestone. Consult the upgrade test documentation for next steps."
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :${{ fromJSON('["desert", "tada"]')[github.event.inputs.dry-run != 'true'] }}: *Upgrade clusters have been prepared for ${{ inputs.milestone }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}> by ${{ github.event.sender.login }}.*
+              - type: "divider"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :arrow_right: Setup your local access to Central by running in your clone of `${{ github.repository }}`:
+                    ```./scripts/release-tools/upgrade-cluster-client.sh ${{ inputs.milestone }}```
 
   notify-failed-clusters:
     name: Notify about failed cluster creation
@@ -148,32 +139,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ needs.properties.outputs.slack-channel }}
-          payload: >-
-            {
-              "text": "Couldn't create upgrade clusters for ${{ inputs.milestone }} milestone. Investigate the output of the <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}> workflow run.",
-
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":${{ fromJSON('["desert", "red_circle"]')[github.event.inputs.dry-run != 'true'] }}: *Couldn't create upgrade clusters for ${{ inputs.milestone }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}> by ${{ github.event.sender.login }}.*"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":arrow_right: *Please investigate the output of the <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}> workflow run and then restart the script from where it failed.*"
-                  }
-                }
-              ]
-            }
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.properties.outputs.slack-channel }}"
+            text: "Couldn't create upgrade clusters for ${{ inputs.milestone }} milestone. Investigate the output of the <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}> workflow run."
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :${{ fromJSON('["desert", "red_circle"]')[github.event.inputs.dry-run != 'true'] }}: *Couldn't create upgrade clusters for ${{ inputs.milestone }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}> by ${{ github.event.sender.login }}.*
+              - type: "divider"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :arrow_right: Please investigate the output of the <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}> workflow run and then restart the script from where it failed.


### PR DESCRIPTION
Porting changes from https://github.com/stackrox/test-gh-actions/pull/186.
The automated upstream patch workflow failed ([link](https://github.com/stackrox/test-gh-actions/actions/runs/12809357155)) because the Slack Action had been bumped in this repository in between, which led to merge conflicts. 