### PR TITLE
chore(ui): Add note about SBOM support for delegated scans

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -89,6 +89,10 @@ function GenerateSbomModal(props: GenerateSbomModalProps) {
                     This file contains a detailed list of all components and dependencies included
                     in the image.
                 </Text>
+                <Text>
+                    (Generating SBOMs from scans delegated to secured clusters is currently not
+                    supported.)
+                </Text>
                 <DescriptionList isHorizontal>
                     <DescriptionListGroup>
                         <DescriptionListTerm>Selected image:</DescriptionListTerm>


### PR DESCRIPTION
### Description

Minor text change noting that delegated scans are not supported during SBOM generation.

In the future, we should be able to detect this via the image response data and disable the option to generate an SBOM.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![image](https://github.com/user-attachments/assets/be361621-db5f-414d-b813-45947a15beac)
