### PR TITLE
ROX-27661: Render EPSS probability with GraphQL data

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -71,6 +71,11 @@ export const deploymentWithVulnerabilitiesFragment = gql`
         imageVulnerabilities(query: $query, pagination: $pagination) {
             vulnerabilityId: id
             cve
+            cveBaseInfo {
+                epss {
+                    epssProbability
+                }
+            }
             operatingSystem
             publishedOn
             summary
@@ -155,6 +160,7 @@ function DeploymentVulnerabilitiesTable({
                         const {
                             vulnerabilityId,
                             cve,
+                            cveBaseInfo,
                             operatingSystem,
                             severity,
                             summary,
@@ -165,7 +171,7 @@ function DeploymentVulnerabilitiesTable({
                             publishedOn,
                             pendingExceptionCount,
                         } = vulnerability;
-                        const epssProbability = undefined; // ccveBaseInfo?.epss?.epssProbability
+                        const epssProbability = cveBaseInfo?.epss?.epssProbability;
                         const isExpanded = expandedRowSet.has(vulnerabilityId);
 
                         return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -17,7 +17,7 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
-import { VulnerabilityState, isVulnerabilitySeverity } from 'types/cve.proto';
+import { EPSS, VulnerabilityState, isVulnerabilitySeverity } from 'types/cve.proto';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
 import useMap from 'hooks/useMap';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
@@ -95,6 +95,11 @@ export const imageVulnerabilitiesFragment = gql`
         scoreVersion
         nvdCvss
         nvdScoreVersion
+        cveBaseInfo {
+            epss {
+                epssProbability
+            }
+        }
         discoveredAtImage
         publishedOn
         pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
@@ -112,6 +117,9 @@ export type ImageVulnerability = {
     scoreVersion: string;
     nvdCvss: number;
     nvdScoreVersion: string; // for example, V3 or UNKNOWN_VERSION
+    cveBaseInfo: {
+        epss: EPSS | null;
+    };
     discoveredAtImage: string | null;
     publishedOn: string | null;
     pendingExceptionCount: number;
@@ -235,6 +243,7 @@ function ImageVulnerabilitiesTable({
                             scoreVersion,
                             nvdCvss,
                             nvdScoreVersion,
+                            cveBaseInfo,
                             imageComponents,
                             discoveredAtImage,
                             publishedOn,
@@ -244,7 +253,7 @@ function ImageVulnerabilitiesTable({
                             (imageComponent) => imageComponent.imageVulnerabilities
                         );
                         const isFixableInImage = getIsSomeVulnerabilityFixable(vulnerabilities);
-                        const epssProbability = undefined; // ccveBaseInfo?.epss?.epssProbability
+                        const epssProbability = cveBaseInfo.epss?.epssProbability;
                         const isExpanded = expandedRowSet.has(cve);
 
                         return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client';
 import { min, parse } from 'date-fns';
 import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
-import { VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
+import { EPSS, VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
 import { SourceType } from 'types/image.proto';
 import { ApiSortOptionSingle } from 'types/search';
 
@@ -216,6 +216,9 @@ export type DeploymentWithVulnerabilities = {
     imageVulnerabilities: {
         vulnerabilityId: string;
         cve: string;
+        cveBaseInfo: {
+            epss: EPSS | null;
+        };
         operatingSystem: string;
         publishedOn: string | null;
         summary: string;
@@ -235,6 +238,9 @@ type DeploymentVulnerabilityImageMapping = {
 export type FormattedDeploymentVulnerability = {
     vulnerabilityId: string;
     cve: string;
+    cveBaseInfo: {
+        epss: EPSS | null;
+    };
     operatingSystem: string;
     severity: VulnerabilitySeverity;
     isFixable: boolean;
@@ -257,8 +263,15 @@ export function formatVulnerabilityData(
     });
 
     return deployment.imageVulnerabilities.map((vulnerability) => {
-        const { vulnerabilityId, cve, operatingSystem, summary, images, pendingExceptionCount } =
-            vulnerability;
+        const {
+            vulnerabilityId,
+            cve,
+            cveBaseInfo,
+            operatingSystem,
+            summary,
+            images,
+            pendingExceptionCount,
+        } = vulnerability;
         // Severity, Fixability, and Discovered date are all based on the aggregate value of all components
         const allVulnerableComponents = vulnerability.images.flatMap((img) => img.imageComponents);
         const allVulnerabilities = allVulnerableComponents.flatMap((c) => c.imageVulnerabilities);
@@ -293,6 +306,7 @@ export function formatVulnerabilityData(
         return {
             vulnerabilityId,
             cve,
+            cveBaseInfo,
             operatingSystem,
             severity: highestVulnSeverity,
             isFixable: isFixableInDeployment,

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -20,6 +20,12 @@ export function isVulnerabilityState(value: unknown): value is VulnerabilityStat
     return vulnerabilityStates.some((state) => state === value);
 }
 
+// epss property is null if not available
+export type EPSS = {
+    epssProbability: number; // float fraction between 0 and 1 inclusive
+    epssPercentile: number; // float fraction between 0 and 1 inclusive
+};
+
 export type CVSSV2 = {
     vector: string;
     attackVector: AttackVectorV2;


### PR DESCRIPTION
### Description

GraphQL resolvers provide data defined in #13713 and #13827

Therefore, 2 of 4 pages render **Not available** because `epss: null` pending data from scanner.

That is, UI will render data as soon as it becomes available.

Do I need to tatoo on my hand?
* unlike REST responses that have new properties whether I ask for it or not
* GraphQL response data consists of only the properties in the query
    I needed to add the following:

    ```
    cveBaseInfo {
        epss {
            epssProbability
        }
    }
    ```

### Changed files

Steps to refresh my future mind:

1. Edit DeploymentVulnerabilitiesTable.tsx file.
    * Update `gql` tagged template literal.
    * Add `cveBaseInfo` to destructuring.
    * See step 3 for types.
    * Replace `undefined` with `cveBaseInfo.epss?.epssProbability` optional chaining.
2. Edit ImageVulnerabilitiesTable.tsx file.
    * Update `gql` tagged template literal.
    * Update `ImageVulnerability` type.
    * Add `cveBaseInfo` to destructuring.
    * Replace `undefined` with `cveBaseInfo.epss?.epssProbability` optional chaining.
3. Edit table.utils.ts file.
    * Update deployment types and `formatVulnerabilityData` function.
4. Edit cve.proto.ts file.
    * Add `EPSS` type from backend source of truth:
        https://github.com/stackrox/stackrox/blob/master/proto/storage/cve.proto#L39-L43

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4617093 - 4617093
        total 402 = 11596371 - 11595969
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Similar testing steps as in #13789

Even if I run UI with staging demo, which has **Scanner V4**, I need to temporarily edit code to invert conditional rendering, because `'ROX_EPSS_SCORE'` feature flag is not enabled.

1. Visit **Workflow CVEs**

    POST /api/graphql?opname=getImageCVEList

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx

    It looks like `cveBaseInfo` nor `epss` properties are avaiable yet:

    > Cannot query field "cveBaseInfo" on type "ImageCVECore".

2. Click a vulnerability link

    POST /api/graphql?opname=getImageCveMetadata

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx

    It looks like `cveBaseInfo` nor `epss` properties are avaiable yet:

    > Cannot query field "cveBaseInfo" on type "ImageCVECore".

3. Click an image link

    POST /api/graphql?opname=getCVEsForImage

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx

    Before changes, see absence of `cveBaseInfo` nor `epss` properties
    ![ImageVulnerabilitiesTable_absence](https://github.com/user-attachments/assets/7465013b-6932-432e-b18f-8747f18a7b1f)

    After changes, see presence of `cveBaseInfo` and `epss: null` properties
    ![ImageVulnerabilitiesTable_presence](https://github.com/user-attachments/assets/d1235d73-de9f-41b5-88d9-9a8d9177ede1)

4. Go back, click **Deployments**, click a deployment link

    POST /api/graphql?opname=getCvesForDeployment

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx

    Before changes, see absence of `cveBaseInfo` nor `epss` properties
    ![DeploymentVulnerabilitiesTable_absence](https://github.com/user-attachments/assets/f9945b36-5156-409d-9fac-0da0352b5cbf)

    After changes, see presence of `cveBaseInfo` and `epss: null` properties
    ![DeploymentVulnerabilitiesTable_presence](https://github.com/user-attachments/assets/ef7199ac-4d80-4a0a-a14d-8cb7c9b9bfec)
