### PR TITLE
ROX-28011: describe problematic service before dying

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -736,7 +736,7 @@ EOM
         else
             info "Something is wrong with the ${service} service. See the following 'describe' output."
             kubectl -n "${ns}" describe "${service}" || true
-            die "ERROR: Timeout waiting for ${service} to obtain endpoint!"
+            die "Timeout waiting for ${service} to obtain endpoint!"
         fi
     done
     local endpoint

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -734,6 +734,8 @@ EOM
             ((attempt++))
             sleep 10
         else
+            info "Something is wrong with the ${service} service. See the following 'describe' output."
+            kubectl -n "${ns}" describe "${service}" || true
             die "ERROR: Timeout waiting for ${service} to obtain endpoint!"
         fi
     done


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

We wait for image prefetcher metrics endpoint to show up.
From time to time this never happens, due to failed load balancer provisioning outside of our control: wrong permissions, lack of quota, etc. (See ticket).
In these cases, it's useful to see a description of the k8s service in question right away, than have to dig through the logs to triage a CI failure correctly.

Also drop the duplicate "ERROR" while at it.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] create and check a dummy PR which exercises this code path: https://github.com/stackrox/stackrox/pull/14210:

```
INFO: Tue Feb 11 09:37:22 UTC 2025: Waiting for service/qa-e2e-metrics to obtain endpoint ...
INFO: Tue Feb 11 09:37:32 UTC 2025: Waiting for service/qa-e2e-metrics to obtain endpoint ...
INFO: Tue Feb 11 09:37:42 UTC 2025: Something is wrong with the service/qa-e2e-metrics service. See the following 'describe' output.
Name:                     qa-e2e-metrics
Namespace:                prefetch-images
Labels:                   <none>
Annotations:              <none>
Selector:                 app=qa-e2e-metrics
Type:                     LoadBalancer
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       34.118.224.253
IPs:                      34.118.224.253
LoadBalancer Ingress:     34.69.40.194
Port:                     grpc  8443/TCP
TargetPort:               8443/TCP
NodePort:                 grpc  30884/TCP
Endpoints:                10.46.129.4:8443
Port:                     http  8080/TCP
TargetPort:               8080/TCP
NodePort:                 http  32424/TCP
Endpoints:                10.46.129.4:8080
Session Affinity:         None
External Traffic Policy:  Cluster
Events:
  Type    Reason                Age   From                Message
  ----    ------                ----  ----                -------
  Normal  EnsuringLoadBalancer  21m   service-controller  Ensuring load balancer
  Normal  EnsuredLoadBalancer   20m   service-controller  Ensured load balancer
ERROR: Timeout waiting for service/qa-e2e-metrics to obtain endpoint!
****
**** 09:37:42: ERROR: test failed [Test failed: exit 1] [QA tests part I]
****
```
![image](https://github.com/user-attachments/assets/a4272c9d-5ff1-41b8-8b7f-c27cedc4f4ed)
