### PR TITLE
ROX-27179: Moving Auto-refresh enabled text below expiry 

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.js
@@ -185,7 +185,7 @@ ClusterSummary.propTypes = {
     clusterId: PropTypes.string.isRequired,
     clusterRetentionInfo: PropTypes.shape({}),
     isManagerTypeNonConfigurable: PropTypes.bool.isRequired,
-    autoRefreshEnabled: PropTypes.boolean,
+    autoRefreshEnabled: PropTypes.bool,
 };
 
 export default ClusterSummary;

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -44,7 +44,6 @@ function CredentialExpiration({
     const distanceElement = (
         <span className="whitespace-nowrap">
             {getDistanceStrictAsPhrase(sensorCertExpiry, currentDatetime)}
-            {autoRefreshEnabled && <div>Auto-refresh enabled</div>}
         </span>
     );
 
@@ -74,6 +73,7 @@ function CredentialExpiration({
                         ? getDayOfWeek(sensorCertExpiry)
                         : getDate(sensorCertExpiry)
                 }`}</span>
+                {autoRefreshEnabled && <div>Auto-refresh enabled</div>}
             </div>
         );
     }

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -73,7 +73,6 @@ function CredentialExpiration({
                         ? getDayOfWeek(sensorCertExpiry)
                         : getDate(sensorCertExpiry)
                 }`}</span>
-                {autoRefreshEnabled && <div>Auto-refresh enabled</div>}
             </div>
         );
     }
@@ -81,7 +80,10 @@ function CredentialExpiration({
     return (
         <HealthStatus icon={icon} iconColor={fgColor}>
             {isList || healthStatus === 'HEALTHY' ? (
-                expirationElement
+                <div>
+                    {expirationElement}
+                    {autoRefreshEnabled && <div>Auto-refresh enabled</div>}
+                </div>
             ) : (
                 <div>
                     {expirationElement}


### PR DESCRIPTION
should look as it did before 
<img width="192" alt="image" src="https://github.com/user-attachments/assets/dae879a7-a7e9-47ef-9661-ee4bf70ad18b" />
<img width="306" alt="image" src="https://github.com/user-attachments/assets/27b2da10-c9c4-4a37-99dc-50299f7e7f92" />

with expiry text (modified in UI/the date should not display like that irl)
<img width="196" alt="image" src="https://github.com/user-attachments/assets/df085404-af2d-4413-a7b6-59894cb78f65" />
