### PR TITLE
ROX-28160: Delete ROX_ACSCS_EMAIL_NOTIFIER feature flag from ui code

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -218,7 +218,6 @@ export const notifierIntegrationsDescriptors: NotifierIntegrationDescriptor[] = 
         image: acscsEmail,
         label: 'RHACS Cloud Service',
         type: 'acscsEmail',
-        featureFlagDependency: ['ROX_ACSCS_EMAIL_NOTIFIER'],
     },
     {
         image: google,

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -2,7 +2,6 @@
 // However, add strings in alphabetical order to minimize merge conflicts when multiple people add strings.
 // prettier-ignore
 export type FeatureFlagEnvVar =
-    | 'ROX_ACSCS_EMAIL_NOTIFIER'
     | 'ROX_ACTIVE_VULN_MGMT'
     | 'ROX_CLUSTERS_PAGE_MIGRATION_UI'
     | 'ROX_COMPLIANCE_HIERARCHY_CONTROL_DATA'


### PR DESCRIPTION
### Description

This feature flag has been enabled since 2024-06-06 in #11389

https://github.com/stackrox/stackrox/tree/master/ui/apps/platform#delete-a-feature-flag-from-frontend-code

By the way, the notifier has conditional rendering by central capabilities:
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/NotifierIntegrationsSection.tsx#L33-L35

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform