### PR TITLE
chore(golangci): replace exportloopref with copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -153,6 +153,7 @@ linters:
   enable:
     - asciicheck
     # - bodyclose
+    - copyloopvar
     # - deadcode
     # - depguard
     # - dogsled
@@ -164,7 +165,6 @@ linters:
     # - gochecknoinits
     # - gocognit
     # - goconst
-    - exportloopref
     - gocritic
     # - gocyclo
     # - godot

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ run:
   timeout: 240m
   build-tags:
   - integration
+  - scanner_db_integration
   - sql_integration
   - test_e2e
   modules-download-mode: readonly

--- a/central/complianceoperator/v2/report/manager/generator/report_gen_impl_test.go
+++ b/central/complianceoperator/v2/report/manager/generator/report_gen_impl_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackrox/rox/central/complianceoperator/v2/report/manager/sender"
-
 	"github.com/pkg/errors"
 	checkResultsMocks "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
 	profileMocks "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
@@ -14,6 +12,7 @@ import (
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
 	snapshotMocks "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore/mocks"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report/manager/generator/mocks"
+	"github.com/stackrox/rox/central/complianceoperator/v2/report/manager/sender"
 	ruleMocks "github.com/stackrox/rox/central/complianceoperator/v2/rules/datastore/mocks"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/generated/storage"

--- a/central/cve/converter/utils/convert_utils_test.go
+++ b/central/cve/converter/utils/convert_utils_test.go
@@ -46,7 +46,6 @@ func TestNVDCVEToEmbeddedCVE_Istio(t *testing.T) {
 	cveEntries := getTestData(t)
 
 	for _, cveEntry := range cveEntries {
-		cveEntry := cveEntry
 		require.NotNil(t, cveEntry)
 		require.NotNil(t, cveEntry.Impact)
 		require.True(t, cveEntry.Impact.BaseMetricV2 != nil || cveEntry.Impact.BaseMetricV3 != nil)

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -171,7 +171,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 
 	// Test Upsert
 	for _, c := range cases {
-		c := c
 		cluster := c.entity.GetScope().GetClusterId()
 		var pushSig concurrency.Signal
 		if c.pass {
@@ -198,7 +197,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 		if c.skipGet {
 			continue
 		}
-		c := c
 		actual, found, err := suite.ds.GetEntity(suite.globalReadAccessCtx, c.entity.GetInfo().GetId())
 		if c.pass {
 			suite.NoError(err)
@@ -241,7 +239,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 
 	// Test Delete
 	for _, c := range cases {
-		c := c
 		cluster := c.entity.GetScope().GetClusterId()
 		if !c.pass {
 			continue
@@ -388,7 +385,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TestSAC() {
 	}
 
 	for _, c := range cases {
-		c := c
 		cluster := c.entity.GetScope().GetClusterId()
 
 		var pushSig concurrency.Signal
@@ -504,7 +500,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TestSAC() {
 	}
 
 	for _, c := range cases {
-		c := c
 		cluster := c.entity.GetScope().GetClusterId()
 
 		var pushSig concurrency.Signal
@@ -583,7 +578,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TestDefaultGraphSetting() {
 	}
 
 	for _, c := range cases {
-		c := c
 		suite.graphConfig.EXPECT().GetNetworkGraphConfig(gomock.Any()).Return(c.graphConfig, nil)
 		actual, err := suite.ds.GetAllEntities(suite.globalReadAccessCtx)
 		suite.NoError(err)

--- a/central/networkpolicies/service/service_impl_test.go
+++ b/central/networkpolicies/service/service_impl_test.go
@@ -945,7 +945,6 @@ func TestCheckAllNamespacesWriteAllowed(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := sac.WithGlobalAccessScopeChecker(context.Background(), c.checker)
@@ -998,7 +997,6 @@ func TestGetNamespacesFromModification(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/central/reprocessor/reprocessor_unit_test.go
+++ b/central/reprocessor/reprocessor_unit_test.go
@@ -75,7 +75,6 @@ func Test_loopImpl_reprocessNode(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			m := mocks{

--- a/central/sac/authorizer/builtin_scoped_authorizer_test.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer_test.go
@@ -133,7 +133,6 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			trace := observe.NewAuthzTrace()
@@ -241,7 +240,6 @@ func TestScopeCheckerWithParallelAccessAndSharedGlobalScopeChecker(t *testing.T)
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			scc := subScopeChecker
@@ -688,7 +686,6 @@ func TestEffectiveAccessScope(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			scc := newGlobalScopeCheckerCore(clusters, namespaces, tc.roles, nil)
@@ -743,7 +740,6 @@ func TestBuiltInScopeAuthorizerPanicsWhenErrorOnComputeAccessScope(t *testing.T)
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			scc := newGlobalScopeCheckerCore(clusters, namespaces, tc.roles, nil)

--- a/central/sensor/service/pipeline/nodeindex/three_pipelines_test.go
+++ b/central/sensor/service/pipeline/nodeindex/three_pipelines_test.go
@@ -289,7 +289,6 @@ func Test_ThreePipelines_Run(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			tt.mocks = &usedMocks{

--- a/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
@@ -142,7 +142,6 @@ func Test_pipelineImpl_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			tt.mocks = mocks{

--- a/central/sensor/service/pipeline/nodeinventory/two_pipelines_test.go
+++ b/central/sensor/service/pipeline/nodeinventory/two_pipelines_test.go
@@ -174,7 +174,6 @@ func Test_TwoPipelines_Run(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			tt.mocks = &usedMocks{

--- a/central/sensor/service/pipeline/nodes/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodes/pipeline_test.go
@@ -98,7 +98,6 @@ func Test_pipelineImpl_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			tt.mocks = mocks{

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -331,7 +331,6 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		c := c
 		t.Run(c.description, func(t *testing.T) {
 			log.Infof("Test = %q", c.description)
 			ver := &currVer

--- a/operator/internal/central/extensions/reconcile_admin_password_test.go
+++ b/operator/internal/central/extensions/reconcile_admin_password_test.go
@@ -152,7 +152,6 @@ func TestReconcileAdminPassword(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -221,7 +220,6 @@ func TestUpdateStatus(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			result := c.reconcileRun.updateStatus(c.status)

--- a/operator/internal/central/extensions/reconcile_central_db_password_test.go
+++ b/operator/internal/central/extensions/reconcile_central_db_password_test.go
@@ -229,7 +229,6 @@ func TestReconcileDBPassword(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/operator/internal/central/extensions/reconcile_scanner_db_password_test.go
+++ b/operator/internal/central/extensions/reconcile_scanner_db_password_test.go
@@ -88,7 +88,6 @@ func TestReconcileScannerDBPassword(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/operator/internal/central/extensions/reconcile_scanner_v4_db_password_test.go
+++ b/operator/internal/central/extensions/reconcile_scanner_v4_db_password_test.go
@@ -89,7 +89,6 @@ func TestReconcileScannerV4DBPassword(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -448,7 +448,6 @@ func TestCreateCentralTLS(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		if strings.Contains(name, "init bundle secrets should be created") {
 			// See ROX-9967.
 			// TODO(ROX-9969): Remove this exclusion after the init-bundle cert rotation stabilization.

--- a/operator/internal/overlays/postrenderer_test.go
+++ b/operator/internal/overlays/postrenderer_test.go
@@ -138,7 +138,6 @@ spec:
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 
 			cr := &dummy{

--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -117,7 +117,6 @@ func TestCredentialManager(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()

--- a/pkg/compliance/checks/kubernetes/control_plane_config_test.go
+++ b/pkg/compliance/checks/kubernetes/control_plane_config_test.go
@@ -34,7 +34,6 @@ func TestControlPlaneConfigChecks(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/compliance/checks/kubernetes/etcd_test.go
+++ b/pkg/compliance/checks/kubernetes/etcd_test.go
@@ -225,7 +225,6 @@ func TestETCDChecks(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/compliance/checks/kubernetes/master_api_server_test.go
+++ b/pkg/compliance/checks/kubernetes/master_api_server_test.go
@@ -80,7 +80,6 @@ func TestMasterAPIServerChecks(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/compliance/checks/kubernetes/master_config_test.go
+++ b/pkg/compliance/checks/kubernetes/master_config_test.go
@@ -175,7 +175,6 @@ func TestMasterConfigChecks(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/compliance/checks/kubernetes/worker_node_config_test.go
+++ b/pkg/compliance/checks/kubernetes/worker_node_config_test.go
@@ -83,7 +83,6 @@ func TestWorkerNodeConfigChecks(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/compliance/checks/nist800-190/check421/check_test.go
+++ b/pkg/compliance/checks/nist800-190/check421/check_test.go
@@ -42,7 +42,6 @@ func TestDockerInfoBasedChecks(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/grpc/endpoints_test.go
+++ b/pkg/grpc/endpoints_test.go
@@ -101,7 +101,6 @@ func (s *misdirectedRequestSuite) testWithEndpoint(name string, baseCfg Endpoint
 		}
 	}()
 	for _, srvAndLis := range servers {
-		srvAndLis := srvAndLis
 		go func() {
 			serverErrs <- srvAndLis.srv.Serve(srvAndLis.listener)
 		}()

--- a/pkg/ioutils/checksum_reader_test.go
+++ b/pkg/ioutils/checksum_reader_test.go
@@ -197,7 +197,6 @@ func TestChecksumReader(t *testing.T) {
 	}
 
 	for algoName, algo := range algos {
-		algo := algo
 		t.Run(algoName, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/k8scfgwatch/cfg_watcher_test.go
+++ b/pkg/k8scfgwatch/cfg_watcher_test.go
@@ -43,7 +43,6 @@ func TestConfigMapTrigger(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
@@ -96,7 +95,6 @@ func TestConfigMapContextCancelled(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()

--- a/pkg/metrics/verifier_test.go
+++ b/pkg/metrics/verifier_test.go
@@ -42,7 +42,6 @@ func TestClientCertVerifier(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			certFile, err := os.ReadFile(c.certFilePath)

--- a/pkg/netutil/default_port_test.go
+++ b/pkg/netutil/default_port_test.go
@@ -25,7 +25,6 @@ func TestWithDefaultPort(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		// Test names must not contain colons.
 		t.Run(strings.ReplaceAll(c.input, ":", ";"), func(t *testing.T) {
 			t.Parallel()

--- a/pkg/notifiers/prune_test.go
+++ b/pkg/notifiers/prune_test.go
@@ -57,7 +57,6 @@ func TestFilterMap(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			filterMap(c.inputMap, c.maxSize, &c.currSize)
 			assert.Equal(t, c.expectedMap, c.inputMap)
@@ -98,7 +97,6 @@ func TestFilterProcesses(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			for _, p := range c.processes {
 				cleanProcessIndicator(p)
@@ -158,7 +156,6 @@ func TestFilterViolations(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			protoassert.SlicesEqual(t, c.violations[:c.expectedNumber], filterViolations(c.violations, c.maxSize, &c.currSize))
 		})

--- a/pkg/protoconv/k8s/quantity_test.go
+++ b/pkg/protoconv/k8s/quantity_test.go
@@ -42,7 +42,6 @@ func TestConvertQuantityToCores(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.quantity.String(), func(t *testing.T) {
 			assert.Equal(t, c.expected, ConvertQuantityToCores(&c.quantity))
 		})
@@ -73,7 +72,6 @@ func TestConvertQuantityToMb(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.quantity.String(), func(t *testing.T) {
 			assert.True(t, math.Abs(float64(c.expected-ConvertQuantityToMB(&c.quantity))) < 0.1)
 		})

--- a/pkg/registries/google/google_test.go
+++ b/pkg/registries/google/google_test.go
@@ -104,7 +104,6 @@ func TestGoogleValidate(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			err := validate(c.config)
 			if c.isValid {

--- a/pkg/scanners/google/google_test.go
+++ b/pkg/scanners/google/google_test.go
@@ -62,7 +62,6 @@ func TestGoogleValidate(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			err := validate(c.config)
 			if c.isValid {

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -832,7 +832,6 @@ func Test_toProtoV4Environment(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := toProtoV4Environment(tt.arg)
 			protoassert.Equal(t, tt.want, got)

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -109,7 +109,6 @@ func TestSecretInformer(t *testing.T) {
 	}
 
 	for name, c := range cases {
-		c := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()

--- a/roxctl/common/flags/endpoint_test.go
+++ b/roxctl/common/flags/endpoint_test.go
@@ -74,7 +74,6 @@ func TestEndpointAndPlaintextSetting(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.givenEndpoint, func(t *testing.T) {
 			t.Setenv(env.EndpointEnv.EnvVar(), tc.givenEndpoint)
 			host, usePlaintext, err := EndpointAndPlaintextSetting()

--- a/roxctl/helm/output/output_lint_test.go
+++ b/roxctl/helm/output/output_lint_test.go
@@ -78,7 +78,6 @@ func (s *HelmChartTestSuite) TestOutputHelmChart() {
 	env := environment.NewTestCLIEnvironment(s.T(), testIO, printer.DefaultColorPrinter())
 
 	for _, tt := range tests {
-		tt := tt
 		for chartName := range common.ChartTemplates {
 			s.Run(fmt.Sprintf("%s-rhacs-%t-flavorProvided-%t-image-defaults-%s", chartName, tt.rhacs, tt.flavorProvided, tt.flavor), func() {
 				outputDir := s.T().TempDir()

--- a/roxctl/maincommand/error_writer_test.go
+++ b/roxctl/maincommand/error_writer_test.go
@@ -40,7 +40,6 @@ func TestErrorWriter(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
 			io, _, out, errorOut := io.TestIO()

--- a/roxctl/netpol/connectivity/diff/command_test.go
+++ b/roxctl/netpol/connectivity/diff/command_test.go
@@ -55,7 +55,6 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			env, _, _ := mocks.NewEnvWithConn(nil, t)
 			diffNetpolCmd := diffNetpolCommand{

--- a/roxctl/netpol/connectivity/diff/diff_output_test.go
+++ b/roxctl/netpol/connectivity/diff/diff_output_test.go
@@ -93,7 +93,6 @@ func (d *diffAnalyzeNetpolTestSuite) TestDiffOutput() {
 	}
 
 	for name, tt := range cases {
-		tt := tt
 		d.Run(name, func() {
 			env, _, _ := mocks.NewEnvWithConn(nil, d.T())
 			diffNetpolCmd := diffNetpolCommand{

--- a/roxctl/netpol/connectivity/diff/diff_test.go
+++ b/roxctl/netpol/connectivity/diff/diff_test.go
@@ -93,7 +93,6 @@ func (d *diffAnalyzeNetpolTestSuite) TestAnalyzeConnectivityDiffWarningsErrors()
 	}
 
 	for name, tt := range cases {
-		tt := tt
 		d.Run(name, func() {
 			env, _, _ := mocks.NewEnvWithConn(nil, d.T())
 			diffNetpolCmd := diffNetpolCommand{

--- a/roxctl/netpol/connectivity/map/command_test.go
+++ b/roxctl/netpol/connectivity/map/command_test.go
@@ -48,7 +48,6 @@ func (d *connectivityMapCommandSuite) TestValidate() {
 	}
 
 	for _, tt := range cases {
-		tt := tt
 		d.Run(tt.name, func() {
 			env, _, _ := mocks.NewEnvWithConn(nil, d.T())
 			analyzeNetpolCmd := Cmd{

--- a/roxctl/netpol/connectivity/map/map_test.go
+++ b/roxctl/netpol/connectivity/map/map_test.go
@@ -169,7 +169,6 @@ func (d *connectivityMapTestSuite) TestAnalyzeNetpol() {
 	}
 
 	for name, tt := range cases {
-		tt := tt
 		d.Run(name, func() {
 			env, _, _ := mocks.NewEnvWithConn(nil, d.T())
 			analyzeNetpolCmd := Cmd{

--- a/roxctl/netpol/generate/generate_test.go
+++ b/roxctl/netpol/generate/generate_test.go
@@ -139,7 +139,6 @@ func (d *generateNetpolTestSuite) TestGenerateNetpol() {
 	}
 
 	for name, tt := range cases {
-		tt := tt
 		d.Run(name, func() {
 			testCmd := &cobra.Command{Use: "test"}
 			testCmd.Flags().String("output-dir", "", "")

--- a/roxctl/netpol/resources/info_test.go
+++ b/roxctl/netpol/resources/info_test.go
@@ -56,7 +56,6 @@ func TestProcessInput(t *testing.T) {
 	}
 
 	for name, tt := range cases {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			_, warns, errs := GetK8sInfos(tt.inputFolderPath1, tt.stopOnFirstError, tt.treatWarningsAsErrors)
 			npg.AssertErrorsContain(t, tt.expectedErr, errs, "errors")

--- a/roxctl/sensor/generate/generate_test.go
+++ b/roxctl/sensor/generate/generate_test.go
@@ -351,7 +351,6 @@ func (s *sensorGenerateTestSuite) TestSlimCollectorSelection() {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
 		s.Run(name, func() {
 			_, errOut, closeF, generateCmd, mock := s.createMockedCommand(getDefaultsFake(testCase.serverHasKernelSupport), postClusterFake)
 			defer closeF()

--- a/scanner/datastore/postgres/vuln_update_test.go
+++ b/scanner/datastore/postgres/vuln_update_test.go
@@ -37,8 +37,10 @@ func TestVulnUpdateStore(t *testing.T) {
 	// Get or init a new key, verify the update time is older.
 	newT := timestamp.Add(-24 * time.Hour)
 	timestamp, err = store.GetOrSetLastVulnerabilityUpdate(ctx, "new", newT)
+	require.NoError(t, err)
 	assert.Equal(t, newT, timestamp, "new was set vuln update time")
 	timestamp, err = store.GetLastVulnerabilityUpdate(ctx)
+	require.NoError(t, err)
 	assert.Equal(t, newT, timestamp, "new did not change the vuln update time")
 }
 

--- a/scanner/enricher/fixedby/fixedby_test.go
+++ b/scanner/enricher/fixedby/fixedby_test.go
@@ -120,7 +120,6 @@ func TestEnrich_Alpine(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -232,7 +231,6 @@ func TestEnrich_AWS(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -351,7 +349,6 @@ func TestEnrich_Debian(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -641,7 +638,6 @@ func TestEnrich_Go(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -734,7 +730,6 @@ func TestEnrich_Java(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -836,7 +831,6 @@ func TestEnrich_Nodejs(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -989,7 +983,6 @@ func TestEnrich_Oracle(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -1092,7 +1085,6 @@ func TestEnrich_Photon(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -1208,7 +1200,6 @@ func TestEnrich_Python(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -1308,7 +1299,6 @@ func TestEnrich_RHCC(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -1507,7 +1497,6 @@ func TestEnrich_RHEL(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -1620,7 +1609,6 @@ func TestEnrich_Ruby(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -1717,7 +1705,6 @@ func TestEnrich_SUSE(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})
@@ -1808,7 +1795,6 @@ func TestEnrich_Ubuntu(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runTest(t, tc)
 		})

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -11,9 +11,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
@@ -39,6 +36,8 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	flowMetrics "github.com/stackrox/rox/sensor/common/networkflow/metrics"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (

--- a/sensor/kubernetes/listener/resources/convert_mutating_test.go
+++ b/sensor/kubernetes/listener/resources/convert_mutating_test.go
@@ -310,7 +310,6 @@ func TestConvertDifferentContainerNumbers(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			actual := newDeploymentEventFromResource(c.inputObj, &c.action, c.deploymentType, testClusterID, c.podLister, mockNamespaceStore, hierarchyFromPodLister(c.podLister), "", c.systemNamespaces).GetDeployment()
 			if actual != nil {

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -89,7 +89,6 @@ func TestPopulateNonStaticFieldWithPod(t *testing.T) {
 	}
 	storeProvider := InitializeStore()
 	for _, c := range cases {
-		c := c
 		ph := references.NewParentHierarchy()
 		newDeploymentEventFromResource(c.inputObj, &c.action, "Pod", testClusterID, nil,
 			mockNamespaceStore, ph, "", storeProvider.orchestratorNamespaces)
@@ -1293,7 +1292,6 @@ func TestConvert(t *testing.T) {
 
 	storeProvider := InitializeStore()
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			actual := newDeploymentEventFromResource(c.inputObj, &c.action, c.deploymentType, testClusterID,
 				c.podLister, mockNamespaceStore, hierarchyFromPodLister(c.podLister), "",

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -1009,8 +1009,6 @@ func TestStoreGetPermissionLevelForDeployment(t *testing.T) {
 		storeWithNoBindings.RemoveClusterBinding(b)
 	}
 	for _, tc := range testCases {
-		tc := tc
-
 		name := fmt.Sprintf("%q in namespace %q should have %q permision level",
 			tc.deployment.ServiceAccount, tc.deployment.Namespace, tc.expected)
 		t.Run(name, func(t *testing.T) {

--- a/sensor/upgrader/preflight/namespace.go
+++ b/sensor/upgrader/preflight/namespace.go
@@ -40,7 +40,6 @@ func namespaceAllowed(resource *k8sobjects.ObjectRef) bool {
 
 func (namespaceCheck) Check(_ *upgradectx.UpgradeContext, execPlan *plan.ExecutionPlan, reporter checkReporter) error {
 	for _, act := range execPlan.Actions() {
-		act := act
 		if !namespaceAllowed(&act.ObjectRef) {
 			logging.Warnf("namespaceAllowed returned false for object \"%v\" in namespace %q and the pod is in namespace %q", act.ObjectRef, act.ObjectRef.Namespace, pods.GetPodNamespace())
 			reporter.Errorf("To-be-%sd object %v is in disallowed namespace %s", act.ActionName, act.ObjectRef, act.ObjectRef.Namespace)

--- a/sensor/upgrader/upgradectx/context.go
+++ b/sensor/upgrader/upgradectx/context.go
@@ -325,7 +325,6 @@ func (c *UpgradeContext) List(resourcePurpose resources.Purpose, listOpts *metav
 			}
 
 			for _, item := range listObj.Items {
-				item := item // create a copy to prevent aliasing
 				result = append(result, &item)
 			}
 		}

--- a/tools/generate-helpers/pg-table-bindings/resource_type_test.go
+++ b/tools/generate-helpers/pg-table-bindings/resource_type_test.go
@@ -117,7 +117,6 @@ func TestGetResourceType(t *testing.T) {
 		{typ: &storage.User{}, resourceType: globallyScoped},
 		{typ: &storage.WatchedImage{}, resourceType: globallyScoped},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("%T (join: %t, perm: %t) -> %d", tc.typ, tc.joinTable, tc.permissionChecker, tc.resourceType), func(t *testing.T) {
 			actual := getResourceType(
 				fmt.Sprintf("%T", tc.typ),


### PR DESCRIPTION
### Description

Replaced exportloopref with copyloopvar, as exportloopref is deprecated in favor of copyloopvar for go1.22+

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

CI