### PR TITLE
ROX-27825: Replace images w/o vulns dropdown with view

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -47,6 +47,7 @@ import {
     vulnerabilitiesPlatformPath,
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesInactiveImagesPath,
+    vulnerabilitiesImagesWithoutCvesPath,
 } from 'routePaths';
 
 import PageNotFound from 'Components/PageNotFound';
@@ -238,6 +239,10 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
     'vulnerabilities/inactive-images': {
         component: makeVulnMgmtUserWorkloadView('inactive-images'),
         path: vulnerabilitiesInactiveImagesPath,
+    },
+    'vulnerabilities/images-without-cves': {
+        component: makeVulnMgmtUserWorkloadView('images-without-cves'),
+        path: vulnerabilitiesImagesWithoutCvesPath,
     },
     'vulnerabilities/reports': {
         component: asyncComponent(

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -18,6 +18,7 @@ import {
     vulnerabilitiesPlatformPath,
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesInactiveImagesPath,
+    vulnerabilitiesImagesWithoutCvesPath,
 } from 'routePaths';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -77,6 +78,14 @@ function getSubnavDescriptionGroups(
                                   'View findings for images not currently deployed as workloads',
                               path: vulnerabilitiesInactiveImagesPath,
                               routeKey: 'vulnerabilities/inactive-images',
+                          },
+                          {
+                              type: 'link',
+                              content: 'Images without CVEs',
+                              description:
+                                  'Images and workloads without observed CVEs (results might include false negatives due to scanner limitations, such as unsupported operating systems)',
+                              path: vulnerabilitiesImagesWithoutCvesPath,
+                              routeKey: 'vulnerabilities/images-without-cves',
                           },
                       ],
                   },

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -35,6 +35,7 @@ import {
     violationsBasePath,
     vulnManagementPath,
     vulnerabilitiesAllImagesPath,
+    vulnerabilitiesImagesWithoutCvesPath,
     vulnerabilitiesInactiveImagesPath,
     vulnerabilitiesNodeCvesPath,
     vulnerabilitiesPlatformCvesPath,
@@ -77,6 +78,7 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                               vulnerabilitiesPlatformPath,
                               vulnerabilitiesAllImagesPath,
                               vulnerabilitiesInactiveImagesPath,
+                              vulnerabilitiesImagesWithoutCvesPath,
                               vulnerabilitiesViewPath,
                           ])
                       ),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ObservedCveModeSelect.tsx
