### PR TITLE
chore(ui): Fix network graph routing on mount

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -178,8 +178,13 @@ const TopologyComponent = ({
         controller.fromModel(model);
         if (selectedNode) {
             panNodeIntoView(selectedNode);
-        } else if (history.location.pathname !== networkBasePath && !selectedNode) {
-            // if the path does not reflect the selected node state, sync URL to state
+        } else if (
+            history.location.pathname !== networkBasePath &&
+            !selectedNode &&
+            model.nodes.length > 0
+        ) {
+            // if the path does not reflect the selected node state or nodes have not
+            // been fetched yet, sync URL to state
             closeSidebar();
         }
     }, [controller, model, selectedNode, history, closeSidebar, panNodeIntoView]);


### PR DESCRIPTION
### Description

**Problem:** 
There was an issue in network graph where users would get redirected to the base path when trying to access a specific detail id on initialization (e.g., `/deployment/123`). This happened because the component was trying to find a selected node before the node data was actually fetched

**Considered Solutions:**
- Set `isLoading` to true by default in `NetworkGraphPage` - This isn't ideal because there is a lot of state change happening around getting cluster id and namespaces before we can make the request, so it's difficult to avoid constant loading states.
- Combine `detailId` with `isClusterNamespaceSelected` and add a `processedFirstRequest` state - This would requiring creating additional state and passing down more props to `TopologyComponent`, I also worry there could be edge cases with this solution.

**Downsides to selected solution:**
The implemented solution has one main downside: When removing required query params or getting a network nodes response without data, the URL won't immediately update to ditch the `:detailId` (e.g., `/deployment/123?s[Cluster]=remote&s[Namespace][0]=stackrox` -> `/main/network-graph/deployment/123`). This is because the `closeSidebar` function will only trigger if the are nodes.

However, this could be beneficial in same cases.
- For example, If a user is looking at a deployment then drops the selected namespace but reselects the same one, the originally selected deployment will reopen in the side panel. 



### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Verified that refreshing the page while viewing an entity with the side panel open maintains the selected entity and keeps the side panel visible
- Confirmed that using the "View Deployment in Network Graph" link on the Risk page correctly navigates to the network graph and automatically opens the deployment details in the side panel