### PR TITLE
fix(ui): Fix SBOM error message display

### DIFF
--- a/ui/apps/platform/src/services/ImageSbomService.ts
+++ b/ui/apps/platform/src/services/ImageSbomService.ts
@@ -9,9 +9,9 @@ export function generateAndSaveSbom({ imageName }: { imageName: string }): Promi
         url: '/api/v1/images/sbom',
         data: { imageName },
         timeout: 0,
-        responseType: 'arraybuffer',
     }).then((response) => {
-        const { file, filename } = parseAxiosResponseAttachment(response);
+        const { filename } = parseAxiosResponseAttachment(response);
+        const file = new Blob([JSON.stringify(response.data)], { type: 'application/json' });
         FileSaver.saveAs(file, filename);
     });
 }


### PR DESCRIPTION
### Description

The network request code for SBOM generation erroneously asserted a type of `arraybuffer` for the response data, which was not needed as the response was a JSON type. This caused the `response.data.message` property to be missing in the error message parsing, since `response.data` was not an object type.

The fix was to remove this asserted response type and simply construct a `Blob` from the returned JSON in the success case.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Test a successful SBOM generation and ensure the file is readable:
![image](https://github.com/user-attachments/assets/240fb25a-1780-4d0e-8f7a-93b990cccc81)
![image](https://github.com/user-attachments/assets/e6017741-a5cb-4b68-a74d-56d52dc2b45d)

Simulate a server error with an invalid payload and ensure the error is propagated to the UI:
![image](https://github.com/user-attachments/assets/5ff76b66-8460-4e9a-8e1a-6e9db307d2c0)
