### PR TITLE
ROX-27931: Revert stopper state propagation

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -195,7 +195,6 @@ func (a *apiImpl) Stop() bool {
 	a.listenersLock.Lock()
 	defer a.listenersLock.Unlock()
 
-	state := true
 	a.debugLog.Logf("Stopping %d listeners", len(a.listeners))
 	for _, listener := range a.listeners {
 		debugMsg := "unknown listener type: "
@@ -207,13 +206,13 @@ func (a *apiImpl) Stop() bool {
 		}
 		if listener.stopper != nil {
 			debugMsg += "stopped"
-			state = listener.stopper() && state
+			listener.stopper()
 		} else {
 			debugMsg += fmt.Sprintf("not stopped in loop. Comparing with grpcServer pointer with listener.srv pointer (%p : %p)", a.grpcServer, listener.srv)
 		}
 		a.debugLog.Log(debugMsg)
 	}
-	return state
+	return true
 }
 
 func (a *apiImpl) unaryInterceptors() []grpc.UnaryServerInterceptor {

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -107,9 +107,9 @@ func (a *APIServerSuite) Test_TwoTestsStartingAPIs() {
 	for i, api := range []API{api1, api2} {
 		// Running two tests that start the API results in failure.
 		a.Run(fmt.Sprintf("API test %d", i), func() {
-			a.T().Cleanup(func() { api.Stop() })
 			waitForPortToBeFree(a.T(), testPort)
 			a.Assert().NoError(api.Start().Wait())
+			a.Require().True(api.Stop())
 		})
 	}
 }


### PR DESCRIPTION
### Description

This PR reverts changes made in #14009 and #14123.

We are getting back to old logic where the execution state of `stopper` was ignored.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

Let CI pipeline run
