### PR TITLE
ROX-27866: Add UI for central-db cert expiry notices

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -71,6 +71,12 @@ export const integrationHealth = {
     vulnDefinitions: '/v1/integrationhealth/vulndefinitions?component=*',
 };
 
+export const credentialHealth = {
+    central: '/v1/credentialexpiry?component=CENTRAL',
+    centralDb: '/v1/credentialexpiry?component=CENTRAL_DB',
+    scanner: '/v1/credentialexpiry?component=SCANNER',
+};
+
 export const integrations = {
     imageIntegrations: '/v1/imageintegrations',
     signatureIntegrations: '/v1/signatureintegrations',

--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -16,6 +16,9 @@ export function setClock(currentDatetime) {
 export const integrationHealthVulnDefinitionsAlias =
     'integrationhealth/vulndefinitions?component=*';
 export const integrationHealthDeclarativeConfigsAlias = 'declarative-config/health';
+export const credentialForCentralExpiryAlias = 'credentialexpiry?component=CENTRAL';
+export const credentialForCentralDbExpiryAlias = 'credentialexpiry?component=CENTRAL_DB';
+export const credentialForScannerExpiryAlias = 'credentialexpiry?component=SCANNER';
 
 const SystemHealthHeadingSelector = 'h1:contains("System Health")';
 const routeMatcherMap = {
@@ -38,6 +41,18 @@ const routeMatcherMap = {
     'integrationhealth/externalbackups': {
         method: 'GET',
         url: api.integrationHealth.externalBackups,
+    },
+    [credentialForCentralExpiryAlias]: {
+        method: 'GET',
+        url: api.credentialHealth.central,
+    },
+    [credentialForCentralDbExpiryAlias]: {
+        method: 'GET',
+        url: api.credentialHealth.centralDb,
+    },
+    [credentialForScannerExpiryAlias]: {
+        method: 'GET',
+        url: api.credentialHealth.scanner,
     },
     externalbackups: {
         method: 'GET',

--- a/ui/apps/platform/cypress/integration/systemHealth/certificateHealthCards.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/certificateHealthCards.test.js
@@ -28,7 +28,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorCentral}:contains(expires in 12 months)`);
+            cy.get(`${statusSelectorCentral}:contains("expires in 12 months")`);
         });
 
         it('should have widget with warning text for less than 2 weeks', () => {
@@ -42,7 +42,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorCentral}:contains(expires in 13 days)`);
+            cy.get(`${statusSelectorCentral}:contains("expires in 13 days")`);
         });
 
         it('should have widget with error text for less than 24 hours', () => {
@@ -56,7 +56,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorCentral}:contains(expires in 1 day)`);
+            cy.get(`${statusSelectorCentral}:contains("expires in 1 day")`);
         });
     });
 
@@ -72,7 +72,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorCentralDb}:contains(expires in 12 months)`);
+            cy.get(`${statusSelectorCentralDb}:contains("expires in 12 months")`);
         });
 
         it('should have widget with warning text for less than 2 weeks', () => {
@@ -86,7 +86,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorCentralDb}:contains(expires in 13 days)`);
+            cy.get(`${statusSelectorCentralDb}:contains("expires in 13 days")`);
         });
 
         it('should have widget with error text for less than 24 hours', () => {
@@ -100,7 +100,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorCentralDb}:contains(expires in 1 day)`);
+            cy.get(`${statusSelectorCentralDb}:contains("expires in 1 day")`);
         });
     });
 
