### PR TITLE
ROX-22250: Switch to sanitizing version of determine-image-tag

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -186,8 +186,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-22250): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -101,10 +101,6 @@ spec:
     description: This sets the expiration time for intermediate OCI artifacts produced and used during builds after which they can be garbage collected.
     name: oci-artifact-expires-after
     type: string
-  - name: image-tag-makefile-directory
-    description: Directory in which to run "make tag" command.
-    default: "."
-    type: string
 
   results:
   - description: ""
@@ -179,42 +175,22 @@ spec:
 
   - name: determine-image-tag
     params:
-    - name: MAKEFILE_DIRECTORY
-      value: $(params.image-tag-makefile-directory)
     - name: TAG_SUFFIX
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: SOURCE_BRANCH
       value: '{{source_branch}}'
-    taskRef: &determine-image-tag-task-ref
+    taskRef:
       params:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        # TODO(ROX-22250): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
       - name: kind
         value: task
       resolver: bundles
-
-  # `determine-main-version` produces the same output as `determine-image-tag` for all containers built with this
-  # pipeline except for `operator`. There's a special case for `operator`.
-  # Main version (same as main image tag) will match the result of `determine-image-tag` (i.e. the tag with which the
-  # `operator` image is tagged) in all cases except for the `operator` builds in `master`.
-  # For `operator` in `master`, the image tag will have `.0`: `4.7.0-514-gba6cde5b55-fast`, while the `main` version has
-  # `.x`: `4.7.x-514-gba6cde5b55-fast`.
-  # TODO(ROX-22250): make Konflux image tags always go with `.0` despite git tag containing `.x` and remove this task.
-  - name: determine-main-version
-    params:
-    - name: MAKEFILE_DIRECTORY
-      value: "."
-    - name: TAG_SUFFIX
-      value: $(params.output-tag-suffix)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
-    taskRef: *determine-image-tag-task-ref
 
   - name: prefetch-dependencies
     params:
@@ -257,7 +233,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - BUILD_TAG=$(tasks.determine-main-version.results.IMAGE_TAG)
+      - BUILD_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -294,7 +270,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - BUILD_TAG=$(tasks.determine-main-version.results.IMAGE_TAG)
+      - BUILD_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -333,7 +309,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - BUILD_TAG=$(tasks.determine-main-version.results.IMAGE_TAG)
+      - BUILD_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -372,7 +348,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - BUILD_TAG=$(tasks.determine-main-version.results.IMAGE_TAG)
+      - BUILD_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -186,7 +186,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        # TODO(ROX-22250): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -186,8 +186,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-22250): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles
@@ -207,7 +206,7 @@ spec:
       - name: name
         value: fetch-external-networks
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -54,8 +54,6 @@ spec:
     value: '0'
   - name: clone-fetch-tags
     value: 'true'
-  - name: image-tag-makefile-directory
-    value: 'operator'
 
   workspaces:
   - name: git-auth

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -284,37 +284,24 @@ spec:
     - name: basic-auth
       workspace: git-auth
 
-  - name: determine-operator-image-tag
+  - name: determine-image-tag
     params:
     - name: TAG_SUFFIX
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: MAKEFILE_DIRECTORY
-      value: ./operator
     - name: SOURCE_BRANCH
       value: '{{source_branch}}'
-    taskRef: &determine-image-tag-ref
+    taskRef:
       params:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        # TODO(ROX-22250): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
       - name: kind
         value: task
       resolver: bundles
-
-  - name: determine-main-image-tag
-    params:
-    - name: TAG_SUFFIX
-      value: $(params.output-tag-suffix)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: MAKEFILE_DIRECTORY
-      value: "."
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
-    taskRef: *determine-image-tag-ref
 
   - name: prefetch-dependencies
     params:
@@ -342,7 +329,7 @@ spec:
   - name: wait-for-operator-image
     params:
     - name: IMAGE
-      value: "$(params.operator-image-build-repo):$(tasks.determine-operator-image-tag.results.IMAGE_TAG)"
+      value: "$(params.operator-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: &wait-for-image-ref
       params:
       - name: name
@@ -358,7 +345,7 @@ spec:
   - name: wait-for-main-image
     params:
     - name: IMAGE
-      value: "$(params.main-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.main-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `main-build.yaml`.
     timeout: 2h40m
@@ -366,7 +353,7 @@ spec:
   - name: wait-for-scanner-image
     params:
     - name: IMAGE
-      value: "$(params.scanner-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.scanner-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `scanner-retag.yaml`
     timeout: 40m
@@ -374,7 +361,7 @@ spec:
   - name: wait-for-scanner-db-image
     params:
     - name: IMAGE
-      value: "$(params.scanner-db-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.scanner-db-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `scanner-db-retag.yaml`
     timeout: 40m
@@ -382,7 +369,7 @@ spec:
   - name: wait-for-scanner-slim-image
     params:
     - name: IMAGE
-      value: "$(params.scanner-slim-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.scanner-slim-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `scanner-slim-retag.yaml`
     timeout: 40m
@@ -390,7 +377,7 @@ spec:
   - name: wait-for-scanner-db-slim-image
     params:
     - name: IMAGE
