### PR TITLE
ROX-14054: Re-enable violations sort by severity test

### DIFF
--- a/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
@@ -122,47 +122,14 @@ export function visitViolationWithFixture(fixturePath) {
     });
 }
 
-// interact
-
-/*
- * Distinguish alerts request for sorted violations from polled request to prevent timing problem.
- * Omit alertscount request because it is same as polled request.
- */
-
-const alertsAscendingAlias = 'alerts_reversed=false';
-const alertsDescendingAlias = 'alerts_reversed=true';
-
-const routeMatcherMapForSortedViolationsMap = {
-    asc: {
-        [alertsAscendingAlias]: {
-            method: 'GET',
-            url: '/v1/alerts?query=&pagination.offset=0&pagination.limit=50&pagination.sortOption.field=Severity&pagination.sortOption.reversed=false',
-        },
-    },
-    desc: {
-        [alertsDescendingAlias]: {
-            method: 'GET',
-            url: '/v1/alerts?query=&pagination.offset=0&pagination.limit=50&pagination.sortOption.field=Severity&pagination.sortOption.reversed=true',
-        },
-    },
-};
-
 /**
  * Assume that current location is violations table without fixture.
  *
  * @param {() => void} interactionCallback
- * @param {'asc' | 'desc'} direction
  */
