### PR TITLE
chore(postgres): inherit latest upstream changes

### DIFF
--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This file is from https://github.com/docker-library/postgres/tree/master/14/bullseye
+# This file is from https://github.com/docker-library/postgres/tree/master/15/bookworm
 set -Eeo pipefail
 # TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
@@ -18,7 +18,7 @@ file_env() {
 	local fileVar="${var}_FILE"
 	local def="${2:-}"
 	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
-		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		printf >&2 'error: both %s and %s are set (but are exclusive)\n' "$var" "$fileVar"
 		exit 1
 	fi
 	local val="$def"
@@ -45,14 +45,14 @@ docker_create_db_directories() {
 
 	mkdir -p "$PGDATA"
 	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
-	chmod 700 "$PGDATA" || :
+	chmod 00700 "$PGDATA" || :
 
 	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
 	mkdir -p /var/run/postgresql || :
-	chmod 775 /var/run/postgresql || :
+	chmod 03775 /var/run/postgresql || :
 
 	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
-	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "${POSTGRES_INITDB_WALDIR:-}" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$user" = '0' ]; then
 			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
@@ -84,18 +84,19 @@ docker_init_database_dir() {
 				NSS_WRAPPER_GROUP="$(mktemp)"
 				export LD_PRELOAD="$wrapper" NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
 				local gid; gid="$(id -g)"
-				echo "postgres:x:$uid:$gid:PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
-				echo "postgres:x:$gid:" > "$NSS_WRAPPER_GROUP"
+				printf 'postgres:x:%s:%s:PostgreSQL:%s:/bin/false\n' "$uid" "$gid" "$PGDATA" > "$NSS_WRAPPER_PASSWD"
+				printf 'postgres:x:%s:\n' "$gid" > "$NSS_WRAPPER_GROUP"
 				break
 			fi
 		done
 	fi
 
-	if [ -n "$POSTGRES_INITDB_WALDIR" ]; then
+	if [ -n "${POSTGRES_INITDB_WALDIR:-}" ]; then
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 
-	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") --encoding=UTF8 '"$POSTGRES_INITDB_ARGS"' "$@"'
+	# --pwfile refuses to handle a properly-empty file (hence the "\n"): https://github.com/docker-library/postgres/issues/1025
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(printf "%s\n" "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
 	# unset/cleanup "nss_wrapper" bits
 	if [[ "${LD_PRELOAD:-}" == */libnss_wrapper.so ]]; then
@@ -109,20 +110,24 @@ docker_init_database_dir() {
 # print large warning if POSTGRES_HOST_AUTH_METHOD is set to 'trust'
 # assumes database is not set up, ie: [ -z "$DATABASE_ALREADY_EXISTS" ]
 docker_verify_minimum_env() {
-	# check password first so we can output the warning before postgres
-	# messes it up
-	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-		cat >&2 <<-'EOWARN'
+	case "${PG_MAJOR:-}" in
+		13) # https://github.com/postgres/postgres/commit/67a472d71c98c3d2fa322a1b4013080b20720b98
+			# check password first so we can output the warning before postgres
+			# messes it up
+			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+				cat >&2 <<-'EOWARN'
 
-			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			  This will not work if used via PGPASSWORD with "psql".
+					  This will not work if used via PGPASSWORD with "psql".
 
-			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-			  https://github.com/docker-library/postgres/issues/507
+					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+					  https://github.com/docker-library/postgres/issues/507
 
-		EOWARN
-	fi
+				EOWARN
+			fi
+			;;
+	esac
 	if [ -z "$POSTGRES_PASSWORD" ] && [ 'trust' != "$POSTGRES_HOST_AUTH_METHOD" ]; then
 		# The - option suppresses leading tabs but *not* spaces. :)
 		cat >&2 <<-'EOE'
@@ -164,7 +169,7 @@ docker_process_init_files() {
 	# psql here for backwards compatibility "${psql[@]}"
 	psql=( docker_process_sql )
 
-	echo
+	printf '\n'
 	local f
 	for f; do
 		case "$f" in
@@ -172,19 +177,20 @@ docker_process_init_files() {
 				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
 				# https://github.com/docker-library/postgres/pull/452
 				if [ -x "$f" ]; then
-					echo "$0: running $f"
+					printf '%s: running %s\n' "$0" "$f"
 					"$f"
 				else
-					echo "$0: sourcing $f"
+					printf '%s: sourcing %s\n' "$0" "$f"
 					. "$f"
 				fi
 				;;
-			*.sql)    echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
-			*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        echo "$0: ignoring $f" ;;
+			*.sql)     printf '%s: running %s\n' "$0" "$f"; docker_process_sql -f "$f"; printf '\n' ;;
+			*.sql.gz)  printf '%s: running %s\n' "$0" "$f"; gunzip -c "$f" | docker_process_sql; printf '\n' ;;
+			*.sql.xz)  printf '%s: running %s\n' "$0" "$f"; xzcat "$f" | docker_process_sql; printf '\n' ;;
+			*.sql.zst) printf '%s: running %s\n' "$0" "$f"; zstd -dc "$f" | docker_process_sql; printf '\n' ;;
+			*)         printf '%s: ignoring %s\n' "$0" "$f" ;;
 		esac
-		echo
+		printf '\n'
 	done
 }
 
