### PR TITLE
chore(cleanup): rename SAC filter generators

### DIFF
--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -1320,7 +1320,7 @@ func (s *storeImpl) retryableGetManyImageMetadata(ctx context.Context, ids []str
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err := sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err := sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -1013,7 +1013,7 @@ func (s *storeImpl) retryableGetManyNodeMetadata(ctx context.Context, ids []stri
 	if err != nil {
 		return nil, nil, err
 	}
-	sacQueryFilter, err := sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
+	sacQueryFilter, err := sac.BuildClusterLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -114,7 +114,7 @@ func (q *queryBuilder) buildAccessScopeQuery(clusters []*storage.Cluster,
 			scopeTree.Merge(sct)
 		}
 	}
-	scopeQuery, err := sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
+	scopeQuery, err := sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
 	if err != nil {
 		return nil, err
 	}

--- a/central/views/common/sac.go
+++ b/central/views/common/sac.go
@@ -23,9 +23,9 @@ func WithSACFilter(ctx context.Context, targetResource permissions.ResourceMetad
 	}
 
 	if clusterLevelResource(targetResource) {
-		sacQueryFilter, err = sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
+		sacQueryFilter, err = sac.BuildClusterLevelSACQueryFilter(scopeTree)
 	} else {
-		sacQueryFilter, err = sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
+		sacQueryFilter, err = sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/sac/query_helper.go
+++ b/pkg/sac/query_helper.go
@@ -11,9 +11,9 @@ var (
 	namespaceField = search.Namespace
 )
 
-// BuildNonVerboseClusterLevelSACQueryFilter builds a Scoped Access Control query filter that can be
+// BuildClusterLevelSACQueryFilter builds a Scoped Access Control query filter that can be
 // injected in search queries for resource types that have direct cluster scope level.
-func BuildNonVerboseClusterLevelSACQueryFilter(root *effectiveaccessscope.ScopeTree) (*v1.Query, error) {
+func BuildClusterLevelSACQueryFilter(root *effectiveaccessscope.ScopeTree) (*v1.Query, error) {
 	if root == nil {
 		return getMatchNoneQuery(), nil
 	}
@@ -43,9 +43,9 @@ func BuildNonVerboseClusterLevelSACQueryFilter(root *effectiveaccessscope.ScopeT
 	}
 }
 
-// BuildNonVerboseClusterNamespaceLevelSACQueryFilter builds a Scoped Access Control query filter that can be
+// BuildClusterNamespaceLevelSACQueryFilter builds a Scoped Access Control query filter that can be
 // injected in search queries for resource types that have direct namespace scope level.
-func BuildNonVerboseClusterNamespaceLevelSACQueryFilter(root *effectiveaccessscope.ScopeTree) (*v1.Query, error) {
+func BuildClusterNamespaceLevelSACQueryFilter(root *effectiveaccessscope.ScopeTree) (*v1.Query, error) {
 	if root == nil {
 		return getMatchNoneQuery(), nil
 	}

--- a/pkg/sac/query_helper_test.go
+++ b/pkg/sac/query_helper_test.go
@@ -31,7 +31,7 @@ type testCase struct {
 	hasError       bool
 }
 
-func TestNonVerboseClusterScopeFilterGeneration(topLevelTest *testing.T) {
+func TestClusterScopeFilterGeneration(topLevelTest *testing.T) {
 	testCases := []testCase{
 		{
 			description:    "nil ScopeTree generates a MatchNone query filter",
@@ -66,40 +66,40 @@ func TestNonVerboseClusterScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Scope tree with one fully included cluster tree generates a Match query filter",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
-			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
+			expected:       clusterMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with one fully included cluster node generates a Match query filter",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
-			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
+			expected:       clusterMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Scope tree with only partial cluster nodes generates a Disjunction of Match query filter",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceMixIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
-				clusterNonVerboseMatch(topLevelTest, planetEarth)),
+				clusterMatch(topLevelTest, planetArrakis),
+				clusterMatch(topLevelTest, planetEarth)),
 		},
 		{
 			description:    "Scope tree with one included cluster tree and partial clusters generate a Disjunction of Match for the included clusters",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
-				clusterNonVerboseMatch(topLevelTest, planetEarth)),
+				clusterMatch(topLevelTest, planetArrakis),
+				clusterMatch(topLevelTest, planetEarth)),
 		},
 		{
 			description:    "Scope tree with multiple included cluster trees generates a Disjunction of Match for the included clusters",
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
-				clusterNonVerboseMatch(topLevelTest, planetEarth)),
+				clusterMatch(topLevelTest, planetArrakis),
+				clusterMatch(topLevelTest, planetEarth)),
 		},
 	}
 
 	for _, tc := range testCases {
 		topLevelTest.Run(tc.description, func(t *testing.T) {
 			eas := tc.scopeGenerator(t)
-			filter, err := BuildNonVerboseClusterLevelSACQueryFilter(eas)
+			filter, err := BuildClusterLevelSACQueryFilter(eas)
 			assert.True(t, tc.hasError == (err != nil))
 			correctFilter := isSameQuery(tc.expected, filter)
 			assert.Truef(t, correctFilter, "mismatch between queries")
@@ -111,7 +111,7 @@ func TestNonVerboseClusterScopeFilterGeneration(topLevelTest *testing.T) {
 	}
 }
 
-func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
+func TestNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 	testCases := []testCase{
 		{
 			description:    "Generated query filter for nil scope tree is MatchNone",
@@ -146,29 +146,29 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 		{
 			description:    "Generated query filter for fully included cluster subtree is simple cluster match",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTreeFullyIncluded,
-			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
+			expected:       clusterMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Generated query filter for included cluster node is simple cluster match",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterRootFullyIncluded,
-			expected:       clusterNonVerboseMatch(topLevelTest, planetArrakis),
+			expected:       clusterMatch(topLevelTest, planetArrakis),
 		},
 		{
 			description:    "Generated query filter for single included namespace is the conjunction of the cluster and namespace matches",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterNamespacePairOnlyIncluded,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
-				namespaceNonVerboseMatch(topLevelTest, nsAtreides),
+				clusterMatch(topLevelTest, planetArrakis),
+				namespaceMatch(topLevelTest, nsAtreides),
 			),
 		},
 		{
 			description:    "Generated query filter for two namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterTwoNamespacesIncluded,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
+				clusterMatch(topLevelTest, planetArrakis),
 				search.DisjunctionQuery(
-					namespaceNonVerboseMatch(topLevelTest, nsAtreides),
-					namespaceNonVerboseMatch(topLevelTest, nsHarkonnen),
+					namespaceMatch(topLevelTest, nsAtreides),
+					namespaceMatch(topLevelTest, nsHarkonnen),
 				),
 			),
 		},
@@ -176,11 +176,11 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for multiple namespaces in the same cluster is the conjunction of the cluster and the disjunction of the namespaces",
 			scopeGenerator: effectiveaccessscope.TestTreeOneClusterMultipleNamespacesIncluded,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetEarth),
+				clusterMatch(topLevelTest, planetEarth),
 				search.DisjunctionQuery(
-					namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
-					namespaceNonVerboseMatch(topLevelTest, nsFraunhofer),
-					namespaceNonVerboseMatch(topLevelTest, nsCERN),
+					namespaceMatch(topLevelTest, nsSkunkWorks),
+					namespaceMatch(topLevelTest, nsFraunhofer),
+					namespaceMatch(topLevelTest, nsCERN),
 				),
 			),
 		},
