### PR TITLE
ROX-27741: Add formatEpssProbabilityAsPercent function

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -26,8 +26,8 @@ import DeploymentComponentVulnerabilitiesTable, {
 } from './DeploymentComponentVulnerabilitiesTable';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
-import { FormattedDeploymentVulnerability } from './table.utils';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { FormattedDeploymentVulnerability, formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCvesDeploymentVulnerabilitiesTable';
 export const defaultColumns = {
@@ -165,6 +165,7 @@ function DeploymentVulnerabilitiesTable({
                             publishedOn,
                             pendingExceptionCount,
                         } = vulnerability;
+                        const epssProbability = undefined; // ccveBaseInfo?.epss?.epssProbability
                         const isExpanded = expandedRowSet.has(vulnerabilityId);
 
                         return (
@@ -217,13 +218,13 @@ function DeploymentVulnerabilitiesTable({
                                     >
                                         <VulnerabilityFixableIconText isFixable={isFixable} />
                                     </Td>
-                                    {!isEpssProbabilityColumnEnabled && (
+                                    {isEpssProbabilityColumnEnabled && (
                                         <Td
                                             className={getVisibilityClass('epssProbability')}
                                             modifier="nowrap"
                                             dataLabel="EPSS probability"
                                         >
-                                            Not available
+                                            {formatEpssProbabilityAsPercent(epssProbability)}
                                         </Td>
                                     )}
                                     <Td

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -47,6 +47,7 @@ import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCvesImageVulnerabilitiesTable';
 export const defaultColumns = {
@@ -243,6 +244,7 @@ function ImageVulnerabilitiesTable({
                             (imageComponent) => imageComponent.imageVulnerabilities
                         );
                         const isFixableInImage = getIsSomeVulnerabilityFixable(vulnerabilities);
+                        const epssProbability = undefined; // ccveBaseInfo?.epss?.epssProbability
                         const isExpanded = expandedRowSet.has(cve);
 
                         return (
@@ -324,7 +326,7 @@ function ImageVulnerabilitiesTable({
                                             modifier="nowrap"
                                             dataLabel="EPSS probability"
                                         >
-                                            Not available
+                                            {formatEpssProbabilityAsPercent(epssProbability)}
                                         </Td>
                                     )}
                                     <Td

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -51,6 +51,7 @@ import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCveOverviewTable';
 export const defaultColumns = {
@@ -319,6 +320,7 @@ function WorkloadCVEOverviewTable({
                                 topNvdCVSS,
                                 distroTuples
                             );
+                            const epssProbability = undefined; // ccveBaseInfo?.epss?.epssProbability
                             const summary =
                                 prioritizedDistros.length > 0 ? prioritizedDistros[0].summary : '';
 
@@ -409,7 +411,7 @@ function WorkloadCVEOverviewTable({
                                                 className={getVisibilityClass('epssProbability')}
                                                 dataLabel="EPSS probability"
                                             >
-                                                Not available
+                                                {formatEpssProbabilityAsPercent(epssProbability)}
                                             </Td>
                                         )}
                                         <Td

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -307,7 +307,7 @@ export function formatVulnerabilityData(
 }
 
 // Given probability as float fraction, return as percent with 3 decimal digits.
-export function formatEpssProbabilityAsPercent(epssProbability: unknown) {
+export function formatEpssProbabilityAsPercent(epssProbability: number | undefined) {
     if (typeof epssProbability === 'number' && epssProbability >= 0 && epssProbability <= 1) {
         const epssPercent = epssProbability * 100;
         return `${epssPercent.toFixed(3)}%`;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -305,3 +305,14 @@ export function formatVulnerabilityData(
         };
     });
 }
+
+// Given probability as float fraction, return as percent with 3 decimal digits.
+export function formatEpssProbabilityAsPercent(epssProbability: unknown) {
+    if (typeof epssProbability === 'number' && epssProbability >= 0 && epssProbability <= 1) {
+        const epssPercent = epssProbability * 100;
+        return `${epssPercent.toFixed(3)}%`;
+    }
+
+    // For any of the following: null, undefined, or number out of range
+    return 'Not available';
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.cy.jsx
@@ -1,12 +1,26 @@
 import React from 'react';
+import { createStore } from 'redux';
 
 import ComponentTestProviders from 'test-utils/ComponentProviders';
 
 import CvePageHeader from './CvePageHeader';
 
+const readOnlyReduxStore = createStore((s) => s, {
+    app: {
+        featureFlags: {
+            featureFlags: [],
+            loading: false,
+            error: null,
+        },
+    },
+});
 function setup(data) {
+    cy.intercept('GET', '/v1/featureFlags', (req) => {
+        req.reply({ data: { featureFlags: [] } });
+    });
+
     cy.mount(
-        <ComponentTestProviders>
+        <ComponentTestProviders reduxStore={readOnlyReduxStore}>
             <CvePageHeader data={data} />
         </ComponentTestProviders>
     );


### PR DESCRIPTION
### Description

### Changed files

1. Edit DeploymentVulnerabilitiesTable.tsx file.
    * Add placeholder `const epssProbability = undefined;` assignment statement.
    * Delete `!` operator that was leftover from temporary changes for testing.
    * Replace **Not available** text with `formatEpssProbabilityAsPercent(epssProbability)` function call.
2. Edit ImageVulnerabilitiesTable.tsx file.
    * Ditto step 1 except leftover
3. Edit WorkloadCVEOverviewTable.tsx file.
    * Ditto step 1 except leftover
4. Edit table.utils.ts file to add `formatEpssProbabilityAsPercent` function.
    * It renders fraction with 5 decimal places as percent with 3 decimal places.
    * It renders **Not available** especially for `undefined` from optional chaining.
5. Edit CvePageHeader.tsx file.
    * Add `numLabels` for clearer conditional logic.
    * Add initial conditional rendering for **EPSS probability** label, pending  GraphQL data which will determine presence or absence of the property for Node CVE.

### Residue

1. Write unit tests for `formatEpssProbabilityAsPercent` function to confirm whether or not binary floating point causes any skew between fraction and corresponding percent.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

#### Manual testing

To expedite progress, I will save the usual steps with pictures for a follow-up contribution with GraphQL:
* Code changes are a subset of presentation at 4.7F sprint demos
* Which was similar to test steps in #13789

