### PR TITLE
chore(ci): fix spelling of CHANGELOG update

### DIFF
--- a/.github/workflows/scripts/patch-changelog.sh
+++ b/.github/workflows/scripts/patch-changelog.sh
@@ -53,7 +53,7 @@ if git ls-remote --quiet --exit-code origin "$CHANGELOG_BRANCH"; then
 fi
 
 git switch --create "$CHANGELOG_BRANCH"
-sed -i "s/## \[NEXT RELEASE\]/\\0\n\n### Added Features\n\n### Removed Features\n\n### Deprecated Fatures\n\n### Technical Changes\n\n## [$VERSION]\n\n/" CHANGELOG.md
+sed -i "s/## \[NEXT RELEASE\]/\\0\n\n### Added Features\n\n### Removed Features\n\n### Deprecated Features\n\n### Technical Changes\n\n## [$VERSION]\n\n/" CHANGELOG.md
 git add CHANGELOG.md
 
 if ! git diff-index --quiet HEAD; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Removed Features
 
-### Deprecated Fatures
+### Deprecated Features
 
 ### Technical Changes
 


### PR DESCRIPTION
### Description

This has been bothering me for so long. Finally took the time to fix it.

### User-facing documentation

- [x] CHANGELOG is updated
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

Ocular inspection
