### PR TITLE
chore(CI): skip coverage uplaod for UI tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -197,11 +197,6 @@ jobs:
     - name: UI Unit Tests
       run: make ui-test
 
-    - uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: ui-unit-tests
-
     - name: Publish Test Report
       uses: test-summary/action@v2
       if: always()


### PR DESCRIPTION
### Description

This PR removes coverage upload for UI tests. This tests do not create coverage report and wrong file is considered as a coverage (`compliance.coverage.utils.tsx`) resulting in errors in codecov UI.

> Unusable report due to issues such as source code unavailability, path mismatch, empty report, or incorrect data format. Please visit our

```
Found 1 possible coverage files:  
ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/compliance.coverage.utils.tsx
```
Refs: 
- https://github.com/stackrox/stackrox/pull/8997 

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
