### PR TITLE
ROX-27894: Add SortAggregate options for EPSS probability

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -40,6 +40,7 @@ import {
     getScoreVersionsForTopNvdCVSS,
     sortCveDistroList,
     aggregateByCVSS,
+    aggregateByEPSS,
     aggregateByCreatedTime,
     aggregateByDistinctCount,
     getSeveritySortOptions,
@@ -254,7 +255,7 @@ function WorkloadCVEOverviewTable({
                     {isEpssProbabilityColumnEnabled && (
                         <Th
                             className={getVisibilityClass('epssProbability')}
-                            sort={getSortParams('EPSS Probability')}
+                            sort={getSortParams('EPSS Probability', aggregateByEPSS)}
                         >
                             EPSS probability
                         </Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -15,6 +15,10 @@ export const aggregateByCVSS: SortAggregate = {
     aggregateFunc: 'max',
 };
 
+export const aggregateByEPSS: SortAggregate = {
+    aggregateFunc: 'max',
+};
+
 export const aggregateByDistinctCount: SortAggregate = {
     aggregateFunc: 'count',
     distinct: 'true',


### PR DESCRIPTION
### Description

### Problem

Query fails when I sort by **EPSS Probability** without `SortAggregate` options.

Only on Workload CVEs page, not on image CVEs nor deployment CVEs pages.

### Analysis and Solution

Thank you, **Charmik** for quick response that it needs same option as **CVSS**:

```ts
export const aggregateByCVSS: SortAggregate = {
    aggregateFunc: 'max',
};
```

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4617317 - 4617317
        total 38 = 11592006 - 11591968
    * `ls -al build/static/js/*.js | wc`
        files 0 = 178 - 178
3. `npm run start` in ui/apps/platform

#### Manual testing

Similar testing steps as in #13789

Even if I run UI with staging demo, which has **Scanner V4**, I need to temporarily edit code to invert conditional rendering, because `'ROX_EPSS_SCORE'` feature flag is not enabled.

Too bad, so sad, no data yet.

1. Visit **Workflow CVEs**

    POST /api/graphql?opname=getImageCVEList

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx

    Before changes, see absence of options and presence of error:
    `sortOption: {field: "EPSS Probability", reversed: true}`
    ![WorkloadCVEOverviewTable_absence](https://github.com/user-attachments/assets/d3072b84-21fe-4b3e-8ca6-9df42f2b2425)

    After changes, see presence of options and absence of error:
    `sortOption: {field: "EPSS Probability", reversed: true, aggregateBy: {aggregateFunc: "max", distinct: false}}`
    ![WorkloadCVEOverviewTable_presence](https://github.com/user-attachments/assets/f5e1c087-5cee-4596-b3c2-3c5debc1b47f)

    Click again to see `reversed: false` as a sanity check :)

2. Click a vulnerability link, and then click an image link

    POST /api/graphql?opname=getCVEsForImage

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx

    Without changes, see absence of options and absence of error:
    `sortOption: {field: "EPSS Probability", reversed: true}`
    ![ImageVulnerabilitiesTable](https://github.com/user-attachments/assets/d48ef3df-c5e3-40e2-a55a-d9f42912902b)

    Click again to see `reversed: false` as a sanity check :)

3. Go back, click **Deployments**, click a deployment link

    POST /api/graphql?opname=getCvesForDeployment

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx

    Without changes, see absence of options and absence of error:
    `sortOption: {field: "EPSS Probability", reversed: true}`
    ![DeploymentVulnerabilitiesTable](https://github.com/user-attachments/assets/b0493b6f-3c7a-4eeb-81ab-d8ea1505b9fa)

    Click again to see `reversed: false` as a sanity check :)
