### PR TITLE
ROX-20811: Roxctl central generate pvc bug

### DIFF
--- a/pkg/containers/detection.go
+++ b/pkg/containers/detection.go
@@ -2,23 +2,26 @@ package containers
 
 import "os"
 
-// IsRunningInContainer checks whether the current process is being executed inside a docker container
+// IsRunningInContainer checks whether the current process is being executed inside one of the containers we check for
 func IsRunningInContainer() bool {
-	return isDocker() || isPodman() || isCryoSpark()
+	return IsDocker() || IsPodman() || IsCryoSpark()
 }
 
-func isDocker() bool {
+// IsDocker returns true if we are running in a docker instance
+func IsDocker() bool {
 	return pathExists("/.dockerenv") ||
 		pathExists("/.dockerinit") ||
 		pathExists("/run/.containerenv") ||
 		pathExists("/var/run/.containerenv")
 }
 
-func isPodman() bool {
+// IsPodman returns true if we are running in a podman instance
+func IsPodman() bool {
 	return os.Getenv("container") == "oci" || os.Getenv("container") == "podman"
 }
 
-func isCryoSpark() bool {
+// IsCryoSpark returns true if we are running in a cryospark instance
+func IsCryoSpark() bool {
 	_, hostnameSet := os.LookupEnv("CRYOSPARC_MASTER_HOSTNAME")
 	_, userSet := os.LookupEnv("CRYOSPARC_USER")
 	return hostnameSet || userSet || pathExists("/opt/cryosparc") || pathExists("/app/cryosparc")

--- a/pkg/containers/detection.go
+++ b/pkg/containers/detection.go
@@ -1,0 +1,30 @@
+package containers
+
+import "os"
+
+// IsRunningInContainer checks whether the current process is being executed inside a docker container
+func IsRunningInContainer() bool {
+	return isDocker() || isPodman() || isCryoSpark()
+}
+
+func isDocker() bool {
+	return pathExists("/.dockerenv") ||
+		pathExists("/.dockerinit") ||
+		pathExists("/run/.containerenv") ||
+		pathExists("/var/run/.containerenv")
+}
+
+func isPodman() bool {
+	return os.Getenv("container") == "oci" || os.Getenv("container") == "podman"
+}
+
+func isCryoSpark() bool {
+	_, hostnameSet := os.LookupEnv("CRYOSPARC_MASTER_HOSTNAME")
+	_, userSet := os.LookupEnv("CRYOSPARC_USER")
+	return hostnameSet || userSet || pathExists("/opt/cryosparc") || pathExists("/app/cryosparc")
+}
+
+func pathExists(filepath string) bool {
+	_, err := os.Stat(filepath)
+	return err == nil
+}

--- a/pkg/containers/detection_test.go
+++ b/pkg/containers/detection_test.go
@@ -1,0 +1,17 @@
+package containers
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Assert that container detection is running correctly by checking if it returns true in CI. Expected to return
+// false when run locally.
+func TestContainerDetection(t *testing.T) {
+	if _, ok := os.LookupEnv("GITHUB_ACTIONS"); !ok {
+		t.Skip("Skipping container detection test outside of github CI")
+	}
+	assert.True(t, IsRunningInContainer())
+}

--- a/pkg/containers/detection_test.go
+++ b/pkg/containers/detection_test.go
@@ -10,8 +10,9 @@ import (
 // Assert that container detection is running correctly by checking if it returns true in CI. Expected to return
 // false when run locally.
 func TestContainerDetection(t *testing.T) {
-	if _, ok := os.LookupEnv("GITHUB_ACTIONS"); !ok {
-		t.Skip("Skipping container detection test outside of github CI")
+	if _, ok := os.LookupEnv("GITHUB_ACTIONS"); ok {
+		assert.True(t, IsRunningInContainer())
+	} else {
+		assert.False(t, IsRunningInContainer())
 	}
-	assert.True(t, IsRunningInContainer())
 }

--- a/pkg/docker/detection.go
+++ b/pkg/docker/detection.go
@@ -1,0 +1,9 @@
+package docker
+
+import "os"
+
+// IsRunningInDocker checks whether the current process is being executed inside a docker container
+func IsRunningInDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
+}

--- a/pkg/docker/detection.go
+++ b/pkg/docker/detection.go
@@ -1,9 +1,0 @@
-package docker
-
-import "os"
-
-// IsRunningInDocker checks whether the current process is being executed inside a docker container
-func IsRunningInDocker() bool {
-	_, err := os.Stat("/.dockerenv")
-	return err == nil
-}

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/certgen"
+	"github.com/stackrox/rox/pkg/docker"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
@@ -277,7 +278,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() {
+	if roxctl.InMainImage() || !docker.IsRunningInDocker() {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/certgen"
-	"github.com/stackrox/rox/pkg/docker"
+	"github.com/stackrox/rox/pkg/containers"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
@@ -278,7 +278,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() || !docker.IsRunningInDocker() {
+	if roxctl.InMainImage() || !containers.IsRunningInContainer() {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")


### PR DESCRIPTION
### Description

The `OutputZip()` function in roxctl does not actually always output a zip file to stdout, even though it says that it does. However making it always do this could now pose a problem for existing docker setups using the logic of `roxctl central generate k8s pvc` where is puts the output into an output path iff `ROX_ROXCTL_IN_MAIN_IMAGE` is unset. 

But the output path is populated by default so checking if that's unset does not work. I propose fixing this problem by checking if we are running inside a docker container, and always outputting the zip to `STDOUT` if we are not. That way the behavior of `roxctl central generate k8s pvc` matches its description.

Alternative idea: Change the description of `roxctl central generate k8s pvc` and explain that it only prints the output to STDOUT if `ROX_ROXCTL_IN_MAIN_IMAGE` is set, but I think that is the worse approach.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Locally ran `roxctl central generate k8s pvc > pvc.zip` and then `file pvc.zip` confirming the file was not empty.
