### PR TITLE
ROX-27985: Update docs links last changed in 4.5

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -220,7 +220,7 @@ function AuthProviders(): ReactElement {
                                         <a
                                             href={getVersionedDocs(
                                                 version,
-                                                'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'
+                                                'operating/managing-user-access#configure-short-lived-access'
                                             )}
                                             target="_blank"
                                             rel="noopener noreferrer"


### PR DESCRIPTION
### Description

### Problem

> OpenShift docs are moving and will soon only be available at docs.redhat.com, the home of all Red Hat product documentation.

### Analysis

Find in Files `getVersionedDocs(` has 15 results in 12 files (excluding definition and tests)

Separate changes according to release in which link was last changed, in case we back patch.

2024-07-09 https://github.com/stackrox/stackrox/pull/11895
2024-06-10 https://github.com/stackrox/stackrox/pull/11439

Therefore, 4.4 preceded and 4.6 will follow in separate contributions.

### Solution

1. Update doc page addresses.
    * Omit `.html` extension.
    * Rename folders if needed.

### Updated doc page addresses

1. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
    2024-06-10 https://github.com/stackrox/stackrox/pull/11439

    * Replace `'operating/manage-user-access/configure-short-lived-access.html#configure-short-lived-access'`
        with `operating/managing-user-access#configure-short-lived-access`

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4645989 - 4645989
        total -32 = 11603744 - 11603776
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Temporarily include updated `getVersionedDocs` function.

Copy link address, replace current unreleased `4.7` with released version `4.6`, and then verify.

1. Visit /main/access-control/auth-providers
    * How to configure short-lived access