### PR TITLE
ROX-27722: Store 'discovered' entities for each cluster

### DIFF
--- a/central/sensor/service/pipeline/networkflowupdate/factory.go
+++ b/central/sensor/service/pipeline/networkflowupdate/factory.go
@@ -37,5 +37,5 @@ func (s *factoryImpl) GetFragment(ctx context.Context, clusterID string) (pipeli
 			return nil, errors.Wrapf(err, "creating flow store for cluster %s", clusterID)
 		}
 	}
-	return NewPipeline(clusterID, newFlowPersister(flowStore, s.networkBaselines, entityDataStore.Singleton())), nil
+	return NewPipeline(clusterID, newFlowPersister(flowStore, s.networkBaselines, entityDataStore.Singleton(), clusterID)), nil
 }

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater.go
@@ -15,11 +15,12 @@ type flowPersister interface {
 	update(ctx context.Context, newFlows []*storage.NetworkFlow, updateTS *time.Time) error
 }
 
-func newFlowPersister(flowStore datastore.FlowDataStore, networkBaselines networkBaselineManager.Manager, entityStore entityDataStore.EntityDataStore) flowPersister {
+func newFlowPersister(flowStore datastore.FlowDataStore, networkBaselines networkBaselineManager.Manager, entityStore entityDataStore.EntityDataStore, clusterID string) flowPersister {
 	return &flowPersisterImpl{
 		flowStore:                 flowStore,
 		baselines:                 networkBaselines,
 		seenBaselineRelevantFlows: make(map[networkgraph.NetworkConnIndicator]struct{}),
 		entityStore:               entityStore,
+		clusterID:                 clusterID,
 	}
 }

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl.go
@@ -165,7 +165,7 @@ func (s *flowPersisterImpl) fixupExternalNetworkEntityIdIfDiscovered(ctx context
 
 	id, err := externalsrcs.NewClusterScopedID(s.clusterID, entityInfo.GetExternalSource().GetCidr())
 
-	if err != nil {
+	if err == nil {
 		entityInfo.Id = id.String()
 	}
 

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -53,7 +53,7 @@ func (suite *FlowStoreUpdaterTestSuite) SetupTest() {
 	suite.mockFlows = nfDSMocks.NewMockFlowDataStore(suite.mockCtrl)
 	suite.mockBaselines = baselineMocks.NewMockManager(suite.mockCtrl)
 	suite.mockEntities = entityMocks.NewMockEntityDataStore(suite.mockCtrl)
-	suite.tested = newFlowPersister(suite.mockFlows, suite.mockBaselines, suite.mockEntities)
+	suite.tested = newFlowPersister(suite.mockFlows, suite.mockBaselines, suite.mockEntities, "cluster")
 }
 
 func (suite *FlowStoreUpdaterTestSuite) TearDownTest() {

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -277,6 +277,8 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 
 	discoveredEntity1 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{1, 2, 3, 4, 32})).ToProto()
 	discoveredEntity2 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32})).ToProto()
+	fixedupDiscoveredEntity1 := networkgraph.DiscoveredExternalEntityClusterScoped("cluster", net.IPNetworkFromCIDRBytes([]byte{1, 2, 3, 4, 32})).ToProto()
+	fixedupDiscoveredEntity2 := networkgraph.DiscoveredExternalEntityClusterScoped("cluster", net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32})).ToProto()
 
 	secondTimestamp := time.Now()
 	newFlows := []*storage.NetworkFlow{
@@ -304,12 +306,12 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 	expectedUpdateProps := []*storage.NetworkFlowProperties{
 		{
 			SrcEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: "someNode1"},
-			DstEntity:  discoveredEntity1,
+			DstEntity:  fixedupDiscoveredEntity1,
 			DstPort:    3,
 			L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
 		},
 		{
-			SrcEntity:  discoveredEntity2,
+			SrcEntity:  fixedupDiscoveredEntity2,
 			DstEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: "someNode1"},
 			DstPort:    4,
 			L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
@@ -328,7 +330,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 				},
 				DstEntity: networkgraph.Entity{
 					Type:                  storage.NetworkEntityInfo_EXTERNAL_SOURCE,
-					ID:                    "__MS4yLjMuNC8zMg",
+					ID:                    "cluster__MS4yLjMuNC8zMg",
 					ExternalEntityAddress: net.IPNetworkFromCIDRBytes([]byte{1, 2, 3, 4, 32}),
 					Discovered:            true,
 				},
