### PR TITLE
chore(ci): upgrade cache action

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -11,14 +11,14 @@ runs:
       shell: bash
 
     - name: Cache Go Dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.cache-paths.outputs.GOMODCACHE }}
         key: go-mod-v1-${{ hashFiles('**/go.sum') }}
 
     - name: Cache Go Build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.cache-paths.outputs.GOCACHE }}

--- a/.github/actions/cache-gradle-dependencies/action.yaml
+++ b/.github/actions/cache-gradle-dependencies/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Cache Gradle Dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Cache UI Dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           /github/home/.npm


### PR DESCRIPTION
### Description

Upgrades the `actions/cache@v3` to `actions/cache@v4`. Note that we already use `actions/cache@v4` in some places, e.g., https://github.com/stackrox/stackrox/blob/59e591d55a1e27416fb4f5f975bb5cdaacb607da/.github/workflows/style.yaml#L147-L155.

The impetus for this change is to have caches show up in the GitHub Action Caches UI.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- [ ] CI results are inspected

#### Automated testing

N/A - existing testing should suffice.

#### How I validated my change

CI is sufficient.
