### PR TITLE
ROX-27745: Adding external ips table to deployment side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -220,6 +220,7 @@ const TopologyComponent = ({
                             edgeState={edgeState}
                             onNodeSelect={onNodeSelect}
                             defaultDeploymentTab={defaultDeploymentTab}
+                            scopeHierarchy={scopeHierarchy}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'EXTERNAL_GROUP' && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -6,6 +6,7 @@ import { EdgeState } from '../components/EdgeStateSelect';
 import { Flow } from '../types/flow.type';
 import InternalFlows from './InternalFlows';
 import ExternalFlows from './ExternalFlows';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export type DeploymentFlowsView = 'external-flows' | 'internal-flows';
 
@@ -18,6 +19,7 @@ type DeploymentFlowsProps = {
     networkFlowsError: string;
     networkFlows: Flow[];
     refetchFlows: () => void;
+    scopeHierarchy: NetworkScopeHierarchy;
 };
 
 function DeploymentFlows({
@@ -29,6 +31,7 @@ function DeploymentFlows({
     networkFlowsError,
     networkFlows,
     refetchFlows,
+    scopeHierarchy,
 }: DeploymentFlowsProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isExternalIpsEnabled = isFeatureFlagEnabled('ROX_EXTERNAL_IPS');
@@ -85,7 +88,10 @@ function DeploymentFlows({
                                 refetchFlows={refetchFlows}
                             />
                         ) : (
-                            <ExternalFlows deploymentId={deploymentId} />
+                            <ExternalFlows
+                                deploymentId={deploymentId}
+                                scopeHierarchy={scopeHierarchy}
+                            />
                         )}
                     </Stack>
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -35,6 +35,7 @@ import useSimulation from '../hooks/useSimulation';
 import { EdgeState } from '../components/EdgeStateSelect';
 import { deploymentTabs } from '../utils/deploymentUtils';
 import useFetchNetworkFlows from '../api/useFetchNetworkFlows';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 const sidebarHeadingStyleConstant = {
     '--pf-v5-u-max-width--MaxWidth': '26ch',
@@ -48,6 +49,7 @@ type DeploymentSideBarProps = {
     edgeState: EdgeState;
     onNodeSelect: (id: string) => void;
     defaultDeploymentTab: string;
+    scopeHierarchy: NetworkScopeHierarchy;
 };
 
 function DeploymentSideBar({
@@ -58,6 +60,7 @@ function DeploymentSideBar({
     edgeState,
     onNodeSelect,
     defaultDeploymentTab,
+    scopeHierarchy,
 }: DeploymentSideBarProps) {
     // component state
     const { hasReadAccess } = usePermissions();
@@ -228,6 +231,7 @@ function DeploymentSideBar({
                                     networkFlowsError={networkFlowsError}
                                     networkFlows={networkFlows}
                                     refetchFlows={refetchFlows}
+                                    scopeHierarchy={scopeHierarchy}
                                 />
                             )}
                         </TabContent>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -1,37 +1,37 @@
+import React, { useMemo, useState } from 'react';
 import { Divider, Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
-import React, { useState } from 'react';
-import AdvancedFlowsFilter, {
-    defaultAdvancedFlowsFilters,
-} from '../common/AdvancedFlowsFilter/AdvancedFlowsFilter';
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import { getAllUniquePorts } from '../utils/flowUtils';
+
 import IPMatchFilter, { MatchType } from '../common/IPMatchFilter';
+import ExternalIpsTable from '../external/ExternalIpsTable';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+
+type ExternalFlowsFilter = {
+    matchType: MatchType;
+    externalIP: string;
+};
 
 type InternalFlowsProps = {
     deploymentId: string;
+    scopeHierarchy: NetworkScopeHierarchy;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function ExternalFlows({ deploymentId }: InternalFlowsProps) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [selectedMatchType, setSelectedMatchType] = useState<MatchType>('Equals');
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [selectedExternalIP, setSelectedExternalIP] = useState('');
-    const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
-        defaultAdvancedFlowsFilters
-    );
-
-    // TODO: Fetch external IPs connected to a deployment using the deploymentID
+function ExternalFlows({ deploymentId, scopeHierarchy }: InternalFlowsProps) {
+    const [appliedFilter, setAppliedFilter] = useState<ExternalFlowsFilter>({
+        matchType: 'Equals',
+        externalIP: '',
+    });
 
     const onSearch = ({ matchType, externalIP }) => {
-        setSelectedMatchType(matchType);
-        setSelectedExternalIP(externalIP);
+        setAppliedFilter({ matchType, externalIP });
     };
 
-    // TODO: Show all unique ports
-    const allUniquePorts = getAllUniquePorts([]);
-
-    // TODO: Filter network flows based on the match type and external IP
+    const advancedFilters = useMemo(
+        () => ({
+            'Deployment ID': deploymentId,
+            'External Source Address': appliedFilter.externalIP,
+        }),
+        [appliedFilter.externalIP, deploymentId]
+    );
 
     return (
         <Stack>
@@ -40,17 +40,18 @@ function ExternalFlows({ deploymentId }: InternalFlowsProps) {
                     <FlexItem flex={{ default: 'flex_1' }}>
                         <IPMatchFilter onSearch={onSearch} />
                     </FlexItem>
-                    <FlexItem>
-                        <AdvancedFlowsFilter
-                            filters={advancedFilters}
-                            setFilters={setAdvancedFilters}
-                            allUniquePorts={allUniquePorts}
-                        />
-                    </FlexItem>
                 </Flex>
             </StackItem>
-            <Divider component="hr" className="pf-v5-u-py-md" />
-            <StackItem isFilled style={{ overflow: 'auto' }}></StackItem>
+            <Divider component="hr" />
+            <StackItem isFilled style={{ overflow: 'auto' }}>
+                <ExternalIpsTable
+                    scopeHierarchy={scopeHierarchy}
+                    advancedFilters={advancedFilters}
+                    setSelectedEntity={() => {
+                        // TODO: Set up routing so this will take you to the external ip detail view
+                    }}
+                />
+            </StackItem>
         </Stack>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
@@ -20,29 +20,35 @@ import {
     ExternalSourceNetworkEntityInfo,
     ExternalNetworkFlowsMetadataResponse,
 } from 'types/networkFlow.proto';
-
+import { SearchFilter } from 'types/search';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export type ExternalIpsTableProps = {
     scopeHierarchy: NetworkScopeHierarchy;
     setSelectedEntity: (entity: ExternalSourceNetworkEntityInfo) => void;
+    advancedFilters?: SearchFilter;
 };
 
-function ExternalIpsTable({ scopeHierarchy, setSelectedEntity }: ExternalIpsTableProps) {
+function ExternalIpsTable({
+    scopeHierarchy,
+    setSelectedEntity,
+    advancedFilters,
+}: ExternalIpsTableProps) {
     const { version } = useMetadata();
     const [page, setPage] = useState(1);
     const [perPage, setPerPage] = useState(10);
     const clusterId = scopeHierarchy.cluster.id;
     const { namespaces, deployments } = scopeHierarchy;
+
     const fetchExternalIpsFlowsMetadata =
         useCallback((): Promise<ExternalNetworkFlowsMetadataResponse> => {
             return getExternalIpsFlowsMetadata(clusterId, namespaces, deployments, {
                 sortOption: {},
                 page,
                 perPage,
-                advancedFilters: {},
+                advancedFilters,
             });
-        }, [page, perPage, clusterId, deployments, namespaces]);
+        }, [page, perPage, clusterId, deployments, namespaces, advancedFilters]);
 
     const {
         data: externalIpsFlowsMetadata,


### PR DESCRIPTION
### Description

This PR adds the ExternalIPsTable, that Brad made, to the External Flows table under the Deployment Side Panel. The table will show the grouped external IPs. 

Next step will be to add routing so clicking on the link will take you to the right place.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![Screenshot 2025-02-04 at 12 36 54 PM](https://github.com/user-attachments/assets/91309585-905e-4815-a6f7-d1e35badf6a7)

