### PR TITLE
fix(ci): due to diff CDN behavior

### DIFF
--- a/central/scannerdefinitions/handler/updater_test.go
+++ b/central/scannerdefinitions/handler/updater_test.go
@@ -39,7 +39,7 @@ func TestUpdate(t *testing.T) {
 	require.NoError(t, u.doUpdate())
 	assertOnFileExistence(t, filePath, true)
 
-	lastUpdatedTime := time.Now().Add(time.Hour)
+	lastUpdatedTime := time.Now()
 	mustSetModTime(t, filePath, lastUpdatedTime)
 	// Should not fetch since it can't be updated in a time in the future.
 	require.NoError(t, u.doUpdate())

--- a/image/rhel/fetch-stackrox-data.sh
+++ b/image/rhel/fetch-stackrox-data.sh
@@ -15,7 +15,7 @@ fetch_stackrox_data() {
     local download_dir
     download_dir="$(mktemp -d --tmpdir external-networks.XXXXXXXXXX)"
     local latest_prefix
-    latest_prefix="$(curl --fail https://definitions.stackrox.io/external-networks/latest_prefix)"
+    latest_prefix="$(curl --fail https://definitions.stackrox.io/external-networks/latest_prefix | sed 's/ /%20/g')"
     curl --fail --output "${download_dir}/checksum" "https://definitions.stackrox.io/${latest_prefix}/checksum"
     test -s "${download_dir}/checksum"
 


### PR DESCRIPTION
### Description

Two separate issues addressed in this PR:

1. A space in the external-networks filename was breaking image builds (must have been OK with the prev CDN) ([ex](https://github.com/stackrox/stackrox/actions/runs/13062430374/job/36448796656))
2. The new CDN doesn't like 'future dates' in the `If-Modified-Since` header which was breaking the scanner definitions tests ([ex](https://github.com/stackrox/stackrox/actions/runs/13062430376/job/36448267008))

**Space in filename breakage**

```
$ curl --fail https://definitions.stackrox.io/external-networks/latest_prefix
external-networks/2025-01-30 10-38-49__645bb476-def6-11ef-9e85-7c1e520c377e

$ latest_prefix="$(curl --fail https://definitions.stackrox.io/external-networks/latest_prefix)"

$ curl --fail "https://definitions.stackrox.io/${latest_prefix}/checksum"
curl: (22) The requested URL returned error: 400 Bad Request

## encode empty space
$ latest_prefix="$(curl --fail https://definitions.stackrox.io/external-networks/latest_prefix | sed 's/ /%20/g')"

## now works
$ curl --fail "https://definitions.stackrox.io/${latest_prefix}/checksum"
b6c5f805dd375e531acb07eed780cc127ecce11b9558d03d556e2d3b021716a8
```

**`If-Modiifed-Since` example breakage:**
 
Test was failing because it was downloading a new file when it was expecting a `304` from the CDN to indicate the file had not been modified. The new CDN appears to not like `If-Modified-Since` dates in the future:

```
$ date
Fri Jan 31 01:53:29 UTC 2025

$ curl -i "https://definitions.stackrox.io/e799c68a-671f-44db-9682-f24248cd0ffe/diff.zip" -H "If-Modified-Since: Fri, 31 Jan 2025 01:52:00 GMT"
HTTP/1.1 304 Not Modified

$ curl -i "https://definitions.stackrox.io/e799c68a-671f-44db-9682-f24248cd0ffe/diff.zip" -H "If-Modified-Since: Fri, 31 Jan 2025 01:53:00 GMT"
HTTP/1.1 304 Not Modified

$ curl -i "https://definitions.stackrox.io/e799c68a-671f-44db-9682-f24248cd0ffe/diff.zip" -H "If-Modified-Since: Fri, 31 Jan 2025 01:54:00 GMT"
HTTP/1.1 200 OK
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI
