### PR TITLE
ROX-27937: retry on error

### DIFF
--- a/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
@@ -8,7 +8,6 @@ import io.stackrox.proto.storage.NotifierOuterClass.Notifier
 import services.NotifierService
 import util.Env
 import util.Helpers
-import util.Timer
 
 import spock.lang.Shared
 import spock.lang.Tag

--- a/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
@@ -34,7 +34,7 @@ class AuditScrubbingTest extends BaseSpecification {
 
     private getAuditEntry(String attemptId) {
         def jsonSlurper = new JsonSlurper()
-        return Helpers.withRetry(30, 1) {
+        return Helpers.evaluateWithRetry(30, 1) {
             def get = new URL("http://localhost:8080").openConnection()
             def objects = jsonSlurper.parseText(get.getInputStream().getText())
             def entry = objects.find {

--- a/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
@@ -33,21 +33,16 @@ class AuditScrubbingTest extends BaseSpecification {
 
     private getAuditEntry(String attemptId) {
         def jsonSlurper = new JsonSlurper()
+        def url = new URL("http://localhost:8080")
         return Helpers.evaluateWithRetry(30, 1) {
-            def get = new URL("http://localhost:8080").openConnection()
+            def get = url.openConnection()
             def objects = jsonSlurper.parseText(get.getInputStream().getText())
             def entry = objects.find {
-                try {
-                    def data = it["data"]["audit"]
-                    return data["request"]["endpoint"] == ENDPOINT &&
-                            (data["request"]["payload"]["state"] as String).endsWith(attemptId)
-                } catch (Exception e) {
-                    log.warn("exception", e)
-                    return false
-                }
+                def req = it?.data?.audit?.request
+                return req?.endpoint == ENDPOINT && req?.payload?.state?.endsWith(attemptId)
             }
             assert entry
-            return entry["data"]["audit"]
+            return entry.data.audit
         }
     }
 


### PR DESCRIPTION
### Description

In AuditScrubbingTest we do retries for 30s until we find a value but we do not handle exceptions (in this case network error). This PR replaces simple waiting with retry that handle exceptions.

Fixes:
- https://issues.redhat.com/browse/ROX-27937
- https://issues.redhat.com/browse/ROX-27938

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
