### PR TITLE
ROX-27230: Set image flavor for Konflux builds to `rhacs`

### DIFF
--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -129,10 +129,9 @@ LABEL \
 
 EXPOSE 8443
 
-# TODO(ROX-22245): set proper image flavor for user-facing GA Fast Stream images.
 ENV PATH="/stackrox:$PATH" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \
-    ROX_IMAGE_FLAVOR="development_build" \
+    ROX_IMAGE_FLAVOR="rhacs" \
     ROX_PRODUCT_BRANDING="RHACS_BRANDING"
 
 COPY .konflux/stackrox-data/external-networks/external-networks.zip /stackrox/static-data/external-networks/external-networks.zip

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -54,8 +54,7 @@ RUN microdnf upgrade -y --nobest && \
 
 COPY LICENSE /licenses/LICENSE
 
-# TODO(ROX-22245): set proper image flavor for user-facing GA Fast Stream images.
-ENV ROX_IMAGE_FLAVOR="development_build"
+ENV ROX_IMAGE_FLAVOR="rhacs"
 
 # The following are numeric uid and gid of `nobody` user in UBI.
 # We can't use symbolic names because otherwise k8s will fail to start the pod with an error like this:


### PR DESCRIPTION
### Description

Only the flavor change.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No change.

#### How I validated my change

It's not possible to test the functioning of this yet.
We'll get to it later.