### PR TITLE
ROX-27711: Remove empty cluster page button text assertion

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -28,7 +28,5 @@ describe('Clusters', () => {
 
         // Replace with h2 if refactoring restores h1 element with Clusters
         cy.get('h1:contains("Secure clusters with a reusable init bundle")');
-        // Button text depends whether or not init bundles exist.
-        cy.get('button:contains("View installation methods")');
     });
 });


### PR DESCRIPTION
### Description

With the addition of CRS, it is no longer guaranteed that an init-bundle will be preset in CI during startup. This changes the rendering of the button in the `should redirect from Dashboard when no secured clusters have been added` cloud service test.

Since the behavior under test is to verify the correct redirection from the main dashboard to the clusters page, and less so on which button is displayed, I removed this assertion for stability.

See https://issues.redhat.com/browse/ROX-27711

Possible follow up - if we think it is important to test the behavior of which button appears on this page, we should add tests that mock the responses and assert on the UI behavior.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI
