### PR TITLE
ci: nosecret labels to bypass gitleaks check

### DIFF
--- a/qa-tests-backend/src/test/groovy/ClientCertAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClientCertAuthTest.groovy
@@ -41,7 +41,7 @@ class ClientCertAuthTest extends BaseSpecification {
             log.info "Client cert auth provider ID is ${providerIDs[i]}"
             GroupService.addDefaultMapping(providerIDs[i], "Continuous Integration")
             certTokens[i] = AuthProviderService.getAuthProviderLoginToken(providerIDs[i])
-            log.info "Certificate token is ${certTokens[i]}  # nosecret"
+            log.info "Certificate token is ${certTokens[i]} #notsecret"
         }
     }
 


### PR DESCRIPTION
To un-trigger gitleaks check, `nosecrets` can be added to the log line.

### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected
- [x] `qa-e2e-tests` logs are available in artifacts

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

```
conf_file=/tmp/gitleaks.osci.7.6.1.toml
curl -o "$conf_file" https://gitlab.cee.redhat.com/infosec-public/apps/rh-gcs-filter/-/raw/main/ansible/files/patterns/gitleaks/7.6.1

curl -L -o /tmp/build-log.txt https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/1877185732074803200/artifacts/merge-gke-qa-e2e-tests/stackrox-stackrox-e2e-test/build-log.txt
cat /tmp/build-log.txt | gitleaks stdin --config "$conf_file" -v
```

This showed only one discovered log entry:
```
$ cat /tmp/build-log.txt | gitleaks stdin --config "$conf_file" -v

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     ...ertificate token is eyJhb***...
Secret:      eyJhbGc***...
RuleID:      70
Entropy:     5.845725

Finding:     ...ertificate token is eyJhb***...
Secret:      eyJhbGc***...
RuleID:      70
Entropy:     5.855085

1:59PM INF scanned ~3266316 bytes (3.27 MB) in 559ms
1:59PM WRN leaks found: 2
```
