### PR TITLE
ROX-27968: Add dele scanning note to SBOM errors 

### DIFF
--- a/central/image/service/http_handler_test.go
+++ b/central/image/service/http_handler_test.go
@@ -62,6 +62,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		err := res.Body.Close()
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+		assert.NotContains(t, recorder.Body.String(), deleScanNotSupported)
 	})
 
 	// Test case: valid json body and enricher returns error
@@ -90,6 +91,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 		err = res.Body.Close()
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+		assert.Contains(t, recorder.Body.String(), deleScanNotSupported)
 	})
 
 	// Test case: valid json body and validate enricher being called


### PR DESCRIPTION
### Description

Adds a note to errors produced by the SBOM handler that the failure 'may' be caused by delegated scanning not being supported.

There didn't seem to be a way in the short amount of time to add this (without over engineering) to determine that if delegated scanning was used the error would NOT have occurred as a result. As a result, the note will be shown on every error message.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ x [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

TBD
