### PR TITLE
ROX-27931: Revert require on api Stop call

### DIFF
--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -107,9 +107,9 @@ func (a *APIServerSuite) Test_TwoTestsStartingAPIs() {
 	for i, api := range []API{api1, api2} {
 		// Running two tests that start the API results in failure.
 		a.Run(fmt.Sprintf("API test %d", i), func() {
+			a.T().Cleanup(func() { api.Stop() })
 			waitForPortToBeFree(a.T(), testPort)
 			a.Assert().NoError(api.Start().Wait())
-			a.Require().True(api.Stop())
 		})
 	}
 }


### PR DESCRIPTION
### Description

This PR reverts changes made in #14009.

The critical part is replacing of: `a.T().Cleanup(func() { api.Stop() })` with `a.Require().True(api.Stop())`. Before, we didn't consider the state of `Close` execution to be relevant for the test state. This PR is putting that behavior back.

We need additional investigation to understand why `Stop` is failing.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

Let CI pipeline run
