### PR TITLE
ROX-27441: Fix Policy As Code CI Flakes

### DIFF
--- a/config-controller/internal/controller/policy_controller.go
+++ b/config-controller/internal/controller/policy_controller.go
@@ -73,6 +73,7 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	desiredState, err := policyCR.Spec.ToProtobuf(r.CentralClient.GetNotifiers())
 	if err != nil {
+		_ = r.CentralClient.FlushCache(ctx)
 		policyCR.Status = configstackroxiov1alpha1.SecurityPolicyStatus{
 			Accepted: false,
 			Message:  err.Error(),

--- a/config-controller/pkg/client/client.go
+++ b/config-controller/pkg/client/client.go
@@ -317,7 +317,7 @@ func (c *client) FlushCache(ctx context.Context) error {
 		return nil
 	}
 
-	log.Info("Flushing policy cache")
+	log.Info("Flushing policy caches")
 
 	log.Debug("Listing policies")
 	allPolicies, err := c.centralSvc.ListPolicies(ctx)

--- a/config-controller/pkg/client/client.go
+++ b/config-controller/pkg/client/client.go
@@ -317,7 +317,7 @@ func (c *client) FlushCache(ctx context.Context) error {
 		return nil
 	}
 
-	log.Info("Flushing policy caches")
+	log.Info("Flushing caches")
 
 	log.Debug("Listing policies")
 	allPolicies, err := c.centralSvc.ListPolicies(ctx)

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -321,7 +321,7 @@ func (pc *PolicyAsCodeSuite) createPolicyInK8s(toCreate *v1alpha1.SecurityPolicy
 	pc.Require().NoError(err)
 
 	message := "status never udpated"
-	timer := time.NewTimer(time.Second * 5)
+	timer := time.NewTimer(time.Minute)
 	for {
 		select {
 		case <-timer.C:
@@ -433,7 +433,7 @@ func (pc *PolicyAsCodeSuite) createCRAndObserveInCentral(policyCR *v1alpha1.Secu
 			}
 		}
 		assert.NotEmpty(collect, policyId)
-	}, time.Minute*5, time.Millisecond*30)
+	}, time.Minute, time.Millisecond*30)
 	return policyId
 }
 

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -187,7 +187,7 @@ func (pc *PolicyAsCodeSuite) TestRenameToDefaultCR() {
 	pc.Require().NoError(err)
 	pc.fromUnstructured(u, k8sPolicy)
 
-	message := "status never udpated"
+	message := "status never updated"
 	timer := time.NewTimer(time.Second * 5)
 	for {
 		accepted := false
@@ -320,7 +320,7 @@ func (pc *PolicyAsCodeSuite) createPolicyInK8s(toCreate *v1alpha1.SecurityPolicy
 	_, err := pc.k8sClient.Create(pc.ctx, pc.toUnstructured(toCreate), metav1.CreateOptions{})
 	pc.Require().NoError(err)
 
-	message := "status never udpated"
+	message := "status never updated"
 	timer := time.NewTimer(time.Minute)
 	for {
 		select {

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -321,7 +321,7 @@ func (pc *PolicyAsCodeSuite) createPolicyInK8s(toCreate *v1alpha1.SecurityPolicy
 	pc.Require().NoError(err)
 
 	message := "status never updated"
-	timer := time.NewTimer(time.Minute)
+	timer := time.NewTimer(time.Second * 5)
 	for {
 		select {
 		case <-timer.C:
@@ -433,7 +433,7 @@ func (pc *PolicyAsCodeSuite) createCRAndObserveInCentral(policyCR *v1alpha1.Secu
 			}
 		}
 		assert.NotEmpty(collect, policyId)
-	}, time.Minute, time.Millisecond*30)
+	}, time.Second*5, time.Millisecond*30)
 	return policyId
 }
 

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -163,7 +163,7 @@ func (pc *PolicyAsCodeSuite) TestCreateDefaultCR() {
 	_, err := pc.k8sClient.Create(pc.ctx, pc.toUnstructured(k8sPolicy), metav1.CreateOptions{})
 	pc.Require().NoError(err)
 
-	message := "status never udpated"
+	message := "status never updated"
 	timer := time.NewTimer(time.Second * 5)
 	for {
 		select {
@@ -433,7 +433,7 @@ func (pc *PolicyAsCodeSuite) createCRAndObserveInCentral(policyCR *v1alpha1.Secu
 			}
 		}
 		assert.NotEmpty(collect, policyId)
-	}, time.Second*5, time.Millisecond*30)
+	}, time.Minute*5, time.Millisecond*30)
 	return policyId
 }
 


### PR DESCRIPTION
### Description

Extended the timeout on waiting for a policy to be created to allow for policy creation to take a few seconds

(Also fixed a random typo)

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Ran the TestCreateCR test, as well as the entire Policy as Code suite and they passed
