### PR TITLE
ROX-28113: make language support configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Technical Changes
 
-- ROX-28113: Scanner V4 may now be configured to skip language package analysis via `ROX_SCANNER_V4_SKIP_LANGUAGE`.
-  - This must be set in both Scanner V4 Indexer and Scanner V4 Matcher.
+- ROX-28113: Scanner V4 may now be configured to skip language package analysis via `ROX_SCANNER_V4_LANGUAGE_SUPPORT`.
+  - To skip language-level support in Scanner V4, `ROX_SCANNER_V4_LANGUAGE_SUPPORT=false` must be set in both Scanner V4 Indexer and Scanner V4 Matcher.
+  - This setting is enabled by default, as it was unconditionally enabled before.
 
 ## [4.7.0]
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -134,10 +134,10 @@ var (
 	// Flattens CVE Data Model for improved accuracy and performance
 	FlattenCVEData = registerFeature("Uses a flattened CVE Data Model improved accuracy and performance", "ROX_FLATTEN_CVE_DATA")
 
-	// ScannerV4SkipLanguage disables any language-level packages support.
+	// ScannerV4LanguageSupport enables language-level package/vulnerability support.
 	//
-	// This must be set in Scanner V4 Indexer to skip analyzing images for language-level packages.
-	// This must be set in Scanner V4 Matcher to skip matching packages to vulnerabilities related to language-level packages.
-	// Note: setting this in Scanner V4 Matcher does not stop Scanner V4 DB from tracking language-related vulnerabilities.
-	ScannerV4SkipLanguage = registerFeature("Scanner V4 will only analyze static images for data related to OS-provided package managers", "ROX_SCANNER_V4_SKIP_LANGUAGE")
+	// This must be set in Scanner V4 Indexer to analyze images for language-level packages.
+	// This must be set in Scanner V4 Matcher to match packages to vulnerabilities related to language-level packages.
+	// Note: disabling this in Scanner V4 Matcher does not stop Scanner V4 DB from tracking language-related vulnerabilities.
+	ScannerV4LanguageSupport = registerFeature("Scanner V4 will analyze static images for data related to languages as well as OS package managers", "ROX_SCANNER_V4_LANGUAGE_SUPPORT", enabled)
 )

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -85,7 +85,7 @@ func ecosystems(ctx context.Context) []*ccindexer.Ecosystem {
 		rhel.NewEcosystem(ctx),
 		rpm.NewEcosystem(ctx),
 	}
-	if !features.ScannerV4SkipLanguage.Enabled() {
+	if features.ScannerV4LanguageSupport.Enabled() {
 		es = append(es,
 			gobin.NewEcosystem(ctx),
 			java.NewEcosystem(ctx),

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -55,7 +55,7 @@ func matcherNames() []string {
 		(*suse.Matcher)(nil).Name(),
 		(*ubuntu.Matcher)(nil).Name(),
 	}
-	if !features.ScannerV4SkipLanguage.Enabled() {
+	if features.ScannerV4LanguageSupport.Enabled() {
 		// Claircore does not register the Node.js factory by default, so register it here.
 		nodeJSMatcher := nodejs.Matcher{}
 		registry.Register(nodeJSMatcher.Name(), driver.MatcherStatic(&nodeJSMatcher))


### PR DESCRIPTION
### Description

Scanner v2 (StackRox Scanner) allows users to set `ROX_LANGUAGE_VULNS` or `LANGUAGE_VULNS` to `false` to disable language-level package analysis/vuln matching. This was not added to Scanner V4, so this PR adds it.

To accomplish the same task, users would have to set `ROX_SCANNER_V4_LANGUAGE_SUPPORT=false` in both Scanner V4 Indexer and Scanner V4 Matcher.

This feature is enabled by default, as it was unconditionally enabled previously.

### User-facing documentation

- [x] CHANGELOG is updated
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

TODO
