### PR TITLE
ROX-13493: Add admission controller support for Scale subresource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ## [NEXT RELEASE]
 
 ### Added Features
+- ROX-13493: Support for scale subresource in the admission controller to enable policy detection and enforcement on admission review requests on the scale subresource.
 
 ### Removed Features
 

--- a/sensor/admission-control/manager/evaluate_deploytime.go
+++ b/sensor/admission-control/manager/evaluate_deploytime.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -114,9 +113,9 @@ func (m *manager) evaluateAdmissionRequest(s *state, req *admission.AdmissionReq
 	var deployment *storage.Deployment
 	if req.SubResource != "" && req.SubResource == ScaleSubResource {
 		if deployment = m.deployments.GetByName(req.Namespace, req.Name); deployment == nil {
-			return nil, errors.New(
-				fmt.Sprintf("could not find deployment with name: %q in namespace %q for this admission review request",
-					req.Name, req.Namespace))
+			return nil, errors.Errorf(
+				"could not find deployment with name: %q in namespace %q for this admission review request",
+				req.Name, req.Namespace)
 		}
 	} else {
 		k8sObj, err := unmarshalK8sObject(req.Kind, req.Object.Raw)

--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -9,7 +9,10 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/protoconv/resources"
+	"github.com/stackrox/rox/pkg/set"
 	"google.golang.org/grpc/connectivity"
+	admission "k8s.io/api/admission/v1"
 )
 
 const (
@@ -140,6 +143,52 @@ func (m *manager) getAvailableImagesAndKickOffScans(ctx context.Context, s *stat
 		close(imgChan)
 	}
 	return images, imgChan
+}
+
+// hasModifiedImages checks if the given deployment has any new images that the old version was not previously using.
+// If there is no old deployment version, or some error is encountered during conversion, true is conservatively
+// returned.
+func hasModifiedImages(s *state, deployment *storage.Deployment, req *admission.AdmissionRequest) bool {
+	if req.OldObject.Raw == nil {
+		return true
+	}
+
+	if req.SubResource != "" && req.SubResource == ScaleSubResource {
+		// TODO: We could consider returning false here since when the admission review request is for the scale
+		// subresource, I do not believe it is possible for a user to change the image on the deployment at the same
+		// time as updating the scale subresource However, the contract of this function as designed was to be
+		// conservative and return true.
+		return true
+	}
+
+	oldK8sObj, err := unmarshalK8sObject(req.Kind, req.OldObject.Raw)
+	if err != nil {
+		log.Errorf("Failed to unmarshal old object into K8s object: %v", err)
+		return true
+	}
+
+	oldDeployment, err := resources.NewDeploymentFromStaticResource(oldK8sObj, req.Kind.Kind, s.clusterID(), s.GetClusterConfig().GetRegistryOverride())
+	if err != nil {
+		log.Errorf("Failed to convert old K8s object into StackRox deployment: %v", err)
+		return true
+	}
+
+	if oldDeployment == nil {
+		return true
+	}
+
+	oldImages := set.NewStringSet()
+	for _, container := range oldDeployment.GetContainers() {
+		oldImages.Add(container.GetImage().GetName().GetFullName())
+	}
+
+	for _, container := range deployment.GetContainers() {
+		if !oldImages.Contains(container.GetImage().GetName().GetFullName()) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *manager) kickOffImgScansAndDetect(

--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -172,7 +172,6 @@ func hasModifiedImages(s *state, deployment *storage.Deployment, req *admission.
 		log.Errorf("Failed to convert old K8s object into StackRox deployment: %v", err)
 		return true
 	}
-
 	if oldDeployment == nil {
 		return true
 	}

--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -9,10 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/images/types"
-	"github.com/stackrox/rox/pkg/protoconv/resources"
-	"github.com/stackrox/rox/pkg/set"
 	"google.golang.org/grpc/connectivity"
-	admission "k8s.io/api/admission/v1"
 )
 
 const (
@@ -143,44 +140,6 @@ func (m *manager) getAvailableImagesAndKickOffScans(ctx context.Context, s *stat
 		close(imgChan)
 	}
 	return images, imgChan
-}
-
-// hasModifiedImages checks if the given deployment has any new images that the old version was not previously using.
-// If there is no old deployment version, or some error is encountered during conversion, true is conservatively
-// returned.
-func hasModifiedImages(s *state, deployment *storage.Deployment, req *admission.AdmissionRequest) bool {
-	if req.OldObject.Raw == nil {
-		return true
-	}
-
-	oldK8sObj, err := unmarshalK8sObject(req.Kind, req.OldObject.Raw)
-	if err != nil {
-		log.Errorf("Failed to unmarshal old object into K8s object: %v", err)
-		return true
-	}
-
-	oldDeployment, err := resources.NewDeploymentFromStaticResource(oldK8sObj, req.Kind.Kind, s.clusterID(), s.GetClusterConfig().GetRegistryOverride())
-	if err != nil {
-		log.Errorf("Failed to convert old K8s object into StackRox deployment: %v", err)
-		return true
-	}
-
-	if oldDeployment == nil {
-		return true
-	}
-
-	oldImages := set.NewStringSet()
-	for _, container := range oldDeployment.GetContainers() {
-		oldImages.Add(container.GetImage().GetName().GetFullName())
-	}
-
-	for _, container := range deployment.GetContainers() {
-		if !oldImages.Contains(container.GetImage().GetName().GetFullName()) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func (m *manager) kickOffImgScansAndDetect(

--- a/sensor/admission-control/manager/responses.go
+++ b/sensor/admission-control/manager/responses.go
@@ -5,6 +5,7 @@ import (
 	"text/template"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/branding"
 	"github.com/stackrox/rox/pkg/enforcers"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/templates"
@@ -55,7 +56,7 @@ func fail(uid types.UID, message string) *admission.AdmissionResponse {
 		Allowed: false,
 		Result: &metav1.Status{
 			Status:  "Failure",
-			Reason:  metav1.StatusReason("Failed currently enforced policies from StackRox"),
+			Reason:  metav1.StatusReason(fmt.Sprintf("Failed currently enforced policies from %s", branding.GetProductNameShort())),
 			Message: message,
 		},
 	}


### PR DESCRIPTION
### Description
There exist 3 ways of scaling a deployment in k8s/Openshift:
1. Update the deployment spec for the `replicas` property.
2. Use `kubectl scale` or `oc scale` on the deployment.
3. Use the `v1/autoscaling scale` subresource (Openshift console uses this)

The admission controller has existing support to run policy detection and enforcement on 1. and 2. above. However, it was missing support for the `scale` subresource. This PR adds that support.

While I was at it, I also fixed a small product branding miss in the output messages/response of the admission controller when the request is denied.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality
- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Testing on an Openshift cluster with admission controller enabled for 3 scenarios:
1. Use Openshift console to scale a deployment that violates the enforced latest tag policy. Operation is disallowed.
```
admission-control/manager: 2025/02/17 21:35:20.733920 evaluate_deploytime.go:106: Debug: Evaluating request &AdmissionRequest{UID:3a469625-7ae3-429f-8de3-8c67890ea279,Kind:autoscaling/v1, Kind=Scale,Resource:{apps v1 deployments},SubResource:scale,Name:nginx,Namespace:default,Operation:UPDATE,UserInfo:{kube:admin  [system:cluster-admins system:authenticated] .......,RequestKind:autoscaling/v1, Kind=Scale,RequestResource:apps/v1, Resource=deployments,RequestSubResource:scale,}
admission-control/manager: 2025/02/17 21:35:20.733970 evaluate_deploytime.go:112: Debug: Not bypassing UPDATE request on default/nginx [autoscaling/v1, Kind=Scale]
admission-control/manager: 2025/02/17 21:35:20.734106 evaluate_deploytime.go:137: Debug: Evaluating policies on id:"6a25ee4b-564c-4998-838f-9f884ca3aeba"  name:"nginx"  hash:1732657809438660397  type:"Deployment"  namespace:"default"  namespace_id:"51c8c679-0899-428a-bc64-c2dfbce24588"  replicas:3  labels:{key:"app"  value:"nginx"}  pod_labels:{key:"app"  value:"nginx"}  label_selector:{match_labels:{key:"app"  value:"nginx"}}  created:{seconds:1739825295}  cluster_id:"f3319a39-884e-4465-ac3c-a003136f5f4e"  containers:{id:"6a25ee4b-564c-4998-838f-9f884ca3aeba:nginx"  config:{}  image:{id:"sha256:088eea90c3d0a540ee5686e7d7471acbd4063b6e97eaf49b5e651665eb7f4dc7"  name:{registry:"docker.io"  remote:"library/nginx"  tag:"latest"  full_name:"docker.io/library/nginx:latest"}}  security_context:{}  resources:{}  name:"nginx"  liveness_probe:{}  readiness_probe:{}}  service_account:"default"  service_account_permission_level:NONE  automount_service_account_token:true  state_timestamp:1739827889595449
admission-control/manager: 2025/02/17 21:35:20.734376 evaluate_deploytime.go:176: Debug: Violated policies: 1, rejecting UPDATE request on default/nginx [autoscaling/v1, Kind=Scale]
admission-control/service: 2025/02/17 21:35:20.734486 service.go:125: Debug: Sending admission review: {"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"3a469625-7ae3-429f-8de3-8c67890ea279","allowed":false,"status":{"metadata":{},"status":"Failure","message":"\nThe attempted operation violated 1 enforced policy, described below:\n\nPolicy: Boo Test policy\n- Description:\n    ↳ \n- Rationale:\n    ↳ \n- Remediation:\n    ↳ \n- Violations:\n    - Container 'nginx' has image with tag 'latest'\n\n\nIn case of emergency, add the annotation {\"admission.stackrox.io/break-glass\": \"ticket-1234\"} to your deployment with an updated ticket number\n\n","reason":"Failed currently enforced policies from StackRox"}}}
admission-control/alerts: 2025/02/17 21:35:20.734667 sender.go:113: Debug: Sending 1 alert results to Sensor
```

2. Use `oc scale` to scale deployment replicas on the same deployment
 ```
ksanchet@ksanchet-mac:~/go/src/github.com/stackrox/stackrox/deploy/openshift$ oc -n default scale deploy/nginx --replicas=5
Error from server (Failed currently enforced policies from StackRox): admission webhook "policyeval.stackrox.io" denied the request: 
The attempted operation violated 1 enforced policy, described below:

Policy: Boo Test policy
- Description:
    ↳ 
- Rationale:
    ↳ 
- Remediation:
    ↳ 
- Violations:
    - Container 'nginx' has image with tag 'latest'


In case of emergency, add the annotation {"admission.stackrox.io/break-glass": "ticket-1234"} to your deployment with an updated ticket number
```
3.  Use deployment edit to update the replicas of the same deployment.
```
ksanchet@ksanchet-mac:~/go/src/github.com/stackrox/stackrox/deploy/openshift$ kubectl -n default edit deploy/nginx
error: deployments.apps "nginx" could not be patched: admission webhook "policyeval.stackrox.io" denied the request: 
The attempted operation violated 1 enforced policy, described below:

Policy: Boo Test policy
- Description:
    ↳ 
- Rationale:
    ↳ 
- Remediation:
    ↳ 
- Violations:
    - Container 'nginx' has image with tag 'latest'


In case of emergency, add the annotation {"admission.stackrox.io/break-glass": "ticket-1234"} to your deployment with an updated ticket number


You can run `kubectl replace -f /var/folders/f2/mx8qpbtd0fs_23ln92y_d7m40000gn/T/kubectl-edit-7uary.yaml` to try this update again.
```
