### PR TITLE
ROX-25897: Adjust test to check for no active violations

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -1,4 +1,4 @@
-import static Services.checkForNoViolations
+import static Services.checkForNoActiveViolations
 import static Services.waitForViolation
 import static util.Helpers.withRetry
 
@@ -326,6 +326,7 @@ nzTe7BpOmVwmqLkIefEJe5L4PSXtp2KFLZqGO/kY5A==
                 ImageOuterClass.Image image = ImageService.getImage(digest, false)
                 assert image
                 assert !image.getNotesList().contains(ImageOuterClass.Image.Note.MISSING_METADATA)
+                assert !image.getNotPullable()
             }
         }
 
@@ -383,7 +384,7 @@ nzTe7BpOmVwmqLkIefEJe5L4PSXtp2KFLZqGO/kY5A==
         if (expectViolations) {
             assert waitForViolation(deployment.name, policyName)
         } else {
-            assert checkForNoViolations(deployment.name, policyName, 15)
+            assert checkForNoActiveViolations(deployment.name, policyName, 60)
         }
 
         where:


### PR DESCRIPTION
### Description

Assertion on no violations is tricky. We can have multiple states during test execution:
1. policy not evaluated -> no violations
2. policy evaluated -> no violations
3. policy evaluated -> no active violations (can happen only after false-positive alerts, they get resolved quickly)

Changes in this PR are trying to ensure that:
- policy is evaluated - by waiting for **pullable** image state and checking on violations multiple times to avoid getting intermediary state
- false-positive alerts are resolved - by waiting on no active violations

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] Check CI logs
- [x] Rerun test 10 times (to ensure no new instabilities are introduced)