@@ -338,7 +340,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 			{
 				SrcEntity: networkgraph.Entity{
 					Type:                  storage.NetworkEntityInfo_EXTERNAL_SOURCE,
-					ID:                    "__Mi4zLjQuNS8zMg",
+					ID:                    "cluster__Mi4zLjQuNS8zMg",
 					ExternalEntityAddress: net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32}),
 					Discovered:            true,
 				},

--- a/pkg/networkgraph/entity.go
+++ b/pkg/networkgraph/entity.go
@@ -113,6 +113,21 @@ func DiscoveredExternalEntity(address net.IPNetwork) Entity {
 	}
 }
 
+// DiscoveredExternalEntityClusterScoped returns an EXTERNAL_SOURCE entity refering to the provided
+// cluster, and network address.
+// It is marked as "Discovered" to constrast with Entities defined by the user or the default ones.
+func DiscoveredExternalEntityClusterScoped(clusterId string, address net.IPNetwork) Entity {
+	id, err := externalsrcs.NewClusterScopedID(clusterId, address.String())
+	utils.Should(errors.Wrapf(err, "generating id for cluster/network %s/%s", clusterId, address.String()))
+
+	return Entity{
+		Type:                  storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+		ID:                    id.String(),
+		ExternalEntityAddress: address,
+		Discovered:            true,
+	}
+}
+
 // InternetProtoWithDesc returns storage.NetworkEntityInfo proto object with Desc field filled in.
 func InternetProtoWithDesc(family net.Family) *storage.NetworkEntityInfo {
 	var cidr string

--- a/pkg/networkgraph/entity.go
+++ b/pkg/networkgraph/entity.go
@@ -65,13 +65,17 @@ func (e Entity) ToProto() *storage.NetworkEntityInfo {
 
 // EntityFromProto converts a storage.NetworkEntityInfo proto to an Entity struct.
 func EntityFromProto(protoEnt *storage.NetworkEntityInfo) Entity {
-	if protoEnt.Type == storage.NetworkEntityInfo_EXTERNAL_SOURCE && protoEnt.GetExternalSource().GetDiscovered() {
-		return DiscoveredExternalEntity(net.IPNetworkFromCIDR(protoEnt.GetExternalSource().GetCidr()))
+	discovered := protoEnt.Type == storage.NetworkEntityInfo_EXTERNAL_SOURCE && protoEnt.GetExternalSource().GetDiscovered()
+	extAddr := net.IPNetwork{}
+	if discovered {
+		extAddr = net.IPNetworkFromCIDR(protoEnt.GetExternalSource().GetCidr())
 	}
+
 	return Entity{
-		Type:       protoEnt.GetType(),
-		ID:         protoEnt.GetId(),
-		Discovered: false,
+		Type:                  protoEnt.GetType(),
+		ID:                    protoEnt.GetId(),
+		Discovered:            discovered,
+		ExternalEntityAddress: extAddr,
 	}
 }
 


### PR DESCRIPTION
### Description

We used to store 'discovered' entities at the global scope, which makes it easy to determine which clusters are accessed by an entity.

However, when considering pruning, we hit a scalability concern: for every entity, we have to verify if there is no flow using it. This search spans all the flows, which is a large set.

The proposal is to insert 'discovered' entities in every cluster they are detected. This duplicates the information, but splits the pruning cost.

Generate an entity ID scoped to the cluster an entity is discovered in. This will store a new copy every time the entity is discovered in a different cluster.

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: ~~the change is GA~~ or otherwise the functionality is gated by a feature flag (runtime config of the cluster)
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

I deployed the produced image and inspected the entities inserted in the database. They all have a Cluster-scoped identifier. Also, those "discovered" entities are properly returned as part of the network-graph UI.
