### PR TITLE
chore(upgrade): Bump 4.4 previous version in upgrade test to 4.4.8

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -10,7 +10,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 EARLIER_TAG="4.1.3"
 EARLIER_SHA="8a4677e3d45ebc4f065ec052d1d66d6ead2084bb"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
-PREVIOUS_RELEASES=("4.1.3" "4.2.5" "4.3.8" "4.4.7" "4.5.5" "4.6.2")
+PREVIOUS_RELEASES=("4.1.3" "4.2.5" "4.3.8" "4.4.8" "4.5.5" "4.6.2")
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"


### PR DESCRIPTION
### Description

https://spaces.redhat.com/display/StackRox/Upstream+Release+Automation#UpstreamReleaseAutomation-update-upgrade-testUpdateUpgradeTest

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
