### PR TITLE
ROX-27438: Add db size to telemetry

### DIFF
--- a/central/globaldb/telemetry.go
+++ b/central/globaldb/telemetry.go
@@ -30,6 +30,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 
 	props["Database Size (Bytes)"] = dbSize
 	props["PostgreSQL version"] = version
+	props["Database is external"] = pgconfig.IsExternalDatabase()
 
 	return props, nil
 }

--- a/central/globaldb/telemetry.go
+++ b/central/globaldb/telemetry.go
@@ -25,7 +25,11 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 		return nil, errors.Wrap(err, "failed to get databaze size")
 	}
 
-	props["Database Size"] = dbSize
+	db := GetPostgres()
+	version := GetPostgresVersion(ctx, db)
+
+	props["Database Size (Bytes)"] = dbSize
+	props["PostgreSQL version"] = version
 
 	return props, nil
 }

--- a/central/globaldb/telemetry.go
+++ b/central/globaldb/telemetry.go
@@ -11,7 +11,17 @@ import (
 
 // Gather database related information.
 // Current properties we gather:
-// "Database size"
+//
+// "Database size (bytes)" - Total size of the active database in PostgreSQL
+// cluster in bytes.
+//
+// "PostgreSQL version" - Text representation of PostgreSQL version in form
+// "X.Y", where X is the major version and Y is the minor version. Might
+// include non-numeric parts as well.
+//
+// "Database is external" - Whether the PostgreSQL installation we use is the
+// ACS default that comes out of the box, or is it an external database
+// provided by the user.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
 	props := make(map[string]any)
 

--- a/central/globaldb/telemetry.go
+++ b/central/globaldb/telemetry.go
@@ -4,11 +4,8 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres/pgadmin"
 	"github.com/stackrox/rox/pkg/postgres/pgconfig"
-	"github.com/stackrox/rox/pkg/sac"
-	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
 
@@ -16,12 +13,6 @@ import (
 // Current properties we gather:
 // "Database size"
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
-	ctx = sac.WithGlobalAccessScopeChecker(ctx,
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Administration),
-		),
-	)
 	props := make(map[string]any)
 
 	_, config, err := pgconfig.GetPostgresConfig()

--- a/central/globaldb/telemetry.go
+++ b/central/globaldb/telemetry.go
@@ -34,9 +34,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 		return nil, errors.Wrap(err, "failed to get databaze size")
 	}
 
-	_ = phonehome.AddTotal(ctx, props, "Database Size", func(_ context.Context) (int, error) {
-		return int(dbSize), nil
-	})
+	props["Database Size"] = dbSize
 
 	return props, nil
 }

--- a/central/globaldb/telemetry.go
+++ b/central/globaldb/telemetry.go
@@ -28,7 +28,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	db := GetPostgres()
 	version := GetPostgresVersion(ctx, db)
 
-	props["Database Size (Bytes)"] = dbSize
+	props["Database size (bytes)"] = dbSize
 	props["PostgreSQL version"] = version
 	props["Database is external"] = pgconfig.IsExternalDatabase()
 

--- a/central/globaldb/telemetry.go
+++ b/central/globaldb/telemetry.go
@@ -1,0 +1,42 @@
+package globaldb
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+)
+
+// Gather database related information.
+// Current properties we gather:
+// "Database size"
+var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration),
+		),
+	)
+	props := make(map[string]any)
+
+	_, config, err := pgconfig.GetPostgresConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get postgres config")
+	}
+
+	dbSize, err := pgadmin.GetDatabaseSize(config, pgconfig.GetActiveDB())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get databaze size")
+	}
+
+	_ = phonehome.AddTotal(ctx, props, "Database Size", func(_ context.Context) (int, error) {
+		return int(dbSize), nil
+	})
+
+	return props, nil
+}

--- a/central/main.go
+++ b/central/main.go
@@ -633,6 +633,7 @@ func startGRPCServer() {
 				gs.AddGatherer(notifierDS.Gather)
 				gs.AddGatherer(roleDataStore.Gather)
 				gs.AddGatherer(signatureIntegrationDS.Gather)
+				gs.AddGatherer(globaldb.Gather)
 			}
 		}
 	}


### PR DESCRIPTION
### Description

Database size is an important factor for making decisions about strategies for upgrade, HA, etc. Make it available via telemetry. This data is currently exposed only for ACSCS, let it flow via telemetry as well.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manual test on an infra cluster with the test API key.