### PR TITLE
perf(PG): add index for image risk score

### DIFF
--- a/generated/storage/image.pb.go
+++ b/generated/storage/image.pb.go
@@ -292,7 +292,7 @@ type Image struct {
 	NotPullable    bool                   `protobuf:"varint,10,opt,name=not_pullable,json=notPullable,proto3" json:"not_pullable,omitempty"`
 	IsClusterLocal bool                   `protobuf:"varint,17,opt,name=is_cluster_local,json=isClusterLocal,proto3" json:"is_cluster_local,omitempty"`
 	Priority       int64                  `protobuf:"varint,11,opt,name=priority,proto3" json:"priority,omitempty" search:"Image Risk Priority,hidden"`                     // @gotags: search:"Image Risk Priority,hidden"
-	RiskScore      float32                `protobuf:"fixed32,12,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty" search:"Image Risk Score,hidden"` // @gotags: search:"Image Risk Score,hidden"
+	RiskScore      float32                `protobuf:"fixed32,12,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty" search:"Image Risk Score,hidden" sql:"index=btree"` // @gotags: search:"Image Risk Score,hidden" sql:"index=btree"
 	// Types that are valid to be assigned to SetTopCvss:
 	//
 	//	*Image_TopCvss

--- a/pkg/postgres/schema/images.go
+++ b/pkg/postgres/schema/images.go
@@ -82,7 +82,7 @@ type Images struct {
 	FixableCves          int32             `gorm:"column:fixablecves;type:integer"`
 	LastUpdated          *time.Time        `gorm:"column:lastupdated;type:timestamp"`
 	Priority             int64             `gorm:"column:priority;type:bigint"`
-	RiskScore            float32           `gorm:"column:riskscore;type:numeric"`
+	RiskScore            float32           `gorm:"column:riskscore;type:numeric;index:images_riskscore,type:btree"`
 	TopCvss              float32           `gorm:"column:topcvss;type:numeric"`
 	Serialized           []byte            `gorm:"column:serialized;type:bytea"`
 }

--- a/proto/storage/image.proto
+++ b/proto/storage/image.proto
@@ -41,7 +41,7 @@ message Image {
 
   reserved 6; // was map<string,string> clusterns_scopes
   int64 priority = 11; // @gotags: search:"Image Risk Priority,hidden"
-  float risk_score = 12; // @gotags: search:"Image Risk Score,hidden"
+  float risk_score = 12; // @gotags: search:"Image Risk Score,hidden" sql:"index=btree"
   oneof set_top_cvss {
     float top_cvss = 13; // @gotags: search:"Image Top CVSS,store"
   }


### PR DESCRIPTION
### Description

The `getImagesAtMostRisk` query on big installations (e.g. 2k namespaces per cluster seen by a user) can take ~300ms. 
This might be the effect of missing index that could be used for sorting huge dataset. 

https://github.com/stackrox/stackrox/blob/1255f88b7e8a50fa9ed98d725c6330d625f4719c/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.tsx#L46-L49 

Below there is a query with `LIKE` operator to mimic SAC filter that includes a lot of data (to keep query small). We can observe that the runtime is much smaller with index on risk score. 

```sql
explain analyze
select deployments_containers.Image_Name_FullName as image, deployments_containers.Image_Name_Remote as image_remote
from deployments
         inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
         inner join images on deployments_containers.Image_Id = images.Id
where deployments.Namespace LIKE '0%'
order by images.RiskScore asc
limit 6;
QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=7711.72..7799.29 rows=6 width=151) (actual time=58.736..66.585 rows=6 loops=1)
   ->  Nested Loop  (cost=7711.72..57875.39 rows=3437 width=151) (actual time=58.735..66.582 rows=6 loops=1)
         ->  Gather Merge  (cost=7711.44..14175.62 rows=56718 width=167) (actual time=58.331..65.297 rows=99 loops=1)
               Workers Planned: 1
               Workers Launched: 1
               ->  Sort  (cost=6711.43..6794.84 rows=33364 width=167) (actual time=54.519..54.546 rows=205 loops=2)
                     Sort Key: images.riskscore
                     Sort Method: quicksort  Memory: 9297kB
                     Worker 0:  Sort Method: quicksort  Memory: 7940kB
                     ->  Hash Join  (cost=769.10..4204.79 rows=33364 width=167) (actual time=6.817..29.461 rows=28939 loops=2)
                           Hash Cond: ((deployments_containers.image_id)::text = (images.id)::text)
                           ->  Parallel Seq Scan on deployments_containers  (cost=0.00..3342.94 rows=35294 width=229) (actual time=0.022..9.939 rows=30000 loops=2)
                           ->  Hash  (cost=724.60..724.60 rows=3560 width=82) (actual time=6.681..6.682 rows=3560 loops=2)
                                 Buckets: 4096  Batches: 1  Memory Usage: 432kB
                                 ->  Seq Scan on images  (cost=0.00..724.60 rows=3560 width=82) (actual time=0.037..5.353 rows=3560 loops=2)
         ->  Index Scan using deployments_pkey on deployments  (cost=0.29..0.77 rows=1 width=16) (actual time=0.013..0.013 rows=0 loops=99)
               Index Cond: (id = deployments_containers.deployments_id)
               Filter: ((namespace)::text ~~ '0%'::text)
               Rows Removed by Filter: 1
 Planning Time: 2.156 ms
 Execution Time: 67.620 ms
(21 rows)

create index image_risk_score ON images (RiskScore);
-- CREATE INDEX
explain analyze
select deployments_containers.Image_Name_FullName as image, deployments_containers.Image_Name_Remote as image_remote
from deployments
         inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
         inner join images on deployments_containers.Image_Id = images.Id
where deployments.Namespace LIKE '0%'
order by images.RiskScore asc
limit 6;
QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.57..107.85 rows=6 width=151) (actual time=0.261..0.951 rows=6 loops=1)
   ->  Nested Loop  (cost=0.57..61457.63 rows=3437 width=151) (actual time=0.260..0.948 rows=6 loops=1)
         ->  Nested Loop  (cost=0.28..17757.85 rows=56718 width=167) (actual time=0.055..0.267 rows=72 loops=1)
               ->  Index Scan using image_risk_score on images  (cost=0.28..2847.45 rows=3560 width=82) (actual time=0.033..0.044 rows=8 loops=1)
               ->  Index Scan using deploymentscontainers_image_id on deployments_containers  (cost=0.00..4.03 rows=16 width=229) (actual time=0.006..0.025 rows=9 loops=8)
                     Index Cond: ((image_id)::text = (images.id)::text)
         ->  Index Scan using deployments_pkey on deployments  (cost=0.29..0.77 rows=1 width=16) (actual time=0.009..0.009 rows=0 loops=72)
               Index Cond: (id = deployments_containers.deployments_id)
               Filter: ((namespace)::text ~~ '0%'::text)
               Rows Removed by Filter: 1
 Planning Time: 0.660 ms
 Execution Time: 0.989 ms
(12 rows)
```

This change is part of the tested improvements for ROX-26848

The aim is to improve the graphQL statement getImagesAtMostRisk

| Scope size | Baseline | With index |
|---|---|---|
| unrestricted | 87 ms | 86 ms |
| 1 | 31 ms | 31 ms |
| 10 | 65 ms | 64 ms |
| 20 | 90 ms | 91 ms |
| 50 | 73 ms | 75 ms |
| 100 | 90 ms | 88 ms |
| 200 | 153 ms | 141 ms |
| 500 | 226 ms | 223 ms |
| 1000 | 249 ms | 242 ms |
| 2000 | 296 ms | 282 ms |

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI

- https://github.com/stackrox/stackrox/pull/13776