### PR TITLE
fix(telemetery): mutex refactoring

### DIFF
--- a/central/telemetry/centralclient/instance_config_test.go
+++ b/central/telemetry/centralclient/instance_config_test.go
@@ -79,7 +79,7 @@ func TestInstanceConfig(t *testing.T) {
 			// non-release builds should provide the same key as in the remote
 			// config to make the remote key effective, otherwise the provided
 			// key is used instead.
-			"hardcoded", "not-equal-to-hardcoded",
+			env.TelemetrySelfManagedURL, "not-equal-to-hardcoded",
 			true, "not-equal-to-hardcoded",
 		},
 		"custom URL, no key": {

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -2,6 +2,11 @@ package env
 
 import "time"
 
+// TelemetrySelfManagedURL is the configuration URL for self-managed instances.
+// TODO(ROX-17726): Set default URL for self-managed installations use, and
+// update the code to not ignore this URL.
+const TelemetrySelfManagedURL = "hardcoded"
+
 var (
 	// Phone-Home telemetry variables:
 
@@ -10,10 +15,9 @@ var (
 		WithDefault("https://console.redhat.com/connections/api"), AllowEmpty())
 
 	// TelemetryConfigURL to retrieve the telemetry configuration from.
-	// TODO(ROX-17726): Set default URL for self-managed installations use.
 	// AllowEmpty() allows for disabling the downloading, and for providing a
 	// custom key to release binary versions.
-	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", AllowEmpty(), WithDefault("hardcoded"))
+	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", AllowEmpty(), WithDefault(TelemetrySelfManagedURL))
 
 	// TelemetryFrequency is the frequency at which we will report telemetry.
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 10*time.Minute)

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -32,7 +32,7 @@ type gatherer struct {
 	period      time.Duration
 	stopSig     concurrency.Signal
 	ctx         context.Context
-	gathering   sync.RWMutex
+	gathering   sync.Mutex
 	gatherFuncs []GatherFunc
 	opts        []telemeter.Option
 
@@ -69,8 +69,8 @@ func (g *gatherer) gather() map[string]any {
 
 func (g *gatherer) identify() {
 	// TODO: might make sense to abort if !TryLock(), but that's harder to test.
-	g.gathering.RLock()
-	defer g.gathering.RUnlock()
+	g.gathering.Lock()
+	defer g.gathering.Unlock()
 	data := g.gather()
 	// Track event makes the properties effective for the user on analytics.
 	// Duplicates are dropped during a day. The daily potential duplicate event

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -109,8 +109,8 @@ func (g *gatherer) Start(opts ...telemeter.Option) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.stopSig.IsDone() {
-		g.reset()
 		concurrency.WithLock(&g.gathering, func() {
+			g.reset()
 			g.opts = opts
 		})
 		go g.loop()

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -63,8 +63,9 @@ func (s *gathererTestSuite) TestGathererTicker() {
 	defer lastTrack.Wait()
 	expectedTraits := matchOptions(telemeter.WithTraits(map[string]any{"key": "value"}))
 	const expectedEvent = "Updated Test Identity"
+	const nTimes = 4
 	gomock.InOrder(
-		t.EXPECT().Track(expectedEvent, nil, expectedTraits).Times(3),
+		t.EXPECT().Track(expectedEvent, nil, expectedTraits).Times(nTimes-1),
 		// Stop gathering after 3rd heartbeat:
 		t.EXPECT().Track(expectedEvent, nil, expectedTraits).Times(1).
 			Do(func(any, any, ...any) {
@@ -86,12 +87,10 @@ func (s *gathererTestSuite) TestGathererTicker() {
 	})
 	g.Start()
 	s.Equal(int64(1), <-n, "gathering should be called once on start")
-	tickChan <- time.Now()
-	s.Equal(int64(2), <-n, "gathering should be called on tick")
-	tickChan <- time.Now()
-	tickChan <- time.Now()
-	s.Equal(int64(3), <-n)
-	s.Equal(int64(4), <-n, "there should have been 4 gathering calls")
+	for i := 2; i <= nTimes; i++ {
+		tickChan <- time.Now()
+		s.Equal(int64(i), <-n, "gathering should be called on tick")
+	}
 }
 
 func (s *gathererTestSuite) TestGathererWithNoDuplicates() {

--- a/pkg/telemetry/phonehome/runtime_config.go
+++ b/pkg/telemetry/phonehome/runtime_config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/version"
 )
@@ -57,8 +58,9 @@ func GetRuntimeConfig(cfgURL, defaultKey string) (*RuntimeConfig, error) {
 
 // downloadConfig downloads the configuration from the provided url.
 func downloadConfig(u string) (*RuntimeConfig, error) {
-	if u == "hardcoded" {
-		// TODO(ROX-17726): Use the hardcoded key for now.
+	// TODO(ROX-17726): Remove this clause:
+	if u == env.TelemetrySelfManagedURL {
+		// Use the hardcoded key for now.
 		return &RuntimeConfig{Key: selfManagedKey}, nil
 	}
 	client := http.Client{

--- a/pkg/telemetry/phonehome/runtime_config_test.go
+++ b/pkg/telemetry/phonehome/runtime_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,11 +29,10 @@ func Test_toDownload(t *testing.T) {
 		"g": {release: true, key: "", cfgURL: "url", download: true},
 		"h": {release: true, key: "abc", cfgURL: "url", download: false},
 
-		// "hardcoded" is a special value.
-		"j": {release: false, key: "", cfgURL: "hardcoded", download: false},
-		"k": {release: false, key: "abc", cfgURL: "hardcoded", download: true},
-		"l": {release: true, key: "", cfgURL: "hardcoded", download: true},
-		"m": {release: true, key: "abc", cfgURL: "hardcoded", download: false},
+		"j": {release: false, key: "", cfgURL: env.TelemetrySelfManagedURL, download: false},
+		"k": {release: false, key: "abc", cfgURL: env.TelemetrySelfManagedURL, download: true},
+		"l": {release: true, key: "", cfgURL: env.TelemetrySelfManagedURL, download: true},
+		"m": {release: true, key: "abc", cfgURL: env.TelemetrySelfManagedURL, download: false},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -73,7 +73,7 @@ func Test_useRemoteKey(t *testing.T) {
 }
 
 func Test_download(t *testing.T) {
-	cfg, err := downloadConfig("hardcoded")
+	cfg, err := downloadConfig(env.TelemetrySelfManagedURL)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cfg.Key)
 
@@ -111,15 +111,15 @@ func Test_GetKey(t *testing.T) {
 		expectedErr error
 	}{
 		"a": {defaultKey: "", cfgURL: ""},
-		"b": {defaultKey: "", cfgURL: "hardcoded"},
+		"b": {defaultKey: "", cfgURL: env.TelemetrySelfManagedURL},
 		"c": {defaultKey: DisabledKey, cfgURL: ""},
-		"d": {defaultKey: "abc", cfgURL: "hardcoded",
+		"d": {defaultKey: "abc", cfgURL: env.TelemetrySelfManagedURL,
 			expectedKey: "abc",
 		},
 		"e": {defaultKey: "ignored", cfgURL: ":bad url:",
 			expectedErr: errors.New("missing protocol scheme"),
 		},
-		"f": {defaultKey: selfManagedKey, cfgURL: "hardcoded",
+		"f": {defaultKey: selfManagedKey, cfgURL: env.TelemetrySelfManagedURL,
 			expectedKey: selfManagedKey,
 		},
 		"g": {defaultKey: remoteKey, cfgURL: server.URL,


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Race spot in this unit test CI run:
https://github.com/stackrox/stackrox/actions/runs/13154335828?pr=13963

The problem is in the concurrent access to `g.ctx`.

```
telemetry/centralclient: 2025/02/05 09:49:34.910912 instance_config.go:128: Info: Telemetry collection is disabled
==================
WARNING: DATA RACE
Write at 0x00c000c901b0 by goroutine 130:
  github.com/stackrox/rox/pkg/telemetry/phonehome.(*gatherer).reset()
      /__w/stackrox/stackrox/pkg/telemetry/phonehome/gatherer.go:56 +0xf8
  github.com/stackrox/rox/pkg/telemetry/phonehome.(*gatherer).Start()
      /__w/stackrox/stackrox/pkg/telemetry/phonehome/gatherer.go:112 +0xe4
  github.com/stackrox/rox/central/telemetry/centralclient.Enable()
      /__w/stackrox/stackrox/central/telemetry/centralclient/instance_config.go:209 +0x5ce
  github.com/stackrox/rox/central/telemetry/centralclient.Test_reloadConfig.func7()
      /__w/stackrox/stackrox/central/telemetry/centralclient/runtime_config_test.go:144 +0x144
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x259
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44
Previous read at 0x00c000c901b0 by goroutine 122:
github.com/stackrox/rox/pkg/telemetry/phonehome.(*gatherer).gather()
/__w/stackrox/stackrox/pkg/telemetry/phonehome/gatherer.go:62 +0xe4
github.com/stackrox/rox/pkg/telemetry/phonehome.(*gatherer).identify()
/__w/stackrox/stackrox/pkg/telemetry/phonehome/gatherer.go:80 +0xc4
github.com/stackrox/rox/pkg/telemetry/phonehome.(*gatherer).loop()
/__w/stackrox/stackrox/pkg/telemetry/phonehome/gatherer.go:90 +0x3e
github.com/stackrox/rox/pkg/telemetry/phonehome.(*gatherer).Start.gowrap2()
/__w/stackrox/stackrox/pkg/telemetry/phonehome/gatherer.go:116 +0x33
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests.