### PR TITLE
ROX-27443: ignore non-Red Hat vulnerabilities in Red Hat layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-28655: When managing a Central installation using the operator
   * Scanner V4 will be installed for new installations unless explicitly disabled (opt-out) and
   * Scanner V4 will remain not installed for upgrades unless explicitly enabled (opt-in).
+- ROX-27443: Scanner V4 may now only show vulnerability data from Red Hat security data sources for official Red Hat container images
+  found in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore) when the environment variable `ROX_SCANNER_V4_RED_HAT_LAYERS_RED_HAT_VULNS_ONLY` is set in Scanner V4 Matcher.
+  - Previously, those who used Scanner V4 would see vulnerability data from various sources for all layers in their images.
+    This led to confusion when users scanned official Red Hat images or images based on official Red Hat images.
+    Scanner V4 claimed the images contained vulnerabilities which the official Red Hat CVE pages claimed did not exist in the same image.
+  - This arose for non-RPM content in official Red Hat container images, such as Go binaries in OpenShift images.
+  - When the variable is set (which it is by default), Scanner V4 will continue to show non-RPM content in official Red Hat container images but will no longer
+    output vulnerabilities from non-Red Hat security data sources for these images.
 
 ### Removed Features
 
@@ -46,14 +54,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
       kubectl label crd/securitypolicies.config.stackrox.io app.kubernetes.io/managed-by=Helm
 
   The above values will need to be updated to match your release name (i.e. "stackrox-central-services") or namespace (i.e. "stackrox") in case you had used different ones.
-- ROX-27443: Scanner V4 may now only show vulnerability data from Red Hat security data sources for official Red Hat container images
-  found in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore) when the environment variable `ROX_SCANNER_V4_RED_HAT_LAYERS` is set in Scanner V4 Matcher.
-  - Previously, those who used Scanner V4 would see vulnerability data from various sources for all layers in their images.
-    This led to confusion when users scanned official Red Hat images or images based on official Red Hat images.
-    Scanner V4 claimed the images contained vulnerabilities which the official Red Hat CVE pages claimed did not exist in the same image.
-  - This arose for non-RPM content in official Red Hat container images, such as Go binaries in OpenShift images.
-  - When the variable is set, Scanner V4 will continue to show non-RPM content in official Red Hat container images but will no longer
-    output vulnerabilities from non-Red Hat security data sources for these images.
 
 ## [4.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
       kubectl label crd/securitypolicies.config.stackrox.io app.kubernetes.io/managed-by=Helm
 
   The above values will need to be updated to match your release name (i.e. "stackrox-central-services") or namespace (i.e. "stackrox") in case you had used different ones.
+- ROX-27443: Scanner V4 may now only show vulnerability data from Red Hat security data sources for official Red Hat container images
+  found in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore) when the environment variable `ROX_SCANNER_V4_RED_HAT_LAYERS` is set in Scanner V4 Matcher.
+  - Previously, those who used Scanner V4 would see vulnerability data from various sources for all layers in their images.
+    This led to confusion when users scanned official Red Hat images or images based on official Red Hat images.
+    Scanner V4 claimed the images contained vulnerabilities which the official Red Hat CVE pages claimed did not exist in the same image.
+  - This arose for non-RPM content in official Red Hat container images, such as Go binaries in OpenShift images.
+  - When the variable is set, Scanner V4 will continue to show non-RPM content in official Red Hat container images but will no longer
+    output vulnerabilities from non-Red Hat security data sources for these images.
 
 ## [4.7.0]
 
@@ -85,14 +93,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
     - from docs dot openshift dot com
     - to docs dot redhat dot com
 - ROX-26763: identify defunct processes before they induce parsing errors in Collector.
-- Scanner V4 may now only show vulnerability data from Red Hat security data sources for official Red Hat container images
-  found in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore) when the environment variable `ROX_SCANNER_V4_RED_HAT_LAYERS` is set in Scanner V4 Matcher.
-  - Previously, those who used Scanner V4 would see vulnerability data from various sources for all layers in their images.
-    This lead to confusion when users scanned official Red Hat images or images based on official Red Hat images
-    and Scanner V4 claimed the images contained vulnerabilities which the official Red Hat CVE pages claimed did not exist in the same image.
-  - This arose for non-RPM content in official Red Hat container images, such as Go binaries in OpenShift images.
-  - When the variable is set, Scanner V4 will continue to show non-RPM content in official Red Hat container images but will no longer
-    output data from non-Red Hat security data sources for these images.
 
 ## [4.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
     - from docs dot openshift dot com
     - to docs dot redhat dot com
 - ROX-26763: identify defunct processes before they induce parsing errors in Collector.
