### PR TITLE
ROX-27743: Add info popover for EPSS probability column

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -27,6 +27,7 @@ import DeploymentComponentVulnerabilitiesTable, {
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { infoForEpssProbability } from './infoForTh';
 import { FormattedDeploymentVulnerability, formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCvesDeploymentVulnerabilitiesTable';
@@ -137,6 +138,7 @@ function DeploymentVulnerabilitiesTable({
                     {isEpssProbabilityColumnEnabled && (
                         <Th
                             className={getVisibilityClass('epssProbability')}
+                            info={infoForEpssProbability}
                             sort={getSortParams('EPSS Probability')}
                         >
                             EPSS probability

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -47,6 +47,7 @@ import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { infoForEpssProbability } from './infoForTh';
 import { formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCvesImageVulnerabilitiesTable';
@@ -199,6 +200,7 @@ function ImageVulnerabilitiesTable({
                     {isEpssProbabilityColumnEnabled && (
                         <Th
                             className={getVisibilityClass('epssProbability')}
+                            info={infoForEpssProbability}
                             sort={getSortParams('EPSS Probability')}
                         >
                             EPSS probability

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -52,6 +52,7 @@ import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { infoForEpssProbability } from './infoForTh';
 import { formatEpssProbabilityAsPercent, getCveBaseInfoFromDistroTuples } from './table.utils';
 
 export const tableId = 'WorkloadCveOverviewTable';
@@ -255,6 +256,7 @@ function WorkloadCVEOverviewTable({
                     {isEpssProbabilityColumnEnabled && (
                         <Th
                             className={getVisibilityClass('epssProbability')}
+                            info={infoForEpssProbability}
                             sort={getSortParams('EPSS Probability', aggregateByEPSS)}
                         >
                             EPSS probability

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
@@ -1,22 +1,37 @@
 import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
 import { ThProps } from '@patternfly/react-table';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import PopoverBodyContent from 'Components/PopoverBodyContent';
 
 export const infoForEpssProbability: ThProps['info'] = {
+    // ariaLabel for OutlinedQuestionCircleIcon
     ariaLabel: 'Information about EPSS probability',
-    popover: <>Likelihood of exploitability</>,
-    popoverProps: {
-        headerContent: 'EPSS probability',
-        footerContent: (
-            <>
-                For more information, see{' '}
-                <ExternalLink>
-                    <a href="https://www.first.org/epss/" target="_blank" rel="noopener noreferrer">
-                        Exploit Prediction Scoring System (EPSS)
-                    </a>
-                </ExternalLink>
-            </>
-        ),
-    },
+    // PopoverBodyContent replaces 5 issues with 1 from axe DevTools:
+    // https://dequeuniversity.com/rules/axe/4.10/aria-dialog-name
+    // Popover element does not have aria=labelledby attribute
+    // rendered if there is a popoverProps.headerContent property.
+    popover: (
+        <PopoverBodyContent
+            headerContent="EPSS probability"
+            bodyContent={
+                <Flex direction={{ default: 'column' }}>
+                    <FlexItem>Likelihood of exploitability</FlexItem>
+                    <FlexItem>
+                        For more information, see{' '}
+                        <ExternalLink>
+                            <a
+                                href="https://www.first.org/epss/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Exploit Prediction Scoring System (EPSS)
+                            </a>
+                        </ExternalLink>
+                    </FlexItem>
+                </Flex>
+            }
+        />
+    ),
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ThProps } from '@patternfly/react-table';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+
+export const infoForEpssProbability: ThProps['info'] = {
+    ariaLabel: 'Information about EPSS probability',
+    popover: <>Information to be determined</>,
+    popoverProps: {
+        headerContent: 'EPSS probability',
+        footerContent: (
+            <>
+                For more information, see{' '}
+                <ExternalLink>
+                    <a href="https://www.first.org/epss/" target="_blank" rel="noopener noreferrer">
+                        Exploit Prediction Scoring System (EPSS)
+                    </a>
+                </ExternalLink>
+            </>
+        ),
+    },
+};

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
@@ -5,7 +5,7 @@ import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 
 export const infoForEpssProbability: ThProps['info'] = {
     ariaLabel: 'Information about EPSS probability',
-    popover: <>Information to be determined</>,
+    popover: <>Likelihood of exploitability</>,
     popoverProps: {
         headerContent: 'EPSS probability',
         footerContent: (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -11,6 +11,9 @@ import {
 } from '../types';
 import { getAppliedSeverities } from './searchUtils';
 
+// ROX-27906 Image CVEs view cannot use search fields as sort options without providing aggregates
+// aggregateByCVSS and aggregateByEPSS might become unnecessary in the future, at least for WorkloadCVEOverviewTable
+
 export const aggregateByCVSS: SortAggregate = {
     aggregateFunc: 'max',
 };


### PR DESCRIPTION
### Description

~Although ready for review, DO NOT MERGE until actual text is available.~

Thank you, **Shubha**, for clear and concise text: Likelihood of exploitability
![Likelihood_of_exploitability](https://github.com/user-attachments/assets/4638be0a-2fca-45e1-8095-6d29d7301d57)

One other change after initial review. axe DevTools reported 5 accessibility issues because of `Popover` element.
* On one side of coin: `PopoverBodyContent` element fixed them, as elsewhere.
* On other side of coin: `info` prop of `Th` element renders in a way that loses `aria-labelledby` attribute, which causes a different issue (explained by comment in code). Too bad, so sad. See pictures in **Manual testing** below.

### Problem

Field represententatives recommended that we preclude concern or confusion by customers about the meaning of Exploit Prediction Scoring System.

### Analysis

1. Vulnerabilities tables have tooltips for some column headings.

    There is no visual hint that a tooltip exists.
    You point to see the tooltip.

2. This situation fits design guidelines for PatternFly `Popover` element.
    https://www.patternfly.org/components/popover/design-guidelines#when-to-use-tooltips-vs.-popovers
    > popovers are used for added description or information in context
    > popovers contain longer descriptions, formatted text, and optional images or links

    https://www.patternfly.org/components/table#custom-row-wrapper-header-tooltips--popovers
    `info` prop displays `OutlinedQuestionCircleIcon` as visual hint
    You click the icon to open the popover.

### Solution

Add `Popover` via `info` prop of `Th` element, similar to integration form fields.

### Residue

1. Replace placeholder text.
2. Investigate accessibility issues.
3. Discuss tooltips and popovers with design team.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4644094 - 4644094
        total 551 = 11593500 - 11592949
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Even if I run UI with staging demo, which has **Scanner V4**, I need to temporarily edit code to invert conditional rendering, because `'ROX_EPSS_SCORE'` feature flag is not enabled.

The following pictures to test responsive design simulate laptop screen height 800px and various widths decreasing from baseline of 1440px.

1. Visit **Workflow CVEs**

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx

    Before changes, see absence of info icon for **EPSS probability** column.
    ![ImageVulnerabilitiesTable_1440_absence](https://github.com/user-attachments/assets/9b93c419-42bd-43eb-bf52-0f7096ede4cf)

    After changes, see presence of info icon and click to see popover for **EPSS probability** column.
    ![WorkloadCVEOverviewTable_1440_presence](https://github.com/user-attachments/assets/ae8714a9-aae0-4dab-8634-27d5fee037cd)

    Screen width 1200px
    ![WorkloadCVEOverviewTable_1200_presence](https://github.com/user-attachments/assets/2d9c72f1-1b8a-4aeb-bf9e-82cf84bbbdfa)

    Screen width 800px
    ![WorkloadCVEOverviewTable_800_presence](https://github.com/user-attachments/assets/d749c9f9-e7f0-4a59-9bd4-e594c2015bcc)

    Presence of issues from axe DevTools
    ![WorkloadCVEOverviewTable_1440_axe_DevTools_presence](https://github.com/user-attachments/assets/a31b32d3-1da2-4fa8-9d7b-622d7c862339)

    Reduction of issues from axe DevTools
    ![axe_DevTools_1](https://github.com/user-attachments/assets/afcf0be6-61e4-483e-9637-dfb8d9c78119)

2. Click a vulnerability link, and then click an image link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx

    Before changes, see absence of info icon for **EPSS probability** column.
    ![ImageVulnerabilitiesTable_1440_absence](https://github.com/user-attachments/assets/1d238b04-1cb0-4a07-99bb-9126a55b27c2)

    After changes, see presence of info icon for **EPSS probability** column.
    ![ImageVulnerabilitiesTable_1440_presence](https://github.com/user-attachments/assets/c075b386-4a43-4547-b8ce-0c815bb7b83d)

3. Go back, click **Deployments**, click a deployment link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx

    Before changes, see absence of info icon for **EPSS probability** column.
    ![DeploymentVulnerabilitiesTable_1440_absence](https://github.com/user-attachments/assets/1431bbaf-8e98-4411-bdc9-1617a31ea0d0)

    After changes, see presence of info icon for **EPSS probability** column.
    ![DeploymentVulnerabilitiesTable_1440_presence](https://github.com/user-attachments/assets/0d68ae38-7ea9-4253-a2db-7575d351560e)
