### PR TITLE
ROX-27970: Add fix to return nulls last in sorted list

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -400,7 +400,7 @@ func (p *parsedPaginationQuery) AsSQL() string {
 		for _, entry := range p.OrderBys {
 			orderByClauses = append(orderByClauses, fmt.Sprintf("%s %s", entry.Field.SelectPath, pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
 		}
-		paginationSB.WriteString(fmt.Sprintf("order by %s", strings.Join(orderByClauses, ", ")))
+		paginationSB.WriteString(fmt.Sprintf("order by %s nulls last", strings.Join(orderByClauses, ", ")))
 	}
 	if p.Limit > 0 {
 		paginationSB.WriteString(fmt.Sprintf(" LIMIT %d", p.Limit))

--- a/pkg/search/postgres/select_query_test.go
+++ b/pkg/search/postgres/select_query_test.go
@@ -822,7 +822,7 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 			expectedQuery: "select count(test_structs.Key1) filter (where test_structs.Enum = $1) as test_string_affected_by_enum1, " +
 				"count(test_structs.Key1) filter (where test_structs.Enum = $2) as test_string_affected_by_enum2, " +
 				"test_structs.Bool as test_bool from test_structs " +
-				"group by test_structs.Bool order by test_string_affected_by_enum1 asc, test_string_affected_by_enum2 desc",
+				"group by test_structs.Bool order by test_string_affected_by_enum1 asc, test_string_affected_by_enum2 desc nulls last",
 			expectedResult: []*DerivedStruct8{
 				{1, 1, false},
 				{1, 1, true},
@@ -878,7 +878,7 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 				"test_structs_nesteds.Nested as test_nested_string " +
 				"from test_structs inner join test_structs_nesteds " +
 				"on test_structs.Key1 = test_structs_nesteds.test_structs_Key1 " +
-				"group by test_structs_nesteds.Nested order by test_structs_nesteds.Nested desc",
+				"group by test_structs_nesteds.Nested order by test_structs_nesteds.Nested desc nulls last",
 			expectedResult: []*DerivedStruct3{
 				{1, 1, "nested_bcs_2"},
 				{2, 2, "nested_bcs_1"},
@@ -905,7 +905,7 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 				"test_structs_nesteds.Nested as test_nested_string " +
 				"from test_structs inner join test_structs_nesteds " +
 				"on test_structs.Key1 = test_structs_nesteds.test_structs_Key1 " +
-				"group by test_structs_nesteds.Nested order by count(test_structs_nesteds.Nested) desc LIMIT 1",
+				"group by test_structs_nesteds.Nested order by count(test_structs_nesteds.Nested) desc nulls last LIMIT 1",
 			expectedResult: []*DerivedStruct3{
 				{2, 2, "nested_bcs_1"},
 			},
@@ -927,7 +927,7 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 				"jsonb_agg(test_structs.String_) as test_string " +
 				"from test_structs inner join test_structs_nesteds " +
 				"on test_structs.Key1 = test_structs_nesteds.test_structs_Key1 " +
-				"group by test_structs_nesteds.Nested order by test_structs.String_ asc",
+				"group by test_structs_nesteds.Nested order by test_structs.String_ asc nulls last",
 			expectedError: "column \"test_structs.string_\" must appear in the GROUP BY clause or be used in an aggregate function",
 		},
 		{
@@ -954,7 +954,7 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 				"from test_structs inner join test_structs_nesteds " +
 				"on test_structs.Key1 = test_structs_nesteds.test_structs_Key1 " +
 				"group by test_structs_nesteds.Nested " +
-				"order by count(test_structs.String_) desc, test_structs_nesteds.Nested asc",
+				"order by count(test_structs.String_) desc, test_structs_nesteds.Nested asc nulls last",
 			expectedResult: []*DerivedStruct9{
 				{2, []string{"bcs", "bcs"}, 2, "nested_bcs_1"},
 				{1, []string{"acs"}, 1, "nested_acs"},


### PR DESCRIPTION
This PR updates the search framework to include NULLS LAST in the ORDER BY clause, ensuring that null values appear last when sorting by EPSS scores.
-->
![Screenshot 2025-02-18 at 1 40 27 PM](https://github.com/user-attachments/assets/045d645c-4096-4187-8407-414384692737)
![Screenshot 2025-02-18 at 2 43 29 PM](https://github.com/user-attachments/assets/bf50ce4e-406b-4d46-a654-3a5d2c237238)

change me!

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