+- Scanner V4 may now only show vulnerability data from Red Hat security data sources for official Red Hat container images
+  found in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore) when the environment variable `ROX_SCANNER_V4_RED_HAT_LAYERS` is set in Scanner V4 Matcher.
+  - Previously, those who used Scanner V4 would see vulnerability data from various sources for all layers in their images.
+    This lead to confusion when users scanned official Red Hat images or images based on official Red Hat images
+    and Scanner V4 claimed the images contained vulnerabilities which the official Red Hat CVE pages claimed did not exist in the same image.
+  - This arose for non-RPM content in official Red Hat container images, such as Go binaries in OpenShift images.
+  - When the variable is set, Scanner V4 will continue to show non-RPM content in official Red Hat container images but will no longer
+    output data from non-Red Hat security data sources for these images.
 
 ## [4.6.0]
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -101,9 +101,6 @@ var (
 	// NetworkGraphExternalIPs enables displaying external IPs in the network graph
 	NetworkGraphExternalIPs = registerFeature("Display external ips in the UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
 
-	// ScannerV4RedHatLayers enables displaying vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers.
-	ScannerV4RedHatLayers = registerFeature("Scanner V4 will only output vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers", "ROX_SCANNER_V4_RED_HAT_LAYERS", enabled)
-
 	// Display RHSA/RHBA/RHEA advisory separately from associated CVE.
 	CVEAdvisorySeparation = registerFeature("Display RHSA/RHBA/RHEA advisory separately from associated CVE", "ROX_CVE_ADVISORY_SEPARATION")
 
@@ -159,4 +156,7 @@ var (
 	//
 	// This must be set in Scanner V4 Matcher to have any effect.
 	ScannerV4RedHatCSAF = registerFeature("Scanner V4 will enrich its results with Red Hat CSAF data", "ROX_SCANNER_V4_RED_HAT_CSAF", enabled)
+
+	// ScannerV4RedHatLayers enables displaying vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers.
+	ScannerV4RedHatLayers = registerFeature("Scanner V4 will only output vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers", "ROX_SCANNER_V4_RED_HAT_LAYERS")
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -158,5 +158,5 @@ var (
 	ScannerV4RedHatCSAF = registerFeature("Scanner V4 will enrich its results with Red Hat CSAF data", "ROX_SCANNER_V4_RED_HAT_CSAF", enabled)
 
 	// ScannerV4RedHatLayers enables displaying vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers.
-	ScannerV4RedHatLayers = registerFeature("Scanner V4 will only output vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers", "ROX_SCANNER_V4_RED_HAT_LAYERS")
+	ScannerV4RedHatLayers = registerFeature("Scanner V4 will only output vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers", "ROX_SCANNER_V4_RED_HAT_LAYERS_RED_HAT_VULNS_ONLY", enabled)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -101,6 +101,9 @@ var (
 	// NetworkGraphExternalIPs enables displaying external IPs in the network graph
 	NetworkGraphExternalIPs = registerFeature("Display external ips in the UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
 
+	// ScannerV4RedHatLayers enables displaying vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers.
+	ScannerV4RedHatLayers = registerFeature("Scanner V4 will only output vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers", "ROX_SCANNER_V4_RED_HAT_LAYERS", enabled)
+
 	// Display RHSA/RHBA/RHEA advisory separately from associated CVE.
 	CVEAdvisorySeparation = registerFeature("Display RHSA/RHBA/RHEA advisory separately from associated CVE", "ROX_CVE_ADVISORY_SEPARATION")
 

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/quay/claircore/rhel/rhcc"
+	"github.com/quay/claircore/rhel/vex"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/clair"
@@ -14,6 +16,16 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
+)
+
+var (
+	// vexUpdater is the name of the Red Hat VEX updater used by Claircore.
+	vexUpdater = (*vex.Updater)(nil).Name()
+
+	// vexRepoName is the name of the "Gold Repository".
+	vexRepoName = rhcc.GoldRepo.Name
+	// vexRepoURI is the URI of the "Gold Repository".
+	vexRepoURI = rhcc.GoldRepo.URI
 )
 
 func imageScan(metadata *storage.ImageMetadata, report *v4.VulnerabilityReport) *storage.ImageScan {

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/quay/claircore/rhel/rhcc"
-	"github.com/quay/claircore/rhel/vex"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/clair"
@@ -16,16 +14,6 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
-)
-
-var (
-	// vexUpdater is the name of the Red Hat VEX updater used by Claircore.
-	vexUpdater = (*vex.Updater)(nil).Name()
-
-	// vexRepoName is the name of the "Gold Repository".
-	vexRepoName = rhcc.GoldRepo.Name
-	// vexRepoURI is the URI of the "Gold Repository".
-	vexRepoURI = rhcc.GoldRepo.URI
 )
 
 func imageScan(metadata *storage.ImageMetadata, report *v4.VulnerabilityReport) *storage.ImageScan {

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/facebookincubator/nvdtools/cvss3"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/rhel/rhcc"
 	"github.com/quay/claircore/rhel/vex"
 	"github.com/quay/claircore/toolkit/types/cpe"
 	"github.com/quay/zlog"
@@ -105,7 +106,8 @@ func ToProtoV4VulnerabilityReport(ctx context.Context, r *claircore.Vulnerabilit
 	if r == nil {
 		return nil, nil
 	}
-	filterPackages(r.Packages, r.Environments, r.PackageVulnerabilities)
+	filterPackages(r)
+	filterVulnerabilities(r)
 	nvdVulns, err := nvdVulnerabilities(r.Enrichments)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: parsing nvd vulns: %w", err)
@@ -891,14 +893,14 @@ func redhatCSAFAdvisories(ctx context.Context, enrichments map[string][]json.Raw
 	return ret, nil
 }
 
-// filterPackages filters out packages from the given map.
-func filterPackages(packages map[string]*claircore.Package, environments map[string][]*claircore.Environment, packageVulns map[string][]string) {
+// filterPackages filters out packages from the given vulnerability report.
+func filterPackages(report *claircore.VulnerabilityReport) {
 	// We only filter out Node.js packages with no known vulnerabilities (if configured to do so) at this time.
 	if !features.ScannerV4PartialNodeJSSupport.Enabled() {
 		return
 	}
-	for pkgID := range packages {
-		envs := environments[pkgID]
+	for pkgID := range report.Packages {
+		envs := report.Environments[pkgID]
 		// This is unexpected, but check here to be safe.
 		if len(envs) == 0 {
 			continue
@@ -906,12 +908,121 @@ func filterPackages(packages map[string]*claircore.Package, environments map[str
 		if srcType, _ := scannerv4.ParsePackageDB(envs[0].PackageDB); srcType != storage.SourceType_NODEJS {
 			continue
 		}
-		if len(packageVulns[pkgID]) == 0 {
-			delete(packages, pkgID)
-			delete(environments, pkgID)
-			delete(packageVulns, pkgID)
+		if len(report.PackageVulnerabilities[pkgID]) == 0 {
+			delete(report.Packages, pkgID)
+			delete(report.Environments, pkgID)
+			delete(report.PackageVulnerabilities, pkgID)
 		}
 	}
+}
+
+// filterVulnerabilities filters out vulnerabilities from the given vulnerability report.
+// Note: This function only modifies the report's PackageVulnerabilities map.
+// It is not trivial to remove all unreferenced vulnerabilities from the report's
+// Vulnerabilities map, so we leave it untouched and accept we may send Scanner V4 clients
+// extra vulnerabilities. It is up to the client to handle this.
+func filterVulnerabilities(report *claircore.VulnerabilityReport) {
+	// We only filter out non-Red Hat vulnerabilities found in Red Hat layers (if configured to do so) at this time.
+	if !features.ScannerV4RedHatLayers.Enabled() {
+		return
+	}
+
+	redhatLayers := rhccLayers(report)
+	if redhatLayers.IsEmpty() {
+		// This image is neither an official Red Hat image nor based on one, so nothing to do here.
+		return
+	}
+	for pkgID, pkg := range report.Packages {
+		// Sanity check.
+		if pkg == nil {
+			continue
+		}
+
+		envs, found := report.Environments[pkgID]
+		if !found {
+			// Did not find a related environment, so we cannot determine the layer.
+			continue
+		}
+
+		// Just use the first environment.
+		// It is possible there are multiple environments associated with this package;
+		// however, for our purposes, we only need the first one,
+		// as the layer index will always be the same between different environments.
+		// Quay does this, too: https://github.com/quay/quay/blob/v3.10.3/data/secscan_model/secscan_v4_model.py#L583.
+		// We also do this in our own client code.
+		env := envs[0]
+		// If this package was introduced in a non-Red Hat layer, skip it.
+		if !redhatLayers.Contains(env.IntroducedIn.String()) {
+			continue
+		}
+
+		var n int
+		for _, vulnID := range report.PackageVulnerabilities[pkgID] {
+			vuln := report.Vulnerabilities[vulnID]
+			// Sanity check.
+			if vuln == nil {
+				continue
+			}
+
+			// If the vulnerability did not come from Red Hat's VEX data, then skip it.
+			if vuln.Updater != vexUpdater {
+				continue
+			}
+
+			report.PackageVulnerabilities[pkgID][n] = vulnID
+			n++
+		}
+
+		// Hint to the GC the filtered vulnerabilities are no longer needed.
+		clear(report.PackageVulnerabilities[pkgID][n:])
+		report.PackageVulnerabilities[pkgID] = report.PackageVulnerabilities[pkgID][:n:n]
+
+		// If there aren't any vulnerabilities from Red Hat's VEX data,
+		// then delete the whole entry.
+		if n == 0 {
+			delete(report.PackageVulnerabilities, pkgID)
+		}
+	}
+}
+
+var (
+	// vexUpdater is the name of the Red Hat VEX updater used by Claircore.
+	vexUpdater = (*vex.Updater)(nil).Name()
+	// rhccRepoName is the name of the "Gold Repository".
+	rhccRepoName = rhcc.GoldRepo.Name
+	// rhccRepoURI is the URI of the "Gold Repository".
+	rhccRepoURI = rhcc.GoldRepo.URI
+)
+
+// rhccLayers returns a set of SHAs for the layers in official Red Hat images.
+// TODO(TODO): account for images built via Konflux, as they do not contain the same identifiers
+// as the old build system.
+func rhccLayers(report *claircore.VulnerabilityReport) set.FrozenStringSet {
+	layers := set.NewStringSet()
+
+	var rhccID string
+	for id, repo := range report.Repositories {
+		if repo.Name == rhccRepoName && repo.URI == rhccRepoURI {
+			rhccID = id
+			break
+		}
+	}
+	if rhccID == "" {
+		// Not an official Red Hat image nor based on one.
+		return layers.Freeze()
+	}
+
+	for _, envs := range report.Environments {
+		for _, env := range envs {
+			for _, repoID := range env.RepositoryIDs {
+				if repoID == rhccID {
+					layers.Add(env.IntroducedIn.String())
+				}
+			}
+		}
+	}
+
+	return layers.Freeze()
 }
 
 // pkgFixedBy unmarshals and returns the package-fixed-by enrichment, if it exists.

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -82,6 +82,13 @@ var (
 		// Catchall
 		regexp.MustCompile(`[A-Z]+-\d{4}[-:]\d+`),
 	}
+
+	// vexUpdater is the name of the Red Hat VEX updater used by Claircore.
+	vexUpdater = (*vex.Updater)(nil).Name()
+	// rhccRepoName is the name of the "Gold Repository".
+	rhccRepoName = rhcc.GoldRepo.Name
+	// rhccRepoURI is the URI of the "Gold Repository".
+	rhccRepoURI = rhcc.GoldRepo.URI
 )
 
 // ToProtoV4IndexReport maps claircore.IndexReport to v4.IndexReport.
@@ -984,15 +991,6 @@ func filterVulnerabilities(report *claircore.VulnerabilityReport) {
 		}
 	}
 }
-
-var (
-	// vexUpdater is the name of the Red Hat VEX updater used by Claircore.
-	vexUpdater = (*vex.Updater)(nil).Name()
-	// rhccRepoName is the name of the "Gold Repository".
-	rhccRepoName = rhcc.GoldRepo.Name
-	// rhccRepoURI is the URI of the "Gold Repository".
-	rhccRepoURI = rhcc.GoldRepo.URI
-)
 
 // rhccLayers returns a set of SHAs for the layers in official Red Hat images.
 // TODO(ROX-29158): account for images built via Konflux, as they do not contain the same identifiers

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -995,7 +995,7 @@ var (
 )
 
 // rhccLayers returns a set of SHAs for the layers in official Red Hat images.
-// TODO(TODO): account for images built via Konflux, as they do not contain the same identifiers
+// TODO(ROX-29158): account for images built via Konflux, as they do not contain the same identifiers
 // as the old build system.
 func rhccLayers(report *claircore.VulnerabilityReport) set.FrozenStringSet {
 	layers := set.NewStringSet()

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -918,7 +918,7 @@ func filterPackages(report *claircore.VulnerabilityReport) {
 
 // filterVulnerabilities filters out vulnerabilities from the given vulnerability report.
 // Note: This function only modifies the report's PackageVulnerabilities map.
-// It is not trivial to remove all unreferenced vulnerabilities from the report's
+// It is non-trivial to remove all unreferenced vulnerabilities from the report's
 // Vulnerabilities map, so we leave it untouched and accept we may send Scanner V4 clients
 // extra vulnerabilities. It is up to the client to handle this.
 func filterVulnerabilities(report *claircore.VulnerabilityReport) {

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -493,6 +493,11 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 						Name:    "my python egg",
 						Version: "2",
 					},
+					"3": {
+						ID:      "3",
+						Name:    "my ruby gem",
+						Version: "3",
+					},
 				},
 				Repositories: map[string]*claircore.Repository{
 					"0": {
@@ -525,11 +530,18 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 							IntroducedIn:  layerA,
 						},
 					},
+					"3": {
+						{
+							RepositoryIDs: []string{"1"},
+							IntroducedIn:  layerB,
+						},
+					},
 				},
 				PackageVulnerabilities: map[string][]string{
 					"0": {"2", "0", "3", "1"},
 					"1": {"1", "2"},
 					"2": {"2", "3"},
+					"3": {"0", "1", "2", "3"},
 				},
 			},
 			want: &v4.VulnerabilityReport{
@@ -560,6 +572,9 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 					"1": {
 						Values: []string{"1", "2"},
 					},
+					"3": {
+						Values: []string{"0", "1", "2", "3"},
+					},
 				},
 				Contents: &v4.Contents{
 					Packages: []*v4.Package{
@@ -585,6 +600,15 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 							Id:      "2",
 							Name:    "my python egg",
 							Version: "2",
+							NormalizedVersion: &v4.NormalizedVersion{
+								V: []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							},
+							Cpe: emptyCPE,
+						},
+						{
+							Id:      "3",
+							Name:    "my ruby gem",
+							Version: "3",
 							NormalizedVersion: &v4.NormalizedVersion{
 								V: []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 							},
@@ -627,6 +651,14 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 								{
 									RepositoryIds: []string{"0"},
 									IntroducedIn:  layerA.String(),
+								},
+							},
+						},
+						"3": {
+							Environments: []*v4.Environment{
+								{
+									RepositoryIds: []string{"1"},
+									IntroducedIn:  layerB.String(),
 								},
 							},
 						},


### PR DESCRIPTION
### Description

Red Hat vulnerability data may be split into two categories: rpm data and non-rpm data. The non-rpm data may also be known as "container-first" content because this data associates a vulnerability to an entire container image (instead of a specific package inside the image), and the fix would require the use of an updated image (opposed to an updated package).

Scanner V4 does, in fact, read this container-first data, and we clearly show container-first vulnerabilities. Users would see this by seeing the name of the container image (or even base container images) as the affected component.

The problem: when Red Hat declares an image is unaffected by some non-RPM-related vulnerability. For example: let's say there is some Go vulnerability which may potentially affect Red Hat Advanced Cluster Security's `main` image. The team looked into it and delcared the image is, in fact, unaffected. Red Hat's vulnerability data will reflect this, and the CVE page would say `advanced-cluster-security/main` is `Unaffected`. So, Scanner V4 sees this and does nothing (as there is no vulnerability). However, Scanner V4 also reads data from other sources: in particular, OSV.dev. According to OSV.dev, the Go binary's dependency (which the team told Red Hat's ProdSec is not vulnerable in this context) is affected by the vulnerability. That's because Scanner V4 (Claircore) uses OSV.dev's data rather generically, and it just sees the vulnerable version of the dependency. It does not know that perhaps the dependency is unused in production.

This PR introduces a feature flag (`ROX_SCANNER_V4_RED_HAT_LAYERS`) + implementation to stop using non-Red Hat data for official Red Hat image layers.

### User-facing documentation

- [x] CHANGELOG is updated
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests

#### How I validated my change

I deployed this version of StackRox to an OpenShift cluster, and I scanned an OpenShift image: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b16edc1b984d74091f05c730dfcb900c152d92568e4f5dd562f018b0f8fec8ea`. These images typically seem vulnerable to many Go vulnerabilities, but this is not always the case.

I compared the results I see in our staging environment:

![staging](https://github.com/user-attachments/assets/d9442655-6ed2-4259-827a-f155a2fbb05c)

with the results I got from this PR:

![pr](https://github.com/user-attachments/assets/18de9863-b596-497d-a233-35163ada8916)
