### PR TITLE
chore(CI): skip major version of k8s updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -55,6 +55,9 @@ updates:
       include: scope
       prefix: chore
     ignore:
+      # k8s minor releases usually bumps go version to the latest one which we do not use.
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-minor"]
       - dependency-name: "github.com/aws/aws-sdk-go"
         update-types: ["version-update:semver-patch"]
       # The Scanner team wants full control over ClairCore updates,


### PR DESCRIPTION
### Description

Follow up for: 
- https://github.com/stackrox/stackrox/pull/13840 
as we got some k8s major version updated outside of the group
- https://github.com/stackrox/stackrox/pull/13854


- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
