### PR TITLE
build: Switch Konflux UI builds from NodeJS 18 to 20

### DIFF
--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -57,7 +57,7 @@ RUN # TODO(ROX-13200): make sure roxctl cli is built without running go mod tidy
 RUN make copy-go-binaries-to-image-dir
 
 
-FROM registry.access.redhat.com/ubi8/nodejs-18:latest AS ui-builder
+FROM registry.access.redhat.com/ubi8/nodejs-20:latest AS ui-builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 


### PR DESCRIPTION
### Description

See https://redhat-internal.slack.com/archives/C7ERNFL0M/p1738574728275579

Mark reports that his local builds are in fact powered by 20. GHA builds also use 20.

Unfortunately, there's no 22 in the catalog for ubi8 base (see [here](https://catalog.redhat.com/search?gs&q=ubi8/nodejs&searchType=containers)), therefore setting the builder stage to 20.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No change.

#### How I validated my change

I'm only going to check that UI _build_ completes successfully. I'm not going to test the UI functioning as part of this change.
Per the investigation in the Slack thread, UI is already built and tested with 20 on GHA.
