### PR TITLE
refactor: extract access control pattern common to 3 write operations

### DIFF
--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
@@ -199,32 +199,9 @@ func (ds *datastoreImpl) UpdateRequestExpiry(ctx context.Context, id, message st
 		return nil, errors.New("comment is required when updating a request's expiry")
 	}
 
-	// Only those with WRITE on either VulnerabilityManagementApprovals or VulnerabilityManagementRequests can make this change
-	if ok, err := requesterOrApproverSAC.WriteAllowedToAny(ctx); err != nil {
-		return nil, err
-	} else if !ok {
-		return nil, sac.ErrResourceAccessDenied
-	}
-
-	req, found, err := ds.store.Get(ctx, id)
+	req, err := ds.ensureApproverOrInitialRequestorReturningRequest(ctx, id)
 	if err != nil {
 		return nil, err
-	}
-	if !found {
-		return nil, errors.Errorf("vulnerability request %s not found", id)
-	}
-
-	// If the user has VulnerabilityManagementRequests but not VulnerabilityManagementApprovals, then this can only be done if current user is the requester
-	if ok, err := requesterSAC.WriteAllowed(ctx); err == nil && ok {
-		if ok, err := approverSAC.WriteAllowed(ctx); err != nil || !ok {
-			user, err := authn.IdentityFromContext(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if req.Requestor.Id != user.UID() {
-				return nil, errors.Wrap(sac.ErrResourceAccessDenied, "requests can only be updated by the original requester")
-			}
-		}
 	}
 
 	if req.GetTargetState() != storage.VulnerabilityState_DEFERRED {
@@ -266,6 +243,39 @@ func (ds *datastoreImpl) UpdateRequest(ctx context.Context, id string, update *c
 		return nil, errors.Errorf("set the environment variable %s=true and retry", features.UnifiedCVEDeferral.EnvVar())
 	}
 
+	req, err := ds.ensureApproverOrInitialRequestorReturningRequest(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.GetExpired() || req.GetStatus() == storage.RequestStatus_DENIED {
+		return nil, errors.Errorf("request %s cannot be updated because it has expired or has been denied", req.GetId())
+	}
+
+	if (req.GetTargetState() == storage.VulnerabilityState_DEFERRED && update.FalsePositiveUpdate != nil) ||
+		(req.GetTargetState() == storage.VulnerabilityState_FALSE_POSITIVE && update.DeferralUpdate != nil) {
+		return nil, errors.Errorf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed", req.GetId())
+	}
+
+	if utils.IsUpdateNoOp(req, update) {
+		return nil, errors.Errorf("the update does not change the exception %s", req.GetId())
+	}
+
+	req.LastUpdated = protocompat.TimestampNow()
+	req.Comments = append(req.Comments, utils.CreateRequestCommentProto(ctx, update.Comment))
+	if update.DeferralUpdate != nil {
+		deferralUpdate(req, update.DeferralUpdate)
+	} else if update.FalsePositiveUpdate != nil {
+		falsePositiveUpdate(req, update.FalsePositiveUpdate)
+	}
+
+	if err := ds.store.Upsert(ctx, req); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+func (ds *datastoreImpl) ensureApproverOrInitialRequestorReturningRequest(ctx context.Context, id string) (*storage.VulnerabilityRequest, error) {
 	// Only those with WRITE on either VulnerabilityManagementApprovals or VulnerabilityManagementRequests can make this change
 	if ok, err := requesterOrApproverSAC.WriteAllowedToAny(ctx); err != nil {
 		return nil, err
@@ -294,30 +304,6 @@ func (ds *datastoreImpl) UpdateRequest(ctx context.Context, id string, update *c
 		}
 	}
 
-	if req.GetExpired() || req.GetStatus() == storage.RequestStatus_DENIED {
-		return nil, errors.Errorf("request %s cannot be updated because it has expired or has been denied", req.GetId())
-	}
-
-	if (req.GetTargetState() == storage.VulnerabilityState_DEFERRED && update.FalsePositiveUpdate != nil) ||
-		(req.GetTargetState() == storage.VulnerabilityState_FALSE_POSITIVE && update.DeferralUpdate != nil) {
-		return nil, errors.Errorf("exception %s cannot be updated. Exception type(defer/false positive) cannot be changed", req.GetId())
-	}
-
-	if utils.IsUpdateNoOp(req, update) {
-		return nil, errors.Errorf("the update does not change the exception %s", req.GetId())
-	}
-
-	req.LastUpdated = protocompat.TimestampNow()
-	req.Comments = append(req.Comments, utils.CreateRequestCommentProto(ctx, update.Comment))
-	if update.DeferralUpdate != nil {
-		deferralUpdate(req, update.DeferralUpdate)
-	} else if update.FalsePositiveUpdate != nil {
-		falsePositiveUpdate(req, update.FalsePositiveUpdate)
-	}
-
-	if err := ds.store.Upsert(ctx, req); err != nil {
-		return nil, err
-	}
 	return req, nil
 }
 
@@ -358,31 +344,9 @@ func falsePositiveUpdate(req *storage.VulnerabilityRequest, update *storage.Fals
 
 func (ds *datastoreImpl) MarkRequestInactive(ctx context.Context, id, comment string) (*storage.VulnerabilityRequest, error) {
 	// Only those with WRITE on either VulnerabilityManagementApprovals or VulnerabilityManagementRequests can make this change
-	if ok, err := requesterOrApproverSAC.WriteAllowedToAny(ctx); err != nil {
-		return nil, err
-	} else if !ok {
-		return nil, sac.ErrResourceAccessDenied
-	}
-
-	req, found, err := ds.store.Get(ctx, id)
+	req, err := ds.ensureApproverOrInitialRequestorReturningRequest(ctx, id)
 	if err != nil {
 		return nil, err
-	}
-	if !found {
-		return nil, errors.Errorf("vulnerability request %s not found", id)
-	}
-
-	// If the user has VulnerabilityManagementRequests but not VulnerabilityManagementApprovals, then this can only be done if current user is the requester
-	if ok, err := requesterSAC.WriteAllowed(ctx); err == nil && ok {
-		if ok, err := approverSAC.WriteAllowed(ctx); err != nil || !ok {
-			user, err := authn.IdentityFromContext(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if req.Requestor.Id != user.UID() {
-				return nil, errors.Wrap(sac.ErrResourceAccessDenied, "requests can only be undone by the original requester")
-			}
-		}
 	}
 
 	if req.GetExpired() {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

One pattern appears to be common to multiple write operations of the Vulnerability Request management datastore. This pattern is extracted to make the functional flow easier to grasp.

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->
No functionality change involved here. The current test harness should be enough.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

In CI we trust.
