### PR TITLE
Draft: Fix empty CPEs

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -672,6 +672,11 @@ func toDigestString(digest claircore.Digest) string {
 }
 
 func toClairCoreCPE(s string) (cpe.WFN, error) {
+	emptyCPE := cpe.WFN{}.BindFS()
+	if s == emptyCPE {
+		return cpe.WFN{}, nil
+	}
+
 	c, err := cpe.Unbind(s)
 	if err != nil {
 		return c, fmt.Errorf("%q: %s", s, strings.TrimPrefix(err.Error(), "cpe: "))

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -131,12 +131,12 @@ func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_empty_c
 			EXPECT().
 			GetVulnerabilities(gomock.Any(), gomock.Eq(&claircore.IndexReport{
 				Packages: map[string]*claircore.Package{
-					"1": {ID: "1", Name: "Foobar", CPE: cpe.MustUnbind(emptyCPE)},
+					"1": {ID: "1", Name: "Foobar", CPE: cpe.WFN{}},
 				},
 			})).
 			Return(&claircore.VulnerabilityReport{
 				Packages: map[string]*claircore.Package{
-					"1": {ID: "1", Name: "Foobar", CPE: cpe.MustUnbind(emptyCPE)},
+					"1": {ID: "1", Name: "Foobar", CPE: cpe.WFN{}},
 				},
 			}, nil)
 		s.matcherMock.


### PR DESCRIPTION
### Description

TODO

When we map claircore's empty CPE value, we create a non-empty default value.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- [ ] CI results are inspected

#### Automated testing

Current testing should suffice.

#### How I validated my change

TODO
