### PR TITLE
chore(ci): Adjust CI performance tests rules

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - master
-      - hack2023/k6-ci-pipeline-tests
     types:
       - labeled
       - synchronize
@@ -12,6 +11,7 @@ jobs:
   wait-for-images:
     name: Wait for images
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci-performance-tests') }}
     strategy:
       matrix:
         image: [main, roxctl]


### PR DESCRIPTION
### Description

Currently, every PR runs wait on images from the `Performance tests` workflow. We want jobs from this workflow to run only when the label is set on PR.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

X

#### How I validated my change

- [x] Check CI without label that all 3 jobs are skipped
- [x] Check CI with a label that all 3 jobs are properly executed
