### PR TITLE
fix(networkgraph): Fixes sorting of entity metadata

### DIFF
--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -175,16 +175,26 @@ func (s *serviceImpl) GetExternalNetworkFlowsMetadata(ctx context.Context, reque
 		}
 	}
 
-	result := maps.Values(entityMeta)
-	total := int32(len(result))
+	// To ensure pagination is consistent/deterministic, sort the keys
+	// and construct the list of metadata objects in order of key (entity ID)
+	keys := maps.Keys(entityMeta)
+	sort.Strings(keys)
+
+	values := make([]*v1.ExternalNetworkFlowMetadata, 0, len(keys))
+
+	for _, key := range keys {
+		values = append(values, entityMeta[key])
+	}
+
+	total := int32(len(values))
 
 	page := request.GetPagination()
 	if page != nil {
-		result = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), result)
+		values = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), values)
 	}
 
 	return &v1.GetExternalNetworkFlowsMetadataResponse{
-		Entities:      result,
+		Entities:      values,
 		TotalEntities: total,
 	}, nil
 }

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"time"
 
@@ -178,7 +179,7 @@ func (s *serviceImpl) GetExternalNetworkFlowsMetadata(ctx context.Context, reque
 	// To ensure pagination is consistent/deterministic, sort the keys
 	// and construct the list of metadata objects in order of key (entity ID)
 	keys := maps.Keys(entityMeta)
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	values := make([]*v1.ExternalNetworkFlowMetadata, 0, len(keys))
 

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -492,15 +492,8 @@ func (s *networkGraphServiceSuite) TestGetExternalNetworkFlowsMetadata() {
 			if tc.expectSuccess {
 				s.NoError(err)
 
-				if tc.request.Pagination != nil {
-					// if paginated response, just verify length, since the
-					// elements themselves are not deterministic
-					s.Assert().Len(response.Entities, len(tc.expected.Entities))
-					s.Assert().Equal(response.TotalEntities, tc.expected.TotalEntities)
-				} else {
-					protoassert.ElementsMatch(s.T(), tc.expected.Entities, response.Entities)
-					s.Assert().Equal(response.TotalEntities, tc.expected.TotalEntities)
-				}
+				s.Assert().Len(response.Entities, len(tc.expected.Entities))
+				s.Assert().Equal(response.TotalEntities, tc.expected.TotalEntities)
 			} else {
 				s.Error(err)
 			}


### PR DESCRIPTION
### Description

While flows and entities are sorted before they're processed into metadata, the use of a map for processing led to indeterminate sorting of returned entities which makes pagination functionally useless. This change further sorts the map by key before constructing the response. 

### Testing and quality

- [ ] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Updated the postgres tests so they take order into account, and will fail if the order of entities is wrong.
