### PR TITLE
ROX-27772: SBOM fix scan time update edge case

### DIFF
--- a/central/image/service/http_handler.go
+++ b/central/image/service/http_handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 	clusterUtil "github.com/stackrox/rox/central/cluster/util"
@@ -35,7 +36,7 @@ type sbomHttpHandler struct {
 
 var _ http.Handler = (*sbomHttpHandler)(nil)
 
-// SBOMHandler returns a handler for get sbom http request
+// SBOMHandler returns a handler for get sbom http request.
 func SBOMHandler(integration integration.Set, enricher enricher.ImageEnricher, clusterSACHelper sachelper.ClusterSacHelper, riskManager manager.Manager) http.Handler {
 	return sbomHttpHandler{
 		integration:      integration,
@@ -43,16 +44,14 @@ func SBOMHandler(integration integration.Set, enricher enricher.ImageEnricher, c
 		clusterSACHelper: clusterSACHelper,
 		riskManager:      riskManager,
 	}
-
 }
 
 func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	// verify scanner v4 is enabled
+	// Verify Scanner V4 is enabled.
 	if !features.ScannerV4.Enabled() {
 		httputil.WriteGRPCStyleError(w, codes.Unimplemented, errors.New("Scanner V4 is disabled. Enable Scanner V4 to generate SBOMs"))
 		return
@@ -61,20 +60,24 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteGRPCStyleError(w, codes.Unimplemented, errors.New("SBOM feature is not enabled"))
 		return
 	}
+
 	var params apiparams.SbomRequestBody
 	sbomGenMaxReqSizeBytes := env.SBOMGenerationMaxReqSizeBytes.IntegerSetting()
-	// timeout api after 10 minutes
 	lr := io.LimitReader(r.Body, int64(sbomGenMaxReqSizeBytes))
 	err := json.NewDecoder(lr).Decode(&params)
 	if err != nil {
 		httputil.WriteGRPCStyleError(w, codes.InvalidArgument, errors.Wrap(err, "decoding json request body"))
 		return
 	}
+	params.ImageName = strings.TrimSpace(params.ImageName)
+
 	ctx, cancel := context.WithTimeout(r.Context(), env.ScanTimeout.DurationSetting())
 	defer cancel()
 	bytes, err := h.getSbom(ctx, params)
 	if err != nil {
-		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrap(err, "generating SBOM"))
+		// Using WriteError instead of WriteGRPCStyleError so that the HTTP status
+		// is derived from the error type.
+		httputil.WriteError(w, errors.Wrap(err, "generating SBOM"))
 		return
 	}
 	if len(bytes) == 0 {
@@ -89,20 +92,19 @@ func (h sbomHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(bytes)
 }
 
-// enrichImage enriches the image with the given name and based on the given enrichment context
+// enrichImage enriches the image with the given name and based on the given enrichment context.
 func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher.EnrichmentContext, imgName string) (*storage.Image, bool, error) {
-
 	// forcedEnrichment is set to true when enrichImage forces an enrichment.
 	forceEnrichment := false
 	img, err := enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
 	if err != nil {
 		return nil, forceEnrichment, err
 	}
-	// verify that image is scanned by scanner v4 if not force enrichment using scanner v4
-	scannedByV4 := h.scannedByScannerv4(img)
 
+	// Verify that image is scanned by Scanner V4 if not force enrichment using Scanner V4.
+	scannedByV4 := h.scannedByScannerv4(img)
 	if enrichmentCtx.FetchOpt != enricher.UseImageNamesRefetchCachedValues && !scannedByV4 {
-		// force scan by scanner v4
+		// Force scan by Scanner V4.
 		addForceToEnrichmentContext(&enrichmentCtx)
 		forceEnrichment = true
 		img, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, imgName)
@@ -111,18 +113,15 @@ func (h sbomHttpHandler) enrichImage(ctx context.Context, enrichmentCtx enricher
 		}
 	}
 
-	// Save the image
-	img.Id = utils.GetSHA(img)
-	if img.GetId() != "" {
-		if err := h.saveImage(img); err != nil {
-			return nil, forceEnrichment, err
-		}
+	err = h.saveImage(img)
+	if err != nil {
+		return nil, forceEnrichment, err
 	}
 
 	return img, forceEnrichment, nil
 }
 
-// getSbom generates an SBOM for the specified parameters
+// getSbom generates an SBOM for the specified parameters.
 func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomRequestBody) ([]byte, error) {
 	enrichmentCtx := enricher.EnrichmentContext{
 		FetchOpt:        enricher.UseCachesIfPossible,
@@ -142,34 +141,42 @@ func (h sbomHttpHandler) getSbom(ctx context.Context, params apiparams.SbomReque
 		}
 		enrichmentCtx.ClusterID = clusterID
 	}
+
 	img, alreadyForcedEnrichment, err := h.enrichImage(ctx, enrichmentCtx, params.ImageName)
 	if err != nil {
 		return nil, err
 	}
-	// verify that index report exists. if not force image enrichment using scanner v4
+
+	// Verify that index report exists. if not force image enrichment using Scanner V4.
 	scannerV4, err := h.getScannerV4SBOMIntegration()
 	if err != nil {
 		return nil, err
 	}
-	sbom, found, err := scannerV4.GetSBOM(img)
 
+	sbom, found, err := scannerV4.GetSBOM(img)
 	if err != nil {
 		return nil, err
 	}
+
 	if !found && !params.Force && !alreadyForcedEnrichment {
-		// since index report for image does not exist force scan by scanner v4
+		// Since index report for image does not exist force scan by Scanner V4.
 		addForceToEnrichmentContext(&enrichmentCtx)
-		_, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, params.ImageName)
+		img, err = enricher.EnrichImageByName(ctx, h.enricher, enrichmentCtx, params.ImageName)
 		if err != nil {
 			return nil, err
 		}
+
+		err = h.saveImage(img)
+		if err != nil {
+			return nil, err
+		}
+
 		sbom, _, err = scannerV4.GetSBOM(img)
-
 		if err != nil {
 			return nil, err
 		}
-
 	}
