### PR TITLE
ROX-27822: Add horizontal subnav support and impl for VM

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -15,6 +15,7 @@ import { clustersBasePath } from 'routePaths';
 import Header from './Header/Header';
 import PublicConfigFooter from './PublicConfig/PublicConfigFooter';
 import NavigationSidebar from './Navigation/NavigationSidebar';
+import HorizontalSubnav from './Navigation/HorizontalSubnav';
 
 import Body from './Body';
 import AcsFeedbackModal from './AcsFeedbackModal';
@@ -101,6 +102,10 @@ function MainPage(): ReactElement {
                         />
                     }
                 >
+                    <HorizontalSubnav
+                        hasReadAccess={hasReadAccess}
+                        isFeatureFlagEnabled={isFeatureFlagEnabled}
+                    />
                     <Body
                         hasReadAccess={hasReadAccess}
                         isFeatureFlagEnabled={isFeatureFlagEnabled}

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.css
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.css
@@ -1,0 +1,38 @@
+/*
+* Top level styles to ensure the sub-navigation is always at the top of the current page
+* and that dropdown entries are not obscured by content
+*/
+nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav {
+  background-color: var(--pf-v5-global--BackgroundColor--dark-300);
+  position: sticky;
+  overflow: visible;
+  z-index: 9999;
+}
+
+nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav .pf-v5-c-nav__list {
+  overflow: visible;
+}
+
+/*
+* Style normalization of the text and colors of a dropdown nav item to match non-dropdown items
+*/
+nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav .pf-v5-c-menu-toggle {
+  font-size: var(--pf-v5-c-nav__link--FontSize);
+  font-weight: var(--pf-v5-c-nav__link--FontWeight);
+  color: var(--pf-v5-c-nav__link--Color);
+  --pf-v5-c-menu-toggle__toggle-icon--Color: var(--pf-v5-c-nav__link--Color);
+  --pf-v5-c-menu-toggle--PaddingLeft: var(--pf-v5-c-nav--m-horizontal-subnav__link--PaddingLeft);
+}
+
+nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav .pf-v5-c-menu {
+  max-width: 300px;
+  white-space: break-spaces;
+  --pf-v5-c-menu__item-description--Color: var(--pf-v5-global--Color--light-300);
+}
+
+/*
+* Applies a highlight to a dropdown nav item when it is the current active item
+*/
+nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav .acs-pf-horizontal-subnav-menu__active {
+  --pf-v5-c-menu__list-item--BackgroundColor: var(--pf-v5-c-menu__list-item--hover--BackgroundColor);
+}

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -1,0 +1,234 @@
+import React, { useState } from 'react';
+import { matchPath, useHistory, useLocation } from 'react-router-dom';
+import {
+    Nav,
+    Dropdown,
+    DropdownItem,
+    DropdownList,
+    MenuToggle,
+    MenuToggleElement,
+    NavItemSeparator,
+    NavItem,
+    NavList,
+} from '@patternfly/react-core';
+
+import {
+    vulnerabilitiesWorkloadCvesPath,
+    vulnerabilitiesPlatformWorkloadCvesPath,
+    vulnerabilitiesNodeCvesPath,
+} from 'routePaths';
+import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import { HasReadAccess } from 'hooks/usePermissions';
+import { ensureExhaustive } from 'utils/type.utils';
+import NavigationItem from './NavigationItem';
+import { filterNavDescriptions, isActiveLink, NavDescription } from './utils';
+
+import './HorizontalSubnav.css';
+
+type SubnavParentKey = 'vulnerabilities';
+
+/*
+ * Function that returns a key/value object that maps parent routes to a list
+ * of sub-navigation description items.
+ */
+function getSubnavDescriptionGroups(
+    isFeatureFlagEnabled: IsFeatureFlagEnabled
+): Record<SubnavParentKey, NavDescription[]> {
+    return {
+        vulnerabilities: isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
+            ? [
+                  {
+                      type: 'link',
+                      content: 'User Workloads',
+                      path: vulnerabilitiesWorkloadCvesPath,
+                      routeKey: 'vulnerabilities/workload-cves',
+                  },
+                  {
+                      type: 'link',
+                      content: 'Platform',
+                      path: vulnerabilitiesPlatformWorkloadCvesPath,
+                      routeKey: 'vulnerabilities/platform-workload-cves',
+                  },
+                  {
+                      type: 'link',
+                      content: 'Nodes',
+                      path: vulnerabilitiesNodeCvesPath,
+                      routeKey: 'vulnerabilities/node-cves',
+                  },
+                  {
+                      type: 'parent',
+                      key: 'More Views',
+                      title: 'More Views',
+                      children: [
+                          {
+                              type: 'link',
+                              content: 'All Images',
+                              description:
+                                  'View findings for user and platform images simultaneously',
+                              // TODO Change these
+                              path: '/main/vulnerabilities/TBD',
+                              routeKey: 'vulnerabilities/workload-cves',
+                          },
+                      ],
+                  },
+              ]
+            : [],
+    };
+}
+
+/*
+ * Given the mapping of parent routes to subnav description groups, return the grouping
+ * that contains a child item with a path matching the user's current path
+ */
+function getSubnavGroupForCurrentPath(
+    subnavDescriptionGroups: Record<SubnavParentKey, NavDescription[]>,
+    pathname: string
+) {
+    return (
+        Object.values(subnavDescriptionGroups).find((subnavDescriptionGroup) => {
+            return subnavDescriptionGroup.some((group) => {
+                if (group.type === 'link') {
+                    return matchPath(pathname, group.path);
+                }
+                return group.children
+                    .filter((child) => child.type === 'link')
+                    .some(({ path }) => matchPath(pathname, path));
+            });
+        }) ?? []
+    );
+}
+
+export type HorizontalSubnavProps = {
+    hasReadAccess: HasReadAccess;
+    isFeatureFlagEnabled: IsFeatureFlagEnabled;
+};
+
+function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSubnavProps) {
+    const history = useHistory();
+    const { pathname } = useLocation();
+    const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
+
+    const subnavDescriptionGroups = getSubnavDescriptionGroups(isFeatureFlagEnabled);
+    const subnavDescriptionGroupForCurrentPath = getSubnavGroupForCurrentPath(
+        subnavDescriptionGroups,
+        pathname
+    );
+    const subnavDescriptions = filterNavDescriptions(
+        subnavDescriptionGroupForCurrentPath,
+        routePredicates
+    );
+
+    const [openDropdownKey, setOpenDropdownKey] = useState<string | null>(null);
+
+    const onToggleClick = (key: string) => {
+        setOpenDropdownKey((currentKey) => (currentKey === key ? null : key));
+    };
+
+    const onSelect = (
+        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        value: string | number | undefined
+    ) => {
+        history.push(value);
+        setOpenDropdownKey(null);
+    };
+
+    if (!subnavDescriptions.length) {
+        return null;
+    }
+
+    return (
+        <Nav variant="horizontal-subnav" className="acs-pf-horizontal-subnav">
+            <NavList>
+                {subnavDescriptions.map((subnavDescription) => {
+                    switch (subnavDescription.type) {
+                        case 'link': {
+                            const { content, path } = subnavDescription;
+                            return (
+                                <NavigationItem
+                                    key={path}
+                                    isActive={isActiveLink(pathname, subnavDescription)}
+                                    path={path}
+                                    content={
+                                        typeof content === 'function'
+                                            ? content(subnavDescriptions)
+                                            : content
+                                    }
+                                />
+                            );
+                        }
+                        case 'parent': {
+                            const { key, title, children } = subnavDescription;
+                            return (
+                                <Dropdown
+                                    key={key}
+                                    isPlain
+                                    onSelect={onSelect}
+                                    isOpen={openDropdownKey === key}
+                                    onOpenChange={(isOpen: boolean) =>
+                                        setOpenDropdownKey(isOpen ? key : null)
+                                    }
+                                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                                        <NavItem
+                                            isActive={subnavDescription.children.some(
+                                                (child) =>
+                                                    child.type === 'link' &&
+                                                    isActiveLink(pathname, child)
+                                            )}
+                                            onClick={() => onToggleClick(key)}
+                                        >
+                                            <MenuToggle
+                                                ref={toggleRef}
+                                                isExpanded={openDropdownKey === key}
+                                                variant="plainText"
+                                            >
+                                                {typeof title === 'function'
+                                                    ? title(subnavDescriptions)
+                                                    : title}
+                                            </MenuToggle>
+                                        </NavItem>
+                                    )}
+                                    shouldFocusToggleOnSelect
+                                >
+                                    <DropdownList>
+                                        {children.map((child) => {
+                                            if (child.type === 'separator') {
+                                                return (
+                                                    <NavItemSeparator
+                                                        key={child.key}
+                                                        role="listitem"
+                                                    />
+                                                );
+                                            }
+                                            const { content, path, description } = child;
+                                            return (
+                                                <DropdownItem
+                                                    component={'a'}
+                                                    className={
+                                                        isActiveLink(pathname, child)
+                                                            ? 'acs-pf-horizontal-subnav-menu__active'
+                                                            : ''
+                                                    }
+                                                    value={path}
+                                                    key={path}
+                                                    description={description}
+                                                >
+                                                    {typeof content === 'function'
+                                                        ? content(subnavDescriptions)
+                                                        : content}
+                                                </DropdownItem>
+                                            );
+                                        })}
+                                    </DropdownList>
+                                </Dropdown>
+                            );
+                        }
+                        default:
+                            return ensureExhaustive(subnavDescription);
+                    }
+                })}
+            </NavList>
+        </Nav>
+    );
+}
+
+export default HorizontalSubnav;

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -61,31 +61,17 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
         ? [
               {
                   type: 'link',
-                  content: 'User Workloads',
+                  content: 'Results',
                   path: vulnerabilitiesWorkloadCvesPath,
                   routeKey: 'vulnerabilities/workload-cves',
-              },
-              {
-                  type: 'link',
-                  content: 'Platform Components',
-                  path: vulnerabilitiesPlatformWorkloadCvesPath,
-                  routeKey: 'vulnerabilities/platform-workload-cves',
-              },
-              {
-                  type: 'link',
-                  content: 'Kubernetes Components',
-                  path: vulnerabilitiesPlatformCvesPath,
-                  routeKey: 'vulnerabilities/platform-cves',
-              },
-              {
-                  type: 'link',
-                  content: 'Nodes',
-                  path: vulnerabilitiesNodeCvesPath,
-                  routeKey: 'vulnerabilities/node-cves',
-              },
-              {
-                  type: 'separator',
-                  key: 'following-workload-cves',
+                  isActive: (pathname) =>
+                      Boolean(
+                          matchPath(pathname, [
+                              vulnerabilitiesWorkloadCvesPath,
+                              vulnerabilitiesPlatformWorkloadCvesPath,
+                              vulnerabilitiesNodeCvesPath,
+                          ])
+                      ),
               },
               {
                   type: 'link',
@@ -102,6 +88,17 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
               {
                   type: 'separator',
                   key: 'following-node-cves',
+              },
+
+              {
+                  type: 'link',
+                  content: 'Platform CVEs',
+                  path: vulnerabilitiesPlatformCvesPath,
+                  routeKey: 'vulnerabilities/platform-cves',
+              },
+              {
+                  type: 'separator',
+                  key: 'following-workload-cves',
               },
               {
                   type: 'link',

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
@@ -1,9 +1,9 @@
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
-import { HasReadAccess } from 'hooks/usePermissions';
 import { ReactElement } from 'react';
 import { matchPath } from 'react-router-dom';
 
 import { isRouteEnabled, RouteKey } from 'routePaths';
+import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import { HasReadAccess } from 'hooks/usePermissions';
 
 // Child example; Compliance (1.0) if Compliance (2.0) is rendered and Compliance otherwise.
 // Parent example: Vulnerability Management (1.0) if Vulnerability Management (2.0) is rendered and so on.


### PR DESCRIPTION
### Description

Adds a horizontal subnav component to the UI, and moves left navigation links for VM to the subnav when the feature flag is enabled.

### Points of interest

#### **(1) Method of determining which subnavigation to show**

Currently, which set of links is shown at the top of the page in the subnav is dependent on the current route. The decision is made like this:

1. A key/value object contains a mapping of top level page names to an array of links to be shown for that page
2. If the current page address matches **any** link in the array, the entire array is used as the nav to be shown

This works right now, but is susceptible to some potential issues in the future:

1. It is not possible to show the subnav if the current page address does not match a child item
2. It is not possible to have a link to a _different_ top level page in the subnav without the potential for conflicts in deciding which subnav to use

Neither of these issues is a problem now and IMO are unlikely in the future. The current approach is mostly declarative, and contained within the nav element itself which I think outweighs the potential drawbacks, but am open to other suggestions.

#### **(2) Styling of nav components**

The new component includes a CSS file with minimal rules, based on existing PatternFly CSS vars. This is used to get visual consistency without much additional complication. The dropdown section for the subnav uses almost identical components that the PF left navigation uses internally, has no a11y errors, and is fully usable via the keyboard.

#### **(3) Compatibility with authz**

The ability to remove or hide a navigation item is handled identically to the main navigation, using the same utilities. There should be no restrictions on hiding a navigation item via feature flag or via permission checks when using the same declarative approach. If for some reason we need to hide a link imperatively, the route predicates are available within the component as well.

#### **(4) Use of `history.push()`**

Unfortunately, I have not been able to find a way to get the `DropdownItem` to use react-router's `Link` as a component, even though the former includes a `component` prop. The reason for this is that if the `to` prop is also specified when calling `DropdownItem`, it is hardcoded internally to use `<a>` instead of the passed component.

The three alternatives I attempted were:
- Wrap `<Link>` in a HoC that captures the `to` prop in a closure, which creates many one off unique components and is complex
- Pass `<Link>` as a child item to `<DropdownItem>`, which causes large dead zones in the list items that do not follow the link
- Manually call `history.push()`, which is not the most elegant but is simple and works well.


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

With the feature flag off, no change:
![image](https://github.com/user-attachments/assets/7a90d649-6f50-4f91-bd1c-a99f98c27aac)

With the feature flag on, see changes in the left navigation and see the new top level navigation when visiting VM results.
![image](https://github.com/user-attachments/assets/7db3e093-f285-4b9b-b988-7fd08120ef08)

Test the other links:
![image](https://github.com/user-attachments/assets/868a1f29-8c5f-4684-87ab-c0aa6f036fdd)
![image](https://github.com/user-attachments/assets/6df6d5d6-74b3-488d-be26-17287bf4601e)

Open the dropdown and select the one unimplemented link within. The top level link in the nav as well as the item within the dropdown will be highlighted as the current route.
![image](https://github.com/user-attachments/assets/9123b2bc-11aa-4baf-944d-c505c7312399)
![image](https://github.com/user-attachments/assets/b7ba5ab8-1739-4baf-ba50-4dc11ea21cda)
![image](https://github.com/user-attachments/assets/0cee073c-995c-4855-8e0c-2c861f7bc814)

Test via aXe dev tools:
![image](https://github.com/user-attachments/assets/2bac8f56-ef51-45a9-9808-ed3798a2efc4)

Test keyboard navigation:


https://github.com/user-attachments/assets/dd73585d-91fd-42a7-a7af-bc2d01ddfc5b

