### PR TITLE
fix(ui): Minor visual tweaks to Platform CVE split

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -99,7 +99,7 @@ function getSubnavDescriptionGroups(
                               type: 'link',
                               content: 'All vulnerable images',
                               description:
-                                  'View findings for user, platform, and inactive images simultaneously',
+                                  'Findings for user, platform, and inactive images simultaneously',
                               path: vulnerabilitiesAllImagesPath,
                               routeKey: 'vulnerabilities/all-images',
                           },
@@ -107,7 +107,7 @@ function getSubnavDescriptionGroups(
                               type: 'link',
                               content: 'Inactive images',
                               description:
-                                  'View findings for watched images and images not currently deployed as workloads based on your image retention settings',
+                                  'Findings for watched images and images not currently deployed as workloads based on your image retention settings',
                               path: vulnerabilitiesInactiveImagesPath,
                               routeKey: 'vulnerabilities/inactive-images',
                           },

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect, useState, ReactElement } from 'react';
 import {
-    PageSection,
-    Bullseye,
     Alert,
+    Bullseye,
+    Button,
+    Flex,
+    PageSection,
+    Popover,
+    Spinner,
     Title,
     Tabs,
     Tab,
     TabTitleText,
     Text,
-    Spinner,
-    Button,
-    Flex,
-    Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
@@ -280,19 +280,14 @@ function ViolationsTablePage(): ReactElement {
                         {isPlatformCveSplitEnabled ? title : 'Violations'}
                     </Title>
                     {isPlatformCveSplitEnabled && (
-                        <Tooltip
-                            aria="none"
-                            aria-live="polite"
-                            content={description}
-                            position="bottom"
+                        <Popover
+                            aria-label="More information about the current page"
+                            bodyContent={description}
                         >
-                            <Button
-                                aria-label="More information about the current page"
-                                variant="plain"
-                            >
+                            <Button title="Page description" variant="plain">
                                 <OutlinedQuestionCircleIcon />
                             </Button>
-                        </Tooltip>
+                        </Popover>
                     )}
                 </Flex>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -74,12 +74,12 @@ const violationPageText: Record<
 > = {
     'Applications view': {
         title: 'User workload violations',
-        description: 'Violations affecting user-managed workloads and images',
+        description: 'Violations affecting user-managed workloads',
     },
     'Platform view': {
         title: 'Platform violations',
         description:
-            'Violations affecting images and workloads used by the OpenShift Platform and layered services',
+            'Violations affecting workloads used by the OpenShift Platform and layered services',
     },
     'Full view': {
         title: 'All violations',
@@ -96,9 +96,9 @@ function getFilteredWorkflowViewText(filteredWorkflowView: FilteredWorkflowView)
 }
 
 const violationsPageDescription: Record<ViolationStateTab, string> = {
-    ACTIVE: 'View Build/Deploy violations for workloads currently in violation, along with unresolved Runtime violations.',
+    ACTIVE: 'View Build/Deploy-phase violations for workloads currently in violation, along with unresolved Runtime violations.',
     RESOLVED:
-        'View Build/Deploy violations for workloads that were removed or modified to be compliant, manually resolved Runtime violations, and violations generated before a policy exclusion was added (all lifecycles)',
+        'View Build/Deploy-phase violations for workloads that were removed or modified to be compliant, manually resolved Runtime violations, and violations generated before a policy exclusion was added (all lifecycles)',
     ATTEMPTED:
         'View would-be violations that caused workload deployment attempts to be blocked by the Admission Controller.',
 };

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -96,11 +96,11 @@ function getFilteredWorkflowViewText(filteredWorkflowView: FilteredWorkflowView)
 }
 
 const violationsPageDescription: Record<ViolationStateTab, string> = {
-    ACTIVE: 'View Build/Deploy-phase violations for workloads currently in violation, along with unresolved Runtime violations.',
+    ACTIVE: 'Build/Deploy-stage violations for workloads currently in violation, along with unresolved Runtime violations.',
     RESOLVED:
-        'View Build/Deploy-phase violations for workloads that were removed or modified to be compliant, manually resolved Runtime violations, and violations generated before a policy exclusion was added (all lifecycles)',
+        'Build/Deploy-stage violations for workloads that were removed or modified to be compliant, manually resolved Runtime violations, and violations generated before a policy exclusion was added (all lifecycles)',
     ATTEMPTED:
-        'View would-be violations that caused workload deployment attempts to be blocked by the Admission Controller.',
+        'Would-be violations that caused workload deployment attempts to be blocked by the Admission Controller.',
 };
 
 function getDescriptionForSelectedViolationState(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -382,9 +382,7 @@ function ImageCvePage() {
             />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>
-                        {pageTitle}
-                    </BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={workloadCveOverviewCvePath}>CVEs</BreadcrumbItemLink>
                     {!metadataRequest.error && (
                         <BreadcrumbItem isActive>
                             {cveName ?? (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -164,8 +164,13 @@ function WorkloadCvesOverviewPage() {
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const { getAbsoluteUrl, pageTitle, pageTitleDescription, baseSearchFilter } =
-        useWorkloadCveViewContext();
+    const {
+        getAbsoluteUrl,
+        pageTitle,
+        pageTitleDescription,
+        baseSearchFilter,
+        overviewEntityTabs,
+    } = useWorkloadCveViewContext();
     const currentVulnerabilityState = useVulnerabilityState();
 
     const { searchFilter, setSearchFilter: setURLSearchFilter } = useURLSearch();
@@ -371,9 +376,7 @@ function WorkloadCvesOverviewPage() {
 
     const entityToggleGroup = (
         <EntityTypeToggleGroup
-            entityTabs={
-                isViewingWithCves ? ['CVE', 'Image', 'Deployment'] : ['Image', 'Deployment']
-            }
+            entityTabs={overviewEntityTabs}
             entityCounts={entityCounts}
             onChange={onEntityTabChange}
         />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -8,9 +8,9 @@ import {
     Flex,
     FlexItem,
     PageSection,
+    Popover,
     Text,
     Title,
-    Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { gql, useApolloClient, useQuery } from '@apollo/client';
@@ -404,19 +404,14 @@ function WorkloadCvesOverviewPage() {
                 >
                     <Title headingLevel="h1">{pageTitle}</Title>
                     {pageTitleDescription && (
-                        <Tooltip
-                            aria="none"
-                            aria-live="polite"
-                            content={pageTitleDescription}
-                            position="bottom"
+                        <Popover
+                            aria-label="More information about the current page"
+                            bodyContent={pageTitleDescription}
                         >
-                            <Button
-                                aria-label="More information about the current page"
-                                variant="plain"
-                            >
+                            <Button title="Page description" variant="plain">
                                 <OutlinedQuestionCircleIcon />
                             </Button>
-                        </Tooltip>
+                        </Popover>
                     )}
                     {!isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT') && (
                         <FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
@@ -1,10 +1,13 @@
 import { createContext } from 'react';
-import { QuerySearchFilter } from '../types';
+import { NonEmptyArray } from 'utils/type.utils';
+
+import { QuerySearchFilter, WorkloadEntityTab } from '../types';
 
 export type WorkloadCveView = {
     getAbsoluteUrl: (path: string) => string;
     baseSearchFilter: QuerySearchFilter;
     pageTitle: string;
+    overviewEntityTabs: NonEmptyArray<WorkloadEntityTab>;
     pageTitleDescription?: string;
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -64,14 +64,14 @@ function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsF
         case allImagesViewId:
             pageTitle = 'All vulnerable images';
             pageTitleDescription =
-                'View findings for user, platform, and inactive images simultaneously';
+                'Findings for user, platform, and inactive images simultaneously';
             baseSearchFilter = { 'Platform Component': ['true', 'false', '-'] };
             getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesAllImagesPath}/${subPath}`;
             break;
         case inactiveImagesViewId:
             pageTitle = 'Inactive images only';
             pageTitleDescription =
-                'View findings for watched images and images not currently deployed as workloads based on your image retention settings';
+                'Findings for watched images and images not currently deployed as workloads based on your image retention settings';
             baseSearchFilter = { 'Platform Component': ['-'] };
             getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesInactiveImagesPath}/${subPath}`;
             break;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -16,6 +16,7 @@ import {
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
 import useFeatureFlags, { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
+import { NonEmptyArray } from 'utils/type.utils';
 import DeploymentPage from './Deployment/DeploymentPage';
 import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
@@ -24,7 +25,7 @@ import NamespaceViewPage from './NamespaceView/NamespaceViewPage';
 import { WorkloadCveViewContext } from './WorkloadCveViewContext';
 
 import './WorkloadCvesPage.css';
-import { QuerySearchFilter } from '../types';
+import { QuerySearchFilter, WorkloadEntityTab } from '../types';
 
 export const userWorkloadViewId = 'user-workloads';
 export const platformViewId = 'platform';
@@ -37,6 +38,7 @@ function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsF
     let pageTitleDescription: string | undefined;
     let baseSearchFilter: QuerySearchFilter = {};
     let getAbsoluteUrl: (subPath: string) => string = () => '';
+    let overviewEntityTabs: NonEmptyArray<WorkloadEntityTab> = ['CVE', 'Image', 'Deployment'];
 
     switch (viewId) {
         case userWorkloadViewId:
@@ -74,6 +76,7 @@ function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsF
                 'Findings for watched images and images not currently deployed as workloads based on your image retention settings';
             baseSearchFilter = { 'Platform Component': ['-'] };
             getAbsoluteUrl = (subPath: string) => `${vulnerabilitiesInactiveImagesPath}/${subPath}`;
+            overviewEntityTabs = ['CVE', 'Image'];
             break;
         case imagesWithoutCvesViewId:
             pageTitle = 'Images without CVEs';
@@ -82,12 +85,19 @@ function getWorkloadCveContextFromView(viewId: string, isFeatureFlagEnabled: IsF
             baseSearchFilter = { 'Image CVE Count': ['0'] };
             getAbsoluteUrl = (subPath: string) =>
                 `${vulnerabilitiesImagesWithoutCvesPath}/${subPath}`;
+            overviewEntityTabs = ['Image', 'Deployment'];
             break;
         default:
         // TODO Handle user-defined views, or error
     }
 
-    return { pageTitle, pageTitleDescription, baseSearchFilter, getAbsoluteUrl };
+    return {
+        pageTitle,
+        pageTitleDescription,
+        baseSearchFilter,
+        getAbsoluteUrl,
+        overviewEntityTabs,
+    };
 }
 
 export type WorkloadCvePageProps = {


### PR DESCRIPTION
### Description

Minor cleanup items for the CVE split, one commit per one change:

1. Use a `Popover` instead of `Tooltip` for page help text
2. Minor *final* wording changes in page descriptions
3. Hide irrelevant entity tabs in Workload CVEs ("CVE" tab in the "Without CVEs" view, "Deployment" tab in the Inactive images view)
4. Revert VM breadcrumb to simply "CVE" instead of custom text for each possible view

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Popovers:
![image](https://github.com/user-attachments/assets/b3fd37f3-cb72-4a56-98ca-e3ddf71a94b6)

Inactive images - no deployment button
![image](https://github.com/user-attachments/assets/ece8bde0-d353-46d7-b34b-a7e9f9bf6ba9)

Image w/o CVEs - no CVEs button
![image](https://github.com/user-attachments/assets/b054670a-7664-48e2-bb81-660f6108e168)

Verify all other views contain all three buttons.

Visit a CVE detail page and see the basic "CVEs" breadcrumb at the top:
![image](https://github.com/user-attachments/assets/c10b420d-c83d-4e1a-aad8-6630874ba803)

