### PR TITLE
ROX-27967: Select max epssProbability from distroTuples

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -324,7 +324,7 @@ export function getCveBaseInfoFromDistroTuples(
     let cveBaseInfoMax: CveBaseInfo | undefined;
 
     if (Array.isArray(distroTuples)) {
-        let epssProbabilityMax = -1; // in case epssProbability is every zero
+        let epssProbabilityMax = -1; // in case epssProbability is ever zero
         distroTuples.forEach(({ cveBaseInfo }) => {
             if (cveBaseInfo?.epss && cveBaseInfo.epss?.epssProbability > epssProbabilityMax) {
                 cveBaseInfoMax = cveBaseInfo;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -319,8 +319,21 @@ export function formatVulnerabilityData(
 export function getCveBaseInfoFromDistroTuples(
     distroTuples: { cveBaseInfo: CveBaseInfo }[]
 ): CveBaseInfo | undefined {
-    // Assume that epss property has same value for each of multiple items.
-    return distroTuples?.[0]?.cveBaseInfo;
+    // Return cveBaseInfo that has max value of epssProbability,
+    // consistent with aggregateFunc: 'max' property in sortUtils.tsx file.
+    let cveBaseInfoMax: CveBaseInfo | undefined;
+
+    if (Array.isArray(distroTuples)) {
+        let epssProbabilityMax = -1; // in case epssProbability is every zero
+        distroTuples.forEach(({ cveBaseInfo }) => {
+            if (cveBaseInfo?.epss && cveBaseInfo.epss?.epssProbability > epssProbabilityMax) {
+                cveBaseInfoMax = cveBaseInfo;
+                epssProbabilityMax = cveBaseInfo.epss.epssProbability;
+            }
+        });
+    }
+
+    return cveBaseInfoMax;
 }
 
 // Given probability as float fraction, return as percent with 3 decimal digits.


### PR DESCRIPTION
### Description

### Problem

Thanks to **David Vail** for seeing that RHSA-2023:7198 has **EPSS probability** of 0.090% in Workload CVEs table but sorts as if about 80%

### Analysis

Thanks to **Surabhi** for digging deep and to **Charmik** for collaborating to conclude that central sorts according to `aggregateFunc: 'max'` but UI displays the first item in `distroTuples` array.

### Solution

Correct my false assumption in `getCveBaseInfoFromDistroTuples` function:

```js
// Assume that epss property has same value for each of multiple items.
```

Instead of first item, find item that has max value.

To minimize changes, `cveBaseInfo` is the return value.

### Residue

1. Although ImageVulnerabilitiesTable and DeploymentVulnerabilitiesTable have only one `epss` property per row, the particular value might not be the max.

    **Shubha** is deciding whether it might reduce confusion to turn off **EPSS probability** column in those tables for 4.7 release, and then turn on with problem solved by CVE/Advisory separation in 4.8 release.

2. Because `null` sorts high, there were multiple pages of **Not available** on staging demo :(

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4645989 - 4645989
        total 122 = 11594326 - 11594204
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Run UI with staging demo, which has **Scanner V4** and `ROX_EPSS_SCORE` feature flag enabled.

1. Visit **Workflow CVEs**

    POST /api/graphql?opname=getImageCVEList

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx

    Before changes with search filter for RHSA-2023:7198, see non-max value
    ![WorkloadCveOverviewTable_without_max](https://github.com/user-attachments/assets/d281cdc2-bc11-4580-b5d2-c1ef92984545)

    After changes sorted descending by **EPSS probability**, see max value
    ![WorkloadCveOverviewTable_with_max](https://github.com/user-attachments/assets/adc24fc0-e288-4233-a590-bda5e235ec88)

2. Click a vulnerability link

    POST /api/graphql?opname=getImageCveMetadata

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx

    Before changes, see non-max value
    ![CvePageHeader_without_max](https://github.com/user-attachments/assets/b10a3d94-2d8e-4957-bb55-e70fdb556a8a)

    After changes, see max value
    ![CvePageHeader_with_max](https://github.com/user-attachments/assets/0519995b-31b0-47c9-ab03-02ac77663414)