@@ -10,6 +10,8 @@ import {
 } from '@patternfly/react-core';
 import { SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
+
 import { ObservedCveMode, isObservedCveMode, observedCveModeValues } from '../../types';
 import { getViewStateDescription, getViewStateTitle } from './string.utils';
 
@@ -24,6 +26,11 @@ function ObservedCveModeSelect({
     observedCveMode,
     setObservedCveMode,
 }: ObservedCveModeSelectProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    if (isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')) {
+        // Delete this component when the above feature flag is removed
+    }
+
     const [isCveModeSelectOpen, setIsCveModeSelectOpen] = useState(false);
 
     const isViewingWithCves = observedCveMode === 'WITH_CVES';
@@ -67,15 +74,15 @@ function ObservedCveModeSelect({
             <SelectList style={{ width }}>
                 <SelectOption
                     value={observedCveModeValues[0]}
-                    description={getViewStateDescription('OBSERVED', 'WITH_CVES')}
+                    description={getViewStateDescription('OBSERVED', true)}
                 >
-                    {getViewStateTitle('OBSERVED', 'WITH_CVES')}
+                    {getViewStateTitle('OBSERVED', true)}
                 </SelectOption>
                 <SelectOption
                     value={observedCveModeValues[1]}
-                    description={getViewStateDescription('OBSERVED', 'WITHOUT_CVES')}
+                    description={getViewStateDescription('OBSERVED', false)}
                 >
-                    {getViewStateTitle('OBSERVED', 'WITHOUT_CVES')}
+                    {getViewStateTitle('OBSERVED', false)}
                 </SelectOption>
             </SelectList>
         </Select>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/string.utils.ts
@@ -1,16 +1,13 @@
-import { ObservedCveMode } from 'Containers/Vulnerabilities/types';
 import { VulnerabilityState } from 'types/cve.proto';
 import { ensureExhaustive } from 'utils/type.utils';
 
 export function getViewStateTitle(
     vulnerabilityState: VulnerabilityState,
-    cveViewingMode: ObservedCveMode
+    isViewingWithCves: boolean
 ): string {
     switch (vulnerabilityState) {
         case 'OBSERVED':
-            return cveViewingMode === 'WITH_CVES'
-                ? 'Image vulnerabilities'
-                : 'Images without vulnerabilities';
+            return isViewingWithCves ? 'Image vulnerabilities' : 'Images without vulnerabilities';
         case 'DEFERRED':
             return 'Deferred vulnerabilities';
         case 'FALSE_POSITIVE':
@@ -22,11 +19,11 @@ export function getViewStateTitle(
 
 export function getViewStateDescription(
     vulnerabilityState: VulnerabilityState,
-    cveViewingMode: ObservedCveMode
+    isViewingWithCves: boolean
 ): string {
     switch (vulnerabilityState) {
         case 'OBSERVED':
-            return cveViewingMode === 'WITH_CVES'
+            return isViewingWithCves
                 ? 'Images and deployments with observed CVEs'
                 : 'Images and deployments without observed CVEs (results might include false negatives due to scanner limitations, such as unsupported operating systems)';
         case 'DEFERRED':

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -7,6 +7,7 @@ import PageTitle from 'Components/PageTitle';
 
 import {
     vulnerabilitiesAllImagesPath,
+    vulnerabilitiesImagesWithoutCvesPath,
     vulnerabilitiesInactiveImagesPath,
     vulnerabilitiesPlatformPath,
     vulnerabilitiesUserWorkloadsPath,
@@ -29,6 +30,7 @@ export const userWorkloadViewId = 'user-workloads';
 export const platformViewId = 'platform';
 export const allImagesViewId = 'all-images';
 export const inactiveImagesViewId = 'inactive-images';
+export const imagesWithoutCvesViewId = 'images-without-cves';
 
 function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsFeatureFlagEnabled) {
     let pageTitle: string = '';
@@ -63,6 +65,12 @@ function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsF
             pageTitle = 'Inactive images only';
             baseSearchFilter = { 'Platform Component': ['-'] };
             getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesInactiveImagesPath}/${subPath}`;
+            break;
+        case imagesWithoutCvesViewId:
+            pageTitle = 'Images without CVEs';
+            baseSearchFilter = { 'Image CVE Count': ['0'] };
+            getAbsoluteUrl = (subPath: string) =>
+                `${vulnerabilitiesImagesWithoutCvesPath}/${subPath}`;
             break;
         default:
         // TODO Handle user-defined views, or error

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -78,6 +78,7 @@ export const vulnerabilitiesNodeCvesPath = `${vulnerabilitiesBasePath}/node-cves
 // System defined "views"
 export const vulnerabilitiesAllImagesPath = `${vulnerabilitiesBasePath}/all-images`;
 export const vulnerabilitiesInactiveImagesPath = `${vulnerabilitiesBasePath}/inactive-images`;
+export const vulnerabilitiesImagesWithoutCvesPath = `${vulnerabilitiesBasePath}/images-without-cves`;
 // user-workload template views path
 export const vulnerabilitiesViewPath = `${vulnerabilitiesBasePath}/results/:viewTemplate/:viewId`;
 
@@ -170,6 +171,7 @@ export type RouteKey =
     | 'vulnerabilities/platform'
     | 'vulnerabilities/all-images'
     | 'vulnerabilities/inactive-images'
+    | 'vulnerabilities/images-without-cves'
     | 'vulnerabilities/platform-cves'
     | 'vulnerabilities/workload-cves'
     | 'vulnerability-management'
@@ -337,6 +339,10 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),
     },
     'vulnerabilities/inactive-images': {
+        featureFlagRequirements: allEnabled(['ROX_PLATFORM_CVE_SPLIT']),
+        resourceAccessRequirements: everyResource(['Deployment', 'Image']),
+    },
+    'vulnerabilities/images-without-cves': {
         featureFlagRequirements: allEnabled(['ROX_PLATFORM_CVE_SPLIT']),
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),
     },


### PR DESCRIPTION
### Description

Moves the existing dropdown functionality of "Images with vulns" and "Images without vulns" into a top level navigation view.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

With feature flag disabled, the dropdown is present and works as expected:
![image](https://github.com/user-attachments/assets/aa11404c-9185-415b-9f41-7cb5402589f1)
![image](https://github.com/user-attachments/assets/d51a044a-ea40-4e6a-ba03-974f2ede06fe)

With the feature flag enabled, the default views all show the "with CVEs" representation:
![image](https://github.com/user-attachments/assets/e6e43d94-4d71-41cf-8b14-e02f4500e87f)
![image](https://github.com/user-attachments/assets/b1db40ff-1c1c-4a3d-ae9d-172d7efdfa8e)

Clicking the "Images w/o CVEs" link in the navigation shows only images and deployments without detected CVEs:
![image](https://github.com/user-attachments/assets/23c1107f-cb09-4163-a246-992b6cc9b1ed)
![image](https://github.com/user-attachments/assets/b7618315-6b8d-4d1f-ac97-7dbe24fd4c7d)

