### PR TITLE
ROX-27916: Update getVersionedDocs and docs links last changed in 4.4

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
@@ -38,7 +38,7 @@ function ClusterStatus({ healthStatus, isList = false }: ClusterStatusProps): Re
             <a
                 href={getVersionedDocs(
                     version,
-                    'troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html'
+                    'troubleshooting_collector/retrieving-and-analyzing-the-collector-logs-and-pod-status'
                 )}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
@@ -74,7 +74,7 @@ function SecureClusterUsingHelmChart({
                         <a
                             href={getVersionedDocs(
                                 version,
-                                '/installing/installing_other/init-bundle-other.html'
+                                'installing/installing-rhacs-on-other-platforms#init-bundle-other'
                             )}
                             target="_blank"
                             rel="noopener noreferrer"
@@ -86,7 +86,7 @@ function SecureClusterUsingHelmChart({
                         <a
                             href={getVersionedDocs(
                                 version,
-                                '/installing/installing_other/install-secured-cluster-other.html'
+                                'installing/installing-rhacs-on-other-platforms#install-secured-cluster-other'
                             )}
                             target="_blank"
                             rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
@@ -26,7 +26,7 @@ function SecureClusterUsingOperator({
                         <a
                             href={getVersionedDocs(
                                 version,
-                                'installing/installing_ocp/init-bundle-ocp.html'
+                                'installing/installing-rhacs-on-red-hat-openshift#init-bundle-ocp'
                             )}
                             target="_blank"
                             rel="noopener noreferrer"
@@ -38,7 +38,7 @@ function SecureClusterUsingOperator({
                         <a
                             href={getVersionedDocs(
                                 version,
-                                'installing/installing_ocp/install-secured-cluster-ocp.html#installing-sc-operator'
+                                'installing/installing-rhacs-on-red-hat-openshift#install-secured-cluster-operator_install-secured-cluster-ocp'
                             )}
                             target="_blank"
                             rel="noopener noreferrer"
@@ -85,7 +85,7 @@ function SecureClusterUsingOperator({
                             <a
                                 href={getVersionedDocs(
                                     version,
-                                    'cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.html#create-resource-init-bundle_init-bundle-cloud-ocp-apply'
+                                    'rhacs_cloud_service/setting-up-rhacs-cloud-service-with-red-hat-openshift-secured-clusters#create-resource-init-bundle_init-bundle-cloud-ocp-apply'
                                 )}
                                 target="_blank"
                                 rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -134,7 +134,7 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
                                     <a
                                         href={getVersionedDocs(
                                             version,
-                                            'configuration/reissue-internal-certificates.html'
+                                            'configuring/reissue-internal-certificates'
                                         )}
                                         target="_blank"
                                         rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
@@ -88,10 +88,7 @@ function GenerateDiagnosticBundle(): ReactElement {
             {version && (
                 <ExternalLink>
                     <a
-                        href={getVersionedDocs(
-                            version,
-                            'configuration/generate-diagnostic-bundle.html'
-                        )}
+                        href={getVersionedDocs(version, 'configuring/generate-diagnostic-bundle')}
                         target="_blank"
                         rel="noopener noreferrer"
                     >

--- a/ui/apps/platform/src/utils/versioning.test.ts
+++ b/ui/apps/platform/src/utils/versioning.test.ts
@@ -23,21 +23,21 @@ describe('versioning utilities', () => {
 
     describe('getVersionedDocs', () => {
         it('returns the correct url for acs documentation', () => {
-            expect(getVersionedDocs('3.73', 'sub-path')).toBe(
-                'https://docs.openshift.com/acs/3.73/sub-path'
+            expect(getVersionedDocs('4.7', 'sub-path')).toBe(
+                'https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.7/html/sub-path'
             );
         });
 
-        it('returns only the major and minor version in the url', () => {
-            expect(getVersionedDocs('3.73.123')).toMatch(/.*\/3\.73\//);
-        });
-
         it('the url ends with the given subPath', () => {
-            expect(getVersionedDocs('3.73.123', 'sub-path#anchor')).toMatch(/.*\/sub-path#anchor/);
+            expect(getVersionedDocs('4.7.123', 'sub-path#anchor')).toBe(
+                'https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.7/html/sub-path#anchor'
+            );
         });
 
-        it('the url ends with the default subpath welcome/index.html when the subpath is not given', () => {
-            expect(getVersionedDocs('3.73.123')).toMatch(/.*\/welcome\/index\.html/);
+        it('the url ends with version when the subpath is not given', () => {
+            expect(getVersionedDocs('4.7.123')).toBe(
+                'https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.7'
+            );
         });
     });
 });

--- a/ui/apps/platform/src/utils/versioning.ts
+++ b/ui/apps/platform/src/utils/versioning.ts
@@ -9,9 +9,13 @@ function getVersionMajorMinor(version: string): string {
     return '';
 }
 
+const basePath =
+    'https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes';
+
 // we may have to consider the release build in the future, where the version may be ahead of documentation that has not yet been created
-function getVersionedDocs(completeVersion: string, subPath = 'welcome/index.html'): string {
-    return `https://docs.openshift.com/acs/${getVersionMajorMinor(completeVersion)}/${subPath}`;
+function getVersionedDocs(completeVersion: string, subPath?: string): string {
+    const basePathWithVersion = `${basePath}/${getVersionMajorMinor(completeVersion)}`;
+    return subPath ? `${basePathWithVersion}/html/${subPath}` : basePathWithVersion;
 }
 
 export { getVersionMajorMinor, getVersionedDocs };


### PR DESCRIPTION
### Description

### Problem

> OpenShift docs are moving and will soon only be available at docs.redhat.com, the home of all Red Hat product documentation.

### Analysis

Find in Files `getVersionedDocs(` has 15 results in 12 files (excluding definition and tests)

Separate changes according to release in which link was last changed, in case we back patch.

2024-02-29 https://github.com/stackrox/stackrox/pull/10180
2024-01-23 https://github.com/stackrox/stackrox/pull/9506
2024-02-05 https://github.com/stackrox/stackrox/pull/9707
2024-02-12 https://github.com/stackrox/stackrox/pull/9856

Therefore, 4.5 and 4.6 will follow in separate contributions.

### Solution

1. Update doc page addresses.
    * Omit `.html` extension.
    * Rename folders if needed.
2. Update `getVersionedDocs` function.
    * Replace base address.
    * Update conditional logic for absence of `subPath` argument.

### Updated doc page addresses

1. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
    2024-01-23 https://github.com/stackrox/stackrox/pull/9506

    * Replace `'troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html'`
        with `'troubleshooting_collector/retrieving-and-analyzing-the-collector-logs-and-pod-status'`

2. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
    2024-02-12 https://github.com/stackrox/stackrox/pull/9856

    * Replace `'/installing/installing_other/init-bundle-other.html'`
        with `'installing/installing-rhacs-on-other-platforms#init-bundle-other'`
    * Replace `'/installing/installing_other/install-secured-cluster-other.html'`
        with `'installing/installing-rhacs-on-other-platforms#install-secured-cluster-other'`

3. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
    2024-02-12 https://github.com/stackrox/stackrox/pull/9856

    * Replace `'installing/installing_ocp/init-bundle-ocp.html'`
        with `'installing/installing-rhacs-on-red-hat-openshift#init-bundle-ocp'`
    * Replace `'installing/installing_ocp/install-secured-cluster-ocp.html#installing-sc-operator'`
        with `'installing/installing-rhacs-on-red-hat-openshift#install-secured-cluster-operator_install-secured-cluster-ocp'`

    2024-02-05 https://github.com/stackrox/stackrox/pull/9707

    * Replace `'cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.html#create-resource-init-bundle_init-bundle-cloud-ocp-apply'`
        with `'rhacs_cloud_service/setting-up-rhacs-cloud-service-with-red-hat-openshift-secured-clusters#create-resource-init-bundle_init-bundle-cloud-ocp-apply'`

4. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
    2024-01-23 https://github.com/stackrox/stackrox/pull/9506

    * Replace `'configuration/reissue-internal-certificates.html'`
        with `'configuring/reissue-internal-certificates'`

5. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
    2024-01-23 https://github.com/stackrox/stackrox/pull/9506

    * Replace `'configuration/generate-diagnostic-bundle.html'`
        with `'configuring/generate-diagnostic-bundle'`

### User-facing documentation

- [x] CHANGELOG update is not needed (yet)
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 79 = 4646068 - 4645989
        total 260 = 11600847 - 11600587
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Copy link address, replace current unreleased `4.7` with released version `4.6`, and then verify.

1. Visit /main/clusters/secure-a-cluster?tab=Helm-chart
    * Generating and applying an init bundle for RHACS on other platforms
    * Installing secured cluster services for RHACS on other platforms

2. Visit /main/clusters/secure-a-cluster?tab=Operator
    * Generating and applying an init bundle for RHACS on Red Hat OpenShift
    * Installing RHACS on secured clusters by using the Operator
    * Creating resources by using the init bundle

3. Visit /main/system-health
    * Reissuing internal certificates

4. Click **Generate diagnostic bundle**
    * Generate a diagnostic bundle

#### Unit testing

* versioning.test.ts
