### PR TITLE
ROX-27902: telemetry campaign headers problem

### DIFF
--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -83,10 +83,10 @@ func addDefaultProps(rp *phonehome.RequestParams, props map[string]any) bool {
 // User-Agent containing the substrings specified in the trackedUserAgents, and
 // have no match in the ignoredPaths list.
 func apiCall(rp *phonehome.RequestParams, props map[string]any) bool {
-	return !ignoredPaths.Match(rp.Path) && telemetryCampaign.ForEachFulfilled(rp,
+	return !ignoredPaths.Match(rp.Path) && telemetryCampaign.CountFulfilled(rp,
 		func(cc *phonehome.APICallCampaignCriterion) {
 			addCustomHeaders(rp, cc, props)
-		})
+		}) > 0
 }
 
 // addCustomHeaders adds additional properties to the event if the telemetry

--- a/pkg/telemetry/phonehome/campaign.go
+++ b/pkg/telemetry/phonehome/campaign.go
@@ -58,8 +58,15 @@ func (c APICallCampaign) Compile() error {
 	return nil
 }
 
-func (c APICallCampaign) IsFulfilled(rp *RequestParams) bool {
-	return slices.ContainsFunc(c, func(cc *APICallCampaignCriterion) bool {
-		return cc.isFulfilled(rp)
-	})
+// ForEachFulfilled calls f on each fulfilled criterion and returns true if
+// any of the compaign critera is fulfilled.
+func (c APICallCampaign) ForEachFulfilled(rp *RequestParams, f func(cc *APICallCampaignCriterion)) bool {
+	fulfilled := false
+	for _, cc := range c {
+		if cc.isFulfilled(rp) {
+			f(cc)
+			fulfilled = true
+		}
+	}
+	return fulfilled
 }

--- a/pkg/telemetry/phonehome/campaign.go
+++ b/pkg/telemetry/phonehome/campaign.go
@@ -58,14 +58,13 @@ func (c APICallCampaign) Compile() error {
 	return nil
 }
 
-// ForEachFulfilled calls f on each fulfilled criterion and returns true if
-// any of the compaign critera is fulfilled.
-func (c APICallCampaign) ForEachFulfilled(rp *RequestParams, f func(cc *APICallCampaignCriterion)) bool {
-	fulfilled := false
+// CountFulfilled calls f on each fulfilled criterion and returns their number.
+func (c APICallCampaign) CountFulfilled(rp *RequestParams, f func(cc *APICallCampaignCriterion)) int {
+	fulfilled := 0
 	for _, cc := range c {
 		if cc.isFulfilled(rp) {
 			f(cc)
-			fulfilled = true
+			fulfilled++
 		}
 	}
 	return fulfilled

--- a/pkg/telemetry/phonehome/campaign_test.go
+++ b/pkg/telemetry/phonehome/campaign_test.go
@@ -18,6 +18,7 @@ func withUserAgent(_ *testing.T, headers map[string][]string, ua string) func(st
 }
 
 func TestCampaignFulfilled(t *testing.T) {
+	doNothing := func(_ *APICallCampaignCriterion) {}
 	t.Run("Empty campaign", func(t *testing.T) {
 		campaign := APICallCampaign{}
 		rp := &RequestParams{
@@ -26,7 +27,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			Path:    "/some/test/path",
 			Code:    202,
 		}
-		assert.False(t, campaign.ForEachFulfilled(rp))
+		assert.False(t, campaign.ForEachFulfilled(rp, doNothing))
 	})
 	t.Run("Empty criterion", func(t *testing.T) {
 		campaign := APICallCampaign{
@@ -38,7 +39,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			Path:    "/some/test/path",
 			Code:    202,
 		}
-		assert.True(t, campaign.ForEachFulfilled(rp))
+		assert.True(t, campaign.ForEachFulfilled(rp, doNothing))
 	})
 	t.Run("Nil criterion", func(t *testing.T) {
 		campaign := APICallCampaign{
@@ -50,7 +51,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			Path:    "/some/test/path",
 			Code:    202,
 		}
-		assert.False(t, campaign.ForEachFulfilled(rp))
+		assert.False(t, campaign.ForEachFulfilled(rp, doNothing))
 	})
 
 	t.Run("Single criterion", func(t *testing.T) {
@@ -114,7 +115,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			for name, campaign := range campaigns {
 				t.Run(name, func(t *testing.T) {
 					require.NoError(t, campaign.Compile())
-					assert.True(t, campaign.ForEachFulfilled(rp))
+					assert.True(t, campaign.ForEachFulfilled(rp, doNothing))
 				})
 			}
 		})
@@ -128,7 +129,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			}
 			for name, campaign := range campaigns {
 				t.Run(name, func(t *testing.T) {
-					assert.False(t, campaign.ForEachFulfilled(rp))
+					assert.False(t, campaign.ForEachFulfilled(rp, doNothing))
 				})
 			}
 		})
@@ -204,7 +205,7 @@ func TestCampaignFulfilled(t *testing.T) {
 				},
 			}
 			for _, rp := range rps {
-				assert.True(t, campaign.ForEachFulfilled(&rp), rp.Headers(userAgentHeaderKey))
+				assert.True(t, campaign.ForEachFulfilled(&rp, doNothing), rp.Headers(userAgentHeaderKey))
 			}
 		})
 
