### PR TITLE
ROX-27736: bump retry times

### DIFF
--- a/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
@@ -19,7 +19,7 @@ class CloudSourcesTest extends BaseSpecification {
         // In case API service is not temporally available, we should add longer retry times to give API service
         // enough time to recover. Our options are limited here, because we depend on 3rd party service availability.
         def cloudSourceId
-        withRetry(5, 20) {
+        withRetry(10, 30) {
             cloudSourceId = CloudSourcesService.createCloudSource(CloudSourceService.CloudSource.newBuilder().
                 setName(CLOUD_SOURCE_NAME).
                 setType(CloudSourceService.CloudSource.Type.TYPE_OCM).
@@ -37,7 +37,7 @@ class CloudSourcesTest extends BaseSpecification {
         "verify we have discovered clusters"
         // The initial sync may take a bit since we are connecting to the "Red Hat1" OCM organization which hosts
         // a lot of clusters.
-        withRetry(30, 10) {
+        withRetry(10, 30) {
             def count = DiscoveredClustersService.countDiscoveredClusters()
             assert count > 0
         }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In the cloud sources qa-test we rely on OCM to respond in time. We observed a flake where the OCM call timed out for all retry attempts. Unfortunately there is not much we can do to avoid flakes when OCM is unresponsive. Here I simply bump the total retry time from 100s to 300s.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI
