### PR TITLE
ROX-26663: Retry scans on failed fetch layer errors

### DIFF
--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -870,6 +870,7 @@ func (ts *DelegatedScanningSuite) scanWithRetries(ctx context.Context, service v
 	retryErrTokens := []string{
 		scan.ErrTooManyParallelScans.Error(),
 		"context deadline exceeded",
+		"could not advance in the tar archive: archive/tar: invalid tar header",
 	}
 
 	retryFunc := func() error {


### PR DESCRIPTION
### Description

This PR should fix one flaky behavior of `TestDelegatedScanning/TestMirrorScans/Scan_ad-hoc_image_from_mirror_via_ImageContentSourcePolicy` test.

Explanation of problem is explain in the ticket.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] Check CI results
- [x] Retest a few times to try reproducing the failure
- [x] Check logs of retry tests and search for `invalid tar header` patterns in scanner logs
