### PR TITLE
ROX-28017: Add getVersionedDocs-subPath lint rule in pluginGeneric

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -282,7 +282,7 @@ const rules = {
                 CallExpression(node) {
                     if (
                         node.callee?.name === 'getVersionedDocs' &&
-                        Array.isArray(node?.arguments) &&
+                        Array.isArray(node.arguments) &&
                         typeof node.arguments[1]?.value === 'string'
                     ) {
                         const { value } = node.arguments[1];

--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -268,6 +268,43 @@ const rules = {
             };
         },
     },
+    'getVersionedDocs-subPath': {
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Require that optional subPath argument of getVersionedDocs function call has no obvious problems',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                CallExpression(node) {
+                    if (
+                        node.callee?.name === 'getVersionedDocs' &&
+                        Array.isArray(node?.arguments) &&
+                        typeof node.arguments[1]?.value === 'string'
+                    ) {
+                        const { value } = node.arguments[1];
+                        if (value.startsWith('/')) {
+                            context.report({
+                                node,
+                                message:
+                                    'Omit leading slash from relative subPath argument of getVersionedDocs function call',
+                            });
+                        }
+                        if (value.includes('.html')) {
+                            context.report({
+                                node,
+                                message:
+                                    'Omit .html extension from relative subPath argument of getVersionedDocs function call',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'pagination-function-call': {
         // Require that pagination property has function call like getPaginationParams.
         // Some classic pages have queryService.getPagination function call instead.

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AzureIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AzureIntegrationForm.tsx
@@ -255,7 +255,7 @@ function AzureIntegrationForm({
                                                 <a
                                                     href={getVersionedDocs(
                                                         version,
-                                                        'integration/integrate-using-short-lived-tokens.html'
+                                                        'integrating/integrate-using-short-lived-tokens'
                                                     )}
                                                     target="_blank"
                                                     rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MicrosoftSentinelForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MicrosoftSentinelForm.tsx
@@ -436,7 +436,7 @@ function MicrosoftSentinelForm({
                                                             <a
                                                                 href={getVersionedDocs(
                                                                     version,
-                                                                    '/integrating/integrate-using-short-lived-tokens'
+                                                                    'integrating/integrate-using-short-lived-tokens'
                                                                 )}
                                                                 target="_blank"
                                                                 rel="noopener noreferrer"


### PR DESCRIPTION
### Description

### Problems

1. Until docs dot openshift dot com site is removed, contributors might get links from it instead of docs dot redhat dot com site, which has become destination of links.
2. Even after previous site is removed, contributors might get link from a doc **preview** which has `.html` extension that customer-facing site does not use.

### Solution

Reduce chance of problems:
* Forbid leading `/` in **relative** path.
* Forbid `.html` in path.

To understand AST of function call and argument, I used the following site:
https://typescript-eslint.io/play/#ts=5.7.3&showAST=es&fileType=.tsx

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform

#### Manual testing

Restart Visual Studio Code editor, and then make temporary changes to provoke the expected errors.

Although despite what I though were my best efforts, the code still had both errors, therefore lint above and editor both reported them.
