### PR TITLE
chore(CI): use pypi for codecov

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -116,6 +116,10 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-postgres-unit-tests
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 'pypy3.10'
+
     - uses: codecov/codecov-action@v5
       with:
         use_pypi: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,8 +37,9 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-unit-tests
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v5
       with:
+        use_pypi: true
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: go-unit-tests
 
@@ -111,8 +112,9 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-postgres-unit-tests
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v5
       with:
+        use_pypi: true
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: go-unit-tests
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,6 +37,10 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-unit-tests
 
+    - uses: actions/setup-python@v5 
+      with:
+        python-version: 'pypy3.10' 
+
     - uses: codecov/codecov-action@v5
       with:
         use_pypi: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,9 +37,7 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-unit-tests
 
-    - uses: actions/setup-python@v5 
-      with:
-        python-version: 'pypy3.10' 
+    - run: update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
     - uses: codecov/codecov-action@v5
       with:
@@ -116,9 +114,7 @@ jobs:
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-postgres-unit-tests
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 'pypy3.10'
+    - run: update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
     - uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
### Description

We cannot upgrade to the latest codcov version as it uses newer glibc that is not available in ubi8. Upgrade to ubi9 is quite complicated as we need to update it both on build/test and run containers.

refs:
- #2133 
- #13939 

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
