### PR TITLE
ROX-27199: Tweak download scanner-vuln-updates curl

### DIFF
--- a/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
@@ -36,7 +36,7 @@ teardown() {
 }
 
 @test "[zip] roxctl scanner upload-db" {
-  run curl --silent --fail --output "${temp_dir}/test-scanner-vuln-updates.zip" --location 'https://install.stackrox.io/scanner/scanner-vuln-updates.zip'
+  run curl --retry 30 --retry-max-time 300 --retry-connrefused --show-error --fail --output "${temp_dir}/test-scanner-vuln-updates.zip" --location 'https://install.stackrox.io/scanner/scanner-vuln-updates.zip'
   assert_success
 
   run roxctl_authenticated scanner upload-db --scanner-db-file "${temp_dir}/test-scanner-vuln-updates.zip"


### PR DESCRIPTION
### Description

We have some instability in bats tests when a larger zip file is downloaded. I have added a few modifications to the curl call to see if that will improve its stability.

Also curl logs should be better now to actually see the failure reason.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] check CI results for nongroovy tests
