### PR TITLE
fix: Accept empty CI_JOB_NAME environment variable in e2e test lib

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -188,7 +188,7 @@ export_test_environment() {
         ci_export FAIL_FAST "true"
     fi
 
-    if [[ "${CI_JOB_NAME}" =~ gke ]]; then
+    if [[ "${CI_JOB_NAME:-}" =~ gke ]]; then
         # GKE uses this network for services. Consider it as a private subnet.
         ci_export ROX_NON_AGGREGATED_NETWORKS "${ROX_NON_AGGREGATED_NETWORKS:-34.118.224.0/20}"
     fi


### PR DESCRIPTION
Accept empty CI_JOB_NAME environment variable for local execution of tests.

I have noticed that I cannot execute the scaner V4 tests locally due to an uninitialized `CI_JOB_NAME` environemnt variable.

This should be an easy fix.

