### PR TITLE
fix(ui): Use current page as horizontal nav title

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -128,7 +128,7 @@ describe('Workload CVE overview page tests', () => {
             });
 
             // Test the 'All vulnerable images' view
-            visitFromMoreViewsDropdown('All vulnerable images');
+            visitFromHorizontalNavExpandable('More views')('All vulnerable images');
             waitAndYieldRequestBodyVariables(['getImageCVEList']).then(({ query }) => {
                 const requestQuery = query.toLowerCase();
                 expect(requestQuery).to.contain('vulnerability state:observed');
@@ -137,7 +137,7 @@ describe('Workload CVE overview page tests', () => {
             });
 
             // Test the 'Inactive images' view
-            visitFromMoreViewsDropdown('Inactive images');
+            visitFromHorizontalNavExpandable('All vulnerable images')('Inactive images');
             waitAndYieldRequestBodyVariables(['getImageCVEList']).then(({ query }) => {
                 const requestQuery = query.toLowerCase();
                 expect(requestQuery).to.contain('vulnerability state:observed');
@@ -146,7 +146,7 @@ describe('Workload CVE overview page tests', () => {
             });
 
             // Test the 'Images without CVEs' view
-            visitFromMoreViewsDropdown('Images without CVEs');
+            visitFromHorizontalNavExpandable('Inactive images')('Images without CVEs');
             waitAndYieldRequestBodyVariables(['getImageList']).then(({ query }) => {
                 const requestQuery = query.toLowerCase();
                 expect(requestQuery).not.to.contain('platform component:observed');

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -128,7 +128,7 @@ describe('Workload CVE overview page tests', () => {
             });
 
             // Test the 'All vulnerable images' view
-            visitFromHorizontalNavExpandable('More views')('All vulnerable images');
+            visitFromHorizontalNavExpandable('More Views')('All vulnerable images');
             waitAndYieldRequestBodyVariables(['getImageCVEList']).then(({ query }) => {
                 const requestQuery = query.toLowerCase();
                 expect(requestQuery).to.contain('vulnerability state:observed');

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.css
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.css
@@ -24,6 +24,12 @@ nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav .pf-v5-c-menu-to
   --pf-v5-c-menu-toggle--PaddingLeft: var(--pf-v5-c-nav--m-horizontal-subnav__link--PaddingLeft);
 }
 
+nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav .pf-v5-c-menu-toggle:after {
+  border-left-width: 1px;
+  border-left-style: solid;
+  border-left-color: var(--pf-v5-global--BackgroundColor--dark-200);
+}
+
 nav.pf-v5-c-nav.pf-m-horizontal-subnav.acs-pf-horizontal-subnav .pf-v5-c-menu {
   max-width: 300px;
   white-space: break-spaces;

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -233,6 +233,10 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                         }
                         case 'parent': {
                             const { key, title, children } = subnavDescription;
+                            const activeChildLink = subnavDescription.children
+                                .filter((c) => c.type === 'link')
+                                .find((child) => isActiveLink(location, child));
+                            const dropdownTitle = activeChildLink?.content ?? title;
                             return (
                                 <Dropdown
                                     key={key}
@@ -244,11 +248,7 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                                     }
                                     toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                                         <NavItem
-                                            isActive={subnavDescription.children.some(
-                                                (child) =>
-                                                    child.type === 'link' &&
-                                                    isActiveLink(location, child)
-                                            )}
+                                            isActive={Boolean(activeChildLink)}
                                             onClick={() => onToggleClick(key)}
                                         >
                                             <MenuToggle
@@ -256,9 +256,9 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                                                 isExpanded={openDropdownKey === key}
                                                 variant="plainText"
                                             >
-                                                {typeof title === 'function'
-                                                    ? title(subnavDescriptions)
-                                                    : title}
+                                                {typeof dropdownTitle === 'function'
+                                                    ? dropdownTitle(subnavDescriptions)
+                                                    : dropdownTitle}
                                             </MenuToggle>
                                         </NavItem>
                                     )}

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -275,14 +275,16 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                                                 );
                                             }
                                             const { content, path, description } = child;
+                                            const isActive = isActiveLink(location, child);
                                             return (
                                                 <DropdownItem
                                                     component={'a'}
                                                     className={
-                                                        isActiveLink(location, child)
+                                                        isActive
                                                             ? 'acs-pf-horizontal-subnav-menu__active'
                                                             : ''
                                                     }
+                                                    isSelected={isActive}
                                                     value={path}
                                                     key={path}
                                                     description={description}


### PR DESCRIPTION
### Description

1. Adds the left border to the dropdown navigation in the horizontal nav bar, for visual consistency
2. Retains the title of the current page in the dropdown toggle, when the active page is one of the child items
3. Shows the `isSelected` checkmark state of the current nav item

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before, no divider before dropdown (subtle)

After
![image](https://github.com/user-attachments/assets/e281f483-807b-49ea-8a8c-f6f6d467daf2)

Selecting an item from the dropdown changes the dropdown text to reflect the current page, instead of unconditionally displaying "More views". When selected, an item also shows that it is current with the `isSelected` checkmark state.
![image](https://github.com/user-attachments/assets/7cde8d05-3ed3-485e-8639-e3fb3a685b40)
![image](https://github.com/user-attachments/assets/9d583ade-0d69-4236-945c-9ee12baeb9bd)
![image](https://github.com/user-attachments/assets/52e17e69-c5a8-4bf8-8cb8-0b081a17ed62)
![image](https://github.com/user-attachments/assets/6274fe54-dee9-4bf6-ac74-c030d436cd80)
