### PR TITLE
ROX-27828: Replace Violations dropdown with nav

### DIFF
--- a/ui/apps/platform/src/Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState.ts
+++ b/ui/apps/platform/src/Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState.ts
@@ -6,10 +6,13 @@ export type FilteredWorkflowViewURLStateResult = {
     setFilteredWorkflowView: (value: FilteredWorkflowView) => void;
 };
 
-function useFilteredWorkflowViewURLState(): FilteredWorkflowViewURLStateResult {
+function useFilteredWorkflowViewURLState(
+    defaultView?: FilteredWorkflowView
+): FilteredWorkflowViewURLStateResult {
     const [filteredWorkflowView, setFilteredWorkflowView] = useURLStringUnion(
         'filteredWorkflowView',
-        filteredWorkflowViews
+        filteredWorkflowViews,
+        defaultView
     );
 
     return {

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -19,7 +19,9 @@ import {
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesInactiveImagesPath,
     vulnerabilitiesImagesWithoutCvesPath,
-    violationsBasePath,
+    violationsFullViewPath,
+    violationsPlatformViewPath,
+    violationsUserWorkloadsViewPath,
 } from 'routePaths';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -44,7 +46,7 @@ function getSubnavDescriptionGroups(
                   {
                       type: 'link',
                       content: 'User Workloads',
-                      path: `${violationsBasePath}?filteredWorkflowView=Applications view`,
+                      path: violationsUserWorkloadsViewPath,
                       isActive: (location) =>
                           location.search.includes(`filteredWorkflowView=Applications view`),
                       routeKey: 'violations',
@@ -52,7 +54,7 @@ function getSubnavDescriptionGroups(
                   {
                       type: 'link',
                       content: 'Platform',
-                      path: `${violationsBasePath}?filteredWorkflowView=Platform view`,
+                      path: violationsPlatformViewPath,
                       isActive: (location) =>
                           location.search.includes(`filteredWorkflowView=Platform view`),
                       routeKey: 'violations',
@@ -60,7 +62,7 @@ function getSubnavDescriptionGroups(
                   {
                       type: 'link',
                       content: 'All Violations',
-                      path: `${violationsBasePath}?filteredWorkflowView=Full view`,
+                      path: violationsFullViewPath,
                       isActive: (location) =>
                           location.search.includes(`filteredWorkflowView=Full view`),
                       routeKey: 'violations',

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -19,6 +19,7 @@ import {
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesInactiveImagesPath,
     vulnerabilitiesImagesWithoutCvesPath,
+    violationsBasePath,
 } from 'routePaths';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -28,7 +29,7 @@ import { filterNavDescriptions, isActiveLink, NavDescription } from './utils';
 
 import './HorizontalSubnav.css';
 
-type SubnavParentKey = 'vulnerabilities';
+type SubnavParentKey = 'violations' | 'vulnerabilities';
 
 /*
  * Function that returns a key/value object that maps parent routes to a list
@@ -38,6 +39,34 @@ function getSubnavDescriptionGroups(
     isFeatureFlagEnabled: IsFeatureFlagEnabled
 ): Record<SubnavParentKey, NavDescription[]> {
     return {
+        violations: isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
+            ? [
+                  {
+                      type: 'link',
+                      content: 'User Workloads',
+                      path: `${violationsBasePath}?filteredWorkflowView=Applications view`,
+                      isActive: (location) =>
+                          location.search.includes(`filteredWorkflowView=Applications view`),
+                      routeKey: 'violations',
+                  },
+                  {
+                      type: 'link',
+                      content: 'Platform',
+                      path: `${violationsBasePath}?filteredWorkflowView=Platform view`,
+                      isActive: (location) =>
+                          location.search.includes(`filteredWorkflowView=Platform view`),
+                      routeKey: 'violations',
+                  },
+                  {
+                      type: 'link',
+                      content: 'All Violations',
+                      path: `${violationsBasePath}?filteredWorkflowView=Full view`,
+                      isActive: (location) =>
+                          location.search.includes(`filteredWorkflowView=Full view`),
+                      routeKey: 'violations',
+                  },
+              ]
+            : [],
         vulnerabilities: isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
             ? [
                   {
@@ -94,6 +123,21 @@ function getSubnavDescriptionGroups(
     };
 }
 
+// Since some subnav links may contain URL parameters, we need to strip these
+// parameters off when determining whether or not to show a set of navigation items at the top.
+// This is because react-router's `matchPath` does a strict comparison that wil always fail when
+// our link's URL includes search parameters.
+function matchBasePath({
+    pathname,
+    descriptionPath,
+}: {
+    pathname: string;
+    descriptionPath: string;
+}): boolean {
+    const basePath = descriptionPath.split('?')[0] ?? '';
+    return Boolean(matchPath(pathname, basePath));
+}
+
 /*
  * Given the mapping of parent routes to subnav description groups, return the grouping
  * that contains a child item with a path matching the user's current path
@@ -106,11 +150,13 @@ function getSubnavGroupForCurrentPath(
         Object.values(subnavDescriptionGroups).find((subnavDescriptionGroup) => {
             return subnavDescriptionGroup.some((group) => {
                 if (group.type === 'link') {
-                    return matchPath(pathname, group.path);
+                    return matchBasePath({ pathname, descriptionPath: group.path });
                 }
                 return group.children
                     .filter((child) => child.type === 'link')
-                    .some(({ path }) => matchPath(pathname, path));
+                    .some(({ path }) => {
+                        return matchBasePath({ pathname, descriptionPath: path });
+                    });
             });
         }) ?? []
     );
@@ -123,13 +169,13 @@ export type HorizontalSubnavProps = {
 
 function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSubnavProps) {
     const history = useHistory();
-    const { pathname } = useLocation();
+    const location = useLocation();
     const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
 
     const subnavDescriptionGroups = getSubnavDescriptionGroups(isFeatureFlagEnabled);
     const subnavDescriptionGroupForCurrentPath = getSubnavGroupForCurrentPath(
         subnavDescriptionGroups,
-        pathname
+        location.pathname
     );
     const subnavDescriptions = filterNavDescriptions(
         subnavDescriptionGroupForCurrentPath,
@@ -164,7 +210,7 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                             return (
                                 <NavigationItem
                                     key={path}
-                                    isActive={isActiveLink(pathname, subnavDescription)}
+                                    isActive={isActiveLink(location, subnavDescription)}
                                     path={path}
                                     content={
                                         typeof content === 'function'
@@ -190,7 +236,7 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                                             isActive={subnavDescription.children.some(
                                                 (child) =>
                                                     child.type === 'link' &&
-                                                    isActiveLink(pathname, child)
+                                                    isActiveLink(location, child)
                                             )}
                                             onClick={() => onToggleClick(key)}
                                         >
@@ -222,7 +268,7 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                                                 <DropdownItem
                                                     component={'a'}
                                                     className={
-                                                        isActiveLink(pathname, child)
+                                                        isActiveLink(location, child)
                                                             ? 'acs-pf-horizontal-subnav-menu__active'
                                                             : ''
                                                     }

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationItem.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationItem.tsx
@@ -11,7 +11,7 @@ export type NavigationItemProps = {
 function NavigationItem({ isActive, path, content }: NavigationItemProps): ReactElement {
     return (
         <NavItem isActive={isActive}>
-            <NavLink exact to={path} activeClassName="pf-m-current">
+            <NavLink exact to={path} className={isActive ? 'pf-m-current' : ''}>
                 {content}
             </NavLink>
         </NavItem>

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -69,9 +69,9 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                   content: 'Results',
                   path: vulnerabilitiesUserWorkloadsPath,
                   routeKey: 'vulnerabilities/user-workloads',
-                  isActive: (pathname) =>
+                  isActive: (location) =>
                       Boolean(
-                          matchPath(pathname, [
+                          matchPath(location.pathname, [
                               vulnerabilitiesWorkloadCvesPath,
                               vulnerabilitiesNodeCvesPath,
                               vulnerabilitiesUserWorkloadsPath,
@@ -115,8 +115,8 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                   content: <NavigationContent variant="Deprecated">Dashboard</NavigationContent>,
                   path: vulnManagementPath,
                   routeKey: 'vulnerability-management',
-                  isActive: (pathname) =>
-                      Boolean(matchPath(pathname, { vulnManagementPath, exact: true })),
+                  isActive: (location) =>
+                      Boolean(matchPath(location.pathname, { vulnManagementPath, exact: true })),
               },
           ]
         : [
@@ -163,8 +163,8 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                   content: <NavigationContent variant="Deprecated">Dashboard</NavigationContent>,
                   path: vulnManagementPath,
                   routeKey: 'vulnerability-management',
-                  isActive: (pathname) =>
-                      Boolean(matchPath(pathname, { vulnManagementPath, exact: true })),
+                  isActive: (location) =>
+                      Boolean(matchPath(location.pathname, { vulnManagementPath, exact: true })),
               },
           ];
 
@@ -226,9 +226,9 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                     content: 'Dashboard',
                     path: complianceBasePath,
                     routeKey: 'compliance',
-                    isActive: (pathname) =>
-                        Boolean(matchPath(pathname, complianceBasePath)) &&
-                        !matchPath(pathname, [
+                    isActive: (location) =>
+                        Boolean(matchPath(location.pathname, complianceBasePath)) &&
+                        !matchPath(location.pathname, [
                             complianceEnhancedCoveragePath,
                             complianceEnhancedSchedulesPath,
                         ]),
@@ -326,7 +326,7 @@ function NavigationSidebar({
     hasReadAccess,
     isFeatureFlagEnabled,
 }: NavigationSidebarProps): ReactElement {
-    const { pathname } = useLocation();
+    const location = useLocation();
     const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
 
     const navDescriptionsFiltered = filterNavDescriptions(
@@ -348,8 +348,8 @@ function NavigationSidebar({
                             const hasChildMatchPath = children.some(
                                 (childDescription) =>
                                     childDescription.type === 'link' &&
-                                    (Boolean(matchPath(pathname, childDescription.path)) ||
-                                        isActiveLink(pathname, childDescription))
+                                    (Boolean(matchPath(location.pathname, childDescription.path)) ||
+                                        isActiveLink(location, childDescription))
                             );
                             return (
                                 <NavExpandable
@@ -369,7 +369,7 @@ function NavigationSidebar({
                                                 <NavigationItem
                                                     key={path}
                                                     isActive={isActiveLink(
-                                                        pathname,
+                                                        location,
                                                         childDescription
                                                     )}
                                                     path={path}
@@ -396,7 +396,7 @@ function NavigationSidebar({
                             return (
                                 <NavigationItem
                                     key={path}
-                                    isActive={isActiveLink(pathname, navDescription)}
+                                    isActive={isActiveLink(location, navDescription)}
                                     path={path}
                                     content={
                                         typeof content === 'function'

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
@@ -9,7 +9,7 @@ import { HasReadAccess } from 'hooks/usePermissions';
 // Parent example: Vulnerability Management (1.0) if Vulnerability Management (2.0) is rendered and so on.
 type TitleCallback = (navDescriptionFiltered: NavDescription[]) => string | ReactElement;
 
-type IsActiveCallback = (pathname: string) => boolean;
+type IsActiveCallback = (location: Location) => boolean;
 
 export type LinkDescription = {
     type: 'link';
@@ -21,8 +21,10 @@ export type LinkDescription = {
 };
 
 // Encapsulate whether path match for child is specific or generic.
-export function isActiveLink(pathname: string, { isActive, path }: LinkDescription) {
-    return typeof isActive === 'function' ? isActive(pathname) : Boolean(matchPath(pathname, path));
+export function isActiveLink(location: Location, { isActive, path }: LinkDescription) {
+    return typeof isActive === 'function'
+        ? isActive(location)
+        : Boolean(matchPath(location.pathname, path));
 }
 
 export type SeparatorDescription = {

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -23,6 +23,7 @@ import { Alert, isDeploymentAlert, isResourceAlert } from 'types/alert.proto';
 import { getDateTime } from 'utils/dateUtils';
 import { VIOLATION_STATE_LABELS } from 'constants/violationStates';
 
+import useFilteredWorkflowViewURLState from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
 import DeploymentTabWithReadAccessForDeployment from './Deployment/DeploymentTabWithReadAccessForDeployment';
 import DeploymentTabWithoutReadAccessForDeployment from './Deployment/DeploymentTabWithoutReadAccessForDeployment';
 import NetworkPolicies from './NetworkPolicies/NetworkPoliciesTab';
@@ -43,6 +44,8 @@ function ViolationDetailsPage(): ReactElement {
     const [isFetchingSelectedAlert, setIsFetchingSelectedAlert] = useState(false);
 
     const { alertId } = useParams();
+
+    const { filteredWorkflowView } = useFilteredWorkflowViewURLState('Full view');
 
     function handleTabClick(_, tabIndex) {
         setActiveTabKey(tabIndex);
@@ -89,7 +92,7 @@ function ViolationDetailsPage(): ReactElement {
 
     return (
         <>
-            <ViolationsBreadcrumbs current={title} />
+            <ViolationsBreadcrumbs current={title} filteredWorkflowView={filteredWorkflowView} />
             <PageSection variant="light">
                 <Title headingLevel="h1">{title}</Title>
                 <Title

--- a/ui/apps/platform/src/Containers/Violations/ViolationsBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsBreadcrumbs.tsx
@@ -1,17 +1,52 @@
-import { Breadcrumb, BreadcrumbItem, Divider, PageSection } from '@patternfly/react-core';
-import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import React, { ReactElement } from 'react';
+import { Breadcrumb, BreadcrumbItem, Divider, PageSection } from '@patternfly/react-core';
 
-import { violationsBasePath } from 'routePaths';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
+
+import {
+    violationsFullViewPath,
+    violationsPlatformViewPath,
+    violationsUserWorkloadsViewPath,
+} from 'routePaths';
+import { ensureExhaustive } from 'utils/type.utils';
+
+function getTopLevelBreadcrumb(filteredWorkflowView: FilteredWorkflowView) {
+    switch (filteredWorkflowView) {
+        case 'Applications view':
+            return {
+                title: 'User workload violations',
+                url: violationsUserWorkloadsViewPath,
+            };
+        case 'Platform view':
+            return {
+                title: 'Platform violations',
+                url: violationsPlatformViewPath,
+            };
+        case 'Full view':
+            return {
+                title: 'All violations',
+                url: violationsFullViewPath,
+            };
+        default:
+            return ensureExhaustive(filteredWorkflowView);
+    }
+}
 
 type ViolationsBreadcrumbsProps = {
     /** The title of the current Violation entity sub-page */
     current?: string;
+    /** The current Violation sub-page workflow filter */
+    filteredWorkflowView: FilteredWorkflowView;
 };
 
-const ViolationsBreadcrumbs = ({ current }: ViolationsBreadcrumbsProps): ReactElement => {
+const ViolationsBreadcrumbs = ({
+    current,
+    filteredWorkflowView,
+}: ViolationsBreadcrumbsProps): ReactElement => {
+    const { title, url } = getTopLevelBreadcrumb(filteredWorkflowView);
     const topLevelBreadcrumb = current ? (
-        <BreadcrumbItemLink to={violationsBasePath}>Violations</BreadcrumbItemLink>
+        <BreadcrumbItemLink to={url}>{title}</BreadcrumbItemLink>
     ) : (
         <BreadcrumbItem>Violations</BreadcrumbItem>
     );

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, ReactElement } from 'react';
+import React, { useEffect, useState, ReactElement } from 'react';
 import {
     PageSection,
     Bullseye,
@@ -33,7 +33,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import FilteredWorkflowViewSelector from 'Components/FilteredWorkflowViewSelector/FilteredWorkflowViewSelector';
 import useFilteredWorkflowViewURLState from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
 import ViolationsTablePanel from './ViolationsTablePanel';
-import tableColumnDescriptor from './violationTableColumnDescriptors';
+import getTableColumnDescriptors from './violationTableColumnDescriptors';
 import { violationStateTabs } from './types';
 
 import './ViolationsTablePage.css';
@@ -91,11 +91,8 @@ function ViolationsTablePage(): ReactElement {
     const [pollEpoch, setPollEpoch] = useState(0);
 
     // To handle sort options.
-    const columns = tableColumnDescriptor;
-    const sortFields = useMemo(
-        () => columns.flatMap(({ sortField }) => (sortField ? [sortField] : [])),
-        [columns]
-    );
+    const columns = getTableColumnDescriptors(filteredWorkflowView);
+    const sortFields = columns.flatMap(({ sortField }) => (sortField ? [sortField] : []));
 
     const defaultSortOption: SortOption = {
         field: 'Violation Time',

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -230,7 +230,6 @@ function ViolationsTablePage(): ReactElement {
                         setIsLoadingAlerts(true);
                         setSearchFilter({});
                         setPage(1);
-                        setFilteredWorkflowView('Applications view');
                         setSelectedViolationStateTab(tab);
                     }}
                     aria-label="Violation state tabs"
@@ -252,7 +251,7 @@ function ViolationsTablePage(): ReactElement {
                     />
                 </Tabs>
             </PageSection>
-            {isPlatformComponentsEnabled && (
+            {isPlatformComponentsEnabled && !isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT') && (
                 <PageSection className="pf-v5-u-py-md" component="div" variant="light">
                     <FilteredWorkflowViewSelector
                         filteredWorkflowView={filteredWorkflowView}

--- a/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
@@ -18,6 +18,7 @@ import { resourceTypes } from 'constants/entityTypes';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import { violationsBasePath } from 'routePaths';
 import { ListAlert } from 'types/alert.proto';
+import { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 
 type EntityTableCellProps = {
     // original: ListAlert;
@@ -88,73 +89,75 @@ function EnforcementColumn({ original }: EnforcementTableCellProps): ReactElemen
     return <span>{message}</span>;
 }
 
-const tableColumnDescriptor = [
-    {
-        Header: 'Policy',
-        accessor: 'policy.name',
-        sortField: 'Policy',
-        Cell: ({ original }) => {
-            const url = `${violationsBasePath}/${original.id as string}`;
-            return (
-                <Tooltip content={original?.policy?.description || 'No description available'}>
-                    <Link to={url}>{original?.policy?.name}</Link>
-                </Tooltip>
-            );
+function getTableColumnDescriptors(filteredWorkflowView: FilteredWorkflowView) {
+    return [
+        {
+            Header: 'Policy',
+            accessor: 'policy.name',
+            sortField: 'Policy',
+            Cell: ({ original }) => {
+                const url = `${violationsBasePath}/${original.id as string}?filteredWorkflowView=${filteredWorkflowView}`;
+                return (
+                    <Tooltip content={original?.policy?.description || 'No description available'}>
+                        <Link to={url}>{original?.policy?.name}</Link>
+                    </Tooltip>
+                );
+            },
         },
-    },
-    {
-        Header: 'Entity',
-        accessor: 'resource.name',
-        Cell: EntityTableCell,
-    },
-    {
-        Header: 'Type',
-        accessor: 'commonEntityInfo.resourceType',
-        Cell: ({ value, original }): string => {
-            const deployment = original?.deployment || {};
-            if (
-                value === resourceTypes.DEPLOYMENT &&
-                deployment.deploymentType &&
-                typeof deployment.deploymentType === 'string' &&
-                deployment.deploymentType.length > 0
-            ) {
-                return deployment.deploymentType as string;
-            }
-            return startCase(value.toLowerCase());
+        {
+            Header: 'Entity',
+            accessor: 'resource.name',
+            Cell: EntityTableCell,
         },
-    },
-    {
-        Header: 'Enforced',
-        accessor: 'enforcementCount',
-        sortField: 'Enforcement',
-        Cell: EnforcementColumn,
-    },
-    {
-        Header: 'Severity',
-        accessor: 'policy.severity',
-        sortField: 'Severity',
-        Cell: ({ value }) => {
-            return <PolicySeverityIconText severity={value} />;
+        {
+            Header: 'Type',
+            accessor: 'commonEntityInfo.resourceType',
+            Cell: ({ value, original }): string => {
+                const deployment = original?.deployment || {};
+                if (
+                    value === resourceTypes.DEPLOYMENT &&
+                    deployment.deploymentType &&
+                    typeof deployment.deploymentType === 'string' &&
+                    deployment.deploymentType.length > 0
+                ) {
+                    return deployment.deploymentType as string;
+                }
+                return startCase(value.toLowerCase());
+            },
         },
-    },
-    {
-        Header: 'Categories',
-        accessor: 'policy.categories',
-        sortField: 'Category',
-        Cell: CategoriesTableCell,
-    },
-    {
-        Header: 'Lifecycle',
-        accessor: 'lifecycleStage',
-        sortField: 'Lifecycle Stage',
-        Cell: ({ value }): ReactElement => <span>{lifecycleStageLabels[value]}</span>,
-    },
-    {
-        Header: 'Time',
-        accessor: 'time',
-        sortField: 'Violation Time',
-        Cell: ({ value }): string => dateFns.format(value, dateTimeFormat),
-    },
-];
+        {
+            Header: 'Enforced',
+            accessor: 'enforcementCount',
+            sortField: 'Enforcement',
+            Cell: EnforcementColumn,
+        },
+        {
+            Header: 'Severity',
+            accessor: 'policy.severity',
+            sortField: 'Severity',
+            Cell: ({ value }) => {
+                return <PolicySeverityIconText severity={value} />;
+            },
+        },
+        {
+            Header: 'Categories',
+            accessor: 'policy.categories',
+            sortField: 'Category',
+            Cell: CategoriesTableCell,
+        },
+        {
+            Header: 'Lifecycle',
+            accessor: 'lifecycleStage',
+            sortField: 'Lifecycle Stage',
+            Cell: ({ value }): ReactElement => <span>{lifecycleStageLabels[value]}</span>,
+        },
+        {
+            Header: 'Time',
+            accessor: 'time',
+            sortField: 'Violation Time',
+            Cell: ({ value }): string => dateFns.format(value, dateTimeFormat),
+        },
+    ];
+}
 
-export default tableColumnDescriptor;
+export default getTableColumnDescriptors;

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -65,6 +65,9 @@ export const systemHealthPath = `${mainPath}/system-health`;
 export const userBasePath = `${mainPath}/user`;
 export const userRolePath = `${userBasePath}/roles/:roleName`;
 export const violationsBasePath = `${mainPath}/violations`;
+export const violationsUserWorkloadsViewPath = `${mainPath}/violations?filteredWorkflowView=Application view`;
+export const violationsPlatformViewPath = `${mainPath}/violations?filteredWorkflowView=Platform view`;
+export const violationsFullViewPath = `${mainPath}/violations?filteredWorkflowView=Full view`;
 export const violationsPath = `${violationsBasePath}/:alertId?`;
 export const vulnManagementPath = `${mainPath}/vulnerability-management`;
 // TODO Deprecate these paths


### PR DESCRIPTION
### Description

Replaces the FilteredWorkflowView dropdown on the Violations page with the horizontal subnav to match the pattern in VM.

**Notes**

This approach retains the URL parameter instead of switching to a path parameter for the following reasons:
- UX does not anticipate a divergence of workflows in the Violations section comparable to what is happening with VM
- This avoids the need to handle backwards compatibility with existing Violation links, and to search and update all internal links in ACS
- This avoids the need to deal with the conflict between the current `/violations/:alertId` URL and potential `/violations/user-workloads` URLs

Relying on URL parameters however does require some additions to the navigation code, which I will comment on inline.



### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit the Violations page and see the dropdown is removed and replaced with the top navigation item:
![image](https://github.com/user-attachments/assets/ce7cc5c8-150d-433e-acab-694941628aee)

Ensure the links correctly filter the data and retain the "isActive" state:
![image](https://github.com/user-attachments/assets/a687fb09-9216-45b6-addf-b1cecdca4b91)
![image](https://github.com/user-attachments/assets/38b5da7b-7c06-4595-96b5-c44f676ef897)

Test that navigating from a section to the detail page retains the workflow state and the breadcrumb navigation:
![image](https://github.com/user-attachments/assets/18f7da06-8bd5-4532-8a97-262f21296d2c)
![image](https://github.com/user-attachments/assets/b83f60f5-c37e-4c7f-941a-8a5afed2b313)
![image](https://github.com/user-attachments/assets/de3a997c-320d-4a2c-a50c-917309e8b866)

Test that unchanged, incoming links to a _detail_ page have a breadcrumb routing back to the "All violations" page. This is due to the fact that we cannot always tell whether an incoming link is a user or platform workload, and using the "all violations" parent page prevent the user from seeing an empty table after visiting a violation.
![image](https://github.com/user-attachments/assets/a96d3a2c-55be-42cd-aae8-99d6abdabafb)
![image](https://github.com/user-attachments/assets/6a8ec314-0d76-47b5-b72e-c179b05d9820)



