### PR TITLE
ROX-27742: Add search filter for EPSS Probability

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.test.ts
@@ -373,6 +373,13 @@ describe('convertFromInternalToExternalConditionText negative', () => {
         );
     });
 
+    it('should render equal to as not valid', () => {
+        // Intentionally omit = because potential problem with floating point
+        expect(convertFromInternalToExternalConditionText(inputProps, '=0.5')).toEqual(
+            '“=0.5” is not valid'
+        );
+    });
+
     it('should render unexpected value as not valid', () => {
         expect(convertFromInternalToExternalConditionText(inputProps, '=1.1')).toEqual(
             '“=1.1” is not valid'
@@ -401,9 +408,7 @@ describe('convertFromInternalToExternalConditionText positive', () => {
         );
     });
 
-    it('should split equal to', () => {
-        expect(convertFromInternalToExternalConditionText(inputProps, '=0.5')).toEqual('=50.000%');
-    });
+    // Intentionally omit = because potential problem with floating point
 
     it('should split less than or equal to', () => {
         expect(convertFromInternalToExternalConditionText(inputProps, '<=0.00345')).toEqual(

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.test.ts
@@ -1,0 +1,417 @@
+import {
+    EPSSProbability,
+    convertFromExternalToInternalText,
+    convertFromInternalToExternalText,
+    externalTextDefault,
+    externalTextRegExp,
+    internalTextRegExp,
+    validateExternalText,
+    validateInternalText,
+} from './epssProbability';
+import { convertFromInternalToExternalConditionText } from '../components/ConditionText';
+
+describe('epssProbability', () => {
+    describe('convertFromExternalToInternalText', () => {
+        it('should convert one digit without period', () => {
+            expect(convertFromExternalToInternalText('0')).toEqual('0');
+        });
+
+        it('should convert two digits with period', () => {
+            // Make asserttion independent of exact value 0.12300000000000001
+            expect(convertFromExternalToInternalText('12.3').startsWith('0.123')).toEqual(true);
+        });
+
+        it('should convert three digits without period', () => {
+            expect(convertFromExternalToInternalText('100')).toEqual('1');
+        });
+
+        it('should convert period preceded by digit but without percent', () => {
+            expect(convertFromExternalToInternalText('0.')).toEqual('0');
+        });
+
+        it('should convert period followed by digit but without percent', () => {
+            expect(convertFromExternalToInternalText('.0')).toEqual('0');
+        });
+
+        it('should convert period followed by digits but without percent', () => {
+            expect(convertFromExternalToInternalText('.123')).toEqual('0.00123');
+        });
+
+        it('should convert period preceded and followed by digit but without percent', () => {
+            expect(convertFromExternalToInternalText('0.0')).toEqual('0');
+        });
+
+        it('should convert period preceded by digit and with percent', () => {
+            expect(convertFromExternalToInternalText('0.%')).toEqual('0');
+        });
+
+        it('should convert period followed by digits and with percent', () => {
+            expect(convertFromExternalToInternalText('.123%')).toEqual('0.00123');
+        });
+
+        it('should convert period followed by digit and with percent', () => {
+            expect(convertFromExternalToInternalText('.0%')).toEqual('0');
+        });
+
+        it('should convert period preceded and followed by digit and with percent', () => {
+            expect(convertFromExternalToInternalText('0.0%')).toEqual('0');
+        });
+
+        it('should convert externalTextDefault', () => {
+            expect(convertFromExternalToInternalText(externalTextDefault)).toEqual('0');
+        });
+
+        it('should convert valid digits but with preceding space', () => {
+            expect(convertFromExternalToInternalText(' 0.')).toEqual('0');
+        });
+
+        it('should convert valid digits but with following space', () => {
+            expect(convertFromExternalToInternalText('.0 ')).toEqual('0');
+        });
+
+        it('should convert valid digits but with preceding and following space', () => {
+            expect(convertFromExternalToInternalText(' 0.0 ')).toEqual('0');
+        });
+    });
+
+    describe('convertFromInternalToExternalText', () => {
+        it('should convert zero without period', () => {
+            expect(convertFromInternalToExternalText('0')).toEqual('0.000%');
+        });
+
+        it('should convert one without period', () => {
+            expect(convertFromInternalToExternalText('1')).toEqual('100.000%');
+        });
+
+        it('should convert period preceded by digit', () => {
+            expect(convertFromInternalToExternalText('0.')).toEqual('0.000%');
+        });
+
+        it('should convert period followed by digit', () => {
+            expect(convertFromInternalToExternalText('.0')).toEqual('0.000%');
+        });
+
+        it('should convert period followed by three digits', () => {
+            expect(convertFromInternalToExternalText('.123')).toEqual('12.300%');
+        });
+
+        it('should convert period followed by five digits', () => {
+            expect(convertFromInternalToExternalText('.12345')).toEqual('12.345%');
+        });
+
+        it('should convert period followed by six digits', () => {
+            // toFixed(3) rounds up, if needed
+            expect(convertFromInternalToExternalText('.123456')).toEqual('12.346%');
+        });
+
+        it('should convert period preceded and followed by digit but without percent', () => {
+            expect(convertFromInternalToExternalText('0.0')).toEqual('0.000%');
+        });
+
+        it('should convert valid digits but with preceding space', () => {
+            expect(convertFromInternalToExternalText(' 0.')).toEqual('0.000%');
+        });
+
+        it('should convert valid digits but with following space', () => {
+            expect(convertFromExternalToInternalText('.0 ')).toEqual('0');
+        });
+
+        it('should convert valid digits but with preceding and following space', () => {
+            expect(convertFromInternalToExternalText(' 0.0 ')).toEqual('0.000%');
+        });
+    });
+
+    describe('externalTextRegExp negative', () => {
+        it('should fail for empty string', () => {
+            expect(externalTextRegExp.test('')).toEqual(false);
+        });
+
+        it('should fail for bogus text', () => {
+            expect(externalTextRegExp.test('bogus')).toEqual(false);
+        });
+
+        it('should fail for period alone', () => {
+            expect(externalTextRegExp.test('.')).toEqual(false);
+        });
+
+        it('should fail for percent alone', () => {
+            expect(externalTextRegExp.test('%')).toEqual(false);
+        });
+
+        it('should fail for negative number', () => {
+            expect(externalTextRegExp.test('-1')).toEqual(false);
+        });
+
+        // Why fail because of space?
+        // To reduce complexity of RegExp, convert function is responsible to trim.
+
+        it('should fail for valid digits but with preceding space', () => {
+            expect(externalTextRegExp.test(' 0.')).toEqual(false);
+        });
+
+        it('should fail for valid digits but with following space', () => {
+            expect(externalTextRegExp.test('.0 ')).toEqual(false);
+        });
+
+        it('should fail for valid digits but with preceding and following space', () => {
+            expect(externalTextRegExp.test(' 0.0 ')).toEqual(false);
+        });
+    });
+
+    describe('externalTextRegExp positive', () => {
+        it('should pass for one digit without period', () => {
+            expect(externalTextRegExp.test('0')).toEqual(true);
+        });
+
+        it('should pass for two digits with period', () => {
+            expect(externalTextRegExp.test('12.3')).toEqual(true);
+        });
+
+        it('should pass for three digits without period', () => {
+            expect(externalTextRegExp.test('100')).toEqual(true);
+        });
+
+        it('should pass for four digits with period', () => {
+            // To reduce complexity of RegExp, convert function is responsible for range.
+            expect(externalTextRegExp.test('1234.567')).toEqual(true);
+        });
+
+        it('should pass for period preceded by digit but without percent', () => {
+            expect(externalTextRegExp.test('0.')).toEqual(true);
+        });
+
+        it('should pass for period followed by digit but without percent', () => {
+            expect(externalTextRegExp.test('.0')).toEqual(true);
+        });
+
+        it('should pass for period followed by digits but without percent', () => {
+            expect(externalTextRegExp.test('.123')).toEqual(true);
+        });
+
+        it('should pass for period preceded and followed by digit but without percent', () => {
+            expect(externalTextRegExp.test('0.0')).toEqual(true);
+        });
+
+        it('should pass for period preceded by digit and with percent', () => {
+            expect(externalTextRegExp.test('0.%')).toEqual(true);
+        });
+        it('should pass for period followed by digits and with percent', () => {
+            expect(externalTextRegExp.test('.123%')).toEqual(true);
+        });
+
+        it('should pass for period followed by digit and with percent', () => {
+            expect(externalTextRegExp.test('.0%')).toEqual(true);
+        });
+
+        it('should pass for period preceded and followed by digit and with percent', () => {
+            expect(externalTextRegExp.test('0.0%')).toEqual(true);
+        });
+
+        it('should pass for externalTextDefault', () => {
+            expect(externalTextRegExp.test(externalTextDefault)).toEqual(true);
+        });
+    });
+
+    describe('internalTextRegExp negative', () => {
+        it('should fail for empty string', () => {
+            expect(internalTextRegExp.test('')).toEqual(false);
+        });
+
+        it('should fail for bogus text', () => {
+            expect(internalTextRegExp.test('bogus')).toEqual(false);
+        });
+
+        it('should fail for period alone', () => {
+            expect(internalTextRegExp.test('.')).toEqual(false);
+        });
+
+        it('should fail for percent alone', () => {
+            expect(internalTextRegExp.test('%')).toEqual(false);
+        });
+
+        it('should fail for negative number', () => {
+            expect(internalTextRegExp.test('-1')).toEqual(false);
+        });
+
+        it('should fail for period preceded by digit and with percent', () => {
+            expect(internalTextRegExp.test('0.%')).toEqual(false);
+        });
+
+        it('should fail for period followed by digit and with percent', () => {
+            expect(internalTextRegExp.test('.0%')).toEqual(false);
+        });
+
+        it('should fail for period preceded and followed by digit and with percent', () => {
+            expect(internalTextRegExp.test('0.0%')).toEqual(false);
+        });
+
+        // Why fail because of space?
+        // To reduce complexity of RegExp, convert function is responsible to trim.
+
+        it('should fail for valid digits but with preceding space', () => {
+            expect(internalTextRegExp.test(' 0.')).toEqual(false);
+        });
+
+        it('should fail for valid digits but with following space', () => {
+            expect(internalTextRegExp.test('.0 ')).toEqual(false);
+        });
+
+        it('should fail for valid digits but with preceding and following space', () => {
+            expect(internalTextRegExp.test(' 0.0 ')).toEqual(false);
+        });
+    });
+
+    describe('internalTextRegExp positive', () => {
+        it('should pass for one digit without period', () => {
+            expect(internalTextRegExp.test('0')).toEqual(true);
+        });
+
+        it('should pass for two digits with period', () => {
+            // To reduce complexity of RegExp, convert function is responsible for range.
+            expect(internalTextRegExp.test('12.3')).toEqual(true);
+        });
+
+        it('should pass for period preceded by digit but without percent', () => {
+            expect(internalTextRegExp.test('0.')).toEqual(true);
+        });
+
+        it('should pass for period followed by digit but without percent', () => {
+            expect(internalTextRegExp.test('.0')).toEqual(true);
+        });
+
+        it('should pass for period followed by digits but without percent', () => {
+            expect(internalTextRegExp.test('.123')).toEqual(true);
+        });
+
+        it('should pass for period preceded and followed by digit but without percent', () => {
+            expect(internalTextRegExp.test('0.0')).toEqual(true);
+        });
+    });
+
+    describe('validateExternalText negative', () => {
+        it('should fail for number that is too large but without percent', () => {
+            expect(validateExternalText('101')).toEqual(false);
+        });
+
+        it('should fail for number that is too large and with percent', () => {
+            expect(validateExternalText('101$')).toEqual(false);
+        });
+    });
+
+    describe('validateExternalText positive', () => {
+        it('should pass for valid digits but with preceding space', () => {
+            expect(validateExternalText(' 0.')).toEqual(true);
+        });
+
+        it('should pass for valid digits but with following space', () => {
+            expect(validateExternalText('.0 ')).toEqual(true);
+        });
+
+        it('should pass for valid digits but with preceding and following space', () => {
+            expect(validateExternalText(' 0.0 ')).toEqual(true);
+        });
+
+        it('should pass for externalTextDefault', () => {
+            expect(validateExternalText(externalTextDefault)).toEqual(true);
+        });
+    });
+
+    describe('validateInternalText negative', () => {
+        it('should fail for number that is too large but without percent', () => {
+            expect(validateInternalText('1.01')).toEqual(false);
+        });
+
+        it('should fail for number that is too large and with percent', () => {
+            expect(validateInternalText('1.01$')).toEqual(false);
+        });
+    });
+
+    describe('validateInternalText positive', () => {
+        it('should pass for valid digits but with preceding space', () => {
+            expect(validateInternalText(' 0.')).toEqual(true);
+        });
+
+        it('should pass for valid digits but with following space', () => {
+            expect(validateInternalText('.0 ')).toEqual(true);
+        });
+
+        it('should pass for valid digits but with preceding and following space', () => {
+            expect(validateInternalText(' 0.0 ')).toEqual(true);
+        });
+    });
+});
+
+// For filter chip: split, convert, and then join.
+// EPSSProbability has specific functions to test genmric function in component.
+
+describe('convertFromInternalToExternalConditionText negative', () => {
+    const { inputProps } = EPSSProbability;
+
+    // Notice typograpical quotes.
+
+    it('should render empty string as not valid', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '')).toEqual(
+            '“” is not valid'
+        );
+    });
+
+    it('should render bogus text as not valid', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, 'bogus')).toEqual(
+            '“bogus” is not valid'
+        );
+    });
+
+    it('should render absence of condition as not valid', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '0')).toEqual(
+            '“0” is not valid'
+        );
+    });
+
+    it('should render unexpected condition as not valid', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '~0')).toEqual(
+            '“~0” is not valid'
+        );
+    });
+
+    it('should render unexpected value as not valid', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '=1.1')).toEqual(
+            '“=1.1” is not valid'
+        );
+    });
+});
+
+describe('convertFromInternalToExternalConditionText positive', () => {
+    const { inputProps } = EPSSProbability;
+
+    it('should split greater than', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '>0')).toEqual('>0.000%');
+    });
+
+    it('should split greater than or equal to', () => {
+        // toFixed(3) did not need to round up apparently (however, see next test)
+        expect(convertFromInternalToExternalConditionText(inputProps, '>=.012345')).toEqual(
+            '>=1.234%'
+        );
+    });
+
+    it('should round up if needed', () => {
+        // toFixed(3) rounds up, if needed
+        expect(convertFromInternalToExternalConditionText(inputProps, '>=.023456')).toEqual(
+            '>=2.346%'
+        );
+    });
+
+    it('should split equal to', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '=0.5')).toEqual('=50.000%');
+    });
+
+    it('should split less than or equal to', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '<=0.00345')).toEqual(
+            '<=0.345%'
+        );
+    });
+
+    it('should split less than', () => {
+        expect(convertFromInternalToExternalConditionText(inputProps, '<1')).toEqual('<100.000%');
+    });
+});

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
@@ -35,8 +35,6 @@ export function validateExternalText(externalText: string) {
 export const internalTextRegExp = /^(\.\d+|\d+(?:\.\d*)?)$/;
 
 export function validateInternalText(internalText: string) {
-    // Assume internalText was serialized by String (see above).
-    // Leading zero followed by optional decimal point and digits.
     if (!internalTextRegExp.test(internalText.trim())) {
         return false;
     }

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
@@ -1,0 +1,65 @@
+import { ConditionTextFilterAttribute } from '../types';
+import { ConditionEntries } from '../components/ConditionText';
+
+const conditionEntries: ConditionEntries = [
+    ['>', 'Is greater than'],
+    ['>=', 'Is greater than or equal to'],
+    ['=', 'Is equal to'],
+    ['<=', 'Is less than or equal to'],
+    ['<', 'Is less than'],
+];
+
+export function convertFromExternalToInternalText(externalText: string) {
+    const float = parseFloat(externalText); // assume validateExternalText
+    return String(float / 100); // from percent to fraction
+}
+
+export function convertFromInternalToExternalText(internalText: string) {
+    const float = parseFloat(internalText); // assume validateInternalText
+    const percent = float * 100; // from fraction to percent
+    return `${percent.toFixed(3)}%`; // same precison as EPSS data
+}
+
+export const externalTextDefault = '0%';
+
+export const externalTextRegExp = /^(\.\d+|\d+(?:\.\d*)?)%?$/;
+
+export function validateExternalText(externalText: string) {
+    if (!externalTextRegExp.test(externalText.trim())) {
+        return false;
+    }
+    const float = parseFloat(externalText);
+    return !Number.isNaN(float) && float >= 0 && float <= 100;
+}
+
+export const internalTextRegExp = /^(\.\d+|\d+(?:\.\d*)?)$/;
+
+export function validateInternalText(internalText: string) {
+    // Assume internalText was serialized by String (see above).
+    // Leading zero followed by optional decimal point and digits.
+    if (!internalTextRegExp.test(internalText.trim())) {
+        return false;
+    }
+    const float = parseFloat(internalText);
+    return !Number.isNaN(float) && float >= 0 && float <= 1;
+}
+
+export const EPSSProbability: ConditionTextFilterAttribute = {
+    displayName: 'EPSS probability',
+    filterChipLabel: 'EPSS probability',
+    searchTerm: 'EPSS Probability',
+    inputType: 'condition-text',
+    featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_EPSS_SCORE'],
+    inputProps: {
+        conditionProps: {
+            conditionEntries,
+        },
+        textProps: {
+            convertFromExternalToInternalText,
+            convertFromInternalToExternalText,
+            externalTextDefault,
+            validateExternalText,
+            validateInternalText,
+        },
+    },
+} as const;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
@@ -4,7 +4,7 @@ import { ConditionEntries } from '../components/ConditionText';
 const conditionEntries: ConditionEntries = [
     ['>', 'Is greater than'],
     ['>=', 'Is greater than or equal to'],
-    ['=', 'Is equal to'],
+    // Intentionally omit = because potential problem with floating point
     ['<=', 'Is less than or equal to'],
     ['<', 'Is less than'],
 ];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -28,8 +28,7 @@ export const EPSSProbability: ConditionTextFilterAttribute = {
     filterChipLabel: 'EPSS probability',
     searchTerm: 'EPSS Probability',
     inputType: 'condition-text',
-    // featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_EPSS_SCORE'],
-    featureFlagDependency: ['ROX_SCANNER_V4'],
+    featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_EPSS_SCORE'],
     inputProps: {
         conditionProps: {
             conditionEntries: [

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -1,6 +1,7 @@
 // If you're adding a new attribute, make sure to add it to "imageCVEAttributes" as well
 
-import { CompoundSearchFilterAttribute, ConditionTextFilterAttribute } from '../types';
+import { CompoundSearchFilterAttribute } from '../types';
+import { EPSSProbability } from './epssProbability';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',
@@ -22,52 +23,5 @@ export const CVSS: CompoundSearchFilterAttribute = {
     searchTerm: 'CVSS',
     inputType: 'condition-number',
 };
-
-export const EPSSProbability: ConditionTextFilterAttribute = {
-    displayName: 'EPSS probability',
-    filterChipLabel: 'EPSS probability',
-    searchTerm: 'EPSS Probability',
-    inputType: 'condition-text',
-    featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_EPSS_SCORE'],
-    inputProps: {
-        conditionProps: {
-            conditionEntries: [
-                ['>', 'Is greater than'],
-                ['>=', 'Is greater than or equal to'],
-                ['=', 'Is equal to'],
-                ['<=', 'Is less than or equal to'],
-                ['<', 'Is less than'],
-            ],
-        },
-        textProps: {
-            convertFromExternalToInternalText: (externalText: string) => {
-                const float = parseFloat(externalText); // assume validateExternalText
-                return String(float / 100); // from percent to fraction
-            },
-            convertFromInternalToExternalText: (internalText: string) => {
-                const float = parseFloat(internalText); // assume validateInternalText
-                const percent = float * 100; // from fraction to percent
-                return `${percent.toFixed(3)}%`; // same precison as EPSS data
-            },
-            externalTextDefault: '0%',
-            validateExternalText: (externalText: string) => {
-                if (!/^(\.\d+|\d+(?:\.\d*)?)%?$/.test(externalText.trim())) {
-                    return false;
-                }
-                const float = parseFloat(externalText);
-                return !Number.isNaN(float) && float >= 0 && float <= 100;
-            },
-            validateInternalText: (internalText: string) => {
-                // Assume internalText was serialized by String (see above).
-                // Leading zero followed by optional decimal point and digits.
-                if (!/^(\.\d+|\d+(?:\.\d*)?)$/.test(internalText.trim())) {
-                    return false;
-                }
-                const float = parseFloat(internalText);
-                return !Number.isNaN(float) && float >= 0 && float <= 1;
-            },
-        },
-    },
-} as const;
 
 export const imageCVEAttributes = [Name, DiscoveredTime, CVSS, EPSSProbability];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "imageCVEAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import { CompoundSearchFilterAttribute, ConditionTextFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',
@@ -23,4 +23,52 @@ export const CVSS: CompoundSearchFilterAttribute = {
     inputType: 'condition-number',
 };
 
-export const imageCVEAttributes = [Name, DiscoveredTime, CVSS];
+export const EPSSProbability: ConditionTextFilterAttribute = {
+    displayName: 'EPSS probability',
+    filterChipLabel: 'EPSS probability',
+    searchTerm: 'EPSS Probability',
+    inputType: 'condition-text',
+    // featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_EPSS_SCORE'],
+    featureFlagDependency: ['ROX_SCANNER_V4'],
+    inputProps: {
+        conditionProps: {
+            conditionEntries: [
+                ['>', 'Is greater than'],
+                ['>=', 'Is greater than or equal to'],
+                ['=', 'Is equal to'],
+                ['<=', 'Is less than or equal to'],
+                ['<', 'Is less than'],
+            ],
+        },
+        textProps: {
+            convertFromExternalToInternalText: (externalText: string) => {
+                const float = parseFloat(externalText); // assume validateExternalText
+                return String(float / 100); // from percent to fraction
+            },
+            convertFromInternalToExternalText: (internalText: string) => {
+                const float = parseFloat(internalText); // assume validateInternalText
+                const percent = float * 100; // from fraction to percent
+                return `${percent.toFixed(3)}%`; // same precison as EPSS data
+            },
+            externalTextDefault: '0%',
+            validateExternalText: (externalText: string) => {
+                if (!/^(\.\d+|\d+(?:\.\d*)?)%?$/.test(externalText.trim())) {
+                    return false;
+                }
+                const float = parseFloat(externalText);
+                return !Number.isNaN(float) && float >= 0 && float <= 100;
+            },
+            validateInternalText: (internalText: string) => {
+                // Assume internalText was serialized by String (see above).
+                // Leading zero followed by optional decimal point and digits.
+                if (!/^(\.\d+|\d+(?:\.\d*)?)$/.test(internalText.trim())) {
+                    return false;
+                }
+                const float = parseFloat(internalText);
+                return !Number.isNaN(float) && float >= 0 && float <= 1;
+            },
+        },
+    },
+} as const;
+
+export const imageCVEAttributes = [Name, DiscoveredTime, CVSS, EPSSProbability];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -27,6 +27,7 @@ import {
 import ConditionNumber from './ConditionNumber';
 import SearchFilterAutocomplete from './SearchFilterAutocomplete';
 import ConditionDate from './ConditionDate';
+import ConditionText from './ConditionText';
 
 export type InputFieldValue =
     | string
@@ -123,6 +124,21 @@ function CompoundSearchFilterInputField({
                         action: 'ADD',
                         category: attribute.searchTerm,
                         value: `${conditionMap[condition]}${number}`,
+                    });
+                }}
+            />
+        );
+    }
+    if (attribute.inputType === 'condition-text') {
+        return (
+            <ConditionText
+                inputProps={attribute.inputProps}
+                onSearch={(internalConditionText) => {
+                    // onChange(newValue); // inputText seems unused in CompoundSearchFilter
+                    onSearch({
+                        action: 'ADD',
+                        category: attribute.searchTerm,
+                        value: internalConditionText,
                     });
                 }}
             />

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.css
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.css
@@ -1,0 +1,4 @@
+/* 100.000% rounded up to 10em overrides 100% */
+.pf-v5-c-form-control.ConditionTextInput {
+    --pf-v5-c-form-control--Width: 8em;
+}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
@@ -61,7 +61,8 @@ export function convertFromInternalToExternalConditionText(
         }
     }
 
-    return `${internalConditionText} is not valid`; // query string in page address
+    // Enclose text in typographical quotes in case it is clearer.
+    return `“${internalConditionText}” is not valid`; // query string in page address
 }
 
 export type ConditionTextProps = {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
@@ -6,9 +6,10 @@ import { NonEmptyArray } from 'utils/type.utils';
 import SimpleSelect from './SimpleSelect';
 
 // Potentially reusable for condition-number and date-picker components.
-type ConditionEntry = [conditionKey: string, conditionText: string];
-type ConditionInputProps = {
-    conditionEntries: NonEmptyArray<ConditionEntry>; // first item has default conditionKey
+export type ConditionEntry = [conditionKey: string, conditionText: string];
+export type ConditionEntries = NonEmptyArray<ConditionEntry>; // first item has default conditionKey
+export type ConditionInputProps = {
+    conditionEntries: ConditionEntries;
 };
 
 type TextInputProps = {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
@@ -15,8 +15,8 @@ type TextInputProps = {
     convertFromExternalToInternalText: (externalText: string) => string; // from TextInput element to query string
     convertFromInternalToExternalText: (internalText: string) => string; // from query string to FilterChip element
     externalTextDefault: string; // initial value for TextInput element
-    validateExternalText: (imputText: string) => boolean; // for search Button element
-    validateInternalText: (queryText: string) => boolean; // for FilterChip element
+    validateExternalText: (externalText: string) => boolean; // for search Button element
+    validateInternalText: (internalText: string) => boolean; // for FilterChip element
 };
 
 export type ConditionTextInputProps = {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
@@ -65,7 +65,7 @@ export function convertFromInternalToExternalConditionText(
 
 export type ConditionTextProps = {
     inputProps: ConditionTextInputProps;
-    onSearch: (value: string) => void;
+    onSearch: (internalConditionText: string) => void;
 };
 
 function ConditionText({ inputProps, onSearch }: ConditionTextProps) {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
@@ -53,11 +53,9 @@ export function convertFromInternalToExternalConditionText(
     let conditionFound;
     conditionEntries.forEach((condition) => {
         const conditionKey = condition[0];
-        if (internalConditionText.startsWith(conditionKey)) {
-            if (conditionKey.length > length) {
-                length = conditionKey.length;
-                conditionFound = condition;
-            }
+        if (internalConditionText.startsWith(conditionKey) && conditionKey.length > length) {
+            length = conditionKey.length;
+            conditionFound = condition;
         }
     });
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -1,9 +1,11 @@
 import { SearchCategory } from 'services/SearchService';
+import { FeatureFlagEnvVar } from 'types/featureFlag';
+import { ConditionTextInputProps } from './components/ConditionText';
 
 // Compound search filter types
 
 export type BaseInputType = 'autocomplete' | 'text' | 'date-picker' | 'condition-number';
-export type InputType = BaseInputType | 'select';
+export type InputType = BaseInputType | 'condition-text' | 'select';
 export type SelectSearchFilterOptions = {
     options: { label: string; value: string }[];
 };
@@ -15,18 +17,28 @@ type BaseSearchFilterAttribute = {
     displayName: string;
     filterChipLabel: string;
     searchTerm: string;
-    inputType: BaseInputType;
+    inputType: InputType;
+    featureFlagDependency?: FeatureFlagEnvVar[];
 };
+
+export type GenericSearchFilterAttribute = {
+    inputType: BaseInputType;
+} & BaseSearchFilterAttribute;
+
+export type ConditionTextFilterAttribute = {
+    inputType: 'condition-text';
+    inputProps: ConditionTextInputProps;
+} & BaseSearchFilterAttribute;
 
 export type SelectSearchFilterAttribute = {
-    displayName: string;
-    filterChipLabel: string;
-    searchTerm: string;
     inputType: 'select';
     inputProps: SelectSearchFilterOptions | SelectSearchFilterGroupedOptions;
-};
+} & BaseSearchFilterAttribute;
 
-export type CompoundSearchFilterAttribute = BaseSearchFilterAttribute | SelectSearchFilterAttribute;
+export type CompoundSearchFilterAttribute =
+    | ConditionTextFilterAttribute
+    | GenericSearchFilterAttribute
+    | SelectSearchFilterAttribute;
 
 export type CompoundSearchFilterEntity = {
     displayName: string;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -5,6 +5,7 @@ import {
     getDefaultAttributeName,
     getDefaultEntityName,
     getEntityAttributes,
+    getSearchFilterConfigWithFeatureFlagDependency,
     makeFilterChipDescriptors,
 } from './utils';
 import { CompoundSearchFilterEntity } from '../types';
@@ -28,29 +29,13 @@ const imageCVESearchFilterConfig: CompoundSearchFilterEntity = {
 };
 
 describe('utils', () => {
-    describe('getEntities', () => {
-        it('should get the entities in a config object', () => {
-            const config = [
-                imageSearchFilterConfig,
-                deploymentSearchFilterConfig,
-                imageCVESearchFilterConfig,
-            ];
-
-            expect(config).toStrictEqual([
-                imageSearchFilterConfig,
-                deploymentSearchFilterConfig,
-                imageCVESearchFilterConfig,
-            ]);
-        });
-    });
-
     describe('getEntityAttributes', () => {
         it('should get the attributes of an entity in a config object', () => {
-            const config = [
-                imageSearchFilterConfig,
-                deploymentSearchFilterConfig,
-                imageCVESearchFilterConfig,
-            ];
+            // Omit EPSSProbability object that has been added to imageCVE attributes.
+            const config = getSearchFilterConfigWithFeatureFlagDependency(
+                () => false,
+                [imageSearchFilterConfig, deploymentSearchFilterConfig, imageCVESearchFilterConfig]
+            );
 
             const result = getEntityAttributes(config, 'Image CVE');
 
@@ -107,7 +92,11 @@ describe('utils', () => {
 
     describe('makeFilterChipDescriptors', () => {
         it('should create an array of FilterChipGroupDescriptor objects from a config object', () => {
-            const config = [imageCVESearchFilterConfig];
+            // Omit EPSSProbability object that has been added to imageCVE attributes.
+            const config = getSearchFilterConfigWithFeatureFlagDependency(
+                () => false,
+                [imageCVESearchFilterConfig]
+            );
 
             const result = makeFilterChipDescriptors(config);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -19,7 +19,7 @@ import useURLSort from 'hooks/useURLSort';
 import { Pagination as PaginationParam } from 'services/types';
 import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
 import NotFoundMessage from 'Components/NotFoundMessage';
-
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import {
     SummaryCardLayout,
@@ -94,7 +94,7 @@ export const deploymentVulnerabilitiesQuery = gql`
 
 const defaultSortFields = ['CVE', 'Severity'];
 
-const searchFilterConfig = [
+const searchFilterConfigWithFeatureFlagDependency = [
     imageSearchFilterConfig,
     imageCVESearchFilterConfig,
     imageComponentSearchFilterConfig,
@@ -192,6 +192,11 @@ function DeploymentPageVulnerabilities({
         (key) => key !== 'epssProbability' || isEpssProbabilityColumnEnabled
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
+
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        searchFilterConfigWithFeatureFlagDependency
+    );
 
     const vulnerabilityData = vulnerabilityRequest.data ?? vulnerabilityRequest.previousData;
     const totalVulnerabilityCount = vulnerabilityData?.deployment?.imageVulnerabilityCount ?? 0;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -21,7 +21,7 @@ import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useMap from 'hooks/useMap';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
-
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import {
     SummaryCardLayout,
@@ -93,7 +93,10 @@ export const imageVulnerabilitiesQuery = gql`
 
 const defaultSortFields = ['CVE', 'CVSS', 'Severity'];
 
-const searchFilterConfig = [imageCVESearchFilterConfig, imageComponentSearchFilterConfig];
+const searchFilterConfigWithFeatureFlagDependency = [
+    imageCVESearchFilterConfig,
+    imageComponentSearchFilterConfig,
+];
 
 export type ImagePageVulnerabilitiesProps = {
     imageId: string;
@@ -194,6 +197,11 @@ function ImagePageVulnerabilities({
             (key !== 'epssProbability' || isEpssProbabilityColumnEnabled)
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
+
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        searchFilterConfigWithFeatureFlagDependency
+    );
 
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -16,9 +16,11 @@ import isEmpty from 'lodash/isEmpty';
 
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import PageTitle from 'Components/PageTitle';
 import useURLPagination from 'hooks/useURLPagination';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import useAnalytics, {
     WATCH_IMAGE_MODAL_OPENED,
@@ -128,7 +130,7 @@ function getSearchFilterEntityByTab(
     }
 }
 
-const searchFilterConfig = [
+const searchFilterConfigWithFeatureFlagDependency = [
     imageSearchFilterConfig,
     imageCVESearchFilterConfig,
     imageComponentSearchFilterConfig,
@@ -139,6 +141,8 @@ const searchFilterConfig = [
 
 function WorkloadCvesOverviewPage() {
     const apolloClient = useApolloClient();
+
+    const { isFeatureFlagEnabled } = useFeatureFlags();
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
@@ -315,6 +319,11 @@ function WorkloadCvesOverviewPage() {
     function onWatchedImagesChange() {
         return apolloClient.refetchQueries({ include: [imageListQuery] });
     }
+
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        searchFilterConfigWithFeatureFlagDependency
+    );
 
     const filterToolbar = (
         <AdvancedFiltersToolbar


### PR DESCRIPTION
### Description

See improved layout of condition selection in testing step 1

~Any advice about responsive shrink of condition `Select` element is welcome.~

~I will fix the layout before merge, for sure.~

### One-time changes for which we knew the day would come

1. Edit src/Components/CompoundSearchFilter/types.ts file.
    * Add `featureFlagDependency?: FeatureFlagEnvVar[]` property.
    * Distinguish `BaseSearchFilterAttribute` type from generic and specific types to remove duplication.
2. Edit src/Components/CompoundSearchFilter/utils/utils.tsx file.
    * Add `getSearchFilterConfigWithFeatureFlagDependency` function.

3. Edit src/Components/CompoundSearchFilter/utils/utils.test.ts file.
    * Delete incomplete test for function that does not exist.
    * Call `getSearchFilterConfigWithFeatureFlagDependency` function in tests whose assertions depend on imageCVE.ts file that now has **EPSS probability** attribute.

### Procedure to add a new search filter component

1. Add search filter component file in src/Components/CompoundSearchFilter/components folder.
    For example, ConditionText.tsx

2. Edit src/Components/CompoundSearchFilter/types.ts file.
    * If `inputProps` property, add to `InputType` instead of `BaseInputType` string enumeration.
        For example, `'condition-text'`
    * If `inputProps` property, add a specific type.
        For example, `ConditionTextFilterAttribute` type

3. Edit src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx file.
    * Add `if` statement for `inputType` to render the search filter element.
        For example, `if (attribute.inputType === 'condition-text') { … }`

4. Edit a file in src/Components/CompoundSearchFilter/attributes folder.
    * Define an object that has type and `inputType` property for the search filter element.
        For example,
        `EPSSProbability: ConditionTextFilterAttribute`
        `inputType: 'condition-text'`
        `inputProps:{ … }`

5. If search filter chip needs conditional rendering, edit src/Components/CompoundSearchFilter/utils/utils.tsx file.
    * Add conditional logic to `makeFilterChipDescriptors` function.
        For example, `if (attribute.inputType === 'condition-text') { … }`

6. Because both long-term `'ROX_SCANNER_V4'` and short-term `'ROX_EPSS_SCORE'`  call `getSearchFilterConfigWithFeatureFlagDependency` function in page components:
    * DeploymentPageVulnerabilities.tsx
    * ImagePageVulnerabilities.tsx
    * WorkloadCvesOverviewPage

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] updated unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before deploy, enable feature flag in ui folder:

```sh
export ROX_EPSS_SCORE=true
npm run deploy
```

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4617154 - 4617154
        total 4333 = 11597637 - 11593304
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Because I run UI with staging demo, which has `'ROX_SCANNER_V4'` enabled but `'ROX_EPSS_SCORE'` not yet enabled, I temporarily omitted from `featureFlagDependency` value for the presence test.

1. Visit **Workflow CVEs**
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx

    Without `ROX_EPSS_SCORE` enabled, see absence of **EPSS probability** attribute
    ![WorkloadCvesOverviewPage_absence](https://github.com/user-attachments/assets/7676ff75-f225-496e-83fc-c7662f396596)

    With `ROX_EPSS_SCORE` enabled, see presence of **EPSS probability** attribute
    ![WorkloadCvesOverviewPage_presence_shrink](https://github.com/user-attachments/assets/3a007aa3-ae1e-4a63-ac15-157e5d7382ac)

    Aha, `SimpleSelect` above renders **value** instead of **text** in its menu toggle.
    Adapted `Select` element below renders **text** in its menu toggle:
    
    ![ConditionText](https://github.com/user-attachments/assets/d1e94cc8-b6a8-4c5e-ab5b-33d7e0488051)

    | external  | internal  | FilterChip  |
    | :---      | :---      |        ---: |
    | >=100%    | >=1       | >= 100.000% |
    | <12.345%  | <0.12345  |    <12.345% |
    | =50       | =0.5      |    =50.000% |
    | <=.123    | <=0.00123 |    <=0.123% |

    Invalid external
    * empty string
    * a
    * %
    * 110%
    * -0

    Invalid internal
    * <1.1
    * =bogus

2. Click a vulnerability link

3. Click an image link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx

    Without `ROX_EPSS_SCORE` enabled, see absence of **EPSS probability** attribute
    ![ImagePageVulnerabilities_absence](https://github.com/user-attachments/assets/d4aff8fd-55bf-4913-bd2a-490a2a7b5688)

    With `ROX_EPSS_SCORE` enabled, see presence of **EPSS probability** attribute
    ![ImagePageVulnerabilities_presence_shrink](https://github.com/user-attachments/assets/1b8af6cb-631f-4ad9-8052-9fa53f6b7e5d)

4. Go back, click **Deployments**, click a deployment link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx

    Without `ROX_EPSS_SCORE` enabled, see absence of **EPSS probability** attribute
    ![DeploymentPageVulnerabilities_absence](https://github.com/user-attachments/assets/746b6f8e-53c9-4cc9-ab57-cb9a437e7a38)

    With `ROX_EPSS_SCORE` enabled, see presence of **EPSS probability** attribute
    ![DeploymentPageVulnerabilities_presence_shrink](https://github.com/user-attachments/assets/12cde97c-ec94-4fe2-88ce-3d149224724b)

### Unit testing

* utils.test.ts fix 2 failing tests and also delete 1 test
