### PR TITLE
fix(sensor): Avoid unnecessary image scan attempts

### DIFF
--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -440,8 +440,12 @@ func (w *DeploymentWrap) populateImages(podSpec v1.PodSpec) {
 			log.Error(err)
 			parsedImage = &storage.ContainerImage{
 				Name: &storage.ImageName{
-					FullName: fmt.Sprintf("%s is an invalid image", c.Image),
+					FullName: fmt.Sprintf("%q is an invalid image", c.Image),
 				},
+				// This Container image (with invalid name) will be sent to Scanner (possibly via Central)
+				// and a scan will be attempted. By setting NonPullable=true, we can avoid the unnecessary API calls,
+				// because we know already here that the FullName is invalid and cannot be pulled
+				NotPullable: true,
 			}
 		}
 		w.Deployment.Containers[i].Image = parsedImage


### PR DESCRIPTION
### Description

Note that on images that are clearly not pullable, we can save the call to Scanner (over Central) and speed up the processing in Sensor - see https://github.com/stackrox/stackrox/blob/d20bca1e92582829ade0146772f232fb5a0b84ed/sensor/common/detector/enricher.go#L269

In a recent incident, we saw in the Central logs that the images including the error string in the name are sent to Central and a scann attempt it made with scanner. This is not necessary and only wastes resources.

Example central log:

```
image/service: 2025/01/16 14:15:51.851516 service_impl.go:366: Error: Enriching image {"image": "  is an invalid image", "image_id": "", "error": "image enrichment error: error getting metadata for image:   is an invalid image error: invalid arguments: no registry is indicated for image \"  is an invalid image\"", "request_image": "  is an invalid image"}
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- I haven't (existing CI only)
