### PR TITLE
chore(ci): Adds autolabeller config for konflux dockerfile changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,7 +68,6 @@ backport:
 konflux-build:
 - changed-files:
   - any-glob-to-any-file:
-    - '**/konflux.Dockerfile'
-    - '**/konflux.*.Dockerfile'
+    - '**/konflux*.Dockerfile'
     - .tekton/**/*
     - .konflux/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -70,3 +70,5 @@ konflux-build:
   - any-glob-to-any-file:
     - '**/konflux.Dockerfile'
     - '**/konflux.*.Dockerfile'
+    - .tekton/**/*
+    - .konflux/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,3 +64,9 @@ ci-all-qa-tests:
 
 backport:
 - base-branch: 'release-*'
+
+konflux-build:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/konflux.Dockerfile'
+    - '**/konflux.*.Dockerfile'


### PR DESCRIPTION
### Description

After missing the label on #13350, this might be useful to avoid such mistakes in the future