### PR TITLE
ROX-27950: Fix rep header

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -87,10 +87,10 @@ func addOptionalColumnstoHeader(optionalColumns *storage.VulnerabilityReportFilt
 	csvHeaderClone := make([]string, len(csvHeader))
 	copy(csvHeaderClone, csvHeader)
 	if optionalColumns.GetIncludeNvdCvss() {
-		csvHeaderClone = append(csvHeader, "NVDCVSS")
+		csvHeaderClone = append(csvHeaderClone, "NVDCVSS")
 	}
 	if optionalColumns.GetIncludeEpssProbability() {
-		csvHeaderClone = append(csvHeader, "EPSS Probability Percentage")
+		csvHeaderClone = append(csvHeaderClone, "EPSS Probability Percentage")
 	}
 	return csvHeaderClone
 }


### PR DESCRIPTION
Currently when user selects both EPSS Probability and NVD CVSS optional columns in report, EPSS header is misaligned with NVD column. This PR fixes this bug.

### Testing and quality
Tested vuln report manually with both columns selected
![Screenshot 2025-02-06 at 12 11 41 PM](https://github.com/user-attachments/assets/5859e866-d74f-4628-93d9-d2c9bb3a5735)


- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
