### PR TITLE
ROX-27782: Make pruning stop after context errors

### DIFF
--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -535,7 +535,7 @@ func (s *genericStore[T, PT]) deleteMany(ctx context.Context, identifiers []stri
 		q := search.NewQueryBuilder().AddDocIDs(identifierBatch...).ProtoQuery()
 
 		if err := RunDeleteRequestForSchema(ctx, s.schema, q, s.db); err != nil {
-			if !continueOnError {
+			if !continueOnError || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return errors.Wrap(err, "unable to delete the records")
 			}
 			log.Errorf("unable to prune the records: %v", err)

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -535,8 +535,11 @@ func (s *genericStore[T, PT]) deleteMany(ctx context.Context, identifiers []stri
 		q := search.NewQueryBuilder().AddDocIDs(identifierBatch...).ProtoQuery()
 
 		if err := RunDeleteRequestForSchema(ctx, s.schema, q, s.db); err != nil {
-			if !continueOnError || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if !continueOnError {
 				return errors.Wrap(err, "unable to delete the records")
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				break
 			}
 			log.Errorf("unable to prune the records: %v", err)
 		}

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -538,6 +538,7 @@ func (s *genericStore[T, PT]) deleteMany(ctx context.Context, identifiers []stri
 			if !continueOnError {
 				return errors.Wrap(err, "unable to delete the records")
 			}
+			// We want to stop processing batches if the context was canceled or timed out.
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				break
 			}


### PR DESCRIPTION
### Description

Updated `pkg/search/postgres/store.go` `deleteMany` method to stop processing more batches if the error returned is a context cancellation error or a context timeout error.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
- Ran pruning test with the context being cancelled before it is even used, and the test exited after one batch failing
- Ran pruning test with the context timeout being set to zero, and the test exited after one batch failing