### PR TITLE
ROX-27829: Remove regex validation from Slack URL field in form

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
@@ -548,6 +548,7 @@ describe('Notifier Integrations', () => {
             // Step 2, no invalid formats to check
 
             // Step 3, check valid form and save
+            getInputByLabel('Integration name').clear().type(integrationName);
             getInputByLabel('Annotation key for Slack webhook').clear().type('slack');
             getInputByLabel('Default Slack webhook')
                 .clear()

--- a/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
@@ -539,22 +539,13 @@ describe('Notifier Integrations', () => {
             getInputByLabel('Annotation key for Slack webhook').click().blur();
 
             getHelperElementByLabel('Integration name').contains('Name is required');
-            getHelperElementByLabel('Default Slack webhook').contains('Slack webhook is required');
-            cy.get(selectors.buttons.test).should('be.disabled');
-            cy.get(selectors.buttons.save).should('be.disabled');
-
-            // Step 2, check fields for invalid formats
-            getInputByLabel('Integration name').clear().type(integrationName);
-            getInputByLabel('Default Slack webhook')
-                .clear()
-                .type('https://hooks.slack.com/services/')
-                .blur();
-
             getHelperElementByLabel('Default Slack webhook').contains(
-                'Must be a valid Slack webhook URL, like https://hooks.slack.com/services/EXAMPLE'
+                'Webhook is required, like https://hooks.slack.com/services/EXAMPLE'
             );
             cy.get(selectors.buttons.test).should('be.disabled');
             cy.get(selectors.buttons.save).should('be.disabled');
+
+            // Step 2, no invalid formats to check
 
             // Step 3, check valid form and save
             getInputByLabel('Annotation key for Slack webhook').clear().type('slack');

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SlackIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SlackIntegrationForm.tsx
@@ -20,19 +20,12 @@ export type SlackIntegration = {
     type: 'slack';
 } & NotifierIntegrationBase;
 
-const validWebhookRegex =
-    /^((https?):\/\/)?([a-zA-Z0-9\-.]\.)?[a-zA-Z0-9\-.]{1,}\.[a-zA-Z]{2,}(\.[a-zA-Z]{2,})?(\/services)(\/[a-zA-Z0-9-]+)+$/;
-
 export const validationSchema = yup.object().shape({
     name: yup.string().trim().required('Name is required'),
     labelDefault: yup
         .string()
         .trim()
-        .required('Slack webhook is required')
-        .matches(
-            validWebhookRegex,
-            'Must be a valid Slack webhook URL, like https://hooks.slack.com/services/EXAMPLE'
-        ),
+        .required('Webhook is required, like https://hooks.slack.com/services/EXAMPLE'),
     labelKey: yup.string().trim(),
 });
 
@@ -101,7 +94,7 @@ function SlackIntegrationForm({
                         fieldId="labelDefault"
                         touched={touched}
                         errors={errors}
-                        helperText="https://hooks.slack.com/services/EXAMPLE"
+                        helperText="For example, https://hooks.slack.com/services/EXAMPLE"
                     >
                         <TextInput
                             isRequired


### PR DESCRIPTION
### Description

A user wanted to use the Slack integration with the Mattermost service, which has a Slack-compatible, according to its docs
https://docs.mattermost.com/about/integrations.html#webhooks

However, our UI has a front-end validation that will not let you submit the Slack integration form, unless the URL is a valid URL with the segment "/services/" in the middle, which is Slack's URL format, but not Mattermost URL format.

This change removes any regex format validation from that field, and only leaves the check that requires that field to not be empty.

(In this case, we could probably require a standard URL, but for some other integrations, we have had customers who used Kubernetes services names, which can be as short as single words–better to be as permissive as possible.)


### User-facing documentation

- [x] CHANGELOG  is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request)  is not needed

### Testing and quality


- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

- I updated the UI e2e test to remove the check for any regex format
- I manually observed the slightly revised helper text
- I manually observed that the field is still required to not be empty
- I manually observed that the filed now accepts a Mattermost style URL

![Screenshot 2025-01-27 at 7 03 33 PM](https://github.com/user-attachments/assets/b76d4612-67f5-43fb-bea6-a9b4eb99be87)

![Screenshot 2025-01-27 at 5 38 14 PM](https://github.com/user-attachments/assets/b31291f1-c480-47ac-9e86-313787d58e0d)

![Screenshot 2025-01-27 at 6 32 41 PM](https://github.com/user-attachments/assets/8d4680e5-8016-4c54-83f2-3689a165d06c)
