### PR TITLE
ROX-27606: add SBOM gen to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Scanner V4 adds supports for openSUSE Leap 15.5 and 15.6
 - ROX-27596: ROX_EXTERNAL_IPS feature flag enabled by default. Note: Collector will still need to be configured for external IPs for this to have an effect.
 - ROX-26088: Introduced Cluster Registration Secrets (CRS) as a successor to init bundles for registering Secured Clusters.
+- ROX-24052: Tech Preview - SBOMs can now be generated from Scanner V4 image scans via the UI, CLI (`roxctl image sbom`), and API (`/api/v1/images/sbom`). Only scans executed via Central are supported, delegated scans will be supported in a future release. This feature can be disabled by setting `ROX_SBOM_GENERATION` to `false`.
 
 ### Removed Features
 


### PR DESCRIPTION
### Description

Adds info related to SBOM generation to the changelog

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

👁️ 📖 
