### PR TITLE
chore(deps): revert bump codecov/codecov-action from 3 to 5

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-unit-tests
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: go-unit-tests
@@ -111,7 +111,7 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-postgres-unit-tests
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: go-unit-tests
@@ -197,7 +197,7 @@ jobs:
     - name: UI Unit Tests
       run: make ui-test
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ui-unit-tests


### PR DESCRIPTION
Since codecove python has some problems running on our container we need to revert this bump 

```
./codecov  create-commit -t <redacted> 
[PYI-69086:ERROR] Failed to load Python shared library '/tmp/_MEIMh1O7F/libpython3.11.so.1.0': dlopen: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /tmp/_MEIMh1O7F/libpython3.11.so.1.0)
```
https://github.com/stackrox/stackrox/actions/runs/11927149827/job/33242093734#step:7:183

Reverts: 
- #13384

Related to:
- https://github.com/stackrox/stackrox/pull/10154
- https://github.com/codecov/codecov-action/issues/1311