### PR TITLE
fix(UI): Update links to support split of Platform CVEs

### DIFF
--- a/ui/apps/platform/src/Components/FilteredWorkflowViewSelector/types.ts
+++ b/ui/apps/platform/src/Components/FilteredWorkflowViewSelector/types.ts
@@ -1,6 +1,14 @@
 import { HistoryAction } from 'hooks/useURLParameter';
 
-export const filteredWorkflowViews = ['Applications view', 'Platform view', 'Full view'] as const;
+export const userWorkloadWorkflowView = 'Applications view';
+export const platformWorkflowView = 'Platform view';
+export const fullWorkflowView = 'Full view';
+
+export const filteredWorkflowViews = [
+    userWorkloadWorkflowView,
+    platformWorkflowView,
+    fullWorkflowView,
+] as const;
 
 export type FilteredWorkflowView = (typeof filteredWorkflowViews)[number];
 

--- a/ui/apps/platform/src/Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState.ts
+++ b/ui/apps/platform/src/Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState.ts
@@ -6,11 +6,13 @@ export type FilteredWorkflowViewURLStateResult = {
     setFilteredWorkflowView: (value: FilteredWorkflowView) => void;
 };
 
+export const filteredWorkflowViewKey = 'filteredWorkflowView';
+
 function useFilteredWorkflowViewURLState(
     defaultView?: FilteredWorkflowView
 ): FilteredWorkflowViewURLStateResult {
     const [filteredWorkflowView, setFilteredWorkflowView] = useURLStringUnion(
-        'filteredWorkflowView',
+        filteredWorkflowViewKey,
         filteredWorkflowViews,
         defaultView
     );

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -7,11 +7,9 @@ import {
     clustersBasePath,
     configManagementPath,
     urlEntityListTypes,
-    violationsBasePath,
+    violationsFullViewPath,
     vulnerabilitiesWorkloadCvesPath,
 } from 'routePaths';
-import { filteredWorkflowViewKey } from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
-import { fullWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 import { resourceTypes } from 'constants/entityTypes';
 import { generatePathWithQuery } from 'utils/searchUtils';
 
@@ -60,7 +58,7 @@ function SummaryCounts({ hasReadAccessForResource }: SummaryCountsProps): ReactE
     const tileLinks: Record<TileResource, string> = {
         Cluster: clustersBasePath,
         Node: `${configManagementPath}/${urlEntityListTypes[resourceTypes.NODE]}`,
-        Alert: `${violationsBasePath}?${filteredWorkflowViewKey}=${fullWorkflowView}`,
+        Alert: violationsFullViewPath,
         Deployment: `${configManagementPath}/${urlEntityListTypes[resourceTypes.DEPLOYMENT]}`,
         Image: generatePathWithQuery(
             vulnerabilitiesWorkloadCvesPath,

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -10,6 +10,8 @@ import {
     violationsBasePath,
     vulnerabilitiesWorkloadCvesPath,
 } from 'routePaths';
+import { filteredWorkflowViewKey } from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
+import { fullWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 import { resourceTypes } from 'constants/entityTypes';
 import { generatePathWithQuery } from 'utils/searchUtils';
 
@@ -58,7 +60,7 @@ function SummaryCounts({ hasReadAccessForResource }: SummaryCountsProps): ReactE
     const tileLinks: Record<TileResource, string> = {
         Cluster: clustersBasePath,
         Node: `${configManagementPath}/${urlEntityListTypes[resourceTypes.NODE]}`,
-        Alert: violationsBasePath,
+        Alert: `${violationsBasePath}?${filteredWorkflowViewKey}=${fullWorkflowView}`,
         Deployment: `${configManagementPath}/${urlEntityListTypes[resourceTypes.DEPLOYMENT]}`,
         Image: generatePathWithQuery(
             vulnerabilitiesWorkloadCvesPath,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
@@ -1,14 +1,12 @@
 import React, { CSSProperties } from 'react';
 import { Button, Flex, FlexItem, Stack, StackItem } from '@patternfly/react-core';
 
-import { violationsBasePath } from 'routePaths';
+import { violationsFullViewPath } from 'routePaths';
 import { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { severityLabels } from 'messages/common';
 import { policySeverityColorMap } from 'constants/severityColors';
 import { policySeverities, PolicySeverity } from 'types/policy.proto';
-import { filteredWorkflowViewKey } from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
-import { fullWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 import LinkShim from 'Components/PatternFly/LinkShim';
 
 import './SeverityTile.css';
@@ -46,7 +44,7 @@ function linkToViolations(searchFilter, severity) {
         ...searchFilter,
         Severity: severity,
     });
-    return `${violationsBasePath}?${queryString}&${filteredWorkflowViewKey}=${fullWorkflowView}`;
+    return `${violationsFullViewPath}&${queryString}`;
 }
 
 export type PolicyViolationTilesProps = {

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/PolicyViolationTiles.tsx
@@ -7,6 +7,8 @@ import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { severityLabels } from 'messages/common';
 import { policySeverityColorMap } from 'constants/severityColors';
 import { policySeverities, PolicySeverity } from 'types/policy.proto';
+import { filteredWorkflowViewKey } from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
+import { fullWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 import LinkShim from 'Components/PatternFly/LinkShim';
 
 import './SeverityTile.css';
@@ -44,7 +46,7 @@ function linkToViolations(searchFilter, severity) {
         ...searchFilter,
         Severity: severity,
     });
-    return `${violationsBasePath}?${queryString}`;
+    return `${violationsBasePath}?${queryString}&${filteredWorkflowViewKey}=${fullWorkflowView}`;
 }
 
 export type PolicyViolationTilesProps = {

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -14,6 +14,8 @@ import {
 } from '@patternfly/react-charts';
 import sortBy from 'lodash/sortBy';
 
+import { filteredWorkflowViewKey } from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
+import { fullWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
 import { AlertGroup } from 'services/AlertsService';
 import { severityLabels } from 'messages/common';
@@ -119,6 +121,7 @@ function linkForViolationsCategory(
     const queryString = getQueryString({
         s: search,
         sortOption: { field: 'Severity', direction: 'desc' },
+        [filteredWorkflowViewKey]: fullWorkflowView,
     });
     return `${violationsBasePath}${queryString}`;
 }

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.tsx
@@ -4,6 +4,8 @@ import { Flex, FlexItem, Title, Button, Divider, Stack, StackItem } from '@patte
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import WidgetCard from 'Components/PatternFly/WidgetCard';
+import { filteredWorkflowViewKey } from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
+import { fullWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 import useURLSearch from 'hooks/useURLSearch';
 import { violationsBasePath } from 'routePaths';
 import { SearchFilter } from 'types/search';
@@ -23,6 +25,7 @@ function getViewAllLink(searchFilter: SearchFilter) {
             ...searchFilter,
         },
         sortOption: { field: 'Severity', direction: 'desc' },
+        [filteredWorkflowViewKey]: fullWorkflowView,
     });
     return `${violationsBasePath}${queryString}`;
 }

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -3,7 +3,11 @@ import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
 
 import { Deployment } from 'types/deployment.proto';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { vulnerabilitiesPlatformPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import {
+    vulnerabilitiesPlatformPath,
+    vulnerabilitiesUserWorkloadsPath,
+    vulnerabilitiesWorkloadCvesPath,
+} from 'routePaths';
 import ContainerConfigurationDescriptionList from './ContainerConfigurationDescriptionList';
 
 export type ContainerConfigurationProps = {
@@ -13,13 +17,14 @@ export type ContainerConfigurationProps = {
 function ContainerConfiguration({ deployment }: ContainerConfigurationProps): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
 
-    const hasPlatformWorkloadCveLink =
-        isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT') &&
-        deployment &&
-        deployment.platformComponent;
-    const vulnMgmtBasePath = hasPlatformWorkloadCveLink
-        ? vulnerabilitiesPlatformPath
-        : vulnerabilitiesWorkloadCvesPath;
+    const hasPlatformWorkloadCveLink = deployment && deployment.platformComponent;
+
+    // eslint-disable-next-line no-nested-ternary
+    const vulnMgmtBasePath = !isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
+        ? vulnerabilitiesWorkloadCvesPath
+        : hasPlatformWorkloadCveLink
+          ? vulnerabilitiesPlatformPath
+          : vulnerabilitiesUserWorkloadsPath;
 
     let content: JSX.Element[] | string = 'None';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -5,7 +5,11 @@ import { DescriptionList } from '@patternfly/react-core';
 
 import dateTimeFormat from 'constants/dateTimeFormat';
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { vulnerabilitiesPlatformPath, vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import {
+    vulnerabilitiesPlatformPath,
+    vulnerabilitiesUserWorkloadsPath,
+    vulnerabilitiesWorkloadCvesPath,
+} from 'routePaths';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { AlertDeployment } from 'types/alert.proto';
 import { Deployment } from 'types/deployment.proto';
@@ -22,10 +26,7 @@ function DeploymentOverview({
     deployment,
 }: DeploymentOverviewProps): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const hasPlatformWorkloadCveLink =
-        isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT') &&
-        deployment &&
-        deployment.platformComponent;
+    const hasPlatformWorkloadCveLink = deployment && deployment.platformComponent;
     return (
         <DescriptionList isCompact isHorizontal>
             <DescriptionListItem
@@ -33,9 +34,12 @@ function DeploymentOverview({
                 desc={
                     <Link
                         to={
-                            hasPlatformWorkloadCveLink
-                                ? `${vulnerabilitiesPlatformPath}/deployments/${alertDeployment.id}`
-                                : `${vulnerabilitiesWorkloadCvesPath}/deployments/${alertDeployment.id}`
+                            // eslint-disable-next-line no-nested-ternary
+                            !isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
+                                ? `${vulnerabilitiesWorkloadCvesPath}/deployments/${alertDeployment.id}`
+                                : hasPlatformWorkloadCveLink
+                                  ? `${vulnerabilitiesPlatformPath}/deployments/${alertDeployment.id}`
+                                  : `${vulnerabilitiesUserWorkloadsPath}/deployments/${alertDeployment.id}`
                         }
                     >
                         {alertDeployment.id}

--- a/ui/apps/platform/src/Containers/Violations/ViolationNotFoundPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationNotFoundPage.tsx
@@ -1,15 +1,22 @@
 import React, { ReactElement } from 'react';
 
 import { violationsBasePath } from 'routePaths';
+import useFilteredWorkflowViewURLState, {
+    filteredWorkflowViewKey,
+} from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
 import NotFoundMessage from 'Components/NotFoundMessage';
 
-const ViolationNotFoundPage = (): ReactElement => (
-    <NotFoundMessage
-        title="404: We couldn't find that page"
-        message="Violation not found. This violation may have been deleted due to data retention settings."
-        actionText="Go to Violations"
-        url={violationsBasePath}
-    />
-);
+const ViolationNotFoundPage = (): ReactElement => {
+    const { filteredWorkflowView } = useFilteredWorkflowViewURLState('Full view');
+
+    return (
+        <NotFoundMessage
+            title="404: We couldn't find that page"
+            message="Violation not found. This violation may have been deleted due to data retention settings."
+            actionText="Go to Violations"
+            url={`${violationsBasePath}?${filteredWorkflowViewKey}=${filteredWorkflowView}`}
+        />
+    );
+};
 
 export default ViolationNotFoundPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, ReactNode } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
     Alert,
     AlertActionCloseButton,
@@ -19,15 +19,9 @@ import {
 } from '@patternfly/react-core';
 import { useParams } from 'react-router-dom';
 
-import {
-    exceptionManagementPath,
-    vulnerabilitiesPlatformPath,
-    vulnerabilitiesWorkloadCvesPath,
-} from 'routePaths';
-import useFeatureFlags from 'hooks/useFeatureFlags';
+import { exceptionManagementPath } from 'routePaths';
 import useSet from 'hooks/useSet';
 import useRestQuery from 'hooks/useRestQuery';
-import useURLPagination from 'hooks/useURLPagination';
 import usePermissions from 'hooks/usePermissions';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useAuthStatus from 'hooks/useAuthStatus';
@@ -50,14 +44,11 @@ import RequestApprovalButtonModal from './components/RequestApprovalButtonModal'
 import RequestDenialButtonModal from './components/RequestDenialButtonModal';
 import RequestCancelButtonModal from './components/RequestCancelButtonModal';
 import RequestUpdateButtonModal from './components/RequestUpdateButtonModal';
-import { getImageScopeSearchValue, getVulnerabilityState } from './utils';
+import { getVulnerabilityState } from './utils';
 
 import './ExceptionRequestDetailsPage.css';
-import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 
 export const contextValues = ['CURRENT', 'PENDING_UPDATE'] as const;
-
-const cveTableContextValues = ['USER_WORKLOADS', 'PLATFORM_COMPONENTS'] as const;
 
 function getSubtitleText(exception: VulnerabilityException) {
     const numCVEs = `${pluralize(exception.cves.length, 'CVE')}`;
@@ -86,38 +77,16 @@ export function getCVEsForUpdatedRequest(exception: VulnerabilityException): str
 }
 
 const tabContentId = 'ExceptionRequestDetails';
-const cveTableTabContentId = 'ExceptionRequestCveTable';
-
-function CveTableTabWrapper({
-    children,
-    isPlatformCveSplitEnabled,
-}: {
-    children: ReactNode;
-    isPlatformCveSplitEnabled: boolean;
-}) {
-    if (!isPlatformCveSplitEnabled) {
-        return children;
-    }
-
-    return <TabContent id={cveTableTabContentId}>{children}</TabContent>;
-}
 
 function ExceptionRequestDetailsPage() {
     const { requestId } = useParams();
     const { hasReadWriteAccess } = usePermissions();
     const { currentUser } = useAuthStatus();
     const hasWriteAccessForApproving = hasReadWriteAccess('VulnerabilityManagementApprovals');
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isPlatformCveSplitEnabled = isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT');
 
     const [selectedContext, setSelectedContext] = useURLStringUnion('context', contextValues);
     const expandedRowSet = useSet<string>();
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
-    const [activeCveTableTabKey, setActiveCveTableTabKey] = useURLStringUnion(
-        'cveTableContext',
-        cveTableContextValues
-    );
-    const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
 
     const vulnerabilityExceptionByIdFn = useCallback(
         () => fetchVulnerabilityExceptionById(requestId),
@@ -132,13 +101,6 @@ function ExceptionRequestDetailsPage() {
 
     function handleTabClick(event, value) {
         setSelectedContext(value);
-    }
-
-    function handleCveTableTabClick(event, value) {
-        if (value !== activeCveTableTabKey) {
-            pagination.setPage(1);
-        }
-        setActiveCveTableTabKey(value);
     }
 
     function onApprovalSuccess() {
@@ -208,20 +170,6 @@ function ExceptionRequestDetailsPage() {
 
     const vulnerabilityState = getVulnerabilityState(vulnerabilityException);
 
-    const searchFilter = {
-        CVE: relevantCVEs.join(','),
-        Image: getImageScopeSearchValue(scope),
-    };
-
-    if (isPlatformCveSplitEnabled) {
-        searchFilter['Platform Component'] =
-            activeCveTableTabKey === 'USER_WORKLOADS' ? ['false', '-'] : ['true'];
-    }
-
-    const vulnMgmtBaseUrl =
-        isPlatformCveSplitEnabled && activeCveTableTabKey === 'PLATFORM_COMPONENTS'
-            ? vulnerabilitiesPlatformPath
-            : vulnerabilitiesWorkloadCvesPath;
     return (
         <>
             <PageTitle title="Exception Management - Request Details" />
@@ -307,36 +255,13 @@ function ExceptionRequestDetailsPage() {
                             context={selectedContext}
                         />
                     </PageSection>
-                    <PageSection className="pf-v5-u-pt-0">
-                        {isPlatformCveSplitEnabled && (
-                            <Tabs
-                                activeKey={activeCveTableTabKey}
-                                onSelect={handleCveTableTabClick}
-                                isBox
-                                aria-label="Exception request CVEs split by affected image scope"
-                                role="region"
-                            >
-                                <Tab
-                                    eventKey={'USER_WORKLOADS'}
-                                    title={<TabTitleText>User workloads</TabTitleText>}
-                                    tabContentId={cveTableTabContentId}
-                                />
-                                <Tab
-                                    eventKey={'PLATFORM_COMPONENTS'}
-                                    title={<TabTitleText>Platform components</TabTitleText>}
-                                    tabContentId={cveTableTabContentId}
-                                />
-                            </Tabs>
-                        )}
-                        <CveTableTabWrapper isPlatformCveSplitEnabled={isPlatformCveSplitEnabled}>
-                            <RequestCVEsTable
-                                searchFilter={searchFilter}
-                                vulnMgmtBaseUrl={vulnMgmtBaseUrl}
-                                pagination={pagination}
-                                expandedRowSet={expandedRowSet}
-                                vulnerabilityState={vulnerabilityState}
-                            />
-                        </CveTableTabWrapper>
+                    <PageSection>
+                        <RequestCVEsTable
+                            cves={relevantCVEs}
+                            scope={scope}
+                            expandedRowSet={expandedRowSet}
+                            vulnerabilityState={vulnerabilityState}
+                        />
                     </PageSection>
                 </TabContent>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -14,17 +14,20 @@ import { useQuery } from '@apollo/client';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { SetResult } from 'hooks/useSet';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
-import { VulnerabilityState } from 'services/VulnerabilityExceptionService';
+import {
+    VulnerabilityExceptionScope,
+    VulnerabilityState,
+} from 'services/VulnerabilityExceptionService';
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { getTableUIState } from 'utils/getTableUIState';
-import { SearchFilter } from 'types/search';
 import {
     aggregateByCVSS,
     aggregateByCreatedTime,
@@ -40,32 +43,38 @@ import {
     cveListQuery,
 } from '../../WorkloadCves/Tables/WorkloadCVEOverviewTable';
 import { VulnerabilitySeverityLabel } from '../../types';
+import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 
+import { getImageScopeSearchValue } from '../utils';
+
 type RequestCVEsTableProps = {
-    searchFilter: SearchFilter;
-    vulnMgmtBaseUrl: string;
-    pagination: UseURLPaginationResult;
+    cves: string[];
+    scope: VulnerabilityExceptionScope;
     expandedRowSet: SetResult<string>;
     vulnerabilityState: VulnerabilityState;
 };
 
 function RequestCVEsTable({
-    searchFilter,
-    vulnMgmtBaseUrl,
-    pagination,
+    cves,
+    scope,
     expandedRowSet,
     vulnerabilityState,
 }: RequestCVEsTableProps) {
-    const { page, perPage, setPage, setPerPage } = pagination;
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
         sortFields: getWorkloadCveOverviewSortFields('CVE'),
         defaultSortOption: getWorkloadCveOverviewDefaultSortOption('CVE'),
         onSort: () => setPage(1),
     });
 
-    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    const queryObject = {
+        CVE: cves.join(','),
+        Image: getImageScopeSearchValue(scope),
+    };
+
+    const query = getRequestQueryStringForSearchFilter(queryObject);
 
     const {
         error,
@@ -76,7 +85,6 @@ function RequestCVEsTable({
             query,
             pagination: getPaginationParams({ page, perPage, sortOption }),
         },
-        fetchPolicy: 'no-cache',
     });
 
     const tableState = getTableUIState({
@@ -89,7 +97,7 @@ function RequestCVEsTable({
     const colSpan = 6;
 
     return (
-        <PageSection variant="light" className="pf-v5-u-pt-0">
+        <PageSection variant="light">
             <Flex direction={{ default: 'column' }}>
                 <Toolbar>
                     <ToolbarContent className="pf-v5-u-justify-content-space-between">
@@ -176,11 +184,11 @@ function RequestCVEsTable({
 
                                 const cveURLQueryOptions = {
                                     s: {
-                                        IMAGE: searchFilter.Image,
+                                        IMAGE: queryObject.Image,
                                     },
                                 };
 
-                                const cveURL = `${vulnMgmtBaseUrl}/${getWorkloadEntityPagePath(
+                                const cveURL = `${vulnerabilitiesWorkloadCvesPath}/${getWorkloadEntityPagePath(
                                     'CVE',
                                     cve,
                                     vulnerabilityState,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
@@ -56,7 +56,6 @@ function useRequestCVEsDetails(exception: VulnerabilityException): UseAffectedIm
             variables: {
                 query,
             },
-            fetchPolicy: 'no-cache',
         }
     );
 


### PR DESCRIPTION
### Description

Updates links throughout ACS to support split views for Violations and VM:
1. Reverts the "User workload"/"Platform" CVE split in exception management. With the addition of the "All images" view, the tabs are no longer necessary and complicate the UI.
2. Updates all* links to Violations to specify the "full view" when the user/platform context is unknown.
3. Updates all links to VM where the context _is_ known to fall back to `/workload-cves` when the feature flag is off.

*The global search links to violations will require more work in a follow up due to complications with how the declarative links are rendered.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit an exception management request page and see the original single table of CVEs. Clicking on a CVE link routes you to the "All images" view.
![image](https://github.com/user-attachments/assets/7908b9ea-7512-4438-8aff-77819add88dd)
![image](https://github.com/user-attachments/assets/5c6fd439-1bcb-42ce-bece-aab98caf97bc)

From the dashboard, click the summary count for Violations:
![image](https://github.com/user-attachments/assets/a46069e5-74ea-486f-b025-e069e6f3628e)
![image](https://github.com/user-attachments/assets/68f053f9-c539-4f00-b4d4-32c5bcfaca34)
Click the by severity tiles in the widget:
![image](https://github.com/user-attachments/assets/d1732c83-45bf-475b-a818-a97b03563826)
Click the individual violations in the by severity widget:
![image](https://github.com/user-attachments/assets/48dd8dca-58bc-4eb6-a10c-3acb3ca9e977)
Click 'View all' in the header of the severity widget:
![image](https://github.com/user-attachments/assets/a75c1701-8849-4515-b347-e089f179bec6)
Click the violations by category link in the widget:
![image](https://github.com/user-attachments/assets/9151e9ef-faef-404d-9418-464ea4a6bb64)
![image](https://github.com/user-attachments/assets/b0b2779c-bd13-4e1a-a5d6-c9ae5b6094d8)

Update the URL for a violations detail page to a bogus ID, and verify that the "Go to violations" link retains the current view:
![image](https://github.com/user-attachments/assets/1c4adc66-8b50-4582-96c6-769b51b4fc6a)
![image](https://github.com/user-attachments/assets/2701798f-a685-413b-8041-31a5c223e5f0)