@@ -244,7 +245,7 @@ func TestCampaignFulfilled(t *testing.T) {
 				},
 			}
 			for _, rp := range rps {
-				assert.False(t, campaign.ForEachFulfilled(&rp), rp.Headers(userAgentHeaderKey))
+				assert.False(t, campaign.ForEachFulfilled(&rp, doNothing), rp.Headers(userAgentHeaderKey))
 			}
 		})
 	})

--- a/pkg/telemetry/phonehome/campaign_test.go
+++ b/pkg/telemetry/phonehome/campaign_test.go
@@ -26,7 +26,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			Path:    "/some/test/path",
 			Code:    202,
 		}
-		assert.False(t, campaign.IsFulfilled(rp))
+		assert.False(t, campaign.ForEachFulfilled(rp))
 	})
 	t.Run("Empty criterion", func(t *testing.T) {
 		campaign := APICallCampaign{
@@ -38,7 +38,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			Path:    "/some/test/path",
 			Code:    202,
 		}
-		assert.True(t, campaign.IsFulfilled(rp))
+		assert.True(t, campaign.ForEachFulfilled(rp))
 	})
 	t.Run("Nil criterion", func(t *testing.T) {
 		campaign := APICallCampaign{
@@ -50,7 +50,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			Path:    "/some/test/path",
 			Code:    202,
 		}
-		assert.False(t, campaign.IsFulfilled(rp))
+		assert.False(t, campaign.ForEachFulfilled(rp))
 	})
 
 	t.Run("Single criterion", func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			for name, campaign := range campaigns {
 				t.Run(name, func(t *testing.T) {
 					require.NoError(t, campaign.Compile())
-					assert.True(t, campaign.IsFulfilled(rp))
+					assert.True(t, campaign.ForEachFulfilled(rp))
 				})
 			}
 		})
@@ -128,7 +128,7 @@ func TestCampaignFulfilled(t *testing.T) {
 			}
 			for name, campaign := range campaigns {
 				t.Run(name, func(t *testing.T) {
-					assert.False(t, campaign.IsFulfilled(rp))
+					assert.False(t, campaign.ForEachFulfilled(rp))
 				})
 			}
 		})
@@ -204,7 +204,7 @@ func TestCampaignFulfilled(t *testing.T) {
 				},
 			}
 			for _, rp := range rps {
-				assert.True(t, campaign.IsFulfilled(&rp), rp.Headers(userAgentHeaderKey))
+				assert.True(t, campaign.ForEachFulfilled(&rp), rp.Headers(userAgentHeaderKey))
 			}
 		})
 
@@ -244,7 +244,7 @@ func TestCampaignFulfilled(t *testing.T) {
 				},
 			}
 			for _, rp := range rps {
-				assert.False(t, campaign.IsFulfilled(&rp), rp.Headers(userAgentHeaderKey))
+				assert.False(t, campaign.ForEachFulfilled(&rp), rp.Headers(userAgentHeaderKey))
 			}
 		})
 	})


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When specifying a criterion for telemetry API Call interception, the resulting event is filled with properties from headers mentioned in all other criteria.

The backend tracks a request if it fulfills at least one campaign criterion, and it stops evaluating once the first matching criterion is found. In the case where a request fulfills multiple criterion, it should have added matching headers from all fulfilled criteria, but instead it adds headers from all.

The backend has to evaluate every criterion in the campaign and add headers only from matching criteria.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests.