-      value: "$(params.scanner-db-slim-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.scanner-db-slim-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `scanner-db-slim-retag.yaml`
     timeout: 40m
@@ -398,7 +385,7 @@ spec:
   - name: wait-for-scanner-v4-image
     params:
     - name: IMAGE
-      value: "$(params.scanner-v4-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.scanner-v4-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `scanner-v4-build.yaml`.
     timeout: 1h10m
@@ -406,7 +393,7 @@ spec:
   - name: wait-for-scanner-v4-db-image
     params:
     - name: IMAGE
-      value: "$(params.scanner-v4-db-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.scanner-v4-db-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `scanner-v4-db-build.yaml`.
     timeout: 1h10m
@@ -414,7 +401,7 @@ spec:
   - name: wait-for-collector-slim-image
     params:
     - name: IMAGE
-      value: "$(params.collector-slim-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.collector-slim-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # The timeout must be the same as the pipeline timeout in `collector-slim-retag.yaml`
     timeout: 40m
@@ -422,7 +409,7 @@ spec:
   - name: wait-for-collector-image
     params:
     - name: IMAGE
-      value: "$(params.collector-full-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.collector-full-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # The timeout must be the same as the pipeline timeout in `collector-full-retag.yaml`
     timeout: 40m
@@ -430,7 +417,7 @@ spec:
   - name: wait-for-roxctl-image
     params:
     - name: IMAGE
-      value: "$(params.roxctl-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.roxctl-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `roxctl-build.yaml`.
     timeout: 1h10m
@@ -438,7 +425,7 @@ spec:
   - name: wait-for-central-db-image
     params:
     - name: IMAGE
-      value: "$(params.central-db-image-build-repo):$(tasks.determine-main-image-tag.results.IMAGE_TAG)"
+      value: "$(params.central-db-image-build-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)"
     taskRef: *wait-for-image-ref
     # This timeout must be the same as the pipeline timeout in `central-db-build.yaml`.
     timeout: 1h40m
@@ -447,7 +434,7 @@ spec:
     params:
     - name: IMAGE
       # Note the operator bundle tag is prefixed with "v".
-      value: $(params.output-image-repo):v$(tasks.determine-operator-image-tag.results.IMAGE_TAG)
+      value: $(params.output-image-repo):v$(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: DOCKERFILE
       value: $(params.dockerfile)
     - name: CONTEXT
@@ -462,7 +449,7 @@ spec:
       value: $(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS
       value:
-      - OPERATOR_IMAGE_TAG=$(tasks.determine-operator-image-tag.results.IMAGE_TAG)
+      - OPERATOR_IMAGE_TAG=$(tasks.determine-image-tag.results.IMAGE_TAG)
       - OPERATOR_IMAGE_REF=$(params.operator-image-catalog-repo)@$(tasks.wait-for-operator-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_MAIN=$(params.main-image-catalog-repo)@$(tasks.wait-for-main-image.results.IMAGE_DIGEST)
       - RELATED_IMAGE_SCANNER=$(params.scanner-image-catalog-repo)@$(tasks.wait-for-scanner-image.results.IMAGE_DIGEST)
@@ -677,8 +664,7 @@ spec:
     - clamav-scan
     - clone-repository
     - deprecated-base-image-check
-    - determine-main-image-tag
-    - determine-operator-image-tag
+    - determine-image-tag
     - init
     - prefetch-dependencies
     - push-dockerfile
@@ -698,7 +684,7 @@ spec:
     - wait-for-scanner-v4-image
     params:
     - name: PRODUCT_VERSION
-      value: $(tasks.determine-main-image-tag.results.IMAGE_TAG)
+      value: $(tasks.determine-image-tag.results.IMAGE_TAG)
     - name: COMPONENTS
       value: |
         [

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -297,8 +297,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-22250): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles
@@ -335,7 +334,7 @@ spec:
       - name: name
         value: wait-for-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles
@@ -772,7 +771,7 @@ spec:
       - name: name
         value: create-snapshot
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/retag-pipeline.yaml
+++ b/.tekton/retag-pipeline.yaml
@@ -121,7 +121,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        # TODO(ROX-22250): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/retag-pipeline.yaml
+++ b/.tekton/retag-pipeline.yaml
@@ -121,8 +121,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-22250): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles
@@ -140,7 +139,7 @@ spec:
         - name: name
           value: determine-dependency-image-tag
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
         - name: kind
           value: task
       resolver: bundles
@@ -160,7 +159,7 @@ spec:
       - name: name
         value: retag-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -186,7 +186,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        # TODO(ROX-22250): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -186,8 +186,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-22250): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles
@@ -207,7 +206,7 @@ spec:
       - name: name
         value: fetch-scanner-v4-vuln-mappings
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:76c8fbd2abac06ce895a765c41be73d14925b00a660b1b5fa6564a50a15cf2ba
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a2477a53bfb4159cb6fa0d15acd736153e1844a193b6c91f8f2a6672d90e3d12
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
### Description

Using task from https://github.com/stackrox/konflux-tasks/pull/30.
Main image tag becomes the same as operator image tag and so we can eliminate some of the extra tasks and discrepancies.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No change.

#### How I validated my change

- [x] All produced image tags have `.0` instead of `.x`.
