### PR TITLE
ROX-27302: Whitelist Alpine apk policy in e2e test case

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -73,6 +73,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             "Mount Container Runtime Socket",
             "Docker CIS 5.15: Ensure that the host's process namespace is not shared",
             "Docker CIS 5.7: Ensure privileged ports are not mapped within containers",
+            "Alert on deployments with the Alpine Linux package manager (apk) present",
             Constants.ANY_FIXED_VULN_POLICY,
     ]
 


### PR DESCRIPTION
### Description

ROX-27302 - Whitelist Alpine apk policy in e2e test case

This test failed after an AKS upgrade. A default component in AKS contained apk. This issue is out of our control, to avoid CI failures we mark this test as whitelisted for default policies.
