### PR TITLE
ROX-27988: Omit EPSS columns for image and deployment in 4.7 release

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -96,7 +96,14 @@ const defaultSortFields = ['CVE', 'Severity'];
 
 const searchFilterConfigWithFeatureFlagDependency = [
     imageSearchFilterConfig,
-    imageCVESearchFilterConfig,
+    // Omit EPSSProbability for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
+    // imageCVESearchFilterConfig,
+    {
+        ...imageCVESearchFilterConfig,
+        attributes: imageCVESearchFilterConfig.attributes.filter(
+            ({ searchTerm }) => searchTerm !== 'EPSS Probability'
+        ),
+    },
     imageComponentSearchFilterConfig,
 ];
 
@@ -185,8 +192,10 @@ function DeploymentPageVulnerabilities({
         },
     });
 
-    const isEpssProbabilityColumnEnabled =
-        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
+    // const isEpssProbabilityColumnEnabled =
+    //     isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    const isEpssProbabilityColumnEnabled = false;
     const filteredColumns = filterManagedColumns(
         defaultColumns,
         (key) => key !== 'epssProbability' || isEpssProbabilityColumnEnabled

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -94,7 +94,14 @@ export const imageVulnerabilitiesQuery = gql`
 const defaultSortFields = ['CVE', 'CVSS', 'Severity'];
 
 const searchFilterConfigWithFeatureFlagDependency = [
-    imageCVESearchFilterConfig,
+    // Omit EPSSProbability for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
+    // imageCVESearchFilterConfig,
+    {
+        ...imageCVESearchFilterConfig,
+        attributes: imageCVESearchFilterConfig.attributes.filter(
+            ({ searchTerm }) => searchTerm !== 'EPSS Probability'
+        ),
+    },
     imageComponentSearchFilterConfig,
 ];
 
@@ -188,8 +195,10 @@ function ImagePageVulnerabilities({
     });
 
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled =
-        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
+    // const isEpssProbabilityColumnEnabled =
+    //     isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    const isEpssProbabilityColumnEnabled = false;
     const filteredColumns = filterManagedColumns(
         defaultColumns,
         (key) =>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import useFeatureFlags from 'hooks/useFeatureFlags';
+// Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
+// import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -112,9 +113,11 @@ function DeploymentVulnerabilitiesTable({
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isEpssProbabilityColumnEnabled =
-        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
+    // const { isFeatureFlagEnabled } = useFeatureFlags();
+    // const isEpssProbabilityColumnEnabled =
+    //     isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    const isEpssProbabilityColumnEnabled = false;
 
     const colSpan = 7 + (isEpssProbabilityColumnEnabled ? 1 : 0) - hiddenColumnCount;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -162,8 +162,10 @@ function ImageVulnerabilitiesTable({
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled =
-        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
+    // const isEpssProbabilityColumnEnabled =
+    //     isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_EPSS_SCORE');
+    const isEpssProbabilityColumnEnabled = false;
 
     const colSpan =
         7 +


### PR DESCRIPTION
### Description

### Problem

Without CVE/advisory separaration in 4.7, **EPSS probability** for RHSA/RHBA/RHEA might differ between WorkloadCVEOverviewTable and the other tables:
* DeploymentVulnerabilitiesTable
* ImageVulnerabilitiesTable

### Analysis

Scanner team reports that even with mitigations, customers might notice differences depending on which CVE are associated with an advisory in a context.

### Solution

Keep **EPSS probability** where it matters most:
* WorkloadCVEOverviewTable
* CvePageHeader

Omit **EPSS probability** for 4.7 release and then undo omission when CVE/advisory separation is available for 4.8 release.

1. On one side of coint, `isEpssProbabilityColumnEnabled` is easy to change for table columns.

2. On other side of coin, search filter config is not quite so easy.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4645989 - 4645989
        total -521 = 11603255 - 11603776
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Run UI with staging demo, which has **Scanner V4** and `ROX_EPSS_SCORE` feature flag enabled.
1. Visit **Workflow CVEs**

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx

    Before and after changes, see **EPSS probability**
    * table column
    * column management
    * search filter
    ![WorkloadCVEOverviewTable](https://github.com/user-attachments/assets/fc374d24-8a40-4693-9c41-de39970c99e8)

2. Click a vulnerability link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx

    Before and after changes, see **EPSS probability** label
    ![CvePageHeader](https://github.com/user-attachments/assets/ac48c709-ff59-498c-94c9-a087c26ecf65)

3. Click an image link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx

    Before changes, see presence of **EPSS probability** (same 3 as step 1)
    ![ImageVulnerabilitiesTable_with](https://github.com/user-attachments/assets/fd981a48-5df4-449c-acb4-99549e1439d4)

    After changes, see absence of **EPSS probability** (same 3 as step 1)
    ![ImageVulnerabilitiesTable_without](https://github.com/user-attachments/assets/40f69b6f-8824-414b-be55-7676567c0fe4)

4. Go back, click **Deployments**, click a deployment link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx

    Before changes, see presence of **EPSS probability** (same 3 as step 1)
    ![DeploymentVulnerabilitiesTable_with](https://github.com/user-attachments/assets/4f840011-3cc6-4d0b-abb4-9712170a2888)

    After changes, see absence of **EPSS probability** (same 3 as step 1)
    ![DeploymentVulnerabilitiesTable_without](https://github.com/user-attachments/assets/bd51415c-f8f3-4c03-8eeb-ac6fbe88d897)
