### PR TITLE
ROX-27066: Render Advisory column without GraphQL data

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AdvisoryLinkOrText.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AdvisoryLinkOrText.tsx
@@ -1,0 +1,47 @@
+import React, { ReactNode } from 'react';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+
+// https://access.redhat.com/security/updates/advisory
+// Red Hat publishes three types of errata:
+// Red Hat Security Advisory (RHSA)
+// Red Hat Bug Advisory (RHBA)
+// Red Hat Enhancement Advisory (RHEA)
+
+// https://access.redhat.com/articles/explaining_redhat_errata
+// All advisories are given a year and a sequential number, which starts at 0001 and ends at the number of advisories shipped for that year.
+
+export function isRedHatAdvisory(advisory: string) {
+    return /^RH[SBE]A-\d\d\d\d:\d+$/.test(advisory);
+}
+
+export type AdvisoryLinkOrTextProps = {
+    advisory: string | undefined;
+};
+
+function AdvisoryLinkOrText({ advisory }: AdvisoryLinkOrTextProps): ReactNode {
+    if (typeof advisory === 'string') {
+        if (isRedHatAdvisory(advisory)) {
+            return (
+                <ExternalLink>
+                    <a
+                        href={`https://access.redhat.com/errata/${advisory}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {advisory}
+                    </a>
+                </ExternalLink>
+            );
+        }
+
+        // Unexpected, because other advisories like GHSA are not separated from CVE.
+        if (advisory.length !== 0) {
+            return advisory;
+        }
+    }
+
+    return 'No advisory';
+}
+
+export default AdvisoryLinkOrText;


### PR DESCRIPTION
### Description

Prerequisite for future demo with realistic data (by temporary code changes).

Similar steps as for **EPSS probability** in #13789 plus #13892

1. Add AdvisoryLinkOrText.tsx file.
2. Add conditional rendering for **Advisory** table column.
    * DeploymentComponentVulnerabilitiesTable.tsx file
    * ImageComponentVulnerabilitiesTable.tsx file

### Residue

When response has `advisory` property:
1. Add property to `gql` definitions.
2. Investigate function for front-end sorting.
3. If needed, add **Advisories** column with count for images but not deployments.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before local deployment, enable feature flag in ui folder:

```sh
export ROX_CVE_ADVISORY_SEPARATION=true
npm run deploy
```

However, I used staging demo instead (see below).

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4617256 - 4617256
        total 787 = 11581577 - 11580790
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178
3. `npm run start` in ui/apps/platform

#### Manual testing

Because advisory depends on **Scanner V4** use staging demo and temporarily edit code to invert conditional rendering of feature flag.

1. Visit /main/vulnerabilities/workload-cves and then click a vulnerability link.

    POST /api/graphql?opname=getCVEsForImage

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx

    Expand the row for an image.

    Before changes, see absence of **Advisory** column following **CVE fixed in** column in component row.
    ![ImageComponentVulnerabilitiesTable_images_absence](https://github.com/user-attachments/assets/b85b67d2-920c-4093-93de-acbd64b65524)

    After changes, see presence of **Advisory** column with **No advisories** as placeholder following **CVE fixed in** column in component row.
    ![ImageComponentVulnerabilitiesTable_images_presence](https://github.com/user-attachments/assets/2afdd742-d5bc-4ac0-8a62-8cf846d66bae)

2. Click an image link, and then expand the row for a vulnerability.

    Ditto for query and component.

    Expand the row for a vulnerability.

    Before changes, see absence of **Advisory** column following **CVE fixed in** column in component row.
    ![ImageComponentVulnerabilitiesTable_image_absence](https://github.com/user-attachments/assets/a29fe262-c5b0-4f6a-af00-2a91fd9f5139)

    After changes, see presence of **Advisory** column with **No advisories** as placeholder following **CVE fixed in** column in component row.
    ![ImageComponentVulnerabilitiesTable_image_presence](https://github.com/user-attachments/assets/f29c2e90-e6d5-474d-9736-8781578497ff)

3. Go back, click **Deployments**, and then expand the row for a deployment.

    POST /api/graphql?opname=getCVEsForDeployment

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx

    For sake of time, I skipped the pictures at this step.

4. Click a deployment link, and then expand the row for a vulnerability.

    Ditto for query and component.

    Before changes, see absence of **Advisory** column following **CVE fixed in** column in component row.
    ![DeploymentComponentVulnerabilitiesTable_deployment_absence](https://github.com/user-attachments/assets/1a84ff49-3ad3-449a-af02-6e02e5be049b)

    After changes, see presence of **Advisories** column with **No advisory** as placeholder following **CVE fixed in** column in component row.
    ![DeploymentComponentVulnerabilitiesTable_deployment_presence](https://github.com/user-attachments/assets/a6a34aaf-3685-4d0e-b0f5-524577c839d9)

Bonus simulation of separation:
* https://access.redhat.com/security/cve/CVE-2019-12900
* https://access.redhat.com/errata/RHSA-2025:0733
![Image_CVE_Advisory_simulation](https://github.com/user-attachments/assets/5eed0ee7-d5d0-49a4-a6ac-6f50f6549504)
