### PR TITLE
ROX-27973: use pgx.CollectRows

### DIFF
--- a/central/complianceoperator/v2/integration/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/integration/datastore/datastore_impl_test.go
@@ -194,7 +194,7 @@ func (s *complianceIntegrationDataStoreTestSuite) TestGetComplianceIntegrationBy
 		if tc.expectedResult != nil {
 			protoassert.SliceContains(s.T(), clusterIntegrations, tc.expectedResult)
 		} else {
-			s.Nil(clusterIntegrations)
+			s.Empty(clusterIntegrations)
 		}
 	}
 }

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -1396,7 +1396,6 @@ func (s *storeImpl) retryableUpdateVulnState(ctx context.Context, cve string, im
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 	var imageCVEEdges []*storage.ImageCVEEdge
 	imageCVEEdges, err = pgutils.ScanRows[storage.ImageCVEEdge](rows)
 	if err != nil || len(imageCVEEdges) == 0 {

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/migration_test.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/migration_test.go
@@ -146,13 +146,13 @@ func (s *migrationTestSuite) TestMigration() {
 	objs, err = newStore.GetByQuery(s.ctx,
 		search.NewQueryBuilder().AddExactMatches(search.CVE, "cve-2023-127").ProtoQuery())
 	assert.NoError(s.T(), err)
-	assert.Nil(s.T(), objs)
+	assert.Empty(s.T(), objs)
 
 	// Verify observed CVEs do not have exception request.
 	objs, err = newStore.GetByQuery(s.ctx,
 		search.NewQueryBuilder().AddExactMatches(search.CVE, "cve-2023-132").ProtoQuery())
 	assert.NoError(s.T(), err)
-	assert.Nil(s.T(), objs)
+	assert.Empty(s.T(), objs)
 
 	// Verify storage.ImageCVEEdge is updated.
 	var edgeObjs []*storage.ImageCVEEdge

--- a/pkg/postgres/pgutils/scan.go
+++ b/pkg/postgres/pgutils/scan.go
@@ -11,16 +11,12 @@ type Unmarshaler[T any] interface {
 }
 
 // ScanRows scan and Unmarshal postgres rows into object of type T.
+//
+// This function closes the rows automatically on return.
 func ScanRows[T any, PT Unmarshaler[T]](rows pgx.Rows) ([]*T, error) {
-	var results []*T
-	for rows.Next() {
-		msg, err := Unmarshal[T, PT](rows)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, msg)
-	}
-	return results, rows.Err()
+	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (*T, error) {
+		return Unmarshal[T, PT](rows)
+	})
 }
 
 // Unmarshal postgres row into object of type T

--- a/pkg/postgres/pgutils/scan.go
+++ b/pkg/postgres/pgutils/scan.go
@@ -14,8 +14,8 @@ type Unmarshaler[T any] interface {
 //
 // This function closes the rows automatically on return.
 func ScanRows[T any, PT Unmarshaler[T]](rows pgx.Rows) ([]*T, error) {
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (*T, error) {
-		return Unmarshal[T, PT](rows)
+	return pgx.CollectRows(rows, func(r pgx.CollectableRow) (*T, error) {
+		return Unmarshal[T, PT](r)
 	})
 }
 

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -967,7 +967,6 @@ func retryableRunGetManyQueryForSchema[T any, PT pgutils.Unmarshaler[T]](ctx con
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	return pgutils.ScanRows[T, PT](rows)
 }
@@ -1038,7 +1037,6 @@ func RunCursorQueryForSchema[T any, PT pgutils.Unmarshaler[T]](ctx context.Conte
 		if err != nil {
 			return nil, errors.Wrap(err, "advancing in cursor")
 		}
-		defer rows.Close()
 
 		return pgutils.ScanRows[T, PT](rows)
 	}, closer, nil


### PR DESCRIPTION
### Description

This is minor change that replaces custom implementation with one delivered by pgx.
The main difference is that `CollectRows` closes `rows` and return empty slice instead of `nil`.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
