### PR TITLE
ROX-27168: Bump scanner memory limits in upgrade tests

### DIFF
--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -105,7 +105,8 @@ deploy_earlier_postgres_central() {
          --set central.image.tag="${EARLIER_TAG}" \
          --set central.db.image.tag="${EARLIER_TAG}" \
          --set scanner.image.tag="$(cat SCANNER_VERSION)" \
-         --set scanner.dbImage.tag="$(cat SCANNER_VERSION)"
+         --set scanner.dbImage.tag="$(cat SCANNER_VERSION)" \
+         --set scanner.resources.limits.memory="6Gi"
 
     # Installing this way returns faster than the scripts but everything isn't running when it finishes like with
     # the scripts.  So we will give it a minute for things to get started before we proceed


### PR DESCRIPTION
### Description

This PR bumps scanner memory limit. We see a lot of OOMKills in upgrade tests.

Ticket: https://issues.redhat.com/browse/ROX-27168

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing test setup

#### How I validated my change

- [x] Run upgrade tests and check in artifacts that the memory limit is set properly
- [x] Re-run the test several times to check if the flaky behavior is fixed
- [x] Check GKE metrics for memory usage and whether it still reaches limits
