### PR TITLE
ROX-25182: Add retries to alert count SACTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -338,13 +338,10 @@ class SACTest extends BaseSpecification {
 
         then:
         assert alertsCount(NOACCESSTOKEN) == 0
-        WithRetry(30, 5) {
+        withRetry(30, 5) {
             // getSummaryCountsToken has access only to QA1 deployment while
             // ALLACCESSTOKEN has access to QA1 and QA2. Since deployments are identical
             // number of alerts for ALLACCESSTOKEN should be twice of getSummaryCountsToken.
-            def sacCount = alertsCount("getSummaryCountsToken")
-            def queryCount = alertsCount(ALLACCESSTOKEN)
-            assert 2 * sacCount == queryCount
             assert 2 * alertsCount("getSummaryCountsToken") == alertsCount(ALLACCESSTOKEN)
         }
     }

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -342,6 +342,9 @@ class SACTest extends BaseSpecification {
             // getSummaryCountsToken has access only to QA1 deployment while
             // ALLACCESSTOKEN has access to QA1 and QA2. Since deployments are identical
             // number of alerts for ALLACCESSTOKEN should be twice of getSummaryCountsToken.
+            def sacCount = alertsCount("getSummaryCountsToken")
+            def queryCount = alertsCount(ALLACCESSTOKEN)
+            assert 2 * sacCount == queryCount
             assert 2 * alertsCount("getSummaryCountsToken") == alertsCount(ALLACCESSTOKEN)
         }
     }

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -338,10 +338,12 @@ class SACTest extends BaseSpecification {
 
         then:
         assert alertsCount(NOACCESSTOKEN) == 0
-        // getSummaryCountsToken has access only to QA1 deployment while
-        // ALLACCESSTOKEN has access to QA1 and QA2. Since deployments are identical
-        // number of alerts for ALLACCESSTOKEN should be twice of getSummaryCountsToken.
-        assert 2 * alertsCount("getSummaryCountsToken") == alertsCount(ALLACCESSTOKEN)
+        WithRetry(30, 5) {
+            // getSummaryCountsToken has access only to QA1 deployment while
+            // ALLACCESSTOKEN has access to QA1 and QA2. Since deployments are identical
+            // number of alerts for ALLACCESSTOKEN should be twice of getSummaryCountsToken.
+            assert 2 * alertsCount("getSummaryCountsToken") == alertsCount(ALLACCESSTOKEN)
+        }
     }
 
     def "Verify ListSecrets using a token without access receives no results"() {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

If the source of flakiness of the test is information propagation delay, then retrying should fix the problem. 

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
-->
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI run on the pull request
