### PR TITLE
fix(sensor): use correct annotations for Sensor TLS secrets

### DIFF
--- a/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository.go
+++ b/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository.go
@@ -212,7 +212,7 @@ func (r *ServiceCertificatesRepoSecrets) createSecret(ctx context.Context, caPem
 			Name:            secretSpec.SecretName,
 			Namespace:       r.Namespace,
 			Labels:          utils.GetSensorKubernetesLabels(),
-			Annotations:     utils.GetSensorKubernetesLabels(),
+			Annotations:     utils.GetSensorKubernetesAnnotations(),
 			OwnerReferences: []metav1.OwnerReference{r.OwnerReference},
 		},
 		Data: r.secretDataForCertificate(secretSpec, caPem, certificate),

--- a/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository_test.go
+++ b/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/sensor/utils"
 	"github.com/stretchr/testify/suite"
 	appsApiv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -163,6 +164,24 @@ func (s *serviceCertificatesRepoSecretsImplSuite) TestPatch() {
 	}
 }
 
+func (s *serviceCertificatesRepoSecretsImplSuite) TestSuccessfulCreate() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fixture := s.newFixture(certSecretsRepoFixtureConfig{skipSecretCreation: true})
+	persistedCertificates, err := fixture.repo.EnsureServiceCertificates(ctx, fixture.certificates)
+	protoassert.SlicesEqual(s.T(), certificates.ServiceCerts, persistedCertificates)
+	s.ErrorIs(err, nil)
+
+	secret, err := fixture.secretsClient.Get(ctx, fixture.secretName, metav1.GetOptions{})
+	s.Require().NoError(err)
+
+	expectedLabels := utils.GetSensorKubernetesLabels()
+	s.Equal(expectedLabels, secret.Labels, "Secret labels do not match expected values")
+	expectedAnnotations := utils.GetSensorKubernetesAnnotations()
+	s.Equal(expectedAnnotations, secret.Annotations, "Secret annotations do not match expected values")
+}
+
 func (s *serviceCertificatesRepoSecretsImplSuite) TestGetNoSecretDataFailure() {
 	fixture := s.newFixture(certSecretsRepoFixtureConfig{emptySecretData: true})
 
@@ -260,6 +279,7 @@ type certSecretsRepoFixture struct {
 	repo          *ServiceCertificatesRepoSecrets
 	secretsClient corev1.SecretInterface
 	certificates  *storage.TypedServiceCertificateSet
+	secretName    string
 }
 
 // newFixture creates a certSecretsRepoFixture that contains:
@@ -276,9 +296,10 @@ func (s *serviceCertificatesRepoSecretsImplSuite) newFixture(config certSecretsR
 	if config.secretOwnerRefUID != "" {
 		ownerRef[0].UID = types.UID(config.secretOwnerRefUID)
 	}
+	secretName := fmt.Sprintf("%s-secret", scannerServiceType)
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-secret", scannerServiceType),
+			Name:            secretName,
 			Namespace:       namespace,
 			OwnerReferences: ownerRef,
 		},
@@ -294,7 +315,12 @@ func (s *serviceCertificatesRepoSecretsImplSuite) newFixture(config certSecretsR
 		delete(secret.Data, secretDataKey)
 	}
 	secrets := map[storage.ServiceType]*v1.Secret{scannerServiceType: secret}
-	clientSet := fake.NewSimpleClientset(sensorDeployment, secret)
+	var clientSet *fake.Clientset
+	if config.skipSecretCreation {
+		clientSet = fake.NewSimpleClientset(sensorDeployment)
+	} else {
+		clientSet = fake.NewSimpleClientset(sensorDeployment, secret)
+	}
 	secretsClient := clientSet.CoreV1().Secrets(namespace)
 	clientSet.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor(config.k8sAPIVerbToError, "secrets", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, &v1.Secret{}, errForced
@@ -304,6 +330,7 @@ func (s *serviceCertificatesRepoSecretsImplSuite) newFixture(config certSecretsR
 		repo:          repo,
 		secretsClient: secretsClient,
 		certificates:  certificates,
+		secretName:    secretName,
 	}
 }
 
@@ -313,6 +340,8 @@ type certSecretsRepoFixtureConfig struct {
 	k8sAPIVerbToError string
 	// If true then the data of the secret used to initialize the fake k8s client set will be empty.
 	emptySecretData bool
+	// If true the fixture will not create a pre-existing secret
+	skipSecretCreation bool
 	// These keys will be removed from the data keys of the secret used to initialize the fake k8s client set.
 	missingSecretDataKeys []string
 	// If set to a non-zero value, then the UID of the owner of the secret used to initialize the fake k8s client


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Secrets created by `ServiceCertificatesRepoSecrets` are using the wrong annotations for secrets that it creates. These secrets are created by:
* CRS secured cluster registration
* secured cluster cert refresh
* local scanner cert refresh

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deployed locally with `./deploy/k8s/deploy-local.sh`

```bash
❯ kubectl -n stackrox get secrets tls-cert-sensor -o yaml
apiVersion: v1
data:
  ...
kind: Secret
metadata:
  annotations:
    owner: stackrox
  creationTimestamp: "2025-01-29T13:04:39Z"
  labels:
    app.kubernetes.io/created-by: sensor
    app.kubernetes.io/managed-by: sensor
    app.kubernetes.io/name: stackrox
  name: tls-cert-sensor
  namespace: stackrox
...
```

Before this change, the annotations were identical to the labels.
