### PR TITLE
ROX-27826: Update description and tooltips for VM results page

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -22,6 +22,7 @@ import {
     violationsFullViewPath,
     violationsPlatformViewPath,
     violationsUserWorkloadsViewPath,
+    vulnerabilitiesPlatformCvesPath,
 } from 'routePaths';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -117,6 +118,14 @@ function getSubnavDescriptionGroups(
                                   'Images and workloads without observed CVEs (results might include false negatives due to scanner limitations, such as unsupported operating systems)',
                               path: vulnerabilitiesImagesWithoutCvesPath,
                               routeKey: 'vulnerabilities/images-without-cves',
+                          },
+                          {
+                              type: 'link',
+                              content: 'Kubernetes components',
+                              description:
+                                  'Vulnerabilities affecting the underlying Kubernetes infrastructure',
+                              path: vulnerabilitiesPlatformCvesPath,
+                              routeKey: 'vulnerabilities/platform-cves',
                           },
                       ],
                   },

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -96,9 +96,9 @@ function getSubnavDescriptionGroups(
                       children: [
                           {
                               type: 'link',
-                              content: 'All Images',
+                              content: 'All vulnerable workloads',
                               description:
-                                  'View findings for user and platform images simultaneously',
+                                  'View findings for user, platform, and inactive images simultaneously',
                               path: vulnerabilitiesAllImagesPath,
                               routeKey: 'vulnerabilities/all-images',
                           },
@@ -106,7 +106,7 @@ function getSubnavDescriptionGroups(
                               type: 'link',
                               content: 'Inactive images',
                               description:
-                                  'View findings for images not currently deployed as workloads',
+                                  'View findings for watched images and images not currently deployed as workloads based on your image retention settings',
                               path: vulnerabilitiesInactiveImagesPath,
                               routeKey: 'vulnerabilities/inactive-images',
                           },

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -80,6 +80,7 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                               vulnerabilitiesInactiveImagesPath,
                               vulnerabilitiesImagesWithoutCvesPath,
                               vulnerabilitiesViewPath,
+                              vulnerabilitiesPlatformCvesPath,
                           ])
                       ),
               },
@@ -94,17 +95,6 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                   content: 'Vulnerability Reporting',
                   path: vulnerabilityReportsPath,
                   routeKey: 'vulnerabilities/reports',
-              },
-              {
-                  type: 'separator',
-                  key: 'following-node-cves',
-              },
-
-              {
-                  type: 'link',
-                  content: 'Platform CVEs',
-                  path: vulnerabilitiesPlatformCvesPath,
-                  routeKey: 'vulnerabilities/platform-cves',
               },
               {
                   type: 'separator',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -152,7 +152,7 @@ function PlatformCvesOverviewPage() {
                     onClose={() => setSnoozeModalOptions(null)}
                 />
             )}
-            <PageTitle title="Platform CVEs Overview" />
+            <PageTitle title="Kubernetes Components Overview" />
             <Divider component="div" />
             <PageSection
                 className="pf-v5-u-display-flex pf-v5-u-flex-direction-row pf-v5-u-align-items-center"
