### PR TITLE
ROX-27753:  Update p/z BuiltinPoliciesTest test image

### DIFF
--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -25,7 +25,7 @@ class BuiltinPoliciesTest extends BaseSpecification {
     // Arch specific test images
     static final private String TRIGGER_MOST_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         "us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/most:0.20":
-        "quay.io/jdao/qa-multi-arch:trigger-policy-violations-most-v0.20")
+        "quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most-v0.20")
     static final private String TRIGGER_ALPINE_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         "us.gcr.io/acs-san-stackroxci/qa/trigger-policy-violations/alpine:0.6":
         "quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-alpine")


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Updated the test image trigger-policy-violations-most to version v0.20 for non-x86_64 architectures

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
- Ran BuiltinPoliciesTest locally with updated image

## Summary by Sourcery

Enhancements:
- Updated the test image tag for the 'most' trigger policy violations image to version v0.20 for non-x86_64 architectures