### PR TITLE
ROX-27971: removes ROX_NETWORK_GRAPH_EXTERNAL_IPS feature flag

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -102,9 +102,6 @@ var (
 	// ExternalIPs enables storing detailed discovered external IPs
 	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS", enabled)
 
-	// NetworkGraphExternalIPs enables displaying external (discovered) entities in the network graph
-	NetworkGraphExternalIPs = registerFeature("Enables display of external IPs in the network graph UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
-
 	// ScannerV4RedHatCVEs enables displaying CVEs instead of RHSAs/RHEAs/RHBAs in the place of fixed vulnerabilities affected Red Hat products.
 	// TODO(ROX-26672): Remove this once we can show both CVEs and RHSAs in the UI + reports.
 	ScannerV4RedHatCVEs = registerFeature("Scanner V4 will output CVEs instead of RHSAs/RHBAs/RHEAs for fixed Red Hat vulnerabilities", "ROX_SCANNER_V4_RED_HAT_CVES")


### PR DESCRIPTION
### Description

It is redundant. Behavior now is as if the flag has been set to false. External IP information is available via other APIs. Aggregation prevents overloading the graph with many nodes.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No new tests added. The behavior is unchanged.

#### How I validated my change

CI should be enough.