@@ -189,12 +189,12 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClusterNamespacePairsIncluded,
 			expected: search.DisjunctionQuery(
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(topLevelTest, planetEarth),
-					namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
+					clusterMatch(topLevelTest, planetEarth),
+					namespaceMatch(topLevelTest, nsSkunkWorks),
 				),
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(topLevelTest, planetArrakis),
-					namespaceNonVerboseMatch(topLevelTest, nsSpacingGuild),
+					clusterMatch(topLevelTest, planetArrakis),
+					namespaceMatch(topLevelTest, nsSpacingGuild),
 				),
 			),
 		},
@@ -203,14 +203,14 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceMixIncluded,
 			expected: search.DisjunctionQuery(
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(topLevelTest, planetArrakis),
-					namespaceNonVerboseMatch(topLevelTest, nsSpacingGuild),
+					clusterMatch(topLevelTest, planetArrakis),
+					namespaceMatch(topLevelTest, nsSpacingGuild),
 				),
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(topLevelTest, planetEarth),
+					clusterMatch(topLevelTest, planetEarth),
 					search.DisjunctionQuery(
-						namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
-						namespaceNonVerboseMatch(topLevelTest, nsJPL)),
+						namespaceMatch(topLevelTest, nsSkunkWorks),
+						namespaceMatch(topLevelTest, nsJPL)),
 				),
 			),
 		},
@@ -218,13 +218,13 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for a full and a partial cluster is the disjunction of the full cluster match and the partial cluster tree",
 			scopeGenerator: effectiveaccessscope.TestTreeClusterNamespaceFullClusterMixIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
