### PR TITLE
chore: improve scan error message

### DIFF
--- a/pkg/registries/types/types.go
+++ b/pkg/registries/types/types.go
@@ -42,6 +42,13 @@ const (
 	RedHatType = "rhel"
 )
 
+// Local scanning registry name prefixes.
+const (
+	PullSecretNamePrefix = "PullSecret"
+	GlobalRegNamePrefix  = "GlobalPullSecret"
+	NoAuthNamePrefix     = "NoAuth"
+)
+
 // Config is the config of the registry, which can be utilized by 3rd party scanners
 type Config struct {
 	Username         string

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -28,8 +28,8 @@ import (
 const (
 	defaultSA = "default"
 
-	PullSecretNamePrefix = "PullSec"
-	GlobalRegNamePrefix  = "Global"
+	PullSecretNamePrefix = "PullSecret"
+	GlobalRegNamePrefix  = "GlobalPullSecret"
 	NoAuthNamePrefix     = "NoAuth"
 )
 

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -25,13 +25,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/registry/metrics"
 )
 
-const (
-	defaultSA = "default"
-
-	PullSecretNamePrefix = "PullSecret"
-	GlobalRegNamePrefix  = "GlobalPullSecret"
-	NoAuthNamePrefix     = "NoAuth"
-)
+const defaultSA = "default"
 
 var (
 	log       = logging.LoggerForModule()
@@ -220,7 +214,7 @@ func (rs *Store) upsertRegistry(namespace, registry string, dce config.DockerCon
 	// remove http/https prefixes from registry, matching may fail otherwise, the created registry.url will have
 	// the appropriate prefix
 	registry = urlfmt.TrimHTTPPrefixes(registry)
-	name := genIntegrationName(PullSecretNamePrefix, namespace, "", registry)
+	name := genIntegrationName(types.PullSecretNamePrefix, namespace, "", registry)
 
 	ii := createImageIntegration(registry, dce, name)
 	inserted, err := regs.UpdateImageIntegration(ii)
@@ -268,7 +262,7 @@ func (rs *Store) getRegistryForImageInNamespace(image *storage.ImageName, namesp
 // upsertGlobalRegistry will store a new registry with the given credentials into the global registry store.
 func (rs *Store) upsertGlobalRegistry(registry string, dce config.DockerConfigEntry) error {
 	var err error
-	name := genIntegrationName(GlobalRegNamePrefix, "", "", registry)
+	name := genIntegrationName(types.GlobalRegNamePrefix, "", "", registry)
 	_, err = rs.globalRegistries.UpdateImageIntegration(createImageIntegration(registry, dce, name))
 	if err != nil {
 		return errors.Wrapf(err, "updating registry store with registry %q", registry)
@@ -315,7 +309,7 @@ func (rs *Store) IsLocal(image *storage.ImageName) bool {
 	}
 
 	if rs.hasClusterLocalRegistryHost(image.GetRegistry()) {
-		// This host is always cluster local irregardless of the DelegatedRegistryConfig (ie: OCP internal registry).
+		// This host is always cluster local regardless of the DelegatedRegistryConfig (ie: OCP internal registry).
 		return true
 	}
 
@@ -512,7 +506,7 @@ func (rs *Store) upsertSecretByName(namespace, secretName string, dockerConfig c
 func (rs *Store) upsertPullSecretByNameNoLock(namespace, secretName, registryAddr string, dce config.DockerConfigEntry) {
 	registryAddr = urlfmt.TrimHTTPPrefixes(registryAddr)
 
-	name := genIntegrationName(PullSecretNamePrefix, namespace, secretName, registryAddr)
+	name := genIntegrationName(types.PullSecretNamePrefix, namespace, secretName, registryAddr)
 	ii := createImageIntegration(registryAddr, dce, name)
 
 	reg, err := rs.factory.CreateRegistry(ii, types.WithGCPTokenManager(gcp.Singleton()))

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -28,8 +28,9 @@ import (
 const (
 	defaultSA = "default"
 
-	pullSecretNamePrefix = "PullSec"
-	globalRegNamePrefix  = "Global"
+	PullSecretNamePrefix = "PullSec"
+	GlobalRegNamePrefix  = "Global"
+	NoAuthNamePrefix     = "NoAuth"
 )
 
 var (
@@ -219,7 +220,7 @@ func (rs *Store) upsertRegistry(namespace, registry string, dce config.DockerCon
 	// remove http/https prefixes from registry, matching may fail otherwise, the created registry.url will have
 	// the appropriate prefix
 	registry = urlfmt.TrimHTTPPrefixes(registry)
-	name := genIntegrationName(pullSecretNamePrefix, namespace, "", registry)
+	name := genIntegrationName(PullSecretNamePrefix, namespace, "", registry)
 
 	ii := createImageIntegration(registry, dce, name)
 	inserted, err := regs.UpdateImageIntegration(ii)
@@ -267,7 +268,7 @@ func (rs *Store) getRegistryForImageInNamespace(image *storage.ImageName, namesp
 // upsertGlobalRegistry will store a new registry with the given credentials into the global registry store.
 func (rs *Store) upsertGlobalRegistry(registry string, dce config.DockerConfigEntry) error {
 	var err error
-	name := genIntegrationName(globalRegNamePrefix, "", "", registry)
+	name := genIntegrationName(GlobalRegNamePrefix, "", "", registry)
 	_, err = rs.globalRegistries.UpdateImageIntegration(createImageIntegration(registry, dce, name))
 	if err != nil {
 		return errors.Wrapf(err, "updating registry store with registry %q", registry)
@@ -511,7 +512,7 @@ func (rs *Store) upsertSecretByName(namespace, secretName string, dockerConfig c
 func (rs *Store) upsertPullSecretByNameNoLock(namespace, secretName, registryAddr string, dce config.DockerConfigEntry) {
 	registryAddr = urlfmt.TrimHTTPPrefixes(registryAddr)
 
-	name := genIntegrationName(pullSecretNamePrefix, namespace, secretName, registryAddr)
+	name := genIntegrationName(PullSecretNamePrefix, namespace, secretName, registryAddr)
 	ii := createImageIntegration(registryAddr, dce, name)
 
 	reg, err := rs.factory.CreateRegistry(ii, types.WithGCPTokenManager(gcp.Singleton()))

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -813,7 +813,7 @@ func TestRegistyStore_Metrics(t *testing.T) {
 		c := metrics.PullSecretEntriesSize
 		metrics.ResetRegistryMetrics()
 
-		name := genIntegrationName(PullSecretNamePrefix, fakeNamespace, "", "example.com")
+		name := genIntegrationName(types.PullSecretNamePrefix, fakeNamespace, "", "example.com")
 		entrySize := float64(createImageIntegration("example.com", dce, name).SizeVT())
 
 		regStore := NewRegistryStore(alwaysInsecureCheckTLS)
@@ -869,7 +869,7 @@ func TestRegistyStore_Metrics(t *testing.T) {
 		c := metrics.PullSecretEntriesSize
 		metrics.ResetRegistryMetrics()
 
-		name := genIntegrationName(PullSecretNamePrefix, fakeNamespace, fakeSecretName, "example.com")
+		name := genIntegrationName(types.PullSecretNamePrefix, fakeNamespace, fakeSecretName, "example.com")
 		entrySize := float64(createImageIntegration("example.com", dce, name).SizeVT())
 		t.Logf("entrySize: %v", entrySize)
 

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -813,7 +813,7 @@ func TestRegistyStore_Metrics(t *testing.T) {
 		c := metrics.PullSecretEntriesSize
 		metrics.ResetRegistryMetrics()
 
-		name := genIntegrationName(pullSecretNamePrefix, fakeNamespace, "", "example.com")
+		name := genIntegrationName(PullSecretNamePrefix, fakeNamespace, "", "example.com")
 		entrySize := float64(createImageIntegration("example.com", dce, name).SizeVT())
 
 		regStore := NewRegistryStore(alwaysInsecureCheckTLS)
@@ -869,7 +869,7 @@ func TestRegistyStore_Metrics(t *testing.T) {
 		c := metrics.PullSecretEntriesSize
 		metrics.ResetRegistryMetrics()
 
-		name := genIntegrationName(pullSecretNamePrefix, fakeNamespace, fakeSecretName, "example.com")
+		name := genIntegrationName(PullSecretNamePrefix, fakeNamespace, fakeSecretName, "example.com")
 		entrySize := float64(createImageIntegration("example.com", dce, name).SizeVT())
 		t.Logf("entrySize: %v", entrySize)
 

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stackrox/rox/pkg/registrymirror"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/tlscheck"
-	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/scannerclient"
 	scannerV1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	"golang.org/x/sync/semaphore"
@@ -445,7 +444,7 @@ func createNoAuthImageRegistry(ctx context.Context, imgName *storage.ImageName, 
 
 	ii := &storage.ImageIntegration{
 		Id:         reg,
-		Name:       fmt.Sprintf("%s/reg:%v", registry.NoAuthNamePrefix, reg),
+		Name:       fmt.Sprintf("%s/reg:%v", registryTypes.NoAuthNamePrefix, reg),
 		Type:       registryTypes.DockerType,
 		Categories: []storage.ImageIntegrationCategory{storage.ImageIntegrationCategory_REGISTRY},
 		IntegrationConfig: &storage.ImageIntegration_Docker{

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -354,7 +354,7 @@ func (s *LocalScan) enrichImageWithMetadata(ctx context.Context, errorList *erro
 		if err != nil {
 			insecure := reg.Config(ctx).GetInsecure()
 			log.Debugf("Failed fetching metadata for image %q (%q) with integration %q (insecure: %t): %v", image.GetName().GetFullName(), image.GetId(), reg.Name(), insecure, err)
-			errs = append(errs, pkgErrors.Wrapf(err, "with integraton %q (insecure: %t)", reg.Name(), insecure))
+			errs = append(errs, pkgErrors.Wrapf(err, "with integration %q (insecure: %t)", reg.Name(), insecure))
 			continue
 		}
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

As part of our dog fooding efforts, we realized that we partially did not understand the scan errors. These are customer visible because they are surfaced in the administration events. We figured if we had problems, some customers might have similar problems. See also https://github.com/stackrox/stackrox/pull/13928, which fixes a problem with incorrect URL constructions in some cases.

This is an attempt to make scan request error messages slightly more contextual. These errors can quickly become hard to read because the errors of every registry attempt are concatenated.

I introduce two small changes which I think make the error message a bit easier to understand:
* more verbose integration type to easier identify (global) pull secret based integrations.
* separation by pull sources to surface image mirror configurations.

Before:
> `common/delegatedregistry: 2025/02/06 14:09:58.014281 delegated_registry_handler.go:136: Error: Scan failed for req "db1fb18e-ffbc-4a3f-9824-db44db32ddf0" image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:00bf8aef1ab5565c981ef94dd6158acbf2162c2c76bc6bbdfca2371a1b8ee0f9": image enrichment errors: [with integration "Public Quay.io" (insecure: false): failed to get the manifest digest: Head "https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:00bf8aef1ab5565c981ef94dd6158acbf2162c2c76bc6bbdfca2371a1b8ee0f9": http: non-successful response (status=401 body=""), with integration "Global/reg:quay.io/rhacs-eng" (insecure: false): failed to get the manifest digest: Head "https://quay.io/rhacs-eng/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:00bf8aef1ab5565c981ef94dd6158acbf2162c2c76bc6bbdfca2371a1b8ee0f9": http: non-successful response (status=404 body="")]`

After:
> `common/delegatedregistry: 2025/02/06 14:09:58.014281 delegated_registry_handler.go:136: Error: Scan failed for req "db1fb18e-ffbc-4a3f-9824-db44db32ddf0" image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:00bf8aef1ab5565c981ef94dd6158acbf2162c2c76bc6bbdfca2371a1b8ee0f9": image enrichment error: for pull source "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:00bf8aef1ab5565c981ef94dd6158acbf2162c2c76bc6bbdfca2371a1b8ee0f9" errors: [with integration "Public Quay.io" (insecure: false): failed to get the manifest digest: Head "https://quay.io/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:00bf8aef1ab5565c981ef94dd6158acbf2162c2c76bc6bbdfca2371a1b8ee0f9": http: non-successful response (status=401 body=""), with global pull secret integration "Global/reg:quay.io/rhacs-eng" (insecure: false): failed to get the manifest digest: Head "https://quay.io/rhacs-eng/v2/openshift-release-dev/ocp-v4.0-art-dev/manifests/sha256:00bf8aef1ab5565c981ef94dd6158acbf2162c2c76bc6bbdfca2371a1b8ee0f9": http: non-successful response (status=404 body="")]`

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Looked at the errors in sensor with delegated scanning.