### PR TITLE
chore(CODEOWNERS): update Scanner team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,20 +46,29 @@ operator/**/* @stackrox/install
 
 # Scanner team's responsibilities include anything related to the scanner itself and scanning utilities
 # such as vulnerability uploading and image integrations.
-/.github/workflows/scanner*                           @stackrox/scanner
-/.github/workflows/update_scanner_periodic.yaml       @stackrox/scanner
-/central/scannerdefinitions/                          @stackrox/scanner
-/central/sensor/service/pipeline/imageintegrations/   @stackrox/scanner
-/pkg/images/enricher/                                 @stackrox/scanner
-/pkg/nodes/                                           @stackrox/scanner
-/pkg/registries/                                      @stackrox/scanner
-/pkg/scanners/                                        @stackrox/scanner
-/pkg/scans/                                           @stackrox/scanner
-/scanner/                                             @stackrox/scanner
-/sensor/common/scannerdefinitions/                    @stackrox/scanner
-/sensor/kubernetes/listener/resources/secrets.go      @stackrox/scanner
-/sensor/kubernetes/listener/resources/secrets_test.go @stackrox/scanner
-/SCANNER_VERSION                                      @stackrox/scanner
+/.github/workflows/scanner*                               @stackrox/scanner
+/.github/workflows/update_scanner_periodic.yaml           @stackrox/scanner
+/central/image/service/                                   @stackrox/scanner
+/central/imageintegration/service/                        @stackrox/scanner
+/central/imageintegration/store/defaults.go               @stackrox/scanner
+/central/scannerdefinitions/                              @stackrox/scanner
+/central/sensor/service/pipeline/imageintegrations/       @stackrox/scanner
+/pkg/images/enricher/                                     @stackrox/scanner
+/pkg/nodes/                                               @stackrox/scanner
+/pkg/registries/                                          @stackrox/scanner
+/pkg/registrymirror/                                      @stackrox/scanner
+/pkg/scanners/                                            @stackrox/scanner
+/pkg/scannerv4/                                           @stackrox/scanner
+/pkg/scans/                                               @stackrox/scanner
+/proto/internalapi/scanner/                               @stackrox/scanner
+/scanner/                                                 @stackrox/scanner
+/sensor/common/registry/                                  @stackrox/scanner
+/sensor/common/scan/                                      @stackrox/scanner
+/sensor/common/scannerclient/                             @stackrox/scanner
+/sensor/common/scannerdefinitions/                        @stackrox/scanner
+/sensor/kubernetes/listener/resources/registrymirrorsets* @stackrox/scanner
+/sensor/kubernetes/listener/resources/secrets*            @stackrox/scanner
+/SCANNER_VERSION                                          @stackrox/scanner
 
 # The RHTAP maintainers for ACS review all changes related to the RHTAP pipelines, such as new pipelines,
 # parameter changes or automated task updates.


### PR DESCRIPTION
### Description

This hasn't been updated in a while and now seemed like a good time to do so. The main purpose is to ensure the team is aware of any (attempted) changes related to any part of the codebase which we own.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

I didn't