### PR TITLE
ROX-27986: Update docs links last changed in 4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - The node scanner never reached out to the Red Hat Container Catalog, so this variable was never used.
 - ROX-27253: Scanner V4 now reads [Red Hat's CSAF data](https://security.access.redhat.com/data/csaf/v2/advisories/) to alleviate inconsistent Red Hat advisory (RHSA/RHBA/RHEA) data.
   - Use of this data may be disabled by setting `ROX_SCANNER_V4_RED_HAT_CSAF` to `false` in Scanner V4 Matcher.
+  - ROX-27916 ROX-27985 ROX-27986: Replace links to docs in console UI
+    - from docs dot openshift dot com
+    - to docs dot redhat dot com
 
 ## [4.6.0]
 

--- a/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
+++ b/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
@@ -34,10 +34,7 @@ function ScannerV4IntegrationBanner() {
     const docsLink = (
         <ExternalLink>
             <a
-                href={getVersionedDocs(
-                    version,
-                    'operating/examine-images-for-vulnerabilities.html'
-                )}
+                href={getVersionedDocs(version, 'operating/examine-images-for-vulnerabilities')}
                 target="_blank"
                 rel="noopener noreferrer"
             >

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -88,7 +88,7 @@ function CredentialExpiration({
                                 <a
                                     href={getVersionedDocs(
                                         version,
-                                        'configuration/reissue-internal-certificates.html#reissue-internal-certificates-secured-clusters'
+                                        'configuring/reissue-internal-certificates#reissue-internal-certificates-secured-clusters'
                                     )}
                                     target="_blank"
                                     rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
@@ -328,7 +328,7 @@ function GcsIntegrationForm({
                                                 <a
                                                     href={getVersionedDocs(
                                                         version,
-                                                        'integration/integrate-using-short-lived-tokens.html'
+                                                        'integrating/integrate-using-short-lived-tokens'
                                                     )}
                                                     target="_blank"
                                                     rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
@@ -412,7 +412,7 @@ function S3IntegrationForm({
                                                 <a
                                                     href={getVersionedDocs(
                                                         version,
-                                                        'integration/integrate-using-short-lived-tokens.html'
+                                                        'integrating/integrate-using-short-lived-tokens'
                                                     )}
                                                     target="_blank"
                                                     rel="noopener noreferrer"


### PR DESCRIPTION
### Description

### Problem

> OpenShift docs are moving and will soon only be available at docs.redhat.com, the home of all Red Hat product documentation.

### Analysis

Find in Files `getVersionedDocs(` has 15 results in 12 files (excluding definition and tests)

Separate changes according to release in which link was last changed, in case we back patch.

2024-10-30 https://github.com/stackrox/stackrox/pull/13166
2024-09-05 https://github.com/stackrox/stackrox/pull/12558
2024-09-24 https://github.com/stackrox/stackrox/pull/12775

Therefore, 4.4 and 4.5 preceded in separate contributions.

### Solution

1. Update doc page addresses.
    * Omit `.html` extension.
    * Rename folders if needed.

### Updated doc page addresses

1. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Components/ScannerV4IntegrationBanner.tsx
    2025-09-05 https://github.com/stackrox/stackrox/pull/12558

    * Replace `'operating/examine-images-for-vulnerabilities.html'`
        with `'operating/examine-images-for-vulnerabilities'`

2. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
    2025-09-05 https://github.com/stackrox/stackrox/pull/12558

    * Replace `'configuration/reissue-internal-certificates.html#reissue-internal-certificates-secured-clusters'`
        with `'configuring/reissue-internal-certificates#reissue-internal-certificates-secured-clusters'`

3. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/GcsIntegrationForm.tsx
    2024-09-24 https://github.com/stackrox/stackrox/pull/12775

    * Replace `'integration/integrate-using-short-lived-tokens.html'`
        with `'integrating/integrate-using-short-lived-tokens'`

4. https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ExternalBackupIntegrations/S3IntegrationForm.tsx
    2024-09-24 https://github.com/stackrox/stackrox/pull/12775

    * Replace `'integration/integrate-using-short-lived-tokens.html'`
        with `'integrating/integrate-using-short-lived-tokens'`

### User-facing documentation

- [x] CHANGELOG is updated
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4645989 - 4645989
        total -32 = 11603744 - 11603776
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Temporarily include updated `getVersionedDocs` function.

Copy link address, replace current unreleased `4.7` with released version `4.6`, and then verify.

1. Visit /main/vulnerabilities/user-workloads and temporarily edit ScannerV4IntegrationBanner.tsx file to display banner even with Scanner V4 enabled.
    * RHACS documentation

2. Visit /main/integrations/backups/gcs/create and open popover for **Short-lived tokens**.
    * RHACS documentation

3. Visit /main/integrations/backups/s3/create and open popover for **Short-lived tokens**.
    * RHACS documentation
