### PR TITLE
chore(govulncheck): remove fixed Go vulns

### DIFF
--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -5,15 +5,6 @@
     },
     "GO-2022-0646": {
       "reason": "Unused portion of the SDK"
-    },
-    "GO-2024-3105": {
-      "reason": "Requires Go 1.22.7 or 1.23.1"
-    },
-    "GO-2024-3106": {
-      "reason": "Requires Go 1.22.7 or 1.23.1"
-    },
-    "GO-2024-3107": {
-      "reason": "Requires Go 1.22.7 or 1.23.1"
     }
   }
 }


### PR DESCRIPTION
### Description

Since we've upgraded to Go 1.23.3 (https://github.com/stackrox/stackrox/pull/13780), we can remove GO-2024-3105, GO-2024-3106, and GO-2024-3107 from the govulncheck ignore list.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No

#### How I validated my change

Added `scan-go-binaries` to this PR. I expect this to come back clean.