### PR TITLE
ROX-26843: Applies default filters before the first request is sent

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -105,7 +105,6 @@ describe('Workload CVE overview page tests', () => {
         ).then(({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
             visitWorkloadCveOverview();
             waitForRequests(['getImageCVEList']); // Wait for the initial request to complete
-            waitForRequests(['getImageCVEList']); // Wait for the second request after the default filters load to complete
             applyDefaultFilters(['Critical', 'Important'], ['Fixable']); // Set the default filters to none to prevent multiple requests on each page visit
             waitForRequests(['getImageCVEList']); // Wait for the third request after the filters have been changed to complete
 
@@ -286,11 +285,8 @@ describe('Workload CVE overview page tests', () => {
 
         it('should default to multi-severity sort and keep in sync with applied filters', () => {
             interceptAndWatchRequests(getRouteMatcherMapForGraphQL(['getImageCVEList'])).then(
-                ({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
+                ({ waitAndYieldRequestBodyVariables }) => {
                     visitWorkloadCveOverview({ clearFiltersOnVisit: false });
-                    // Wait for the initial request to complete, this fires twice due to the default filters being applied.
-                    // Ideally we fix this in the future to avoid the additional overhead.
-                    waitForRequests();
 
                     // Check the default sort
                     waitAndYieldRequestBodyVariables().then(

--- a/ui/apps/platform/src/hooks/useIsFirstRender.ts
+++ b/ui/apps/platform/src/hooks/useIsFirstRender.ts
@@ -1,0 +1,8 @@
+import { useRef } from 'react';
+
+export function useIsFirstRender() {
+    const ref = useRef(true);
+    const firstRender = ref.current;
+    ref.current = false;
+    return firstRender;
+}


### PR DESCRIPTION
### Description

The test flakes for ROX-26843 happen when a test asserts that the filters for a GraphQL request match "Severity: Critical, Important", but instead the test received "Severity: Critical, Important, Moderate, Low". This page does in fact always sent the latter, followed by the former, due to the default filters being applied and a second request being sent to the server.

The tests _do_ account for the double request, but every couple weeks or so there is a failure as if a request was "missed".

I have not figured out exactly why this happens, but a better fix is to simply not request the CVE list twice when the user visits the page. This change does so by tracking the first render of the WorkloadCvesPage (default filters only apply on the first render) and substituting the default filters in instead of the empty filter object from the URL. The `useEffect` that syncs the local storage state with the URL still fires, but does not result in a second request since the search filters are compared in the hook by deep equality, not referential.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

This behavior is tested extensively via Cypress tests.
