### PR TITLE
fix: verify-release refresh cache on fetch

### DIFF
--- a/.github/workflows/scripts/verify-release.sh
+++ b/.github/workflows/scripts/verify-release.sh
@@ -81,8 +81,8 @@ validate_helm_charts() {
         fi
     fi
 
-    check_url_yaml_contains "https://charts.stackrox.io/index.yaml" ".entries.central-services[] | select( .appVersion == \"${RELEASE_PATCH}\")"
-    check_url_yaml_contains "https://charts.stackrox.io/index.yaml" ".entries.secured-cluster-services[] | select( .appVersion == \"${RELEASE_PATCH}\")"
+    check_url_yaml_contains "https://charts.stackrox.io/index.yaml?v=$(date +%s)" ".entries.central-services[] | select( .appVersion == \"${RELEASE_PATCH}\")"
+    check_url_yaml_contains "https://charts.stackrox.io/index.yaml?v=$(date +%s)" ".entries.secured-cluster-services[] | select( .appVersion == \"${RELEASE_PATCH}\")"
 }
 
 validate_images() {


### PR DESCRIPTION
### Description

During verify release we can get cached version of `index.yaml` without latest release. We should force cache invalidation by passing a query param. Alternatively we should somehow force cache invalidation wehn new version is released. 

https://github.com/stackrox/stackrox/actions/runs/13328327518/job/37226608012#step:4:19

```yaml
# curl -s https://charts.stackrox.io/index.yaml | grep 400.4.8
# curl -s https://charts.stackrox.io/index.yaml\?v\=1 | grep 400.4.8
        - stackrox-central-services-400.4.8.tgz
      version: 400.4.8
        - stackrox-secured-cluster-services-400.4.8.tgz
      version: 400.4.8
        - stackrox-central-services-400.4.8.tgz
      version: 400.4.8
        - stackrox-secured-cluster-services-400.4.8.tgz
      version: 400.4.8
```

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
