### PR TITLE
ROX-27719:  Scanner v4 env conflict

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -138,8 +138,6 @@ spec:
               resource: limits.cpu
         - name: ROX_CALL_NODE_INVENTORY_ENABLED
           value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
-        - name: ROX_NODE_INDEX_ENABLED
-          value: "false"
       {{- if eq ._rox.env.openshift 4 }}
         - name: ROX_NODE_INDEX_HOST_PATH
           value: "/hostindex"

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -205,8 +205,6 @@ spec:
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"
-        - name: ROX_NODE_INDEX_ENABLED
-          value: "true"
         {{- end }}
         [<- if (not .KubectlOutput) >]
         {{- if ._rox.sensor.localImageScanning.enabled }}


### PR DESCRIPTION
### Description

Attempt removing usage of `ROX_NODE_INDEX_ENABLED` in `.yaml` templates instead of disabling the new feature flag.

After some discussion it's seems now that `ROX_NODE_INDEX_ENABLED` being disabled in collector was a relic from the previous release since the feature had not gone GA yet. There should be no unexpected behavior by removing it from the template and defaulting the feature flag to enabled

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Discussed the implications of doing this, [Slack Thread](https://redhat-internal.slack.com/archives/C073B14UE10/p1739366358737919?thread_ts=1739294931.668939&cid=C073B14UE10) and there should not be any problems.
Running /test gke-scanner-v4-install-tests to see if those pass, will merge when they do.
