### PR TITLE
chore(CI): Batch disable identified flaky tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -484,7 +484,8 @@ class NetworkFlowTest extends BaseSpecification {
 
     @Tag("NetworkFlowVisualization")
     // TODO: additional handling may be needed for P/Z - see ROX-19615
-    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
+    // TODO(ROX-24299): CI improvements 2025-02-12: Disabling for OCP.
+    @IgnoreIf({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT || Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     def "Verify connections from external sources"() {
         given:
         "Deployment A, where an external source communicates to A"

--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -688,6 +688,7 @@ func (ts *DelegatedScanningSuite) TestMirrorScans() {
 	t := ts.T()
 	ctx := ts.ctx
 
+	t.Skip("Disabled! ROX-26663: CI improvements 2025-02-12: The test is unstable.")
 	ts.skipIfNotOpenShift()
 
 	// Create mirroring CRs and update OCP global pull secret, this will

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveListExceptionFlow.test.js
@@ -41,7 +41,8 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
         });
     });
 
-    it('should defer multiple selected CVEs', () => {
+    // TODO(ROX-27510): CI improvements 2025-02-12: The test is unstable.
+    it.skip('should defer multiple selected CVEs', () => {
         visitImageSinglePageWithMockedResponses().then((image) => {
             selectMultipleCvesForException('DEFERRAL').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);
@@ -74,7 +75,8 @@ describe('Workload CVE Image page deferral and false positive flows', () => {
         });
     });
 
-    it('should mark multiple selected CVEs as false positive', () => {
+    // TODO(ROX-27251): CI improvements 2025-02-12: The test is unstable.
+    it.skip('should mark multiple selected CVEs as false positive', () => {
         visitImageSinglePageWithMockedResponses().then((image) => {
             selectMultipleCvesForException('FALSE_POSITIVE').then((cveNames) => {
                 verifySelectedCvesInModal(cveNames);


### PR DESCRIPTION
### Description

This PR is disabling the following tests:

| Suite | Test | Failure rate | Ticket |
| :---- | :---- | :---- | :---- |
| ui-e2e-tests | Workload CVE Image page deferral and false positive flows / should defer multiple selected CVEs | 8% | [ROX-27510](https://issues.redhat.com/browse/ROX-27510)  |
| qa-e2e-tests | NetworkFlowTest / Verify connections from external sources | 3% | [ROX-24299](https://issues.redhat.com/browse/ROX-24299)  |
| ui-e2e-tests | Workload CVE Image page deferral and false positive flows /  should mark multiple selected CVEs as false positive | 2% | [ROX-27251](https://issues.redhat.com/browse/ROX-27251)  |
| nongroovy-e2e-tests | TestDelegatedScanning / TestMirrorScans | 2% | [ROX-26663](https://issues.redhat.com/browse/ROX-26663)  |

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [ ] ensure all listed suites are executed
- [ ] check that disabled tests are skipped
- [ ] check that `NetworkFlowTest` still runs on GKE
