### PR TITLE
fix(PG): optimize enum queries

### DIFF
--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -224,7 +224,7 @@ func TestMultiTableQueries(t *testing.T) {
 				ProtoQuery(),
 			schema:        imagesSchema,
 			expectedFrom:  "images",
-			expectedWhere: "((deployments.PlatformComponent = $$ or deployments.PlatformComponent is null) and (image_cve_edges.State = $$))",
+			expectedWhere: "((deployments.PlatformComponent = $$ or deployments.PlatformComponent is null) and image_cve_edges.State = $$)",
 			expectedJoinTables: map[string]JoinType{
 				"image_component_edges":     Inner,
 				"image_component_cve_edges": Inner,
@@ -436,7 +436,7 @@ func TestCountQueries(t *testing.T) {
 				"inner join image_component_cve_edges on image_component_edges.ImageComponentId = image_component_cve_edges.ImageComponentId " +
 				"inner join image_cves on image_component_cve_edges.ImageCveId = image_cves.Id " +
 				"inner join image_cve_edges on(images.Id = image_cve_edges.ImageId and image_component_cve_edges.ImageCveId = image_cve_edges.ImageCveId) " +
-				"where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and (image_cve_edges.State = $2))",
+				"where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cve_edges.State = $2)",
 			expectedData: []interface{}{"false", "0"},
 		},
 	} {
@@ -641,7 +641,7 @@ func TestSelectQueries(t *testing.T) {
 				"inner join images on image_component_edges.ImageId = images.Id left join deployments_containers on images.Id = deployments_containers.Image_Id " +
 				"left join deployments on deployments_containers.deployments_Id = deployments.Id " +
 				"inner join image_cve_edges on(image_component_edges.ImageId = image_cve_edges.ImageId and image_cves.Id = image_cve_edges.ImageCveId) " +
-				"where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and (image_cve_edges.State = $2))",
+				"where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cve_edges.State = $2)",
 		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -643,6 +643,23 @@ func TestSelectQueries(t *testing.T) {
 				"inner join image_cve_edges on(image_component_edges.ImageId = image_cve_edges.ImageId and image_cves.Id = image_cve_edges.ImageCveId) " +
 				"where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cve_edges.State = $2)",
 		},
+		{
+			desc: "select with multiple enum values with IN operator",
+			q: search.NewQueryBuilder().
+				AddSelectFields(
+					search.NewQuerySelect(search.CVE),
+				).
+				AddRegexes(search.VulnerabilityState, ".+ED").
+				ProtoQuery(),
+			schema: imageCVEsSchema,
+			expectedQuery: "select image_cves.CveBaseInfo_Cve as cve " +
+				"from image_cves " +
+				"inner join image_component_cve_edges on image_cves.Id = image_component_cve_edges.ImageCveId " +
+				"inner join image_component_edges on image_component_cve_edges.ImageComponentId = image_component_edges.ImageComponentId " +
+				"inner join images on image_component_edges.ImageId = images.Id " +
+				"inner join image_cve_edges on(image_component_edges.ImageId = image_cve_edges.ImageId and image_cves.Id = image_cve_edges.ImageCveId) " +
+				"where image_cve_edges.State IN ($1, $2)",
+		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {
 			ctx := c.ctx

--- a/pkg/search/postgres/query/enum_query.go
+++ b/pkg/search/postgres/query/enum_query.go
@@ -22,7 +22,7 @@ func enumEquality(columnName string, enumValues []int32) (WhereClause, error) {
 		values = append(values, entry.Values...)
 	}
 	return WhereClause{
-		Query:  fmt.Sprintf("(%s)", strings.Join(queries, " or ")),
+		Query:  fmt.Sprintf("%s", strings.Join(queries, " or ")),
 		Values: values,
 		equivalentGoFunc: func(foundValue interface{}) bool {
 			asInt := int32(foundValue.(int))

--- a/pkg/search/postgres/query/enum_query.go
+++ b/pkg/search/postgres/query/enum_query.go
@@ -22,7 +22,7 @@ func enumEquality(columnName string, enumValues []int32) (WhereClause, error) {
 		values = append(values, entry.Values...)
 	}
 	return WhereClause{
-		Query:  fmt.Sprintf("%s", strings.Join(queries, " or ")),
+		Query:  strings.Join(queries, " or "),
 		Values: values,
 		equivalentGoFunc: func(foundValue interface{}) bool {
 			asInt := int32(foundValue.(int))

--- a/pkg/search/postgres/query/enum_query.go
+++ b/pkg/search/postgres/query/enum_query.go
@@ -15,24 +15,18 @@ func enumEquality(columnName string, enumValues []int32) (WhereClause, error) {
 		return WhereClause{}, fmt.Errorf("missing values for %q", columnName)
 	}
 
-	var queries []string
-	var values []interface{}
+	values := make([]any, 0, len(enumValues))
 	for _, s := range enumValues {
-		entry, err := newStringQueryWhereClause(columnName, strconv.Itoa(int(s)), pkgSearch.Equality)
-		if err != nil {
-			return WhereClause{}, err
-		}
-		queries = append(queries, entry.Query)
-		values = append(values, entry.Values...)
+		values = append(values, strconv.Itoa(int(s)))
 	}
-	query := queries[0]
-	if len(queries) > 1 {
-		query = fmt.Sprintf("%s IN (%s$$)", columnName, strings.Join(make([]string, len(queries)), "$$, "))
+	query := fmt.Sprintf("%s = $$", columnName)
+	if len(values) > 1 {
+		query = fmt.Sprintf("%s IN (%s$$)", columnName, strings.Join(make([]string, len(values)), "$$, "))
 	}
 	return WhereClause{
 		Query:  query,
 		Values: values,
-		equivalentGoFunc: func(foundValue interface{}) bool {
+		equivalentGoFunc: func(foundValue any) bool {
 			asInt := int32(foundValue.(int))
 			for _, enumValue := range enumValues {
 				if enumValue == asInt {

--- a/pkg/search/postgres/query/enum_query.go
+++ b/pkg/search/postgres/query/enum_query.go
@@ -26,7 +26,7 @@ func enumEquality(columnName string, enumValues []int32) (WhereClause, error) {
 	return WhereClause{
 		Query:  query,
 		Values: values,
-		equivalentGoFunc: func(foundValue any) bool {
+		equivalentGoFunc: func(foundValue interface{}) bool {
 			asInt := int32(foundValue.(int))
 			for _, enumValue := range enumValues {
 				if enumValue == asInt {

--- a/pkg/search/postgres/query/enum_query_test.go
+++ b/pkg/search/postgres/query/enum_query_test.go
@@ -1,0 +1,34 @@
+package pgsearch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEnumQuery(t *testing.T) {
+	const colName = "blah"
+	cases := []struct {
+		values         []int32
+		expectedQuery  string
+		expectedValues []any
+		expectErr      bool
+	}{
+		{values: nil, expectedQuery: "", expectedValues: nil, expectErr: true},
+		{values: []int32{1}, expectedQuery: "blah = $$", expectedValues: []any{"1"}},
+		{values: []int32{1, 2}, expectedQuery: "blah IN ($$, $$)", expectedValues: []any{"1", "2"}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.expectedQuery, func(t *testing.T) {
+			actual, err := enumEquality(colName, testCase.values)
+			if testCase.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedQuery, actual.Query)
+			assert.Equal(t, testCase.expectedValues, actual.Values)
+		})
+	}
+}

--- a/pkg/search/postgres/select_query_test.go
+++ b/pkg/search/postgres/select_query_test.go
@@ -760,8 +760,8 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 						),
 				).ProtoQuery(),
 			resultStruct: DerivedStruct7{},
-			expectedQuery: "select count(test_structs.Key1) filter (where (test_structs.Enum = $1)) as test_string_affected_by_enum1, " +
-				"count(test_structs.Key1) filter (where (test_structs.Enum = $2)) as test_string_affected_by_enum2 " +
+			expectedQuery: "select count(test_structs.Key1) filter (where test_structs.Enum = $1) as test_string_affected_by_enum1, " +
+				"count(test_structs.Key1) filter (where test_structs.Enum = $2) as test_string_affected_by_enum2 " +
 				"from test_structs",
 			expectedResult: []*DerivedStruct7{
 				{2, 2},
@@ -787,8 +787,8 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 						),
 				).AddGroupBy(search.TestBool).ProtoQuery(),
 			resultStruct: DerivedStruct8{},
-			expectedQuery: "select count(test_structs.Key1) filter (where (test_structs.Enum = $1)) as test_string_affected_by_enum1, " +
-				"count(test_structs.Key1) filter (where (test_structs.Enum = $2)) as test_string_affected_by_enum2, " +
+			expectedQuery: "select count(test_structs.Key1) filter (where test_structs.Enum = $1) as test_string_affected_by_enum1, " +
+				"count(test_structs.Key1) filter (where test_structs.Enum = $2) as test_string_affected_by_enum2, " +
 				"test_structs.Bool as test_bool from test_structs " +
 				"group by test_structs.Bool",
 			expectedResult: []*DerivedStruct8{
@@ -819,8 +819,8 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 					AddSortOption(search.NewSortOption(search.TestEnum1Custom)).
 					AddSortOption(search.NewSortOption(search.TestEnum2Custom).Reversed(true))).ProtoQuery(),
 			resultStruct: DerivedStruct8{},
-			expectedQuery: "select count(test_structs.Key1) filter (where (test_structs.Enum = $1)) as test_string_affected_by_enum1, " +
-				"count(test_structs.Key1) filter (where (test_structs.Enum = $2)) as test_string_affected_by_enum2, " +
+			expectedQuery: "select count(test_structs.Key1) filter (where test_structs.Enum = $1) as test_string_affected_by_enum1, " +
+				"count(test_structs.Key1) filter (where test_structs.Enum = $2) as test_string_affected_by_enum2, " +
 				"test_structs.Bool as test_bool from test_structs " +
 				"group by test_structs.Bool order by test_string_affected_by_enum1 asc, test_string_affected_by_enum2 desc",
 			expectedResult: []*DerivedStruct8{
@@ -850,8 +850,8 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 				WithPagination(search.NewPagination().
 					AddSortOption(search.NewSortOption(search.TestInvalidEnumCustom))).ProtoQuery(),
 			resultStruct: DerivedStruct8{},
-			expectedQuery: "select count(test_structs.Key1) filter (where (test_structs.Enum = $1)) as test_string_affected_by_enum1, " +
-				"count(test_structs.Key1) filter (where (test_structs.Enum = $2)) as test_string_affected_by_enum2, " +
+			expectedQuery: "select count(test_structs.Key1) filter (where test_structs.Enum = $1) as test_string_affected_by_enum1, " +
+				"count(test_structs.Key1) filter (where test_structs.Enum = $2) as test_string_affected_by_enum2, " +
 				"test_structs.Bool as test_bool from test_structs " +
 				"group by test_structs.Bool",
 			expectedResult: []*DerivedStruct8{


### PR DESCRIPTION
### Description

This PR removes unnecessary `()` around enum selects and replaces multiple `OR` with `IN`.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
