### PR TITLE
ROX-25373: default values if no config is found

### DIFF
--- a/central/delegatedregistryconfig/datastore/telemetry.go
+++ b/central/delegatedregistryconfig/datastore/telemetry.go
@@ -19,8 +19,8 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 				sac.ResourceScopeKeys(resources.Administration),
 			),
 		)
-		cfg, ok, err := ds.GetConfig(ctx)
-		if !ok || err != nil {
+		cfg, _, err := ds.GetConfig(ctx)
+		if err != nil {
 			return nil, errors.Wrap(err, "failed to get delegated registry config")
 		}
 		props := map[string]any{

--- a/central/delegatedregistryconfig/datastore/telemetry_postgres_test.go
+++ b/central/delegatedregistryconfig/datastore/telemetry_postgres_test.go
@@ -26,42 +26,41 @@ func TestGather(t *testing.T) {
 	)
 
 	testCases := map[string]struct {
-		enabledFor              storage.DelegatedRegistryConfig_EnabledFor
-		defaultClusterID        string
-		registries              []*storage.DelegatedRegistryConfig_DelegatedRegistry
+		config                  *storage.DelegatedRegistryConfig
 		registriesWithClusterID int
 	}{
 		"enabled for all": {
-			enabledFor:       storage.DelegatedRegistryConfig_ALL,
-			defaultClusterID: "my-cluster",
-			registries: []*storage.DelegatedRegistryConfig_DelegatedRegistry{
-				{Path: "quay.io/rhacs-eng/qa"},
+			config: &storage.DelegatedRegistryConfig{
+				EnabledFor:       storage.DelegatedRegistryConfig_ALL,
+				DefaultClusterId: "my-cluster",
+				Registries: []*storage.DelegatedRegistryConfig_DelegatedRegistry{
+					{Path: "quay.io/rhacs-eng/qa"},
+				},
 			},
 		},
 		"enabled for none": {
-			enabledFor: storage.DelegatedRegistryConfig_NONE,
-			registries: []*storage.DelegatedRegistryConfig_DelegatedRegistry{},
+			config: &storage.DelegatedRegistryConfig{
+				EnabledFor: storage.DelegatedRegistryConfig_NONE,
+				Registries: []*storage.DelegatedRegistryConfig_DelegatedRegistry{},
+			},
 		},
 		"enabled for specific": {
-			enabledFor:       storage.DelegatedRegistryConfig_SPECIFIC,
-			defaultClusterID: "my-cluster",
-			registries: []*storage.DelegatedRegistryConfig_DelegatedRegistry{
-				{Path: "quay.io/rhacs-eng/qa", ClusterId: "my-cluster"},
-				{Path: "quay.io/rhacs-eng/main"},
+			config: &storage.DelegatedRegistryConfig{
+				EnabledFor:       storage.DelegatedRegistryConfig_SPECIFIC,
+				DefaultClusterId: "my-cluster",
+				Registries: []*storage.DelegatedRegistryConfig_DelegatedRegistry{
+					{Path: "quay.io/rhacs-eng/qa", ClusterId: "my-cluster"},
+					{Path: "quay.io/rhacs-eng/main"},
+				},
 			},
 			registriesWithClusterID: 1,
 		},
+		"default values when no config is found": {},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := ds.UpsertConfig(ctx,
-				&storage.DelegatedRegistryConfig{
-					EnabledFor:       tc.enabledFor,
-					DefaultClusterId: tc.defaultClusterID,
-					Registries:       tc.registries,
-				},
-			)
+			err := ds.UpsertConfig(ctx, tc.config)
 			require.NoError(t, err)
 
 			gatherFunc := Gather(ds)
@@ -69,9 +68,9 @@ func TestGather(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedProps := map[string]any{
-				"Delegated Scanning Config Enabled For":                           tc.enabledFor.String(),
-				"Delegated Scanning Config Default Cluster ID Populated":          tc.defaultClusterID != "",
-				"Total Delegated Scanning Config Registries":                      len(tc.registries),
+				"Delegated Scanning Config Enabled For":                           tc.config.GetEnabledFor().String(),
+				"Delegated Scanning Config Default Cluster ID Populated":          tc.config.GetDefaultClusterId() != "",
+				"Total Delegated Scanning Config Registries":                      len(tc.config.GetRegistries()),
 				"Total Delegated Scanning Config Registries Cluster ID Populated": tc.registriesWithClusterID,
 			}
 			assert.Equal(t, expectedProps, props)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Fix telemetry collection such that when no delegated config is found, the default/zero values are still collected.

Fix for edge case missed in #13959.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

see test