### PR TITLE
ROX-27747: Include CIDR block modal when filtering

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -3,7 +3,6 @@ import {
     Alert,
     AlertActionCloseButton,
     Bullseye,
-    Button,
     Divider,
     PageSection,
     Spinner,
@@ -51,6 +50,8 @@ import { getPropertiesForAnalytics } from './utils/networkGraphURLUtils';
 import getSimulation from './utils/getSimulation';
 import { getSearchFilterFromScopeHierarchy } from './utils/simulatorUtils';
 import CIDRFormModal from './components/CIDRFormModal';
+import { CIDRFormModalProvider } from './components/CIDRFormModalProvider';
+import CIDRFormModalButton from './components/CIDRFormModalButton';
 
 import './NetworkGraphPage.css';
 
@@ -97,7 +98,6 @@ function NetworkGraphPage() {
     const [isLoading, setIsLoading] = useState(false);
     const [timeWindow, setTimeWindow] = useState<(typeof timeWindows)[number]>(timeWindows[0]);
     const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('');
-    const [isCIDRBlockFormOpen, setIsCIDRBlockFormOpen] = useState(false);
     const [isBannerDismissed, setIsBannerDismissed] = useState(false);
 
     const { analyticsTrack } = useAnalytics();
@@ -279,21 +279,17 @@ function NetworkGraphPage() {
         deploymentCount,
     ]);
 
-    function toggleCIDRBlockForm() {
-        if (!isCIDRBlockFormOpen) {
-            const properties = getPropertiesForAnalytics(searchFilter);
+    function onCIDRFormModalOpenCallback() {
+        const properties = getPropertiesForAnalytics(searchFilter);
 
-            analyticsTrack({
-                event: CIDR_BLOCK_FORM_OPENED,
-                properties,
-            });
-        }
-
-        setIsCIDRBlockFormOpen(!isCIDRBlockFormOpen);
+        analyticsTrack({
+            event: CIDR_BLOCK_FORM_OPENED,
+            properties,
+        });
     }
 
     return (
-        <>
+        <CIDRFormModalProvider>
             {!isBannerDismissed && (
                 <Alert
                     variant="info"
@@ -339,13 +335,13 @@ function NetworkGraphPage() {
                             >
                                 {hasWriteAccessForBlocks && (
                                     <ToolbarItem>
-                                        <Button
+                                        <CIDRFormModalButton
                                             variant="secondary"
-                                            onClick={toggleCIDRBlockForm}
                                             isDisabled={!selectedClusterId}
+                                            onOpenCallback={onCIDRFormModalOpenCallback}
                                         >
                                             Manage CIDR blocks
-                                        </Button>
+                                        </CIDRFormModalButton>
                                     </ToolbarItem>
                                 )}
                                 {hasReadAccessForGenerator && (
@@ -440,13 +436,9 @@ function NetworkGraphPage() {
                         scopeHierarchy={scopeHierarchy}
                     />
                 )}
-                <CIDRFormModal
-                    selectedClusterId={selectedClusterId || ''}
-                    isOpen={isCIDRBlockFormOpen}
-                    onClose={toggleCIDRBlockForm}
-                />
+                <CIDRFormModal selectedClusterId={selectedClusterId || ''} />
             </PageSection>
-        </>
+        </CIDRFormModalProvider>
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/IPMatchFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/IPMatchFilter.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 import { Flex, SearchInput, SelectOption } from '@patternfly/react-core';
 import SimpleSelect from 'Components/CompoundSearchFilter/components/SimpleSelect';
 
@@ -12,7 +12,10 @@ export type IPMatchFilterResult = {
 };
 
 type IPMatchFilterProps = {
+    filter: IPMatchFilterResult;
+    onChange: ({ matchType, externalIP }: IPMatchFilterResult) => void;
     onSearch: ({ matchType, externalIP }: IPMatchFilterResult) => void;
+    onClear: () => void;
 };
 
 function ensureMatchType(value: unknown): MatchType {
@@ -22,10 +25,7 @@ function ensureMatchType(value: unknown): MatchType {
     return 'Equals';
 }
 
-function IPMatchFilter({ onSearch }: IPMatchFilterProps): ReactElement {
-    const [matchType, setMatchType] = useState<MatchType>('Equals');
-    const [externalIP, setExternalIP] = useState('');
-
+function IPMatchFilter({ filter, onChange, onSearch, onClear }: IPMatchFilterProps): ReactElement {
     return (
         <Flex
             direction={{ default: 'row' }}
@@ -34,8 +34,10 @@ function IPMatchFilter({ onSearch }: IPMatchFilterProps): ReactElement {
         >
             <SimpleSelect
                 menuToggleClassName="pf-v5-u-flex-shrink-0"
-                value={matchType}
-                onChange={(value) => setMatchType(ensureMatchType(value))}
+                value={filter.matchType}
+                onChange={(value) => {
+                    onChange({ ...filter, matchType: ensureMatchType(value) });
+                }}
                 ariaLabelMenu="external ip comparison selector menu"
                 ariaLabelToggle="external ip comparison selector toggle"
             >
@@ -48,12 +50,14 @@ function IPMatchFilter({ onSearch }: IPMatchFilterProps): ReactElement {
             </SimpleSelect>
             <SearchInput
                 placeholder="Find by external IP"
-                value={externalIP}
-                onChange={(_event, value) => setExternalIP(value)}
-                onSearch={() => {
-                    onSearch({ matchType, externalIP });
+                value={filter.externalIP}
+                onChange={(_event, value) => {
+                    onChange({ ...filter, externalIP: value });
                 }}
-                onClear={() => setExternalIP('')}
+                onSearch={() => {
+                    onSearch({ ...filter });
+                }}
+                onClear={onClear}
             />
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
@@ -76,12 +76,19 @@ function CIDRFormModal({ selectedClusterId }: CIDRFormModalProps) {
           }
         : emptyCIDRBlockRow;
 
-    const initialValues = {
-        entities:
-            CIDRBlocks.entities.length > 0
-                ? [...CIDRBlocks.entities]
-                : [...CIDRBlocks.entities, initialCIDRBlockRow],
-    };
+    let initialValues;
+
+    if (CIDRBlocks.entities.length === 0) {
+        initialValues = {
+            entities: [initialCIDRBlockRow],
+        };
+    } else {
+        initialValues = {
+            entities: initialCIDRFormValue
+                ? [...CIDRBlocks.entities, initialCIDRBlockRow]
+                : [...CIDRBlocks.entities],
+        };
+    }
 
     const formik = useFormik({
         initialValues,

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModalButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModalButton.tsx
@@ -1,0 +1,39 @@
+import React, { ReactNode } from 'react';
+import { Button } from '@patternfly/react-core';
+
+import { useCIDRFormModal } from './CIDRFormModalProvider';
+
+interface CIDRFormModalButtonProps extends React.ComponentProps<typeof Button> {
+    children: ReactNode;
+    isInline?: boolean;
+    isDisabled?: boolean;
+    onOpenCallback?: () => void;
+}
+
+function CIDRFormModalButton({
+    children,
+    isInline = false,
+    isDisabled = false,
+    onOpenCallback,
+    ...props
+}: CIDRFormModalButtonProps) {
+    const { toggleCIDRFormModal } = useCIDRFormModal();
+
+    function toggleCIDRBlockForm() {
+        onOpenCallback?.();
+        toggleCIDRFormModal();
+    }
+
+    return (
+        <Button
+            {...props}
+            isInline={isInline}
+            onClick={toggleCIDRBlockForm}
+            isDisabled={isDisabled}
+        >
+            {children}
+        </Button>
+    );
+}
+
+export default CIDRFormModalButton;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModalProvider.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModalProvider.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const defaultValue = {
+    isCIDRFormModalOpen: false,
+    initialCIDRFormValue: '',
+    toggleCIDRFormModal: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    setInitialCIDRFormValue: (value: string) => {},
+};
+
+const CIDRFormModalContext = createContext(defaultValue);
+
+export const CIDRFormModalProvider = ({ children }) => {
+    const [isCIDRFormModalOpen, setIsCIDRFormModalOpen] = useState(false);
+    const [initialCIDRFormValue, setInitialCIDRFormValue] = useState<string>('');
+
+    const toggleCIDRFormModal = () => {
+        setIsCIDRFormModalOpen((prevValue) => !prevValue);
+    };
+
+    return (
+        <CIDRFormModalContext.Provider
+            value={{
+                isCIDRFormModalOpen,
+                initialCIDRFormValue,
+                setInitialCIDRFormValue,
+                toggleCIDRFormModal,
+            }}
+        >
+            {children}
+        </CIDRFormModalContext.Provider>
+    );
+};
+
+export const useCIDRFormModal = () => useContext(CIDRFormModalContext);

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModalProvider.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModalProvider.tsx
@@ -1,14 +1,20 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, Dispatch, SetStateAction, useContext, useState } from 'react';
+
+interface CIDRFormModalContextType {
+    isCIDRFormModalOpen: boolean;
+    initialCIDRFormValue: string;
+    toggleCIDRFormModal: () => void;
+    setInitialCIDRFormValue: Dispatch<SetStateAction<string>>;
+}
 
 const defaultValue = {
     isCIDRFormModalOpen: false,
     initialCIDRFormValue: '',
     toggleCIDRFormModal: () => {},
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    setInitialCIDRFormValue: (value: string) => {},
+    setInitialCIDRFormValue: () => {},
 };
 
-const CIDRFormModalContext = createContext(defaultValue);
+const CIDRFormModalContext = createContext<CIDRFormModalContextType>(defaultValue);
 
 export const CIDRFormModalProvider = ({ children }) => {
     const [isCIDRFormModalOpen, setIsCIDRFormModalOpen] = useState(false);


### PR DESCRIPTION
### Description

This PR makes a few changes to add a CIDR block using the modal within the External flows section. We are using React context for this because of the following reason:

**The modal component is rendered within `NetworkGraphPage`, 6 levels up from the `ExternalFlows` component. We don't want to prop drill that many levels. I'd consider prop drilling for simplicity if it were 2 (maybe even 3). Since it's 6 levels deep, I think it warrants the use of React Context.**

We also needed to pass the External IP value to the modal to display as the initial value when the modal opens. The React Context for the CIDR form modal will keep the state to allow for that behavior. 


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![Screenshot 2025-01-23 at 9 39 48 AM](https://github.com/user-attachments/assets/abdfc7f0-8463-4578-a9ea-0f1837dbcc6d)
![Screenshot 2025-01-23 at 9 40 16 AM](https://github.com/user-attachments/assets/8e63fb47-6436-4968-95f5-328de3644697)
