### PR TITLE
ROX-27719: revert Enable FF for RHCOS node scanning with scanner V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Added Features
 
-- ROX-26847: RHCOS Node Scanning with Scanner V4
-    - ROX-27719: is now enabled by default on all secured clusters and will be preferred over the Stackrox Scanner if Scanner V4 is installed and connected to Central.
-    - ROX-25625: can now detect vulnerabilities for the containerized image of the RHCOS itself.
-    - ROX-26849: uses report caching to avoid repeated IO load on the nodes.
+- ROX-25625: RHCOS Node Scanning with Scanner V4 can now detect vulnerabilities for the containerized image of the RHCOS itself.
+- ROX-26849: Introduce report caching for RHCOS Node Indexing.
 - ROX-25638: Introduce configurable log rotation. `ROX_LOGGING_MAX_ROTATION_FILES` and `ROX_LOGGING_MAX_SIZE_MB` variables allow for configuring the number and the size of a central log rotation file.
 - ROX-14332: Automatic service certificate renewal for Secured Clusters installed using Helm or operator.
 - Scanner V4 adds supports for openSUSE Leap 15.5 and 15.6

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
@@ -65,10 +66,10 @@ func (p *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 }
 
 func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSensor, injector common.MessageInjector) error {
-	if !features.NodeIndexEnabled.Enabled() || !features.ScannerV4.Enabled() {
+	if !env.NodeIndexEnabled.BooleanSetting() || !features.ScannerV4.Enabled() {
 		// Node Indexing only works correctly when both, itself and Scanner v4 are enabled
 		log.Debugf("Skipping node index message (Node Indexing Enabled: %t, Scanner V4 Enabled: %t",
-			features.NodeIndexEnabled.Enabled(), features.ScannerV4.Enabled())
+			env.NodeIndexEnabled.BooleanSetting(), features.ScannerV4.Enabled())
 		// ACK the message to prevent frequent retries.
 		// If support for NodeIndex is disabled on Central or Scanner V4 is missing, but NodeIndex msg arrives to Central,
 		// then we must acknowledge the reception to prevent the compliance container resending the message, as

--- a/central/sensor/service/pipeline/nodeindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestPipelineWithEmptyIndex(t *testing.T) {
-	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 	t.Setenv(features.ScannerV4.EnvVar(), "true")
 	p := &pipelineImpl{}
 	expectedError := "unexpected resource type"
@@ -28,7 +29,7 @@ func TestPipelineWithEmptyIndex(t *testing.T) {
 }
 
 func TestPipelineWithIncorrectAction(t *testing.T) {
-	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 	t.Setenv(features.ScannerV4.EnvVar(), "true")
 	p := &pipelineImpl{}
 	msg := createMsg()
@@ -40,7 +41,7 @@ func TestPipelineWithIncorrectAction(t *testing.T) {
 }
 
 func TestPipelineEnrichesAndUpserts(t *testing.T) {
-	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 	t.Setenv(features.ScannerV4.EnvVar(), "true")
 	node := storage.Node{
 		Id: "1",

--- a/central/sensor/service/pipeline/nodeindex/three_pipelines_test.go
+++ b/central/sensor/service/pipeline/nodeindex/three_pipelines_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/metrics"
 	nodeEnricher "github.com/stackrox/rox/pkg/nodes/enricher"
@@ -119,7 +120,7 @@ func Test_ThreePipelines_Run(t *testing.T) {
 			},
 			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
 				t.Setenv(features.ScannerV4.EnvVar(), "true")
-				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 				gomock.InOrder(
 					// node index arrives
 					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).MinTimes(1).Return(nil, false, nil),
@@ -141,7 +142,7 @@ func Test_ThreePipelines_Run(t *testing.T) {
 			},
 			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
 				t.Setenv(features.ScannerV4.EnvVar(), "true")
-				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 				gomock.InOrder(
 					// node arrives
 					m.clusterStore.EXPECT().GetClusterName(gomock.Any(), gomock.Eq(clusterID)).Times(1).Return(clusterID, true, nil),
@@ -176,7 +177,7 @@ func Test_ThreePipelines_Run(t *testing.T) {
 			},
 			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
 				t.Setenv(features.ScannerV4.EnvVar(), "true")
-				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 				gomock.InOrder(
 					// node inventory arrives
 					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScore, true, nil),
@@ -212,7 +213,7 @@ func Test_ThreePipelines_Run(t *testing.T) {
 			},
 			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
 				t.Setenv(features.ScannerV4.EnvVar(), "true")
-				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 				gomock.InOrder(
 					// node index arrives
 					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScore, true, nil),
@@ -245,7 +246,7 @@ func Test_ThreePipelines_Run(t *testing.T) {
 			},
 			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
 				t.Setenv(features.ScannerV4.EnvVar(), "false")
-				t.Setenv(features.NodeIndexEnabled.EnvVar(), "false")
+				t.Setenv(env.NodeIndexEnabled.EnvVar(), "false")
 				gomock.InOrder(
 					// node inventory arrives
 					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Return(nodeWithScore, true, nil),
@@ -270,7 +271,7 @@ func Test_ThreePipelines_Run(t *testing.T) {
 			},
 			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
 				t.Setenv(features.ScannerV4.EnvVar(), "true")
-				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				t.Setenv(env.NodeIndexEnabled.EnvVar(), "true")
 				gomock.InOrder(
 					// node inventory arrives
 					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Return(nodeWithScore, true, nil),

--- a/central/sensor/service/pipeline/nodeinventory/pipeline.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
@@ -128,7 +129,7 @@ func shouldDiscardMsg(node *storage.Node) bool {
 	}
 	// Discard this v2 message if NodeScanning v4 and v2 are running in parallel on the same cluster.
 	// v4 scans are prioritized in that case.
-	if features.ScannerV4.Enabled() && features.NodeIndexEnabled.Enabled() {
+	if features.ScannerV4.Enabled() && env.NodeIndexEnabled.BooleanSetting() {
 		return true
 	}
 	// If either ScannerV4 or the feature flag are disabled, v2 scans are processed and persisted normally,

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
@@ -113,7 +112,7 @@ func (c *Compliance) Start() {
 
 	go func(ctx context.Context) {
 		defer wg.Add(-1)
-		if features.NodeIndexEnabled.Enabled() {
+		if env.NodeIndexEnabled.BooleanSetting() {
 			log.Infof("Node Index v4 enabled")
 			nodeIndexesC := c.manageNodeIndexScanLoop(ctx)
 			// sending node indexes into output toSensorC
@@ -202,7 +201,7 @@ func (c *Compliance) manageNodeIndexScanLoop(ctx context.Context) <-chan *sensor
 					cmetrics.ObserveNodePackageReportTransmissions(nodeName, cmetrics.InventoryTransmissionResendingCacheHit, cmetrics.ScannerVersionV4)
 				}
 			case <-t.C:
-				if features.NodeIndexEnabled.Enabled() {
+				if env.NodeIndexEnabled.BooleanSetting() {
 					index := c.runNodeIndex(ctx)
 					if index != nil {
 						nodeIndexesC <- index

--- a/pkg/env/node_index.go
+++ b/pkg/env/node_index.go
@@ -3,6 +3,9 @@ package env
 import "time"
 
 var (
+	// NodeIndexEnabled defines whether Compliance will actually run indexing code.
+	NodeIndexEnabled = RegisterBooleanSetting("ROX_NODE_INDEX_ENABLED", false)
+
 	// NodeIndexHostPath sets the path where the R/O host node filesystem is mounted to the container.
 	// that should be scanned by Scanners NodeIndexer
 	NodeIndexHostPath = RegisterSetting("ROX_NODE_INDEX_HOST_PATH", WithDefault("/host"))

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -49,9 +49,6 @@ var (
 	// VulnMgmtLegacySnooze enables APIs and UI for the legacy VM 1.0 "snooze CVE" functionality in the new VM 2.0 sections
 	VulnMgmtLegacySnooze = registerFeature("Enables the ability to snooze Node and Platform CVEs in VM 2.0", "ROX_VULN_MGMT_LEGACY_SNOOZE")
 
-	// NodeIndexEnabled defines whether Compliance will actually run indexing code.
-	NodeIndexEnabled = registerFeature("Instructs Central to prefer NodeIndex (Node scanning V4) messages over NodeInventory (Node scanning V2)", "ROX_NODE_INDEX_ENABLED", enabled)
-
 	// ComplianceReporting enables support for compliance reporting.
 	ComplianceReporting = registerFeature("Enable support for V2 compliance reporting", "ROX_COMPLIANCE_REPORTING", enabled)
 

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -219,7 +219,7 @@ func (s *Sensor) Start() {
 
 	// Enable endpoint to retrieve vulnerability definitions if local image scanning or Node Indexing is enabled.
 	// Node Indexing requires access to the repo to cpe mapping file hosted by central.
-	if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() {
+	if env.LocalImageScanningEnabled.BooleanSetting() || env.NodeIndexEnabled.BooleanSetting() {
 		route, err := s.newScannerDefinitionsRoute(s.centralEndpoint, centralCertificates)
 		if err != nil {
 			utils.Should(errors.Wrap(err, "Failed to create scanner definition route"))


### PR DESCRIPTION
Reverts 
- stackrox/stackrox#14154

The original PR adds a feature flags which lands in the pod spec [via this file](https://github.com/stackrox/stackrox/blob/master/image/templates/helm/stackrox-secured-cluster/feature-flag-values.yaml.htpl) and conflicts with the [direct mention](https://github.com/stackrox/stackrox/blob/035712f70344f70399b9720095d84b0b69667a50/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl#L208) causing https://issues.redhat.com/browse/ROX-27651.