@@ -215,7 +221,7 @@ docker_setup_db() {
 		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
 			CREATE DATABASE :"db" ;
 		EOSQL
-		echo
+		printf '\n'
 	fi
 }
 
@@ -230,6 +236,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'
@@ -249,12 +256,12 @@ pg_setup_hba_conf() {
 	auth="$(postgres -C password_encryption "$@")"
 	: "${POSTGRES_HOST_AUTH_METHOD:=$auth}"
 	{
-		echo
+		printf '\n'
 		if [ 'trust' = "$POSTGRES_HOST_AUTH_METHOD" ]; then
-			echo '# warning trust is enabled for all connections'
-			echo '# see https://www.postgresql.org/docs/12/auth-trust.html'
+			printf '# warning trust is enabled for all connections\n'
+			printf '# see https://www.postgresql.org/docs/17/auth-trust.html\n'
 		fi
-		echo "host all all all $POSTGRES_HOST_AUTH_METHOD"
+		printf 'host all all all %s\n' "$POSTGRES_HOST_AUTH_METHOD"
 	} >> "$PGDATA/pg_hba.conf"
 }
 
@@ -334,13 +341,17 @@ _main() {
 			docker_temp_server_stop
 			unset PGPASSWORD
 
-			echo
-			echo 'PostgreSQL init process complete; ready for start up.'
-			echo
+			cat <<-'EOM'
+
+				PostgreSQL init process complete; ready for start up.
+
+			EOM
 		else
-			echo
-			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
-			echo
+			cat <<-'EOM'
+
+				PostgreSQL Database directory appears to contain a database; Skipping initialization
+
+			EOM
 		fi
 	fi
 

--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -96,7 +96,7 @@ docker_init_database_dir() {
 	fi
 
 	# --pwfile refuses to handle a properly-empty file (hence the "\n"): https://github.com/docker-library/postgres/issues/1025
-	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(printf "%s\n" "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(printf "%s\n" "$POSTGRES_PASSWORD") --encoding=UTF8 '"$POSTGRES_INITDB_ARGS"' "$@"'
 
 	# unset/cleanup "nss_wrapper" bits
 	if [[ "${LD_PRELOAD:-}" == */libnss_wrapper.so ]]; then

--- a/scanner/image/db/scripts/docker-entrypoint.sh
+++ b/scanner/image/db/scripts/docker-entrypoint.sh
@@ -6,7 +6,7 @@ set -Eeo pipefail
 ### Community][1]. Any StackRox modification or comments are tagged with this
 ### comment.
 ###
-### [1]: https://github.com/docker-library/postgres/blob/master/15/bullseye/docker-entrypoint.sh
+### [1]: https://github.com/docker-library/postgres/blob/master/15/bookworm/docker-entrypoint.sh
 
 ### STACKROX MODIFIED - Fast shutdown to kill and rollback in-flight transactions.
 shutdown() {

--- a/scanner/image/db/scripts/docker-entrypoint.sh
+++ b/scanner/image/db/scripts/docker-entrypoint.sh
@@ -12,6 +12,7 @@ set -Eeo pipefail
 shutdown() {
   pg_ctl -D "$PGDATA" stop -m fast
 }
+
 trap shutdown SIGINT SIGTERM
 
 # usage: file_env VAR [DEFAULT]
@@ -115,20 +116,24 @@ docker_init_database_dir() {
 # print large warning if POSTGRES_HOST_AUTH_METHOD is set to 'trust'
 # assumes database is not set up, ie: [ -z "$DATABASE_ALREADY_EXISTS" ]
 docker_verify_minimum_env() {
-	# check password first so we can output the warning before postgres
-	# messes it up
-	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
-		cat >&2 <<-'EOWARN'
+	case "${PG_MAJOR:-}" in
+		13) # https://github.com/postgres/postgres/commit/67a472d71c98c3d2fa322a1b4013080b20720b98
+			# check password first so we can output the warning before postgres
+			# messes it up
+			if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+				cat >&2 <<-'EOWARN'
 
-			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+					WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
 
-			  This will not work if used via PGPASSWORD with "psql".
+					  This will not work if used via PGPASSWORD with "psql".
 
-			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
-			  https://github.com/docker-library/postgres/issues/507
+					  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+					  https://github.com/docker-library/postgres/issues/507
 
-		EOWARN
-	fi
+				EOWARN
+			fi
+			;;
+	esac
 	if [ -z "$POSTGRES_PASSWORD" ] && [ 'trust' != "$POSTGRES_HOST_AUTH_METHOD" ]; then
 		# The - option suppresses leading tabs but *not* spaces. :)
 		cat >&2 <<-'EOE'
@@ -237,6 +242,7 @@ docker_setup_env() {
 	: "${POSTGRES_HOST_AUTH_METHOD:=}"
 
 	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
 	# look specifically for PG_VERSION, as it is expected in the DB dir
 	if [ -s "$PGDATA/PG_VERSION" ]; then
 		DATABASE_ALREADY_EXISTS='true'
@@ -259,7 +265,7 @@ pg_setup_hba_conf() {
 		printf '\n'
 		if [ 'trust' = "$POSTGRES_HOST_AUTH_METHOD" ]; then
 			printf '# warning trust is enabled for all connections\n'
-			printf '# see https://www.postgresql.org/docs/12/auth-trust.html\n'
+			printf '# see https://www.postgresql.org/docs/17/auth-trust.html\n'
 		fi
 		printf 'host all all all %s\n' "$POSTGRES_HOST_AUTH_METHOD"
 	} >> "$PGDATA/pg_hba.conf"


### PR DESCRIPTION
### Description

Sometimes I like to look at the upstream script https://github.com/docker-library/postgres/blob/master/15/bookworm/docker-entrypoint.sh and ensure we inherit the latest changes. This is what this PR is all about. It takes in all the latest changes while keeping our own StackRox changes.

I do not plan on merging this until 4.7 development is over.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

If it runs, it runs.

Note: most of the changes to `image/postgres/scripts/docker-entrypoint.sh` were already present in `scanner/image/db/scripts/docker-entrypoint.sh` because the latter was last updated more recently. For a set of differences between the two files after this is merged:

```
$ diff -du image/postgres/scripts/docker-entrypoint.sh scanner/image/db/scripts/docker-entrypoint.sh
--- image/postgres/scripts/docker-entrypoint.sh	2025-02-17 09:23:13
+++ scanner/image/db/scripts/docker-entrypoint.sh	2025-02-17 09:22:26
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# This file is from https://github.com/docker-library/postgres/tree/master/15/bookworm
 set -Eeo pipefail
 # TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
+### STACKROX MODIFIED - This file was copied from [the PostgreSQL Docker
+### Community][1]. Any StackRox modification or comments are tagged with this
+### comment.
+###
+### [1]: https://github.com/docker-library/postgres/blob/master/15/bookworm/docker-entrypoint.sh
+
+### STACKROX MODIFIED - Fast shutdown to kill and rollback in-flight transactions.
 shutdown() {
-  pg_ctl -D /var/lib/postgresql/data/pgdata stop -m fast
+  pg_ctl -D "$PGDATA" stop -m fast
 }
 
 trap shutdown SIGINT SIGTERM
@@ -96,7 +102,7 @@
 	fi
 
 	# --pwfile refuses to handle a properly-empty file (hence the "\n"): https://github.com/docker-library/postgres/issues/1025
-	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(printf "%s\n" "$POSTGRES_PASSWORD") --encoding=UTF8 '"$POSTGRES_INITDB_ARGS"' "$@"'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(printf "%s\n" "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
 
 	# unset/cleanup "nss_wrapper" bits
 	if [[ "${LD_PRELOAD:-}" == */libnss_wrapper.so ]]; then
@@ -316,6 +322,9 @@
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
+			### STACKROX MODIFIED - gosu is not installed in our
+			### image, but we use the postgres user, so this line
+			### will not be reached.
 			# then restart script as postgres user
 			exec gosu postgres "$BASH_SOURCE" "$@"
 		fi
@@ -355,7 +364,11 @@
 		fi
 	fi
 
-	flock /var/lib/postgresql/data/pglock "$@" &
+	### STACKROX MODIFIED - Start Postgres as a child process and
+	### prevent multiple pods on the same node from using this instance.
+	### Note: this may not be needed with ReadWriteOncePod.
+	local ROX_PGLOCK_DIR="$PGDATA/.."
+	flock "$ROX_PGLOCK_DIR/pglock" "$@" &
 	child=$!
 	echo "Waiting for child process $child to exit"
 	wait "$child"
```