-export function interactAndWaitForSortedViolationsResponses(interactionCallback, direction) {
-    interactAndWaitForResponses(
-        interactionCallback,
-        routeMatcherMapForSortedViolationsMap[direction]
-    );
-
-    cy.location('search').should(
-        'eq',
-        `?sortOption[field]=Severity&sortOption[direction]=${direction}`
-    );
+export function interactAndWaitForViolationsResponses(interactionCallback) {
+    interactAndWaitForResponses(interactionCallback, routeMatcherMapForViolations);
+    cy.get('table tbody[aria-busy="false"]');
 }
 
 /*

--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -11,7 +11,7 @@ import {
     clickDeploymentTabWithFixture,
     exportAndWaitForNetworkPolicyYaml,
     interactAndWaitForNetworkPoliciesResponse,
-    interactAndWaitForSortedViolationsResponses,
+    interactAndWaitForViolationsResponses,
     selectFilteredWorkflowView,
     visitViolationFromTableWithFixture,
     visitViolationWithFixture,
@@ -221,8 +221,10 @@ describe('Violations', () => {
         // Conditionally rendered: Policy scope
     });
 
-    it.skip('should sort the Severity column', () => {
-        visitViolations();
+    it('should sort the Severity column', () => {
+        interactAndWaitForViolationsResponses(() => {
+            visitViolations();
+        });
 
         const thSelector = 'th[scope="col"]:contains("Severity")';
         const tdSelector = 'td[data-label="Severity"]';
@@ -231,25 +233,23 @@ describe('Violations', () => {
         cy.get(thSelector).should('have.attr', 'aria-sort', 'none');
 
         // 1. Sort decending by the Severity column.
-        interactAndWaitForSortedViolationsResponses(() => {
+        interactAndWaitForViolationsResponses(() => {
             cy.get(thSelector).click();
-        }, 'desc');
+        });
 
         cy.get(thSelector).should('have.attr', 'aria-sort', 'descending');
 
-        cy.wait(1000); // prevent timing failures
         cy.get(tdSelector).then((items) => {
             assertSortedItems(items, callbackForPairOfDescendingPolicySeverityValuesFromElements);
         });
 
         // 2. Sort ascending by the Severity column.
-        interactAndWaitForSortedViolationsResponses(() => {
+        interactAndWaitForViolationsResponses(() => {
             cy.get(thSelector).click();
-        }, 'asc');
+        });
 
         cy.get(thSelector).should('have.attr', 'aria-sort', 'ascending');
 
-        cy.wait(1000); // prevent timing failures
         cy.get(tdSelector).then((items) => {
             assertSortedItems(items, callbackForPairOfAscendingPolicySeverityValuesFromElements);
         });

--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -226,13 +226,17 @@ describe('Violations', () => {
             visitViolations();
         });
 
+        interactAndWaitForViolationsResponses(() => {
+            selectFilteredWorkflowView('All Violations');
+        });
+
         const thSelector = 'th[scope="col"]:contains("Severity")';
         const tdSelector = 'td[data-label="Severity"]';
 
         // 0. Initial table state is sorted descending by Time.
         cy.get(thSelector).should('have.attr', 'aria-sort', 'none');
 
-        // 1. Sort decending by the Severity column.
+        // 1. Sort descending by the Severity column.
         interactAndWaitForViolationsResponses(() => {
             cy.get(thSelector).click();
         });

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -219,8 +219,6 @@ function ViolationsTablePage(): ReactElement {
                 setCurrentPageAlerts(alerts);
                 setAlertCount(counts);
                 setCurrentPageAlertsErrorMessage('');
-                setIsLoadingAlerts(false);
-                setIsTableDataUpdating(false);
             })
             .catch((error) => {
                 if (error instanceof CancelledPromiseError) {
@@ -230,6 +228,8 @@ function ViolationsTablePage(): ReactElement {
                 setAlertCount(0);
                 const parsedMessage = getAxiosErrorMessage(error);
                 setCurrentPageAlertsErrorMessage(parsedMessage);
+            })
+            .finally(() => {
                 setIsLoadingAlerts(false);
                 setIsTableDataUpdating(false);
             });

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -136,6 +136,10 @@ function ViolationsTablePage(): ReactElement {
     const [currentPageAlertsErrorMessage, setCurrentPageAlertsErrorMessage] = useState('');
     const [alertCount, setAlertCount] = useState(0);
 
+    // Flag to signal that the table is in an updating state
+    // Note: This would be better replaced with a consistent "polling" state in TBodyUnified
+    const [isTableDataUpdating, setIsTableDataUpdating] = useState(true);
+
     // To handle page/count refreshing.
     const [pollEpoch, setPollEpoch] = useState(0);
 
@@ -191,6 +195,7 @@ function ViolationsTablePage(): ReactElement {
 
     // When any of the deps to this effect change, we want to reload the alerts and count.
     useEffect(() => {
+        setIsTableDataUpdating(true);
         const filteredWorkflowFilter = getFilteredWorkflowViewSearchFilter(filteredWorkflowView);
         const alertSearchFilter: SearchFilter = {
             ...searchFilter,
@@ -215,6 +220,7 @@ function ViolationsTablePage(): ReactElement {
                 setAlertCount(counts);
                 setCurrentPageAlertsErrorMessage('');
                 setIsLoadingAlerts(false);
+                setIsTableDataUpdating(false);
             })
             .catch((error) => {
                 if (error instanceof CancelledPromiseError) {
@@ -225,6 +231,7 @@ function ViolationsTablePage(): ReactElement {
                 const parsedMessage = getAxiosErrorMessage(error);
                 setCurrentPageAlertsErrorMessage(parsedMessage);
                 setIsLoadingAlerts(false);
+                setIsTableDataUpdating(false);
             });
 
         return () => {
@@ -362,6 +369,7 @@ function ViolationsTablePage(): ReactElement {
                             onSearch={onSearch}
                             additionalContextFilter={additionalContextFilter}
                             hasActiveViolations={selectedViolationStateTab === 'ACTIVE'}
+                            isTableDataUpdating={isTableDataUpdating}
                         />
                     </PageSection>
                 )}

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -59,6 +59,7 @@ type ViolationsTablePanelProps = {
     onSearch: OnSearchCallback;
     additionalContextFilter: SearchFilter;
     hasActiveViolations: boolean;
+    isTableDataUpdating: boolean;
 };
 
 function ViolationsTablePanel({
@@ -77,6 +78,7 @@ function ViolationsTablePanel({
     onSearch,
     additionalContextFilter,
     hasActiveViolations,
+    isTableDataUpdating,
 }: ViolationsTablePanelProps): ReactElement {
     const isRouteEnabled = useIsRouteEnabled();
     const { hasReadWriteAccess } = usePermissions();
@@ -283,7 +285,7 @@ function ViolationsTablePanel({
                             )}
                         </Tr>
                     </Thead>
-                    <Tbody>
+                    <Tbody aria-live="polite" aria-busy={isTableDataUpdating ? 'true' : 'false'}>
                         {violations.map((violation, rowIndex) => {
                             const { state, lifecycleStage, enforcementAction, policy, id } =
                                 violation;


### PR DESCRIPTION
### Description

Uses some recent patterns to re-enable an old, skipped + flagged Violations test that checks sorting by severity.

1. Simplify `interactAndWait` calls
2. Remove Cypress `wait` commands
3. Add attribute to table body to hook onto for a request "complete" notifier*

* This would be better handled with a proper polling state/UI implemented in TBodyUnified, but it works for now as the _only_ method of detecting that the request has finished via user-visible DOM properties.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Local Cypress run:
![image](https://github.com/user-attachments/assets/25b87e35-8f48-4d68-aaa9-f98b9d4964c6)
