### PR TITLE
ROX-26015: retry network graph SACTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -33,6 +33,7 @@ import util.NetworkGraphUtil
 
 import org.junit.AssumptionViolatedException
 import spock.lang.Ignore
+import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -602,6 +603,7 @@ class SACTest extends BaseSpecification {
         "searchDeploymentsImagesToken"     | NAMESPACE_QA1  | [SSOC.SearchCategory.IMAGES]
     }
 
+    @Retry(count=30, delay=5000)
     def "Verify that SAC has the same effect as query restriction for network flows"() {
         given:
         "The network graphs retrieved by admin with a query and the SAC restricted token with and without query"

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -603,63 +603,59 @@ class SACTest extends BaseSpecification {
     }
 
     def "Verify that SAC has the same effect as query restriction for network flows"() {
-        given:
+        when:
         "The network graphs retrieved by admin with a query and the SAC restricted token with and without query"
         // Default behaviour is to use flows for last 5 mins. That can produce different results between calls.
         def since = Timestamp.newBuilder().setSeconds(System.currentTimeSeconds() - 600).build()
 
-        // Make all service calls in a short succession to avoid potential new flows between calls.
-        def networkGraphWithAllAccess = NetworkGraphService.getNetworkGraph(since, "Namespace:stackrox")
-        useToken("stackroxNetFlowsToken")
-        def networkGraphWithSAC = NetworkGraphService.getNetworkGraph(since, "Namespace:stackrox")
-        def networkGraphWithSACNoQuery = NetworkGraphService.getNetworkGraph(since)
-
-        when:
-        "The network graph for the StackRox namespace with all access"
-        def allAccessFlows = NetworkGraphUtil.flowStrings(networkGraphWithAllAccess)
-        allAccessFlows.removeAll(UNSTABLE_FLOWS)
-        log.info "allAccessFlows: ${allAccessFlows}"
-
-        def allAccessFlowsWithoutNeighbors = allAccessFlows.findAll {
-            it.matches("(stackrox/.*|INTERNET) -> (stackrox/.*|INTERNET)")
-        }
-        log.info "allAccessFlowsWithoutNeighbors: ${allAccessFlowsWithoutNeighbors}"
-
-        and:
-        "The network graph for the StackRox namespace with a SAC restricted token"
-        def sacFlows = NetworkGraphUtil.flowStrings(networkGraphWithSAC)
-        sacFlows.removeAll(UNSTABLE_FLOWS)
-        log.info "sacFlows: ${sacFlows}"
-
-        and:
-        "The network graph for the StackRox namespace with a SAC restricted token and no query"
-        def sacFlowsNoQuery = NetworkGraphUtil.flowStrings(networkGraphWithSACNoQuery)
-        sacFlowsNoQuery.removeAll(UNSTABLE_FLOWS)
-        log.info "sacFlowsNoQuery: ${sacFlowsNoQuery}"
-
         then:
-        "Query-restricted and non-restricted flows should be equal under SAC"
-        assert sacFlows == sacFlowsNoQuery
+        withRetry(30, 5) {
+            // Make all service calls in a short succession to avoid potential new flows between calls.
+            def networkGraphWithAllAccess = NetworkGraphService.getNetworkGraph(since, "Namespace:stackrox")
+            useToken("stackroxNetFlowsToken")
+            def networkGraphWithSAC = NetworkGraphService.getNetworkGraph(since, "Namespace:stackrox")
+            def networkGraphWithSACNoQuery = NetworkGraphService.getNetworkGraph(since)
 
-        and:
-        "The flows should be equal to the flows obtained with all access after removing masked endpoints"
-        Set<String> sacFlowsFiltered = sacFlows.findAll { !it.contains("masked deployment") }
-        Set<String> sacFlowsNoQueryFiltered = sacFlowsNoQuery.findAll { !it.contains("masked deployment") }
+            // "The network graph for the StackRox namespace with all access"
+            def allAccessFlows = NetworkGraphUtil.flowStrings(networkGraphWithAllAccess)
+            allAccessFlows.removeAll(UNSTABLE_FLOWS)
+            log.info "allAccessFlows: ${allAccessFlows}"
 
-        assert allAccessFlowsWithoutNeighbors == sacFlowsFiltered
-        assert allAccessFlowsWithoutNeighbors == sacFlowsNoQueryFiltered
+            def allAccessFlowsWithoutNeighbors = allAccessFlows.findAll {
+                it.matches("(stackrox/.*|INTERNET) -> (stackrox/.*|INTERNET)")
+            }
+            log.info "allAccessFlowsWithoutNeighbors: ${allAccessFlowsWithoutNeighbors}"
 
-        and:
-        "The flows obtained with SAC should contain some masked deployments"
-        assert sacFlowsFiltered.size() < sacFlows.size()
-        assert sacFlowsNoQueryFiltered.size() < sacFlowsNoQuery.size()
+            // "The network graph for the StackRox namespace with a SAC restricted token"
+            def sacFlows = NetworkGraphUtil.flowStrings(networkGraphWithSAC)
+            sacFlows.removeAll(UNSTABLE_FLOWS)
+            log.info "sacFlows: ${sacFlows}"
 
-        and:
-        "The masked deployments should be external to stackrox namespace"
-        assert sacFlows.intersect(sacFlowsFiltered) ==
-                allAccessFlows.intersect(allAccessFlowsWithoutNeighbors)
-        assert sacFlowsNoQuery.intersect(sacFlowsNoQueryFiltered) ==
-                allAccessFlows.intersect(allAccessFlowsWithoutNeighbors)
+            // "The network graph for the StackRox namespace with a SAC restricted token and no query"
+            def sacFlowsNoQuery = NetworkGraphUtil.flowStrings(networkGraphWithSACNoQuery)
+            sacFlowsNoQuery.removeAll(UNSTABLE_FLOWS)
+            log.info "sacFlowsNoQuery: ${sacFlowsNoQuery}"
+
+            // "Query-restricted and non-restricted flows should be equal under SAC"
+            assert sacFlows == sacFlowsNoQuery
+
+            // "The flows should be equal to the flows obtained with all access after removing masked endpoints"
+            Set<String> sacFlowsFiltered = sacFlows.findAll { !it.contains("masked deployment") }
+            Set<String> sacFlowsNoQueryFiltered = sacFlowsNoQuery.findAll { !it.contains("masked deployment") }
+
+            assert allAccessFlowsWithoutNeighbors == sacFlowsFiltered
+            assert allAccessFlowsWithoutNeighbors == sacFlowsNoQueryFiltered
+
+            // "The flows obtained with SAC should contain some masked deployments"
+            assert sacFlowsFiltered.size() < sacFlows.size()
+            assert sacFlowsNoQueryFiltered.size() < sacFlowsNoQuery.size()
+
+            // "The masked deployments should be external to stackrox namespace"
+            assert sacFlows.intersect(sacFlowsFiltered) ==
+                        allAccessFlows.intersect(allAccessFlowsWithoutNeighbors)
+            assert sacFlowsNoQuery.intersect(sacFlowsNoQueryFiltered) ==
+                        allAccessFlows.intersect(allAccessFlowsWithoutNeighbors)
+        }
     }
 
     def "test role aggregation should not combine permissions sets"() {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Ticket ROX-26015 highlight flakiness of SACTest `Verify that SAC has the same effect as query restriction for network flows`.
The test performs two calls to the NetworkGraph service to retrieve the network graph since a fixed point in time, one with a user token having restricted scope, and one with a query restricting the results to the same expected domain as the restricted access scope.
It could happen that between these two calls, some network activity result in additional flows being reported by the second call.

There are potentially two ways of reducing the flakiness of this tests:
- Fix both ends of the time period where the network activity is compared (see PR #13887 )
- Retry the network graph calls hoping that the network activity stabilizes and no new network flow appears between calls (that is the current PR)

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
-->
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

PR CI test run