+
 	return sbom, nil
 }
 
@@ -177,7 +184,7 @@ func addForceToEnrichmentContext(enrichmentCtx *enricher.EnrichmentContext) {
 	enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues
 }
 
-// getScannerV4SBOMIntegration returns the SBOM interface of scanner v4
+// getScannerV4SBOMIntegration returns the SBOM interface of Scanner V4.
 func (h sbomHttpHandler) getScannerV4SBOMIntegration() (scannerTypes.SBOMer, error) {
 	scanners := h.integration.ScannerSet()
 	for _, scanner := range scanners.GetAll() {
@@ -187,19 +194,24 @@ func (h sbomHttpHandler) getScannerV4SBOMIntegration() (scannerTypes.SBOMer, err
 			}
 		}
 	}
-	return nil, errors.New("Scanner v4 integration not found")
+	return nil, errors.New("Scanner V4 integration not found")
 }
 
-// scannedByScannerv4 checks if image is scanned by scanner v4
+// scannedByScannerv4 checks if image is scanned by Scanner V4.
 func (h sbomHttpHandler) scannedByScannerv4(img *storage.Image) bool {
 	return img.GetScan().GetDataSource().GetId() == iiStore.DefaultScannerV4Integration.GetId()
 }
 
-// saveImage saves the image to the scanner database
+// saveImage saves the image to Central's database.
 func (h sbomHttpHandler) saveImage(img *storage.Image) error {
+	img.Id = utils.GetSHA(img)
+	if img.GetId() == "" {
+		return nil
+	}
+
 	if err := h.riskManager.CalculateRiskAndUpsertImage(img); err != nil {
 		log.Errorw("Error upserting image", logging.ImageName(img.GetName().GetFullName()), logging.Err(err))
-		return err
+		return fmt.Errorf("saving image: %w", err)
 	}
 	return nil
 }

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -26,8 +26,8 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func getFakeSbom(_ any) ([]byte, bool, error) {
-	sbom := createMockSbom()
+func getFakeSBOM(_ any) ([]byte, bool, error) {
+	sbom := createMockSBOM()
 	sbomBytes, err := json.Marshal(sbom)
 	if err != nil {
 		return nil, false, err
@@ -35,7 +35,7 @@ func getFakeSbom(_ any) ([]byte, bool, error) {
 	return sbomBytes, true, nil
 }
 
-func createMockSbom() map[string]interface{} {
+func createMockSBOM() map[string]interface{} {
 	return map[string]interface{}{
 		"SPDXID":      "SPDXRef-DOCUMENT",
 		"spdxVersion": "SPDX-2.3",
@@ -74,7 +74,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: false, ScanResult: enricher.ScanNotDone}, errors.New("Image enrichment failed")).AnyTimes()
 
-		reqBody := &apiparams.SbomRequestBody{
+		reqBody := &apiparams.SBOMRequestBody{
 			ImageName: "test-image",
 			Force:     false,
 		}
@@ -108,12 +108,12 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: true, ScanResult: enricher.ScanSucceeded}, nil).AnyTimes()
 		scanner.EXPECT().Type().Return(scannerTypes.ScannerV4).AnyTimes()
-		scanner.EXPECT().GetSBOM(gomock.Any()).DoAndReturn(getFakeSbom).AnyTimes()
+		scanner.EXPECT().GetSBOM(gomock.Any()).DoAndReturn(getFakeSBOM).AnyTimes()
 		set.EXPECT().ScannerSet().Return(scannerSet).AnyTimes()
 		fsr.EXPECT().GetScanner().Return(scanner).AnyTimes()
 		scannerSet.EXPECT().GetAll().Return([]scannerTypes.ImageScannerWithDataSource{fsr}).AnyTimes()
 
-		reqBody := &apiparams.SbomRequestBody{
+		reqBody := &apiparams.SBOMRequestBody{
 			ImageName: "quay.io/quay-qetest/nodejs-test-image:latest",
 			Force:     false,
 		}
@@ -238,7 +238,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 				firstGetSBOMInvocation = false
 				return nil, false, nil
 			}
-			return getFakeSbom(nil)
+			return getFakeSBOM(nil)
 		}
 
 		ctrl := gomock.NewController(t)
@@ -267,7 +267,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		mockRiskManager.EXPECT().CalculateRiskAndUpsertImage(gomock.Any()).Times(2)
 
 		// Prepare the SBOM generation request.
-		reqBody := &apiparams.SbomRequestBody{
+		reqBody := &apiparams.SBOMRequestBody{
 			ImageName: "quay.io/quay-qetest/nodejs-test-image:latest",
 			Force:     false,
 		}

--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/imageintegration"
+	iiStore "github.com/stackrox/rox/central/imageintegration/store"
+	riskManagerMocks "github.com/stackrox/rox/central/risk/manager/mocks"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
@@ -32,7 +36,6 @@ func getFakeSbom(_ any) ([]byte, bool, error) {
 }
 
 func createMockSbom() map[string]interface{} {
-
 	return map[string]interface{}{
 		"SPDXID":      "SPDXRef-DOCUMENT",
 		"spdxVersion": "SPDX-2.3",
@@ -47,7 +50,6 @@ func createMockSbom() map[string]interface{} {
 }
 
 func TestHttpHandler_ServeHTTP(t *testing.T) {
-
 	// Test case: Invalid request method
 	t.Run("Invalid request method", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/sbom", nil)
@@ -68,7 +70,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		t.Setenv(features.ScannerV4.EnvVar(), "true")
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		// initliaze mocks
+		// initialize mocks
 		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
 		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).Return(enricher.EnrichmentResult{ImageUpdated: false, ScanResult: enricher.ScanNotDone}, errors.New("Image enrichment failed")).AnyTimes()
 
@@ -97,7 +99,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		// initliaze mocks
+		// initialize mocks
 		scannerSet := scannerMocks.NewMockSet(ctrl)
 		set := intergrationMocks.NewMockSet(ctrl)
 		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
@@ -144,6 +146,25 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		res := recorder.Result()
 		err := res.Body.Close()
 		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	// Test case: empty image name
+	t.Run("empty image name", func(t *testing.T) {
+		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
+		t.Setenv(features.ScannerV4.EnvVar(), "true")
+
+		reqBody := []byte(`{"imageName": "   "}`)
+		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(reqBody))
+		recorder := httptest.NewRecorder()
+
+		handler := SBOMHandler(imageintegration.Set(), nil, nil, nil)
+		handler.ServeHTTP(recorder, req)
+
+		res := recorder.Result()
+		err := res.Body.Close()
+		assert.NoError(t, err)
+		assert.Contains(t, recorder.Body.String(), "image name")
 		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 	})
 
@@ -196,4 +217,73 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 	})
 
+	// Tests case: edge case where an image scan existed in Central DB from Scanner V4
+	// but the Scanner V4 Indexer did not have the corresponding index report.
+	// A forced enrichment is expected and the result saved to Central DB.
+	t.Run("image saved to Central when index report did not exist", func(t *testing.T) {
+		t.Setenv(features.SBOMGeneration.EnvVar(), "true")
+		t.Setenv(features.ScannerV4.EnvVar(), "true")
+
+		// enrichImageFunc will fake enrich an image by Scanner V4.
+		enrichImageFunc := func(ctx context.Context, enrichCtx enricher.EnrichmentContext, img *storage.Image) (enricher.EnrichmentResult, error) {
+			img.Id = "fake-id"
+			img.Scan = &storage.ImageScan{DataSource: &storage.DataSource{Id: iiStore.DefaultScannerV4Integration.Id}}
+			return enricher.EnrichmentResult{ImageUpdated: true, ScanResult: enricher.ScanSucceeded}, nil
+		}
+
+		// getSBOMFunc will indicate an index report is missing on first invocation and found on subsequent invocations.
+		firstGetSBOMInvocation := true
+		getSBOMFunc := func(_ any) ([]byte, bool, error) {
+			if firstGetSBOMInvocation {
+				firstGetSBOMInvocation = false
+				return nil, false, nil
+			}
+			return getFakeSbom(nil)
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// Initialize mocks.
+		mockScanner := scannerTypesMocks.NewMockScannerSBOMer(ctrl)
+		mockScanner.EXPECT().GetSBOM(gomock.Any()).DoAndReturn(getSBOMFunc).AnyTimes()
+		mockScanner.EXPECT().Type().Return(scannerTypes.ScannerV4).AnyTimes()
+
+		mockImageScannerWithDS := scannerTypesMocks.NewMockImageScannerWithDataSource(ctrl)
+		mockImageScannerWithDS.EXPECT().GetScanner().Return(mockScanner).AnyTimes()
+
+		mockScannerSet := scannerMocks.NewMockSet(ctrl)
+		mockScannerSet.EXPECT().GetAll().Return([]scannerTypes.ImageScannerWithDataSource{mockImageScannerWithDS}).AnyTimes()
+
+		mockIntegrationSet := intergrationMocks.NewMockSet(ctrl)
+		mockIntegrationSet.EXPECT().ScannerSet().Return(mockScannerSet).AnyTimes()
+
+		mockEnricher := enricherMock.NewMockImageEnricher(ctrl)
+		mockEnricher.EXPECT().EnrichImage(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(enrichImageFunc).AnyTimes()
+
+		mockRiskManager := riskManagerMocks.NewMockManager(ctrl)
+		// Image is expected to be saved after each successful enrichment, for this edge case will
+		// be multiple successful enrichments.
+		mockRiskManager.EXPECT().CalculateRiskAndUpsertImage(gomock.Any()).Times(2)
+
+		// Prepare the SBOM generation request.
+		reqBody := &apiparams.SbomRequestBody{
+			ImageName: "quay.io/quay-qetest/nodejs-test-image:latest",
+			Force:     false,
+		}
+		reqJson, err := json.Marshal(reqBody)
+		assert.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/sbom", bytes.NewReader(reqJson))
+		recorder := httptest.NewRecorder()
+		handler := SBOMHandler(mockIntegrationSet, mockEnricher, nil, mockRiskManager)
+
+		// Make the SBOM generation request.
+		handler.ServeHTTP(recorder, req)
+
+		// Validate was successful.
+		res := recorder.Result()
+		err = res.Body.Close()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
 }

--- a/pkg/apiparams/policy.go
+++ b/pkg/apiparams/policy.go
@@ -4,10 +4,3 @@ package apiparams
 type SaveAsCustomResourcesRequest struct {
 	IDs []string `json:"ids"`
 }
-
-// SbomRequestBody represents the HTTP API request for generating an SBOM from an image scan.
-type SbomRequestBody struct {
-	Cluster   string `json:"cluster"`
-	ImageName string `json:"imageName"`
-	Force     bool   `json:"force"`
-}

--- a/pkg/apiparams/sbom.go
+++ b/pkg/apiparams/sbom.go
@@ -1,0 +1,8 @@
+package apiparams
+
+// SBOMRequestBody represents the HTTP API request for generating an SBOM from an image scan.
+type SBOMRequestBody struct {
+	Cluster   string `json:"cluster"`
+	ImageName string `json:"imageName"`
+	Force     bool   `json:"force"`
+}

--- a/roxctl/image/sbom/sbom.go
+++ b/roxctl/image/sbom/sbom.go
@@ -89,7 +89,7 @@ func (i *imageSBOMCommand) construct(cobraCmd *cobra.Command) error {
 	}
 
 	// Create the request.
-	req := apiparams.SbomRequestBody{
+	req := apiparams.SBOMRequestBody{
 		Cluster:   i.cluster,
 		ImageName: i.image,
 		Force:     i.force,


### PR DESCRIPTION
### Description

If SBOM generation results in a successful image scan ensures that the image scan is saved.

Also ensures that the HTTP error code when generating an SBOM is derived from the error and not always `500` (for example, if the image name is empty the error should be `400` due to `errox.InvalidArgs` being wrapped [here](https://github.com/stackrox/stackrox/blob/5161acdc393b056c0b35ae1ecfece141d38a15e6/pkg/images/enricher/util.go#L16))

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing
- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

Unit tests + manual test.

<details>
<summary>Image Name missing 400</summary>

**Before Fix:**

Notice HTTP `500` is returned 

```
$ cat payload.json 
{
    "imageName": "",
    "force": false,
    "cluster": ""
}

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" -X POST "https://$ROX_ENDPOINT/api/v1/images/sbom" -i -d @payload.json
HTTP/2 500 
vary: Accept-Encoding
content-type: text/plain; charset=utf-8
content-length: 88
date: Mon, 03 Feb 2025 23:47:02 GMT

{"code":13,"message":"generating SBOM: image name must be specified: invalid arguments"}

---

$ cat payload.json 
{
    "imageName": "  ",
    "force": false,
    "cluster": ""
}

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" -X POST "https://$ROX_ENDPOINT/api/v1/images/sbom" -i -d @payload.json
HTTP/2 500 
vary: Accept-Encoding
content-type: text/plain; charset=utf-8
content-length: 116
date: Mon, 03 Feb 2025 23:48:06 GMT

{"code":13,"message":"generating SBOM: error parsing image name '   ': invalid reference format: invalid arguments"}
```


**After Fix:**

```
$ cat payload.json 
{
    "imageName": "",
    "force": false,
    "cluster": ""
}

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" -X POST "https://$ROX_ENDPOINT/api/v1/images/sbom" -i -d @payload.json
HTTP/2 400 
vary: Accept-Encoding
content-type: text/plain; charset=utf-8
content-length: 87
date: Mon, 03 Feb 2025 23:31:51 GMT

{"code":3,"message":"generating SBOM: image name must be specified: invalid arguments"}

---

$ cat payload.json 
{
    "imageName": "  ",
    "force": false,
    "cluster": ""
}

$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" -X POST "https://$ROX_ENDPOINT/api/v1/images/sbom" -i -d @payload.json
HTTP/2 400 
vary: Accept-Encoding
content-type: text/plain; charset=utf-8
content-length: 87
date: Mon, 03 Feb 2025 23:30:59 GMT

{"code":3,"message":"generating SBOM: image name must be specified: invalid arguments"}
```
</details>

<details>
<summary>Scan Time Update</summary>

In between each of the tests, ran the following to remove the index report from scanner v4 db (the digest is that of `nginx:1.27` at the time of writing this). This is necessary to setup the test condition where Central DB has a Scanner V4 scan but Scanner V4 has no index report.

```sql
roxdb scannerv4

DELETE 
  FROM manifest 
 WHERE hash in (
       SELECT concat('sha512:', 
           encode(sha512('/v4/containerimage/sha256:2426c815287ed75a3a33dd28512eba4f0f783946844209ccf3fa8990817a4eb9'::bytea), 'hex')
       ));
```

**Before Fix:**

Scan time did not change unless using the `-f` flag.

**After Fix:**

Start

![image](https://github.com/user-attachments/assets/70b1069c-74a9-4434-a58b-e87f74217a4f)

Sanity check, generate SBOM and observe no new scan executed:

```
rctl image sbom --image=nginx:1.27 
```

![image](https://github.com/user-attachments/assets/979cf213-803d-481a-a0f1-2389a9adc429)

Now delete index report using query above, and re-try:

```
rctl image sbom --image=nginx:1.27 
```

![image](https://github.com/user-attachments/assets/8d3c960d-96c4-42e2-98c2-b0e41ec2c79b)

</details>