### PR TITLE
feat(cancel-scan): Stop scan request if the context is canceled

### DIFF
--- a/pkg/contextutil/contextmerge.go
+++ b/pkg/contextutil/contextmerge.go
@@ -1,0 +1,17 @@
+package contextutil
+
+import (
+	"context"
+)
+
+// MergeContext returns a context that will be canceled if either ctx1 or ctx2 are canceled.
+// The returned stop function needs to be called after the returned ctx is canceled or
+// the function that uses it finishes, otherwise if ctx1 is the context that triggered the cancellation,
+// we will leak the AfterFunc goroutine.
+func MergeContext(ctx1, ctx2 context.Context) (ctx context.Context, stop func() bool) {
+	ctx, cancel := context.WithCancel(ctx1)
+	stop = context.AfterFunc(ctx2, func() {
+		cancel()
+	})
+	return ctx, stop
+}

--- a/pkg/contextutil/contextmerge_test.go
+++ b/pkg/contextutil/contextmerge_test.go
@@ -1,0 +1,56 @@
+package contextutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+)
+
+func TestMergeContext(t *testing.T) {
+	t.Run("text first context is canceled", func(tt *testing.T) {
+		defer goleak.VerifyNone(tt)
+		ctx1, cancel := context.WithCancel(context.Background())
+		ctx2 := context.Background()
+		ctx, stopper := MergeContext(ctx1, ctx2)
+		defer func() {
+			_ = stopper()
+		}()
+		cancel()
+		select {
+		case <-ctx.Done():
+		case <-time.After(100 * time.Millisecond):
+			tt.Error("timeout waiting for the context to be canceled")
+			tt.FailNow()
+		}
+		select {
+		case <-ctx2.Done():
+			tt.Error("the second context should not be canceled")
+			tt.FailNow()
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+	t.Run("text second context is canceled", func(tt *testing.T) {
+		defer goleak.VerifyNone(tt)
+		ctx1 := context.Background()
+		ctx2, cancel := context.WithCancel(context.Background())
+		ctx, stopper := MergeContext(ctx1, ctx2)
+		defer func() {
+			_ = stopper()
+		}()
+		cancel()
+		select {
+		case <-ctx.Done():
+		case <-time.After(100 * time.Millisecond):
+			tt.Error("timeout waiting for the context to be canceled")
+			tt.FailNow()
+		}
+		select {
+		case <-ctx1.Done():
+			tt.Error("the first context should not be canceled")
+			tt.FailNow()
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+}

--- a/pkg/contextutil/contextmerge_test.go
+++ b/pkg/contextutil/contextmerge_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMergeContext(t *testing.T) {
-	t.Run("text first context is canceled", func(tt *testing.T) {
+	t.Run("First context is canceled", func(tt *testing.T) {
 		defer goleak.VerifyNone(tt)
 		ctx1, cancel := context.WithCancel(context.Background())
 		ctx2 := context.Background()
@@ -31,15 +31,58 @@ func TestMergeContext(t *testing.T) {
 		case <-time.After(100 * time.Millisecond):
 		}
 	})
-	t.Run("text second context is canceled", func(tt *testing.T) {
+	t.Run("Second context is canceled", func(tt *testing.T) {
 		defer goleak.VerifyNone(tt)
 		ctx1 := context.Background()
 		ctx2, cancel := context.WithCancel(context.Background())
 		ctx, stopper := MergeContext(ctx1, ctx2)
 		defer func() {
+			// If ctx2 is canceled, we don't need to call this stopper, but
+			// it is still good to do it to illustrate the correct use of MergeContext
 			_ = stopper()
 		}()
 		cancel()
+		select {
+		case <-ctx.Done():
+		case <-time.After(100 * time.Millisecond):
+			tt.Error("timeout waiting for the context to be canceled")
+			tt.FailNow()
+		}
+		select {
+		case <-ctx1.Done():
+			tt.Error("the first context should not be canceled")
+			tt.FailNow()
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+	t.Run("Both contexts are canceled", func(tt *testing.T) {
+		defer goleak.VerifyNone(tt)
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		ctx, stopper := MergeContext(ctx1, ctx2)
+		defer func() {
+			// If ctx2 is canceled, we don't need to call this stopper, but
+			// it is still good to do it to illustrate the correct use of MergeContext
+			_ = stopper()
+		}()
+		cancel1()
+		cancel2()
+		select {
+		case <-ctx.Done():
+		case <-time.After(100 * time.Millisecond):
+			tt.Error("timeout waiting for the context to be canceled")
+			tt.FailNow()
+		}
+	})
+	t.Run("Second context is canceled without calling stop should not leak", func(tt *testing.T) {
+		defer goleak.VerifyNone(tt)
+		ctx1 := context.Background()
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		// For this test we do not call the stop function,
+		// and we should not have any goroutine leaks.
+		// NOTICE: This is not the correct way use the MergeContext function.
+		ctx, _ := MergeContext(ctx1, ctx2)
+		cancel2()
 		select {
 		case <-ctx.Done():
 		case <-time.After(100 * time.Millisecond):

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -586,7 +586,9 @@ func (d *detectorImpl) processIndicator() {
 			if item == nil {
 				continue
 			}
-			images := d.enricher.getImages(item.Deployment)
+			// If ROX_CAPTURE_INTERMEDIATE_EVENTS is enabled,
+			// the context will not be canceled with sensor disconnects
+			images := d.enricher.getImages(item.Ctx, item.Deployment)
 
 			// Run detection now
 			alerts := d.unifiedDetector.DetectProcess(booleanpolicy.EnhancedDeployment{
@@ -700,7 +702,9 @@ func (d *detectorImpl) processAlertsForFlowOnEntity() {
 			}
 			log.Debugf("processing network flow for deployment %s with id %s", item.Deployment.GetName(), item.Deployment.GetId())
 
-			images := d.enricher.getImages(item.Deployment)
+			// If ROX_CAPTURE_INTERMEDIATE_EVENTS is enabled,
+			// the context will not be canceled with sensor disconnects
+			images := d.enricher.getImages(item.Ctx, item.Deployment)
 			alerts := d.unifiedDetector.DetectNetworkFlowForDeployment(booleanpolicy.EnhancedDeployment{
 				Deployment:             item.Deployment,
 				Images:                 images,

--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
 )
 
 type enricherSuite struct {
@@ -367,7 +368,7 @@ func (s *enricherSuite) TestStopRunScan() {
 		// Cancel the context
 		cancel()
 		waitGroup.Wait()
-		s.Assert().Equal(types.ToImage(req.containerImage), result.image)
+		proto.Equal(types.ToImage(req.containerImage), result.image)
 	})
 	s.Run("stop due stop signal triggered", func() {
 		replySignal := concurrency.NewSignal()
@@ -392,6 +393,6 @@ func (s *enricherSuite) TestStopRunScan() {
 		// Trigger the stopSig
 		s.enricher.stopSig.Signal()
 		waitGroup.Wait()
-		s.Assert().Equal(types.ToImage(req.containerImage), result.image)
+		proto.Equal(types.ToImage(req.containerImage), result.image)
 	})
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In the kuberentes listeners' path to the detector we expire messages if the connection drops. This means the messages will not be sent to Central. In that case we can cancel the request to scan images as the results are not going to be sent regardless.

In the runtime path (process indicators and network flows) we do not cancel the context as we sent messages that arrived while Sensor was disconnected.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] New unit tests added