@@ -160,7 +160,7 @@ function PlatformCvesOverviewPage() {
             >
                 <Flex alignItems={{ default: 'alignItemsCenter' }} className="pf-v5-u-flex-grow-1">
                     <Flex direction={{ default: 'column' }} className="pf-v5-u-flex-grow-1">
-                        <Title headingLevel="h1">Platform CVEs</Title>
+                        <Title headingLevel="h1">Kubernetes components</Title>
                         <FlexItem>Prioritize and manage scanned CVEs across clusters</FlexItem>
                     </Flex>
                     <FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -99,11 +99,11 @@ function PlatformCvePage() {
 
     return (
         <>
-            <PageTitle title={`Platform CVEs - PlatformCVE ${cveName}`} />
+            <PageTitle title={`Kubernetes components - Vulnerability ${cveName}`} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={workloadCveOverviewCvePath}>
-                        Platform CVEs
+                        Kubernetes components
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
                         {cveName ?? <Skeleton screenreaderText="Loading CVE name" width="200px" />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
@@ -5,6 +5,7 @@ export type WorkloadCveView = {
     getAbsoluteUrl: (path: string) => string;
     baseSearchFilter: QuerySearchFilter;
     pageTitle: string;
+    pageTitleDescription?: string;
 };
 
 /**

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -34,13 +34,16 @@ export const imagesWithoutCvesViewId = 'images-without-cves';
 
 function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsFeatureFlagEnabled) {
     let pageTitle: string = '';
+    let pageTitleDescription: string | undefined;
     let baseSearchFilter: QuerySearchFilter = {};
     let getAbsoluteUrl: (subPath: string) => string = () => '';
 
     switch (viewId) {
         case userWorkloadViewId:
             if (isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')) {
-                pageTitle = 'User Workload Vulnerabilities';
+                pageTitle = 'User workload vulnerabilities';
+                pageTitleDescription =
+                    'Vulnerabilities affecting user-managed workloads and images';
                 baseSearchFilter = { 'Platform Component': ['false'] };
                 getAbsoluteUrl = (subPath: string) =>
                     `${vulnerabilitiesUserWorkloadsPath}/${subPath}`;
@@ -52,22 +55,30 @@ function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsF
             }
             break;
         case platformViewId:
-            pageTitle = 'Platform Vulnerabilities';
+            pageTitle = 'Platform vulnerabilities';
+            pageTitleDescription =
+                'Vulnerabilities affecting images and workloads used by the OpenShift Platform and layered services';
             baseSearchFilter = { 'Platform Component': ['true'] };
             getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesPlatformPath}/${subPath}`;
             break;
         case allImagesViewId:
-            pageTitle = 'All detected images';
+            pageTitle = 'All vulnerable images';
+            pageTitleDescription =
+                'View findings for user, platform, and inactive images simultaneously';
             baseSearchFilter = { 'Platform Component': ['true', 'false', '-'] };
             getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesAllImagesPath}/${subPath}`;
             break;
         case inactiveImagesViewId:
             pageTitle = 'Inactive images only';
+            pageTitleDescription =
+                'View findings for watched images and images not currently deployed as workloads based on your image retention settings';
             baseSearchFilter = { 'Platform Component': ['-'] };
             getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesInactiveImagesPath}/${subPath}`;
             break;
         case imagesWithoutCvesViewId:
             pageTitle = 'Images without CVEs';
+            pageTitleDescription =
+                'Images and workloads without observed CVEs (results might include false negatives due to scanner limitations, such as unsupported operating systems)';
             baseSearchFilter = { 'Image CVE Count': ['0'] };
             getAbsoluteUrl = (subPath: string) =>
                 `${vulnerabilitiesImagesWithoutCvesPath}/${subPath}`;
@@ -76,7 +87,7 @@ function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsF
         // TODO Handle user-defined views, or error
     }
 
-    return { pageTitle, baseSearchFilter, getAbsoluteUrl };
+    return { pageTitle, pageTitleDescription, baseSearchFilter, getAbsoluteUrl };
 }
 
 export type WorkloadCvePageProps = {


### PR DESCRIPTION
### Description

Updates page titles, descriptions, tooltips, and navigation wording for VM after alignment with UX and PM teams.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Open the VM sidebar item and navigation dropdown. "Platform CVEs" has been renamed to the more appropriate "Kubernetes components" and moved within the horizontal nav dropdown.
![image](https://github.com/user-attachments/assets/d67c8ded-274c-45ba-8719-6287c0399994)![image](https://github.com/user-attachments/assets/255014d1-d152-4495-ab34-f9e789a650c5)

User workload based pages now have a tooltip next to the main page title explaining more about what the current view entails:
![image](https://github.com/user-attachments/assets/a953e269-4110-4ecf-bdd0-8be56c3a4a8a)

Page descriptions for each of the Observed/Deferred/False positive tabs have been updated:
![image](https://github.com/user-attachments/assets/325f25ec-89ce-4494-a357-626d298a1a75)
![image](https://github.com/user-attachments/assets/d455abae-a36e-42f4-96a1-df11c33fb2ec)
![image](https://github.com/user-attachments/assets/78e08a8a-7dc1-43fc-84db-3bec1fcc6197)

The "Images without CVEs" view removes the violation state tabs and has alternative text above the table.
![image](https://github.com/user-attachments/assets/8ca80875-b3d6-4752-916f-c2a792acc3e4)

