### PR TITLE
ROX-27936: Fixes lost handling of quotes in filename payload

### DIFF
--- a/ui/apps/platform/cypress/integration/systemHealth/bundle.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/bundle.test.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
 import { interactAndWaitForResponses } from '../../helpers/request';
@@ -19,11 +21,12 @@ function openDiagnosticBundleDialogBox() {
 
 const diagnosticBundleAlias = '/api/extensions/diagnostics';
 
+const mockResponseFilename = 'stackrox_diagnostic_2020_10_20_21_22_23.zip';
+
 const staticResponseMapForDiagnosticBundle = {
     [diagnosticBundleAlias]: {
         headers: {
-            'content-disposition':
-                'attachment; filename="stackrox_diagnostic_2020_10_20_21_22_23.zip"',
+            'content-disposition': `attachment; filename="${mockResponseFilename}"`,
             'content-type': 'application/zip',
         },
         // https://stackoverflow.com/questions/29234912/how-to-create-minimum-size-empty-zip-file-which-has-22b
@@ -51,6 +54,8 @@ function downloadDiagnosticBundle(query) {
         routeMatcherMap,
         staticResponseMapForDiagnosticBundle
     );
+
+    cy.readFile(path.join(Cypress.config('downloadsFolder'), mockResponseFilename)).should('exist');
 }
 
 describe('Download Diagnostic Data', () => {

--- a/ui/apps/platform/src/services/DownloadService.js
+++ b/ui/apps/platform/src/services/DownloadService.js
@@ -24,7 +24,7 @@ export function saveFile({ method, url, data, name = '', timeout = 0 }) {
                 if (name && typeof name === 'string') {
                     FileSaver.saveAs(file, name);
                 } else if (filename) {
-                    FileSaver.saveAs(file, filename);
+                    FileSaver.saveAs(file, filename.replace(/['"]/g, ''));
                 } else {
                     throw new Error('Unable to extract file name');
                 }


### PR DESCRIPTION
### Description

During the SBOM changes, the call to remove quotes from incoming filenames was lost. This resulted in the filename for diagnostic bundles as well as other downloads being surrounded by `_` characters. This is degraded UX as the OS does not correctly detect the file as .zip and requires a rename or other additional steps to extract the contents.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Updated tests to assert on expected download filename.

View recent downloads - see presence of filename wrapped in underscores previously, with recent downloads having the correct filename.
![image](https://github.com/user-attachments/assets/2f2ed8bc-3631-4fa3-b5c1-a8ce7d171e64)
