### PR TITLE
ROX-27904: Use fake ticker in test

### DIFF
--- a/sensor/kubernetes/clusterhealth/updater_test.go
+++ b/sensor/kubernetes/clusterhealth/updater_test.go
@@ -300,7 +300,7 @@ func (s *UpdaterTestSuite) createNewUpdater(interval time.Duration) *updaterImpl
 func (s *UpdaterTestSuite) assertOfflineMode(updater *updaterImpl, ticker chan<- time.Time) *message.ExpiringMessage {
 	ticker <- time.Now()
 	select {
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		s.Fail("timeout waiting for sensor message")
 	case msg := <-updater.ResponsesC():
 		return msg

--- a/sensor/kubernetes/clusterhealth/updater_test.go
+++ b/sensor/kubernetes/clusterhealth/updater_test.go
@@ -195,32 +195,41 @@ func (s *UpdaterTestSuite) TestExpiredMessages() {
 	s.addNodes(4)
 	s.addDeployment(makeAdmissionControlDeployment())
 	updater := s.createNewUpdater(updateInterval)
-	s.Require().NoError(updater.Start())
+	// Create a fake ticker to control the update execution
+	fakeTicker := make(chan time.Time)
+	defer close(fakeTicker)
+	go updater.run(fakeTicker)
 	defer updater.Stop(nil)
 	var expiredMessages []*message.ExpiringMessage
 	for _, state := range states {
 		updater.Notify(state)
-		if expiredMsg := s.assertOfflineMode(state, updater, updateInterval); expiredMsg != nil {
+		if expiredMsg := s.assertOfflineMode(updater, fakeTicker); expiredMsg != nil {
 			expiredMessages = append(expiredMessages, expiredMsg)
 		}
 	}
+	// We should have exactly the same number of messages as the length of states
+	s.Assert().Len(expiredMessages, len(states))
+	// Notify Central is reachable.
+	// Going back online should cancel the context and expire all messages until now.
 	updater.Notify(common.SensorComponentEventCentralReachable)
 	// All the messages received until now should be expired at this point
 	for _, msg := range expiredMessages {
 		select {
 		case <-msg.Context.Done():
 			continue
-		case <-time.After(time.Second):
+		case <-time.After(500 * time.Millisecond):
 			s.Fail("the messages that were attempted to be sent while offline should be expired")
 		}
 	}
+
+	fakeTicker <- time.Now()
 	// The last message should not be expired
 	select {
 	case msg := <-updater.ResponsesC():
 		select {
 		case <-msg.Context.Done():
 			s.Fail("the last message should not be cancelled")
-		case <-time.After(10 * updateInterval):
+		case <-time.After(500 * time.Millisecond):
 			break
 		}
 	case <-time.After(10 * time.Second):
@@ -288,24 +297,13 @@ func (s *UpdaterTestSuite) createNewUpdater(interval time.Duration) *updaterImpl
 	return updater
 }
 
-func (s *UpdaterTestSuite) assertOfflineMode(state common.SensorComponentEvent, updater *updaterImpl, interval time.Duration) *message.ExpiringMessage {
-	switch state {
-	case common.SensorComponentEventCentralReachable:
-		select {
-		case <-time.After(updateTimeout):
-			s.Fail("timeout waiting for sensor message")
-		case msg := <-updater.ResponsesC():
-			return msg
-		}
-	case common.SensorComponentEventOfflineMode:
-		select {
-		case <-time.After(10 * interval):
-			return nil
-		// Depending on our luck with the internal ticker, we could have a message already waiting in ResponsesC.
-		// If that's the case, we return it here and later assert that the message is cancelled.
-		case msg := <-updater.ResponsesC():
-			return msg
-		}
+func (s *UpdaterTestSuite) assertOfflineMode(updater *updaterImpl, ticker chan<- time.Time) *message.ExpiringMessage {
+	ticker <- time.Now()
+	select {
+	case <-time.After(500 * time.Millisecond):
+		s.Fail("timeout waiting for sensor message")
+	case msg := <-updater.ResponsesC():
+		return msg
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

`TestExpiredMessages` can be a little bit flaky because races may occur between `Notify` and the ticker in `run`. This PR changes the test to use a fake ticker that can be controlled in the test execution.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Ran `go test -race -count=100 github.com/stackrox/rox/sensor/kubernetes/clusterhealth` multiple times
- [x] CI
