### PR TITLE
chore(qa): add types to Kubernetes helpers

### DIFF
--- a/qa-tests-backend/codenarc-rules.groovy
+++ b/qa-tests-backend/codenarc-rules.groovy
@@ -110,7 +110,7 @@ ruleset {
     AbstractClassWithoutAbstractMethod 
     AssignmentToStaticFieldFromInstanceMethod 
     BooleanMethodReturnsNull 
-    BuilderMethodWithSideEffects
+    // BuilderMethodWithSideEffects
     CloneableWithoutClone 
     CloseWithoutCloseable 
     CompareToWithoutComparable 

--- a/qa-tests-backend/codenarc-rules.groovy
+++ b/qa-tests-backend/codenarc-rules.groovy
@@ -110,7 +110,7 @@ ruleset {
     AbstractClassWithoutAbstractMethod 
     AssignmentToStaticFieldFromInstanceMethod 
     BooleanMethodReturnsNull 
-    // BuilderMethodWithSideEffects
+    BuilderMethodWithSideEffects
     CloneableWithoutClone 
     CloseWithoutCloseable 
     CompareToWithoutComparable 

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -192,6 +192,7 @@ class Kubernetes implements OrchestratorMain {
         Deployment Methods
     */
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createDeployment(Deployment deployment) {
         ensureNamespaceExists(deployment.namespace)
         createDeploymentNoWait(deployment)
@@ -543,6 +544,7 @@ class Kubernetes implements OrchestratorMain {
         DaemonSet Methods
     */
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createDaemonSet(DaemonSet daemonSet) {
         ensureNamespaceExists(daemonSet.namespace)
         createDaemonSetNoWait(daemonSet)
@@ -852,6 +854,7 @@ class Kubernetes implements OrchestratorMain {
     */
 
     @CompileDynamic
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createService(Deployment deployment) {
         withRetry(2, 3) {
             Service service = new Service(
@@ -889,6 +892,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     @CompileDynamic
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createService(objects.Service s) {
         withRetry(2, 3) {
             Service service = new Service(
@@ -1008,6 +1012,7 @@ class Kubernetes implements OrchestratorMain {
         Route Methods
     */
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createRoute(String routeName, String namespace) {
         throw new RuntimeException("K8s does not support routes")
     }
@@ -1332,6 +1337,7 @@ class Kubernetes implements OrchestratorMain {
         }
     }
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createServiceAccount(K8sServiceAccount serviceAccount) {
         withRetry(1, 2) {
             ServiceAccount sa = toServiceAccount(serviceAccount)
@@ -1470,6 +1476,7 @@ class Kubernetes implements OrchestratorMain {
         }
     }
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createRole(K8sRole role) {
         withRetry(1, 2) {
             Role r = new Role(
@@ -1531,6 +1538,7 @@ class Kubernetes implements OrchestratorMain {
         }
     }
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createRoleBinding(K8sRoleBinding roleBinding) {
         withRetry(1, 2) {
             RoleBinding r = new RoleBinding(
@@ -1590,6 +1598,7 @@ class Kubernetes implements OrchestratorMain {
         }
     }
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createClusterRole(K8sRole role) {
         withRetry(2, 3) {
             ClusterRole r = new ClusterRole(
@@ -1649,6 +1658,7 @@ class Kubernetes implements OrchestratorMain {
         }
     }
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createClusterRoleBinding(K8sRoleBinding roleBinding) {
         withRetry(2, 3) {
             ClusterRoleBinding r = new ClusterRoleBinding(
@@ -2424,6 +2434,7 @@ class Kubernetes implements OrchestratorMain {
         log.debug "delete admission controllers stub: ${name}"
     }
 
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createAdmissionController(ValidatingWebhookConfiguration config) {
         log.debug "create admission controllers stub: ${config}"
     }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -29,7 +29,7 @@ class OpenShift extends Kubernetes {
     }
 
     @Override
-    def ensureNamespaceExists(String ns) {
+    void ensureNamespaceExists(String ns) {
         ProjectRequest projectRequest = new ProjectRequestBuilder()
                 .withNewMetadata()
                 .withName(ns)
@@ -95,7 +95,7 @@ class OpenShift extends Kubernetes {
     */
 
     @Override
-    def createRoute(String routeName, String namespace) {
+    void createRoute(String routeName, String namespace) {
         log.debug "Creating a route: " + routeName
         withRetry(2, 3) {
             Route route = new RouteBuilder().withNewMetadata().withName(routeName).endMetadata()
@@ -105,7 +105,7 @@ class OpenShift extends Kubernetes {
     }
 
     @Override
-    def deleteRoute(String routeName, String namespace) {
+    void deleteRoute(String routeName, String namespace) {
         log.debug "Deleting a route: " + routeName
         withRetry(2, 3) {
             Route route = new RouteBuilder().withNewMetadata().withName(routeName).endMetadata().build()

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -95,6 +95,7 @@ class OpenShift extends Kubernetes {
     */
 
     @Override
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createRoute(String routeName, String namespace) {
         log.debug "Creating a route: " + routeName
         withRetry(2, 3) {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -45,6 +45,7 @@ interface OrchestratorMain {
     K8sDeployment getOrchestratorDeployment(String ns, String name)
     K8sDeployment createOrchestratorDeployment(K8sDeployment dep)
     boolean createDeploymentNoWait(Deployment deployment)
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createDeployment(Deployment deployment)
     void updateDeployment(Deployment deployment)
     boolean updateDeploymentNoWait(Deployment deployment)
@@ -65,6 +66,7 @@ interface OrchestratorMain {
     boolean deploymentReady(String ns, String name)
 
     //DaemonSets
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createDaemonSet(DaemonSet daemonSet)
     void deleteDaemonSet(DaemonSet daemonSet)
     boolean containsDaemonSetContainer(String ns, String name, String containerName)
@@ -91,7 +93,9 @@ interface OrchestratorMain {
     Set<String> getStaticPodCount(String ns)
 
     //Services
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createService(Deployment deployment)
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createService(Service service)
     void deleteService(String serviceName, String namespace)
     void waitForServiceDeletion(Service service)
@@ -99,6 +103,7 @@ interface OrchestratorMain {
     void addOrUpdateServiceLabel(String serviceName, String ns, String name, String value)
 
     //Routes
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createRoute(String routeName, String namespace)
     void deleteRoute(String routeName, String namespace)
 
@@ -137,6 +142,7 @@ interface OrchestratorMain {
 
     //Service Accounts
     List<K8sServiceAccount> getServiceAccounts()
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createServiceAccount(K8sServiceAccount serviceAccount)
     void deleteServiceAccount(K8sServiceAccount serviceAccount)
     void addServiceAccountImagePullSecret(String accountName, String secretName, String namespace)
@@ -144,21 +150,25 @@ interface OrchestratorMain {
 
     //Roles
     List<K8sRole> getRoles()
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createRole(K8sRole role)
     void deleteRole(K8sRole role)
 
     //RoleBindings
     List<K8sRoleBinding> getRoleBindings()
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createRoleBinding(K8sRoleBinding roleBinding)
     void deleteRoleBinding(K8sRoleBinding roleBinding)
 
     //ClusterRoles
     List<K8sRole> getClusterRoles()
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createClusterRole(K8sRole role)
     void deleteClusterRole(K8sRole role)
 
     //ClusterRoleBindings
     List<K8sRoleBinding> getClusterRoleBindings()
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createClusterRoleBinding(K8sRoleBinding roleBinding)
     void deleteClusterRoleBinding(K8sRoleBinding roleBinding)
 
@@ -184,5 +194,6 @@ interface OrchestratorMain {
 
     ValidatingWebhookConfiguration getAdmissionController()
     void deleteAdmissionController(String name)
+    @SuppressWarnings('BuilderMethodWithSideEffects')
     void createAdmissionController(ValidatingWebhookConfiguration config)
 }

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -27,6 +27,8 @@ class Env {
     static final QA_TEST_DEBUG_LOGS = System.getenv("QA_TEST_DEBUG_LOGS") ?: ""
     static final HAS_WORKLOAD_IDENTITIES = (System.getenv("SETUP_WORKLOAD_IDENTITIES") == "true")
 
+    static final String IMAGE_PULL_POLICY_FOR_QUAY_IO = System.getenv("IMAGE_PULL_POLICY_FOR_QUAY_IO")
+
     // REMOTE_CLUSTER_ARCH specifies architecture of a remote cluster on which tests are to be executed
     // the remote cluster arch can be ppc64le or s390x, default is x86_64
     static final REMOTE_CLUSTER_ARCH = System.getenv("REMOTE_CLUSTER_ARCH") ?: "x86_64"


### PR DESCRIPTION
### Description

This PR adds types to Kubernetes.grooovy to make it easier to reason what will be returned from the method.
The goal was to enable `@CompileStatic` on Kubernetes.groovy. It was done partially as I don't know why some methods crashes the compiler (`Execution failed for task ':compileGroovy'. > java.lang.StackOverflowError (no error message)`) I annotated problematic methods with `@CompileDynamic`. I annotated other classes with `@CompileStatic` as well as this make it easier to enable `@CompileStatic` on Kubernetes.
I need to disabled `codenarc` rule as we have `create*` methods that returns `void`. We can fix it in the future but I tried to have minimal PR.
 
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
