### PR TITLE
ROX-27814: match all registries with the same hostname

### DIFF
--- a/sensor/common/image/interfaces.go
+++ b/sensor/common/image/interfaces.go
@@ -13,7 +13,7 @@ import (
 //go:generate mockgen-wrapper
 type registryStore interface {
 	GetPullSecretRegistries(image *storage.ImageName, namespace string, imagePullSecrets []string) ([]registryTypes.ImageRegistry, error)
-	GetGlobalRegistry(*storage.ImageName) (registryTypes.ImageRegistry, error)
+	GetGlobalRegistries(*storage.ImageName) ([]registryTypes.ImageRegistry, error)
 	GetCentralRegistries(*storage.ImageName) []registryTypes.ImageRegistry
 	IsLocal(*storage.ImageName) bool
 }

--- a/sensor/common/image/mocks/interfaces.go
+++ b/sensor/common/image/mocks/interfaces.go
@@ -59,19 +59,19 @@ func (mr *MockregistryStoreMockRecorder) GetCentralRegistries(arg0 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCentralRegistries", reflect.TypeOf((*MockregistryStore)(nil).GetCentralRegistries), arg0)
 }
 
-// GetGlobalRegistry mocks base method.
-func (m *MockregistryStore) GetGlobalRegistry(arg0 *storage.ImageName) (types.ImageRegistry, error) {
+// GetGlobalRegistries mocks base method.
+func (m *MockregistryStore) GetGlobalRegistries(arg0 *storage.ImageName) ([]types.ImageRegistry, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGlobalRegistry", arg0)
-	ret0, _ := ret[0].(types.ImageRegistry)
+	ret := m.ctrl.Call(m, "GetGlobalRegistries", arg0)
+	ret0, _ := ret[0].([]types.ImageRegistry)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetGlobalRegistry indicates an expected call of GetGlobalRegistry.
-func (mr *MockregistryStoreMockRecorder) GetGlobalRegistry(arg0 any) *gomock.Call {
+// GetGlobalRegistries indicates an expected call of GetGlobalRegistries.
+func (mr *MockregistryStoreMockRecorder) GetGlobalRegistries(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGlobalRegistry", reflect.TypeOf((*MockregistryStore)(nil).GetGlobalRegistry), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGlobalRegistries", reflect.TypeOf((*MockregistryStore)(nil).GetGlobalRegistries), arg0)
 }
 
 // GetPullSecretRegistries mocks base method.

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -344,13 +344,11 @@ func (rs *Store) IsLocal(image *storage.ImageName) bool {
 // registries that are only accessible from this cluster. These hosts will be factored
 // into IsLocal decisions. Is OK to call repeatedly for the same host.
 func (rs *Store) addClusterLocalRegistryHost(host string) {
-	trimmed := urlfmt.TrimHTTPPrefixes(host)
-
 	rs.clusterLocalRegistryHostsMutex.Lock()
 	defer rs.clusterLocalRegistryHostsMutex.Unlock()
 
-	if rs.clusterLocalRegistryHosts.Add(trimmed) {
-		log.Infof("Added cluster local registry host %q", trimmed)
+	if rs.clusterLocalRegistryHosts.Add(host) {
+		log.Infof("Added cluster local registry host %q", host)
 
 		metrics.SetClusterLocalHostsCount(len(rs.clusterLocalRegistryHosts))
 	}
@@ -517,8 +515,6 @@ func (rs *Store) upsertSecretByName(namespace, secretName string, dockerConfig c
 }
 
 func (rs *Store) upsertPullSecretByNameNoLock(namespace, secretName, registry, host string, dce config.DockerConfigEntry) {
-	host = urlfmt.TrimHTTPPrefixes(host)
-
 	name := genIntegrationName(types.PullSecretNamePrefix, namespace, secretName, registry)
 	ii := createImageIntegration(host, dce, name)
 

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -616,8 +616,7 @@ func isRegistryMatch(image *storage.ImageName, host string) (bool, error) {
 	// `url.Parse` requires a valid scheme - prepend one for parsing if empty.
 	regURL, err := url.Parse(urlfmt.FormatURL(host, urlfmt.HTTPS, urlfmt.NoTrailingSlash))
 	if err != nil {
-		log.Errorf("Failed to parse host URL %q: %w", host, err)
-		return false, errors.Wrap(err, "parsing registry host %q")
+		return false, errors.Wrapf(err, "parsing registry host %q", host)
 	}
 	// Remove leading `/` from the path.
 	regPath := regURL.Path
@@ -637,7 +636,7 @@ func (rs *Store) getPullSecretRegistriesNoLock(secretNameToHost secretNameToHost
 		for host, reg := range secretNameToHost[secretName] {
 			isMatch, err := isRegistryMatch(image, host)
 			if err != nil {
-				log.Warnf("Failed to match registry: %w", err)
+				log.Warnf("Failed to match registry: %s", err.Error())
 				continue
 			}
 			if isMatch {

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -641,7 +641,7 @@ func (rs *Store) getPullSecretRegistriesNoLock(secretNameToHost secretNameToHost
 		for host, reg := range secretNameToHost[secretName] {
 			isMatch, err := isRegistryMatch(image, host)
 			if err != nil {
-				log.Errorf("Failed to match registry: %w", err)
+				log.Warnf("Failed to match registry: %w", err)
 				continue
 			}
 			if isMatch {

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -293,8 +293,8 @@ func (s *LocalScan) getRegistries(ctx context.Context, namespace string, imgName
 		}
 	}
 
-	// Add global pull secret registry.
-	// An err indicates no registry was found, only append if was no err.
+	// Add global pull secret registries.
+	// An err indicates no registries were found, only append if was no err.
 	if gRegs, err := s.getGlobalRegistries(imgName); err == nil {
 		regs = append(regs, gRegs...)
 	}

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -58,7 +58,7 @@ type LocalScan struct {
 	createNoAuthImageRegistry func(context.Context, *storage.ImageName, registries.Factory) (registryTypes.ImageRegistry, error)
 	getCentralRegistries      func(*storage.ImageName) []registryTypes.ImageRegistry
 	getPullSecretRegistries   func(*storage.ImageName, string, []string) ([]registryTypes.ImageRegistry, error)
-	getGlobalRegistry         func(*storage.ImageName) (registryTypes.ImageRegistry, error)
+	getGlobalRegistries       func(*storage.ImageName) ([]registryTypes.ImageRegistry, error)
 
 	// scanSemaphore limits the number of active scans.
 	scanSemaphore *semaphore.Weighted
@@ -82,7 +82,7 @@ type LocalScanRequest struct {
 
 type registryStore interface {
 	GetPullSecretRegistries(image *storage.ImageName, namespace string, imagePullSecrets []string) ([]registryTypes.ImageRegistry, error)
-	GetGlobalRegistry(*storage.ImageName) (registryTypes.ImageRegistry, error)
+	GetGlobalRegistries(*storage.ImageName) ([]registryTypes.ImageRegistry, error)
 	GetCentralRegistries(*storage.ImageName) []registryTypes.ImageRegistry
 }
 
@@ -110,7 +110,7 @@ func NewLocalScan(registryStore registryStore, mirrorStore registrymirror.Store)
 		createNoAuthImageRegistry: createNoAuthImageRegistry,
 		getCentralRegistries:      registryStore.GetCentralRegistries,
 		getPullSecretRegistries:   registryStore.GetPullSecretRegistries,
-		getGlobalRegistry:         registryStore.GetGlobalRegistry,
+		getGlobalRegistries:       registryStore.GetGlobalRegistries,
 	}
 	return ls
 }
@@ -295,8 +295,8 @@ func (s *LocalScan) getRegistries(ctx context.Context, namespace string, imgName
 
 	// Add global pull secret registry.
 	// An err indicates no registry was found, only append if was no err.
-	if reg, err := s.getGlobalRegistry(imgName); err == nil {
-		regs = append(regs, reg)
+	if reg, err := s.getGlobalRegistries(imgName); err == nil {
+		regs = append(regs, reg...)
 	}
 
 	// Create a no auth registry if no other registries have been found.

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -295,8 +295,8 @@ func (s *LocalScan) getRegistries(ctx context.Context, namespace string, imgName
 
 	// Add global pull secret registry.
 	// An err indicates no registry was found, only append if was no err.
-	if reg, err := s.getGlobalRegistries(imgName); err == nil {
-		regs = append(regs, reg...)
+	if gRegs, err := s.getGlobalRegistries(imgName); err == nil {
+		regs = append(regs, gRegs...)
 	}
 
 	// Create a no auth registry if no other registries have been found.

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -454,9 +454,10 @@ func createNoAuthImageRegistry(ctx context.Context, imgName *storage.ImageName, 
 		return nil, pkgErrors.Wrapf(err, "unable to check TLS for registry %q", reg)
 	}
 
+	name := fmt.Sprintf("%s/reg:%v", registryTypes.NoAuthNamePrefix, reg)
 	ii := &storage.ImageIntegration{
-		Id:         reg,
-		Name:       fmt.Sprintf("%s/reg:%v", registryTypes.NoAuthNamePrefix, reg),
+		Id:         name,
+		Name:       name,
 		Type:       registryTypes.DockerType,
 		Categories: []storage.ImageIntegrationCategory{storage.ImageIntegrationCategory_REGISTRY},
 		IntegrationConfig: &storage.ImageIntegration_Docker{


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The goal of this PR is to provide a stop gap solution to avoid incorrect registry resolution for pull secrets of the form

```
{
  "auths": {
    "quay.io": {
      "auth": "xxx"
    },
    "quay.io/rhacs-eng": {
       "auth": "yyy"
    }
  }
}
```

Sensor in the status quo would choose only one of the above records and constructs wrong docker API endpoints such as `quay.io/rhacs-eng/v2/<repository>/<image>`. As a result, scan requests will fail randomly based on which secret is chosen.

This PR introduces two main changes:

1. Create underlying registries with just the host endpoint, i.e. only consider the `quay.io` part of `quay.io/rhacs-eng`.
2. Consider all registry entries in the global pull secret regardless of path.

In the above example, we now create two image integrations `quay.io` and `quay.io/rhacs-eng` - however, both are matched against `quay.io` when pulling images. There is no actual matching on the path - this should be improved as a next step. Edit: Path matching has been added after the review process, but only for namespace scoped pull secrets.

A better long term solution would be to remove the custom matcher and introduce a k8s key chain library such as https://github.com/google/go-containerregistry/blob/main/pkg/authn/k8schain/README.md. However, I think this PR at least improves the status quo and reduces possible bugs with real-world pull secrets.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested the change on an OCP cluster with two different quay secrets in the global pull secret.