### PR TITLE
ROX-28037: Render Advisories column without GraphQL data

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -198,11 +198,15 @@ function ImagePageVulnerabilities({
     // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
     // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isEpssProbabilityColumnEnabled = false;
+    const isAdvisoryColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') &&
+        isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
     const filteredColumns = filterManagedColumns(
         defaultColumns,
         (key) =>
             (key !== 'nvdCvss' || isNvdCvssColumnEnabled) &&
-            (key !== 'epssProbability' || isEpssProbabilityColumnEnabled)
+            (key !== 'epssProbability' || isEpssProbabilityColumnEnabled) &&
+            (key !== 'totalAdvisories' || isAdvisoryColumnEnabled)
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -48,7 +48,7 @@ import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayo
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import { infoForEpssProbability } from './infoForTh';
-import { formatEpssProbabilityAsPercent } from './table.utils';
+import { formatEpssProbabilityAsPercent, formatTotalAdvisories } from './table.utils';
 
 export const tableId = 'WorkloadCvesImageVulnerabilitiesTable';
 export const defaultColumns = {
@@ -70,6 +70,10 @@ export const defaultColumns = {
     },
     epssProbability: {
         title: 'EPSS probability',
+        isShownByDefault: true,
+    },
+    totalAdvisories: {
+        title: 'Advisories',
         isShownByDefault: true,
     },
     affectedComponents: {
@@ -165,11 +169,15 @@ function ImageVulnerabilitiesTable({
     // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
     // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isEpssProbabilityColumnEnabled = false;
+    const isAdvisoryColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') &&
+        isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
 
     const colSpan =
         7 +
         (isNvdCvssColumnEnabled ? 1 : 0) +
         (isEpssProbabilityColumnEnabled ? 1 : 0) +
+        (isAdvisoryColumnEnabled ? 1 : 0) +
         (canSelectRows ? 1 : 0) +
         (createTableActions ? 1 : 0) +
         (showExceptionDetailsLink ? 1 : 0) +
@@ -206,6 +214,9 @@ function ImageVulnerabilitiesTable({
                         >
                             EPSS probability
                         </Th>
+                    )}
+                    {isAdvisoryColumnEnabled && (
+                        <Th className={getVisibilityClass('totalAdvisories')}>Advisories</Th>
                     )}
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
@@ -255,6 +266,7 @@ function ImageVulnerabilitiesTable({
                         );
                         const isFixableInImage = getIsSomeVulnerabilityFixable(vulnerabilities);
                         const epssProbability = cveBaseInfo?.epss?.epssProbability;
+                        const totalAdvisories = undefined;
                         const isExpanded = expandedRowSet.has(cve);
 
                         return (
@@ -337,6 +349,15 @@ function ImageVulnerabilitiesTable({
                                             dataLabel="EPSS probability"
                                         >
                                             {formatEpssProbabilityAsPercent(epssProbability)}
+                                        </Td>
+                                    )}
+                                    {isAdvisoryColumnEnabled && (
+                                        <Td
+                                            className={getVisibilityClass('totalAdvisories')}
+                                            modifier="nowrap"
+                                            dataLabel="Advisories"
+                                        >
+                                            {formatTotalAdvisories(totalAdvisories)}
                                         </Td>
                                     )}
                                     <Td

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -2,6 +2,8 @@ import { gql } from '@apollo/client';
 import { min, parse } from 'date-fns';
 import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
+import pluralize from 'pluralize';
+
 import { CveBaseInfo, VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
 import { SourceType } from 'types/image.proto';
 import { ApiSortOptionSingle } from 'types/search';
@@ -345,4 +347,17 @@ export function formatEpssProbabilityAsPercent(epssProbability: number | undefin
 
     // For any of the following: null, undefined, or number out of range
     return 'Not available';
+}
+
+export function formatTotalAdvisories(totalAdvisories: number | undefined) {
+    if (
+        typeof totalAdvisories === 'number' &&
+        Number.isSafeInteger(totalAdvisories) &&
+        totalAdvisories > 0
+    ) {
+        return `${totalAdvisories} ${pluralize('advisory', totalAdvisories)}`;
+    }
+
+    // For any of the following: undefined, or number out of range
+    return 'No advisories';
 }


### PR DESCRIPTION
### Description

Prerequisite for future demo with realistic data (by temporary code changes).

Tentative decision by cross-team to omit **Advisories** column for deployment, for which image becomes and extra level of aggregation:
* to preclude potential scale problem
* to reduce backend effort
* maybe not as intuitive nor useful for customers?

From frontend viewpoint, it that decision changed, then apply same changes to DeploymentVulnerabilitiesTable.tsx file.

#### Changed files

1. Edit table.utils.ts file.
    * Add `formatTotalAdvisories` function.
2. Edit ImageVulnerabilitiesTable.tsx file.
    * Add conditional rendering for **Advisories** table column.
3. Edit ImagePageVulnerabilities.tsx file.
    * Add `totalAdvisories` to `filterManagedColumns` function call.
        Forgot this at first, although in the back of my mind, something seemed missing.

### Residue

When response has `totalAdvisories` property:
1. Add property to `gql` definitions.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4646307 - 4646307
        total 461 = 11566145 - 11565684
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

Run UI with staging demo, which has **Scanner V4**. Temporarily edit code to invert conditional rendering, because `ROX_CVE_ADVISORY_SEPARATION` feature flag is not enabled yet.

1. Visit /main/vulnerabilities/user-workloads and then click a CVE link in the table.

    Before changes, see absence **Advisories** column
    ![ImageVulnerabilitiesTable_absence](https://github.com/user-attachments/assets/95b5a79a-437d-4224-9226-2f3ef1a89061)

    After changes, see presence of **Advisories** column with **No advisories** placeholder value.
    ![ImageVulnerabilitiesTable_presence](https://github.com/user-attachments/assets/ac77d818-0768-4cab-80a3-f654842dec66)
