### PR TITLE
Jv test if crd data type can be changed TEST DON'T REVIEW

### DIFF
--- a/operator/api/v1alpha1/securedcluster_types.go
+++ b/operator/api/v1alpha1/securedcluster_types.go
@@ -121,7 +121,7 @@ type AdmissionControlComponentSpec struct {
 	// Set this to 'true' to enable preventive policy enforcement for object creations.
 	//+kubebuilder:default=true
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
-	ListenOnCreates *bool `json:"listenOnCreates,omitempty"`
+	ListenOnCreates *string `json:"listenOnCreates,omitempty"`
 
 	// Set this to 'true' to enable preventive policy enforcement for object updates.
 	//

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -65,7 +65,7 @@ func (in *AdmissionControlComponentSpec) DeepCopyInto(out *AdmissionControlCompo
 	*out = *in
 	if in.ListenOnCreates != nil {
 		in, out := &in.ListenOnCreates, &out.ListenOnCreates
-		*out = new(bool)
+		*out = new(string)
 		**out = **in
 	}
 	if in.ListenOnUpdates != nil {

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -88,10 +88,10 @@ spec:
                       type: object
                     type: array
                   listenOnCreates:
-                    default: true
+                    default: "true"
                     description: Set this to 'true' to enable preventive policy enforcement
                       for object creations.
-                    type: boolean
+                    type: string
                   listenOnEvents:
                     default: true
                     description: Set this to 'true' to enable monitoring and enforcement

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -91,7 +91,7 @@ spec:
                     default: true
                     description: Set this to 'true' to enable preventive policy enforcement
                       for object creations.
-                    type: boolean
+                    type: string
                   listenOnEvents:
                     default: true
                     description: Set this to 'true' to enable monitoring and enforcement

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -88,7 +88,7 @@ spec:
                       type: object
                     type: array
                   listenOnCreates:
-                    default: true
+                    default: "true"
                     description: Set this to 'true' to enable preventive policy enforcement
                       for object creations.
                     type: string

--- a/operator/internal/securedcluster/values/translation/translation.go
+++ b/operator/internal/securedcluster/values/translation/translation.go
@@ -261,7 +261,7 @@ func (t Translator) getAdmissionControlValues(admissionControl *platform.Admissi
 	acv := translation.NewValuesBuilder()
 
 	acv.AddChild(translation.ResourcesKey, translation.GetResources(admissionControl.Resources))
-	acv.SetBool("listenOnCreates", admissionControl.ListenOnCreates)
+	acv.SetString("listenOnCreates", admissionControl.ListenOnCreates)
 	acv.SetBool("listenOnUpdates", admissionControl.ListenOnUpdates)
 	acv.SetBool("listenOnEvents", admissionControl.ListenOnEvents)
 	dynamic := translation.NewValuesBuilder()

--- a/operator/internal/securedcluster/values/translation/translation.go
+++ b/operator/internal/securedcluster/values/translation/translation.go
@@ -269,7 +269,8 @@ func (t Translator) getAdmissionControlValues(admissionControl *platform.Admissi
 	// the single spec.admissionControl.listenOn* setting in CR. This is because
 	// redeployment is natively part of the CR lifecycle when we have an operator, so
 	// no need to distinguish between the static and dynamic part.
-	dynamic.SetBool("enforceOnCreates", admissionControl.ListenOnCreates)
+	listenOnCreatesBool, _ := strconv.ParseBool(*admissionControl.ListenOnCreates)
+	dynamic.SetBool("enforceOnCreates", &listenOnCreatesBool)
 	dynamic.SetBool("enforceOnUpdates", admissionControl.ListenOnUpdates)
 	if admissionControl.ContactImageScanners != nil {
 		switch *admissionControl.ContactImageScanners {
@@ -446,7 +447,7 @@ func (t Translator) setDefaults(sc *platform.SecuredCluster) {
 		sc.Spec.AdmissionControl = &platform.AdmissionControlComponentSpec{}
 	}
 	if sc.Spec.AdmissionControl.ListenOnCreates == nil {
-		sc.Spec.AdmissionControl.ListenOnCreates = pointers.Bool(true)
+		sc.Spec.AdmissionControl.ListenOnCreates = pointers.String("true")
 	}
 	if sc.Spec.AdmissionControl.ListenOnUpdates == nil {
 		sc.Spec.AdmissionControl.ListenOnUpdates = pointers.Bool(true)

--- a/operator/internal/securedcluster/values/translation/translation_test.go
+++ b/operator/internal/securedcluster/values/translation/translation_test.go
@@ -139,7 +139,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						"enforceOnCreates": true,
 						"enforceOnUpdates": true,
 					},
-					"listenOnCreates": true,
+					"listenOnCreates": "true",
 					"listenOnUpdates": true,
 				},
 				"scanner": map[string]interface{}{
@@ -185,7 +185,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						"enforceOnCreates": true,
 						"enforceOnUpdates": true,
 					},
-					"listenOnCreates": true,
+					"listenOnCreates": "true",
 					"listenOnUpdates": true,
 				},
 				"scanner": map[string]interface{}{
@@ -221,7 +221,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						"enforceOnCreates": true,
 						"enforceOnUpdates": true,
 					},
-					"listenOnCreates": true,
+					"listenOnCreates": "true",
 					"listenOnUpdates": true,
 				},
 				"scanner": map[string]interface{}{
@@ -261,7 +261,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						"enforceOnCreates": true,
 						"enforceOnUpdates": true,
 					},
-					"listenOnCreates": true,
+					"listenOnCreates": "true",
 					"listenOnUpdates": true,
 				},
 				"scanner": map[string]interface{}{
@@ -308,7 +308,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 							},
 						},
 						AdmissionControl: &platform.AdmissionControlComponentSpec{
-							ListenOnCreates:      pointer.Bool(true),
+							ListenOnCreates:      pointer.String("true"),
 							ListenOnUpdates:      pointer.Bool(false),
 							ListenOnEvents:       pointer.Bool(true),
 							ContactImageScanners: platform.ScanIfMissing.Pointer(),
@@ -595,7 +595,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						"disableBypass":    false,
 						"timeout":          4,
 					},
-					"listenOnCreates": true,
+					"listenOnCreates": "true",
 					"listenOnUpdates": false,
 					"listenOnEvents":  true,
 					"nodeSelector": map[string]interface{}{
@@ -860,7 +860,7 @@ func (s *TranslationTestSuite) TestTranslate() {
 						"enforceOnCreates": true,
 						"enforceOnUpdates": true,
 					},
-					"listenOnCreates": true,
+					"listenOnCreates": "true",
 					"listenOnUpdates": true,
 				},
 				"scanner": map[string]interface{}{


### PR DESCRIPTION
This is just for testing. I don't think a data type in a CRD can be changed. I just want to confirm that.

I am working on adding a check to crd-schema-checker for changes in data types. I thought it would be good to do this test before merging that. https://github.com/openshift/crd-schema-checker/pull/38