+				clusterMatch(topLevelTest, planetArrakis),
 				search.ConjunctionQuery(
-					clusterNonVerboseMatch(topLevelTest, planetEarth),
+					clusterMatch(topLevelTest, planetEarth),
 					search.DisjunctionQuery(
-						namespaceNonVerboseMatch(topLevelTest, nsSkunkWorks),
-						namespaceNonVerboseMatch(topLevelTest, nsFraunhofer),
-						namespaceNonVerboseMatch(topLevelTest, nsCERN),
+						namespaceMatch(topLevelTest, nsSkunkWorks),
+						namespaceMatch(topLevelTest, nsFraunhofer),
+						namespaceMatch(topLevelTest, nsCERN),
 					),
 				),
 			),
@@ -233,10 +233,10 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for a minimal scope tree matches exactly the tree structure",
 			scopeGenerator: effectiveaccessscope.TestTreeMinimalPartialTree,
 			expected: search.ConjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
+				clusterMatch(topLevelTest, planetArrakis),
 				search.DisjunctionQuery(
-					namespaceNonVerboseMatch(topLevelTest, nsAtreides),
-					namespaceNonVerboseMatch(topLevelTest, nsHarkonnen),
+					namespaceMatch(topLevelTest, nsAtreides),
+					namespaceMatch(topLevelTest, nsHarkonnen),
 				),
 			),
 		},
@@ -244,8 +244,8 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 			description:    "Generated query filter for two fully included cluster tree is the disjunction of the cluster ID matches",
 			scopeGenerator: effectiveaccessscope.TestTreeTwoClustersFullyIncluded,
 			expected: search.DisjunctionQuery(
-				clusterNonVerboseMatch(topLevelTest, planetArrakis),
-				clusterNonVerboseMatch(topLevelTest, planetEarth),
+				clusterMatch(topLevelTest, planetArrakis),
+				clusterMatch(topLevelTest, planetEarth),
 			),
 		},
 	}
@@ -253,7 +253,7 @@ func TestNonVerboseNamespaceScopeFilterGeneration(topLevelTest *testing.T) {
 	for _, tc := range testCases {
 		topLevelTest.Run(tc.description, func(t *testing.T) {
 			eas := tc.scopeGenerator(t)
-			filter, err := BuildNonVerboseClusterNamespaceLevelSACQueryFilter(eas)
+			filter, err := BuildClusterNamespaceLevelSACQueryFilter(eas)
 			assert.True(t, tc.hasError == (err != nil))
 			correctFilter := isSameQuery(tc.expected, filter)
 			assert.Truef(t, correctFilter, "mismatch between queries")

--- a/pkg/sac/query_testutils.go
+++ b/pkg/sac/query_testutils.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
-func clusterNonVerboseMatch(_ *testing.T, clusterID string) *v1.Query {
+func clusterMatch(_ *testing.T, clusterID string) *v1.Query {
 	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID)
 	return query.ProtoQuery()
 }
 
-func namespaceNonVerboseMatch(_ *testing.T, namespace string) *v1.Query {
+func namespaceMatch(_ *testing.T, namespace string) *v1.Query {
 	query := search.NewQueryBuilder().AddExactMatches(search.Namespace, namespace)
 	return query.ProtoQuery()
 }

--- a/pkg/search/postgres/sac.go
+++ b/pkg/search/postgres/sac.go
@@ -109,13 +109,13 @@ func getSACQuery(ctx context.Context, targetResource permissions.ResourceMetadat
 		if err != nil {
 			return nil, err
 		}
-		return sac.BuildNonVerboseClusterLevelSACQueryFilter(scopeTree)
+		return sac.BuildClusterLevelSACQueryFilter(scopeTree)
 	case permissions.NamespaceScope:
 		scopeTree, err := scopeChecker.EffectiveAccessScope(action(targetResource))
 		if err != nil {
 			return nil, err
 		}
-		return sac.BuildNonVerboseClusterNamespaceLevelSACQueryFilter(scopeTree)
+		return sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
 	}
 	return nil, fmt.Errorf("could not prepare SAC Query for %s", targetResource)
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Verbose SAC filters are a leftover from the early phase of the Postgres SAC implementation.

Following the removal of the last calls to the verbose variant of the SAC filter helper functions, the non-verbose variants are being renamed to `BuildXXXLevelSACQueryFilter`.

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
-->
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Internal function renaming. The existing CI validation should be enough.
