### PR TITLE
fix(networkgraph): Reinstates external IPs feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-25638: Introduce configurable log rotation. `ROX_LOGGING_MAX_ROTATION_FILES` and `ROX_LOGGING_MAX_SIZE_MB` variables allow for configuring the number and the size of a central log rotation file.
 - ROX-14332: Automatic service certificate renewal for Secured Clusters installed using Helm or operator.
 - Scanner V4 adds supports for openSUSE Leap 15.5 and 15.6
-- ROX-27596: ROX_EXTERNAL_IPS feature flag enabled by default. Note: Collector will still need to be configured for external IPs for this to have an effect.
 - ROX-26088: Introduced Cluster Registration Secrets (CRS) as a successor to init bundles for registering Secured Clusters.
 - ROX-24052: Tech Preview - SBOMs can now be generated from Scanner V4 image scans via the UI, CLI (`roxctl image sbom`), and API (`/api/v1/images/sbom`). Only scans executed via Central are supported, delegated scans will be supported in a future release. This feature can be disabled by setting `ROX_SBOM_GENERATION` to `false`.
 - ROX-21529: Short-lived token authentication for Azure integrations with Azure workload or managed identities.

--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/networkgraph/tree"
@@ -180,11 +181,15 @@ func (a *aggregateExternalConnByNameImpl) Aggregate(flows []*storage.NetworkFlow
 			continue
 		}
 
-		// If the entity is discovered, anonymize it to avoid overloading
-		// the graph with many nodes (external IP details are still accessible
-		// via other APIs)
-		flowProps.SrcEntity = anonymizeDiscoveredEntity(flowProps.SrcEntity)
-		flowProps.DstEntity = anonymizeDiscoveredEntity(flowProps.DstEntity)
+		// With the addition of the External-IPs feature, 'discovered' external entities can now be the source/destination
+		// of network-flows, and they will likely be numerous.
+		// Since the network-graph is not ready yet to display a large amount of external-entities, we aggregate 'discovered'
+		// entities under the control of the NetworkGraphExternalIPs feature-flag (enabling it is experimental).
+		// Aggregation is achieved by anonymizing 'discovered' entities (replacing them by the Internet entity).
+		if !features.NetworkGraphExternalIPs.Enabled() {
+			flowProps.SrcEntity = anonymizeDiscoveredEntity(flowProps.SrcEntity)
+			flowProps.DstEntity = anonymizeDiscoveredEntity(flowProps.DstEntity)
+		}
 
 		srcEntity, dstEntity = flowProps.SrcEntity, flowProps.DstEntity
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -105,9 +105,6 @@ var (
 	// ExternalIPs enables storing detailed discovered external IPs
 	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS")
 
-	// NetworkGraphExternalIPs enables displaying external (discovered) entities in the network graph
-	NetworkGraphExternalIPs = registerFeature("Enables display of external IPs in the network graph UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
-
 	// ScannerV4RedHatCVEs enables displaying CVEs instead of RHSAs/RHEAs/RHBAs in the place of fixed vulnerabilities affected Red Hat products.
 	// TODO(ROX-26672): Remove this once we can show both CVEs and RHSAs in the UI + reports.
 	ScannerV4RedHatCVEs = registerFeature("Scanner V4 will output CVEs instead of RHSAs/RHBAs/RHEAs for fixed Red Hat vulnerabilities", "ROX_SCANNER_V4_RED_HAT_CVES")

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -103,7 +103,10 @@ var (
 	SensorPullSecretsByName = registerFeature("Sensor will capture pull secrets by name and registry host instead of just registry host", "ROX_SENSOR_PULL_SECRETS_BY_NAME", enabled)
 
 	// ExternalIPs enables storing detailed discovered external IPs
-	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS", enabled)
+	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS")
+
+	// NetworkGraphExternalIPs enables displaying external (discovered) entities in the network graph
+	NetworkGraphExternalIPs = registerFeature("Enables display of external IPs in the network graph UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
 
 	// ScannerV4RedHatCVEs enables displaying CVEs instead of RHSAs/RHEAs/RHBAs in the place of fixed vulnerabilities affected Red Hat products.
 	// TODO(ROX-26672): Remove this once we can show both CVEs and RHSAs in the UI + reports.


### PR DESCRIPTION
### Description

External IPs may not ship in 4.7, so this reinstates feature flags to restore backend functionality to 4.6.

