### PR TITLE
chore(ci): Disable flaky scanner nongroovy test

### DIFF
--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -685,6 +685,8 @@ func (ts *DelegatedScanningSuite) TestDeploymentScans() {
 // that delegated scanning is able to scan images from mirrors defined by the various
 // mirroring CRs (ie: ImageContentSourcePolicy, ImageDigestMirrorSet, ImageTagMirrorSet)
 func (ts *DelegatedScanningSuite) TestMirrorScans() {
+	ts.T().Skip("Disabled! ROX-26663: CI improvements 2025-02-12: The test is unstable.")
+
 	t := ts.T()
 	ctx := ts.ctx
 


### PR DESCRIPTION
### Description

This PR is disabling the following test:

| Suite | Test | Failure rate | Ticket |
| :---- | :---- | :---- | :---- |
| nongroovy-e2e-tests | TestDelegatedScanning / TestMirrorScans | 2% | [ROX-26663](https://issues.redhat.com/browse/ROX-26663)  |

**Note:** This PR contains changes pulled from #14271 - to address this comment: https://github.com/stackrox/stackrox/pull/14271#discussion_r1955056370

> Plan to look into this failure now that we had the 4.7 code freeze , however should this PR be merged and given the 2% failure rate for this particular test we likely will be re-enabling it in the near future in order to measure the improvements.

> What are your thoughts on a mechanism to keep these tests running, still measure them, but perhaps not block? (and do we introduce risk by doing so)

> Also what is the availability goal? Disabling a test with a 98% success seems suspect, targeting 100% for a test that relies on external services (ie: quay) seems unachievable (unless we remove our reliance on those services).

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] ensure all listed suites are executed
- [x] check that disabled tests are skipped
- [ ] all tickets are marked with `CI_Disabled` label
