### PR TITLE
fix(release): Removes collector-slim vuln check from release scripts

### DIFF
--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -99,7 +99,6 @@ ALLOWED_VULNS=$(jq -c '.[]' "$DIR/allowed_vulns.json")
 compare_fixable_vulns "main" "$RELEASE_TAG"
 
 # check collector images
-compare_fixable_vulns "collector" "${COLLECTOR_TAG}-slim"
 compare_fixable_vulns "collector" "${COLLECTOR_TAG}"
 
 # check scanner images


### PR DESCRIPTION
### Description

We no longer publish slim Collector images, so we no longer need to check them for vulns.