### PR TITLE
fix(fake-workloads): Inject real k8s client to identify sensor

### DIFF
--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -62,11 +62,13 @@ func main() {
 	signal.Notify(sigs, os.Interrupt, unix.SIGTERM)
 
 	var sharedClientInterface client.Interface
+	var sharedClientInterfaceToFetchingPodOwnership client.Interface
 
 	// Workload manager is only non-nil when we are mocking out the k8s client
 	workloadManager := fake.NewWorkloadManager(fake.ConfigDefaults())
 	if workloadManager != nil {
 		sharedClientInterface = workloadManager.Client()
+		sharedClientInterfaceToFetchingPodOwnership = client.MustCreateInterface()
 	} else {
 		sharedClientInterface = client.MustCreateInterface()
 	}
@@ -82,7 +84,8 @@ func main() {
 		WithK8sClient(sharedClientInterface).
 		WithCentralConnectionFactory(centralConnFactory).
 		WithCertLoader(certLoader).
-		WithWorkloadManager(workloadManager))
+		WithWorkloadManager(workloadManager).
+		WithRealK8sClient(sharedClientInterfaceToFetchingPodOwnership))
 	utils.CrashOnError(err)
 
 	s.Start()

--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -62,13 +62,13 @@ func main() {
 	signal.Notify(sigs, os.Interrupt, unix.SIGTERM)
 
 	var sharedClientInterface client.Interface
-	var sharedClientInterfaceToFetchingPodOwnership client.Interface
+	var sharedClientInterfaceForFetchingPodOwnership client.Interface
 
 	// Workload manager is only non-nil when we are mocking out the k8s client
 	workloadManager := fake.NewWorkloadManager(fake.ConfigDefaults())
 	if workloadManager != nil {
 		sharedClientInterface = workloadManager.Client()
-		sharedClientInterfaceToFetchingPodOwnership = client.MustCreateInterface()
+		sharedClientInterfaceForFetchingPodOwnership = client.MustCreateInterface()
 	} else {
 		sharedClientInterface = client.MustCreateInterface()
 	}
@@ -85,7 +85,7 @@ func main() {
 		WithCentralConnectionFactory(centralConnFactory).
 		WithCertLoader(certLoader).
 		WithWorkloadManager(workloadManager).
-		WithRealK8sClient(sharedClientInterfaceToFetchingPodOwnership))
+		WithIntrospectionK8sClient(sharedClientInterfaceForFetchingPodOwnership))
 	utils.CrashOnError(err)
 
 	s.Start()

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -19,7 +19,7 @@ type CreateOptions struct {
 	certLoader                         centralclient.CertLoader
 	localSensor                        bool
 	k8sClient                          client.Interface
-	realK8sClient                      client.Interface
+	introspectionK8sClient             client.Interface
 	traceWriter                        io.Writer
 	eventPipelineQueueSize             int
 	networkFlowServiceAuthFuncOverride func(context.Context, string) (context.Context, error)
@@ -40,7 +40,7 @@ func ConfigWithDefaults() *CreateOptions {
 		centralConnFactory:                 nil,
 		certLoader:                         centralclient.EmptyCertLoader(),
 		k8sClient:                          nil,
-		realK8sClient:                      nil,
+		introspectionK8sClient:             nil,
 		localSensor:                        false,
 		traceWriter:                        nil,
 		eventPipelineQueueSize:             queue.ScaleSizeOnNonDefault(env.EventPipelineQueueSize),
@@ -58,11 +58,11 @@ func (cfg *CreateOptions) WithK8sClient(k8s client.Interface) *CreateOptions {
 	return cfg
 }
 
-// WithRealK8sClient sets the real k8s client.
+// WithIntrospectionK8sClient sets the introspection k8s client.
 // This is necessary if we want to use the fake-workloads with a CRS installation.
 // Default: nil
-func (cfg *CreateOptions) WithRealK8sClient(k8s client.Interface) *CreateOptions {
-	cfg.realK8sClient = k8s
+func (cfg *CreateOptions) WithIntrospectionK8sClient(k8s client.Interface) *CreateOptions {
+	cfg.introspectionK8sClient = k8s
 	return cfg
 }
 

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -19,6 +19,7 @@ type CreateOptions struct {
 	certLoader                         centralclient.CertLoader
 	localSensor                        bool
 	k8sClient                          client.Interface
+	realK8sClient                      client.Interface
 	traceWriter                        io.Writer
 	eventPipelineQueueSize             int
 	networkFlowServiceAuthFuncOverride func(context.Context, string) (context.Context, error)
@@ -39,6 +40,7 @@ func ConfigWithDefaults() *CreateOptions {
 		centralConnFactory:                 nil,
 		certLoader:                         centralclient.EmptyCertLoader(),
 		k8sClient:                          nil,
+		realK8sClient:                      nil,
 		localSensor:                        false,
 		traceWriter:                        nil,
 		eventPipelineQueueSize:             queue.ScaleSizeOnNonDefault(env.EventPipelineQueueSize),
@@ -53,6 +55,14 @@ func ConfigWithDefaults() *CreateOptions {
 // Default: nil
 func (cfg *CreateOptions) WithK8sClient(k8s client.Interface) *CreateOptions {
 	cfg.k8sClient = k8s
+	return cfg
+}
+
+// WithRealK8sClient sets the real k8s client.
+// This is necessary if we want to use the fake-workloads with a CRS installation.
+// Default: nil
+func (cfg *CreateOptions) WithRealK8sClient(k8s client.Interface) *CreateOptions {
+	cfg.realK8sClient = k8s
 	return cfg
 }
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -74,13 +74,12 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	log.Infof("Install method: %q", helmManagedConfig.GetManagedBy())
 	installmethod.Set(helmManagedConfig.GetManagedBy())
 
-	k8sFetcher := cfg.k8sClient.Kubernetes()
-	if cfg.realK8sClient != nil {
-		// This is used so we can still identify sensor's deployment with the fake-workloads
-		k8sFetcher = cfg.realK8sClient.Kubernetes()
+	if cfg.introspectionK8sClient == nil {
+		// This is used so we can still identify sensor's deployment with the fake-workloads.
+		cfg.introspectionK8sClient = cfg.k8sClient
 	}
 
-	deploymentIdentification := FetchDeploymentIdentification(context.Background(), k8sFetcher)
+	deploymentIdentification := FetchDeploymentIdentification(context.Background(), cfg.introspectionK8sClient.Kubernetes())
 	log.Infof("Determined deployment identification: %s", protoutils.NewWrapper(deploymentIdentification))
 
 	auditLogEventsInput := make(chan *sensorInternal.AuditEvents)
@@ -178,13 +177,13 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 		podName := os.Getenv("POD_NAME")
 		components = append(components,
-			certrefresh.NewSecuredClusterTLSIssuer(k8sFetcher, sensorNamespace, podName))
+			certrefresh.NewSecuredClusterTLSIssuer(cfg.introspectionK8sClient.Kubernetes(), sensorNamespace, podName))
 
 		// Local scanner can be started even if scanner-tls certs are available in the same namespace because
 		// it ignores secrets not owned by Sensor.
 		if env.LocalImageScanningEnabled.BooleanSetting() {
 			components = append(components,
-				certrefresh.NewLocalScannerTLSIssuer(k8sFetcher, sensorNamespace, podName))
+				certrefresh.NewLocalScannerTLSIssuer(cfg.introspectionK8sClient.Kubernetes(), sensorNamespace, podName))
 		}
 	}
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

If ACS is installed using the CRS method, the fake-workloads will not work due to `Fetching Sensor's Ownership` and `Fetching Deployment Identification` logics. This is because the fake-workloads mock the kubernetes client and that mocked client does not contain `sensor's deployment`, nor the `kube-system` and `stackrox` namespaces.

There are two ways I can see of fixing this issue:

1. Inject a real (meaning connects to the cluster's API) k8s client to the `fetcher` logics so we can retrieve this information. 
2. Fake these resources (`sensor's deployment`, `kube-system` namespace, etc) in the fake k8s client. 
 
I opted for (1) as it seems simpler but this breaks `local-sensor`'s ability to run completely offline. I do think we should implement (2) later if possible.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Deployed ACS with CRS and run fake-workloads
