### PR TITLE
ROX-27284: Update accuracy of CVE link text

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/textUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/textUtils.test.ts
@@ -1,0 +1,52 @@
+import { getDistroLinkText } from './textUtils';
+
+describe('getDistroLinkText', () => {
+    const testCases = [
+        { link: 'https://www.cve.org/CVE-2021-1234', expected: 'View at cve.org' },
+        {
+            link: 'https://security.alpinelinux.org/vuln/CVE-2021-1234',
+            expected: 'View in Alpine CVE database',
+        },
+        {
+            link: 'https://alas.aws.amazon.com/ALAS-2021-1234',
+            expected: 'View in Amazon CVE database',
+        },
+        {
+            link: 'https://security-tracker.debian.org/tracker/CVE-2021-1234',
+            expected: 'View in Debian CVE database',
+        },
+        {
+            link: 'https://access.redhat.com/security/cve/CVE-2021-1234',
+            expected: 'View in Red Hat CVE database',
+        },
+        {
+            link: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-1234',
+            expected: 'View in MITRE CVE database',
+        },
+        {
+            link: 'https://linux.oracle.com/cve/CVE-2021-1234',
+            expected: 'View in Oracle CVE database',
+        },
+        {
+            link: 'https://ubuntu.com/security/CVE-2021-1234',
+            expected: 'View in Ubuntu CVE database',
+        },
+        { link: 'https://osv.dev/CVE-2021-1234', expected: 'View in OSV CVE database' },
+    ];
+
+    testCases.forEach(({ link, expected }) => {
+        test(`returns '${expected}' for link: ${link}`, () => {
+            expect(getDistroLinkText({ link })).toBe(expected);
+        });
+    });
+
+    test('returns generic message for unknown domain', () => {
+        expect(getDistroLinkText({ link: 'https://example.com/cve/1234' })).toBe(
+            'View additional information at example.com'
+        );
+    });
+
+    test('returns generic message when given an invalid URL', () => {
+        expect(getDistroLinkText({ link: 'invalid-url' })).toBe('View additional information');
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/textUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/textUtils.ts
@@ -1,22 +1,26 @@
-import { ensureExhaustive } from 'utils/type.utils';
-import { Distro } from './sortUtils';
+const urlToLinkTextTuples = [
+    ['www.cve.org', 'View at cve.org'],
+    ['security.alpinelinux.org', 'View in Alpine CVE database'],
+    ['alas.aws.amazon.com', 'View in Amazon CVE database'],
+    ['security-tracker.debian.org', 'View in Debian CVE database'],
+    ['access.redhat.com', 'View in Red Hat CVE database'],
+    ['cve.mitre.org', 'View in MITRE CVE database'],
+    ['linux.oracle.com', 'View in Oracle CVE database'],
+    ['ubuntu.com', 'View in Ubuntu CVE database'],
+    ['osv.dev', 'View in OSV CVE database'],
+];
 
-export function getDistroLinkText({ distro }: { distro: Distro }): string {
-    switch (distro) {
-        case 'rhel':
-        case 'centos':
-            return 'View in Red Hat CVE database';
-        case 'ubuntu':
-            return 'View in Ubuntu CVE database';
-        case 'debian':
-            return 'View in Debian CVE database';
-        case 'alpine':
-            return 'View in Alpine Linux CVE database';
-        case 'amzn':
-            return 'View in Amazon Linux CVE database';
-        case 'other':
-            return 'View additional information';
-        default:
-            return ensureExhaustive(distro);
+export function getDistroLinkText({ link }: { link: string }): string {
+    const [, vendorText] = urlToLinkTextTuples.find(([url]) => link.includes(url)) ?? [];
+
+    if (vendorText) {
+        return vendorText;
+    }
+
+    try {
+        const url = new URL(link);
+        return `View additional information at ${url.host}`;
+    } catch {
+        return 'View additional information';
     }
 }


### PR DESCRIPTION
### Description

Updates the link text to outgoing CVE database links to be dependent on the content of the URL, instead of inferring the link location from the provided `distro` field. This does not impact prioritization, etc. of the links.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Spot check of CVE links on a couple of CVE pages:
![image](https://github.com/user-attachments/assets/27258b62-2cdb-4712-a439-60eea9db4d6c)
![image](https://github.com/user-attachments/assets/079a6605-36e9-48b9-af2c-1efe0ab7701f)

Unit test validation to ensure expected functionality and that invalid/unexpected URLs are handled without error.