@@ -116,7 +116,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorScanner}:contains(expires in 12 months)`);
+            cy.get(`${statusSelectorScanner}:contains("expires in 12 months")`);
         });
 
         it('should have widget with warning text for less than 2 weeks', () => {
@@ -130,7 +130,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorScanner}:contains(expires in 13 days)`);
+            cy.get(`${statusSelectorScanner}:contains("expires in 13 days")`);
         });
 
         it('should have widget with error text for less than 24 hours', () => {
@@ -144,7 +144,7 @@ describe('System Health Certificate Health Cards', () => {
             setClock(currentDatetime); // call before visit
             visitSystemHealth(staticResponseMap);
 
-            cy.get(`${statusSelectorScanner}:contains(expires in 1 day)`);
+            cy.get(`${statusSelectorScanner}:contains("expires in 1 day")`);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/systemHealth/certificateHealthCards.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/certificateHealthCards.test.js
@@ -1,0 +1,150 @@
+import withAuth from '../../helpers/basicAuth';
+import {
+    credentialForCentralExpiryAlias,
+    credentialForCentralDbExpiryAlias,
+    credentialForScannerExpiryAlias,
+    setClock,
+    visitSystemHealth,
+} from '../../helpers/systemHealth';
+
+const statusSelectorCentral = 'div:has(.pf-v5-c-card__header:contains("Central certificate"))';
+const statusSelectorCentralDb =
+    'div:has(.pf-v5-c-card__header:contains("Central Database certificate"))';
+const statusSelectorScanner =
+    'div:has(.pf-v5-c-card__header:contains("StackRox Scanner certificate"))';
+
+describe('System Health Certificate Health Cards', () => {
+    withAuth();
+
+    describe('Central certificate', () => {
+        it('should have widget and up to date text', () => {
+            const currentDatetime = new Date('2025-05-21T02:04:59.377369440Z'); // about 355 days until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForCentralExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorCentral}:contains(expires in 12 months)`);
+        });
+
+        it('should have widget with warning text for less than 2 weeks', () => {
+            const currentDatetime = new Date('2026-05-07T02:04:59.377369440Z'); // about 13 days until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForCentralExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorCentral}:contains(expires in 13 days)`);
+        });
+
+        it('should have widget with error text for less than 24 hours', () => {
+            const currentDatetime = new Date('2026-05-19T02:05:59.377369440Z'); // about 23 hours, 59 minutes until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForCentralExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorCentral}:contains(expires in 1 day)`);
+        });
+    });
+
+    describe('Central Database certificate', () => {
+        it('should have widget and up to date text', () => {
+            const currentDatetime = new Date('2025-05-21T02:04:59.377369440Z'); // about 355 days until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForCentralDbExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorCentralDb}:contains(expires in 12 months)`);
+        });
+
+        it('should have widget with warning text for less than 2 weeks', () => {
+            const currentDatetime = new Date('2026-05-07T02:04:59.377369440Z'); // about 13 days until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForCentralDbExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorCentralDb}:contains(expires in 13 days)`);
+        });
+
+        it('should have widget with error text for less than 24 hours', () => {
+            const currentDatetime = new Date('2026-05-19T02:05:59.377369440Z'); // about 23 hours, 59 minutes until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForCentralDbExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorCentralDb}:contains(expires in 1 day)`);
+        });
+    });
+
+    describe('StackRox Scanner certificate', () => {
+        it('should have widget and up to date text', () => {
+            const currentDatetime = new Date('2025-05-21T02:04:59.377369440Z'); // about 355 days until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForScannerExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorScanner}:contains(expires in 12 months)`);
+        });
+
+        it('should have widget with warning text for less than 2 weeks', () => {
+            const currentDatetime = new Date('2026-05-07T02:04:59.377369440Z'); // about 13 days until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForScannerExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorScanner}:contains(expires in 13 days)`);
+        });
+
+        it('should have widget with error text for less than 24 hours', () => {
+            const currentDatetime = new Date('2026-05-19T02:05:59.377369440Z'); // about 23 hours, 59 minutes until expiry
+            const expiry = '2026-05-20T03:04:59.377369440Z';
+
+            const staticResponseMap = {
+                [credentialForScannerExpiryAlias]: { body: { expiry } },
+            };
+
+            setClock(currentDatetime); // call before visit
+            visitSystemHealth(staticResponseMap);
+
+            cy.get(`${statusSelectorScanner}:contains(expires in 1 day)`);
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
@@ -29,6 +29,10 @@ function Banners(): ReactElement {
                 showCertGenerateAction={showCertGenerateAction}
             />
             <CredentialExpiryBanner
+                component="CENTRAL_DB"
+                showCertGenerateAction={showCertGenerateAction}
+            />
+            <CredentialExpiryBanner
                 component="SCANNER"
                 showCertGenerateAction={showCertGenerateAction}
             />

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -110,7 +110,9 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
                 </Flex>
             </CardHeader>
             <CardBody>
-                {hasAdministrationWritePermission ? (
+                {hasAdministrationWritePermission &&
+                // if the DB is external, the expiry will be returned as null, and we do not want to show renewal
+                (component !== 'CENTRAL_DB' || expirationDate) ? (
                     <Flex>
                         <FlexItem>
                             To update the certificate, download the YAML file and apply it to your

--- a/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
@@ -107,6 +107,9 @@ const SystemHealthDashboardPage = () => {
                         <CertificateCard component="CENTRAL" pollingCount={pollingCountSlower} />
                     </GridItem>
                     <GridItem span={12}>
+                        <CertificateCard component="CENTRAL_DB" pollingCount={pollingCountSlower} />
+                    </GridItem>
+                    <GridItem span={12}>
                         <CertificateCard component="SCANNER" pollingCount={pollingCountSlower} />
                     </GridItem>
                     {isScannerV4Enabled && (

--- a/ui/apps/platform/src/services/CertGenerationService.ts
+++ b/ui/apps/platform/src/services/CertGenerationService.ts
@@ -8,6 +8,7 @@ const pathSegmentForComponent: Record<CertExpiryComponent, string> = {
     CENTRAL: 'central',
     SCANNER: 'scanner',
     SCANNER_V4: 'scanner?v=4',
+    CENTRAL_DB: 'central-db',
 };
 
 export function generateCertSecretForComponent(component: CertExpiryComponent) {

--- a/ui/apps/platform/src/types/credentialExpiryService.proto.ts
+++ b/ui/apps/platform/src/types/credentialExpiryService.proto.ts
@@ -1,1 +1,1 @@
-export type CertExpiryComponent = 'CENTRAL' | 'SCANNER' | 'SCANNER_V4'; // omit 'UNKNOWN'
+export type CertExpiryComponent = 'CENTRAL' | 'CENTRAL_DB' | 'SCANNER' | 'SCANNER_V4'; // omit 'UNKNOWN'

--- a/ui/apps/platform/src/utils/credentialExpiry.ts
+++ b/ui/apps/platform/src/utils/credentialExpiry.ts
@@ -44,4 +44,5 @@ export const nameOfComponent: Record<CertExpiryComponent, string> = {
     CENTRAL: 'Central',
     SCANNER: 'StackRox Scanner',
     SCANNER_V4: 'Scanner V4',
+    CENTRAL_DB: 'Central Database',
 };


### PR DESCRIPTION
### Description

This change add UI elements to show the health, and if necessary imminent expiration of the Central-DB certificate.

This change is necessary because several orgs were alerts by their instance of the need to renew the other certificates, for Central and Scanner, but were not aware that they also needed to renew the certificate for the on-prem Central DB Postgres instance.

#### Additions: 
- New card, which is always present on the System Health page, that shows the status of the central-db certificate and the relative and absolute time until expiry
- - Green if expiry is more than 14 days away
- - Yellow if expiry is less than 14 days, but more than 3 days away
- - Red if expiry is less than 3 days away
- Yellow banner at top of all pages, present only if expiry is less than 14 days, but more than 3 days away
- Red banner at top of all pages, present only if expiry is less than 3 days away

Note: 
- These UI changes depend upon API changes in a different PR, https://github.com/stackrox/stackrox/pull/13870.
- UI changes were developed and tests against a cluster in which that API PR's image was deployed

#### Addition

API changed to return a NULL if an external DB is being used, so added to this PR a check to only show the renewal action if the card is NOT for the Central-DB OR an expiry time exist. (Option already not shown on network error.)

Example screenshot with API response mocked with no expiry in response:
![Screenshot 2025-02-11 at 3 55 21 PM](https://github.com/user-attachments/assets/12167420-8798-4361-a8fe-108899592696)

Truth table used:
<img width="667" alt="Screenshot 2025-02-11 at 6 05 08 PM" src="https://github.com/user-attachments/assets/7667bce6-4ce5-4777-9f2e-7e854359ed14" />

^ cc: @charmik-redhat 


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request)  is not needed

### Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are inspected

#### Automated testing

- [x] added e2e tests

#### How I validated my change

I added new UI e2e tests added for this change. (In fact, none of the existing System Health cards were covered by UI e2e tests yet; so, I created a new test file and wrote 3 tests--green, yellow, and red states-- with mocks for all 3 of the credential widgets, this new one, and the existing Central and Scanner widgets.)

New Central-DB card (green):
![Screenshot 2025-02-06 at 2 31 05 PM](https://github.com/user-attachments/assets/e342a65d-9600-4ae6-a11e-b2ed228bd356)


New Central-DB card (yellow):
![Screenshot 2025-02-06 at 2 27 46 PM](https://github.com/user-attachments/assets/520d8f4c-6ffe-47f5-8e67-01f33af21981)


New Central-DB card (red):
![Screenshot 2025-02-06 at 2 30 09 PM](https://github.com/user-attachments/assets/0e0840a0-6563-4029-aa75-0c0c77967dda)


New `central-db-tls.yaml` file downloaded from button on new card:
![Screenshot 2025-02-06 at 2 32 23 PM](https://github.com/user-attachments/assets/183fa1c3-24cf-4ac1-9473-259a2bc846d3)


New Central-DB warning banner (yellow):
![Screenshot 2025-02-06 at 3 23 03 PM](https://github.com/user-attachments/assets/c238f2f5-32e7-41b3-b933-7ce2feb0da17)


New Central-DB error banner (red):
![Screenshot 2025-02-06 at 3 21 03 PM](https://github.com/user-attachments/assets/656b51a8-a943-447f-975f-711b1aa551f8)
