### PR TITLE
ROX-27607: create swagger doc for SBOM custom route

### DIFF
--- a/central/docs/api_custom_routes/.gitignore
+++ b/central/docs/api_custom_routes/.gitignore
@@ -1,0 +1,1 @@
+asciidoc/

--- a/central/docs/api_custom_routes/README.md
+++ b/central/docs/api_custom_routes/README.md
@@ -13,7 +13,8 @@ The OpenAPI specs must be converted to AsciiDoc for publishing to the official d
 
 Sample steps to modify, validate, and convert these specs:
 
-1. Load the `yaml` into https://editor.swagger.io/ (or use the equiv offline variation) and make appropriate changes and validate syntax
+1. Load the `yaml` into https://editor.swagger.io/ (or use the equiv offline variation) and make appropriate changes and validate syntax.
+   - _Refer to the [OpenAPI guide](https://swagger.io/docs/specification/v3_0/about/) and/or [official specs](https://spec.openapis.org/) for more details_
 
 2. Copy the modified `yaml` back into this repo
 

--- a/central/docs/api_custom_routes/README.md
+++ b/central/docs/api_custom_routes/README.md
@@ -1,0 +1,5 @@
+This directory includes manually created OpenAPI/Swagger specs for Central's custom routes defined in [/central/main.go](/central/main.go) (refer to `customRoutes()`)
+
+These particular specs are currently NOT accessible via Central, instead they are/will be available in the official docs.
+
+TODO(ROX-28173): improve doc creation, automation, serving, etc..

--- a/central/docs/api_custom_routes/README.md
+++ b/central/docs/api_custom_routes/README.md
@@ -1,5 +1,42 @@
+# Custom Route API specs
 This directory includes manually created OpenAPI/Swagger specs for Central's custom routes defined in [/central/main.go](/central/main.go) (refer to `customRoutes()`)
 
 These particular specs are currently NOT accessible via Central, instead they are/will be available in the official docs.
 
 TODO(ROX-28173): improve doc creation, automation, serving, etc..
+
+## Manually Modifying and Converting to AsciiDoc
+
+_Disclaimer: Before executing these steps confirm with the docs team if the process, scripts, etc. is still accurate. These steps represent an initial PoC and can/should be improved, which is in scope for ROX-28173_
+
+The OpenAPI specs must be converted to AsciiDoc for publishing to the official docs.
+
+Sample steps to modify, validate, and convert these specs:
+
+1. Load the `yaml` into https://editor.swagger.io/ (or use the equiv offline variation) and make appropriate changes and validate syntax
+
+2. Copy the modified `yaml` back into this repo
+
+3. Generate an AsciiDoc from the modified `yaml` (change `swagger_dir` and `srcfile` as appropriate)
+          
+       swagger_dir=/path-to-stackrox-repo/central/docs/api_custom_routes
+
+       srcfile=image_service_swagger.yaml
+
+       docker run --rm -v "$swagger_dir:/local" openapitools/openapi-generator-cli generate -i /local/$srcfile -g asciidoc -o /local/asciidoc
+
+4. Clone `rhacs-api-docs-gen` repo: https://github.com/gaurav-nelson/rhacs-api-docs-gen
+
+5. Move the generated `adoc` file to `scripts/` dir of `rhacs-api-docs-gen` tool
+
+       mv $swagger_dir/asciidoc/index.adoc /path-to-rhacs-api-docs-gen-repo/scripts
+
+6. Execute `scripts/updateasciidoc.js` to cleanup the `adoc` file (will be modified in place)
+
+       cd /path-to-rhacs-api-docs-gen-repo
+
+       node scripts/updateasciidoc.js index.adoc
+
+7. Provide the new `adoc` file(s) to docs team for publishing
+
+8. Commit/push/merge updated `yaml`

--- a/central/docs/api_custom_routes/image_service_swagger.yaml
+++ b/central/docs/api_custom_routes/image_service_swagger.yaml
@@ -11,8 +11,8 @@ produces:
 paths:
   /api/v1/images/sbom:
     post:
-      summary: generate sbom
-      operationId: ImageService_ScanImage
+      summary: Generate an SPDX 2.3 SBOM from an image scan.
+      operationId: GenerateSBOM
       responses:
         '200':
           description: A successful response.
@@ -36,8 +36,13 @@ definitions:
     properties:
       imageName:
         type: string
+        description: "Image name and reference. (e.g. nginx:latest or nginx@sha256:...)"
       force:
         type: boolean
+        description: "Bypass Central's cache for the image and force a new pull from the Scanner"
+        default: false
+    required:
+    - imageName
   SBOM-SPDX23-Document:
     description: "SPDX 2.3 document, refer to https://spdx.github.io/spdx-spec/v2.3/ for more details."
     type: object

--- a/central/docs/api_custom_routes/image_service_swagger.yaml
+++ b/central/docs/api_custom_routes/image_service_swagger.yaml
@@ -115,4 +115,3 @@ definitions:
         format: int32
       message:
         type: string
-   

--- a/central/docs/api_custom_routes/image_service_swagger.yaml
+++ b/central/docs/api_custom_routes/image_service_swagger.yaml
@@ -1,0 +1,118 @@
+swagger: '2.0'
+info:
+  title: Image Service Custom Routes
+  version: v1
+tags:
+  - name: ImageService
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /api/v1/images/sbom:
+    post:
+      summary: generate sbom
+      operationId: ImageService_ScanImage
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/SBOM-SPDX23-Document'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/imageSBOMRequest'
+      tags:
+        - ImageService
+definitions:
+  imageSBOMRequest:
+    type: object
+    properties:
+      imageName:
+        type: string
+      force:
+        type: boolean
+  SBOM-SPDX23-Document:
+    description: "SPDX 2.3 document, refer to https://spdx.github.io/spdx-spec/v2.3/ for more details."
+    type: object
+    properties:
+      spdxVersion:
+        type: string
+        example: "SPDX-2.3"
+      dataLicense:
+        type: string
+        example: "CC0-1.0"
+      SPDXID:
+        type: string
+        example: "SPDXRef-DOCUMENT"
+      name:
+        type: string
+        example: "sha256:2107993405718600b5e53aae90c78647eff44086e6605862fc69389a4f9d1a09"
+      documentNamespace:
+        type: string
+        example: "https://quay.io/rhacs-eng/scanner-v4-665956d1-21dc-4f7c-ae96-48f7cdd460ff"
+      creationInfo:
+        type: object
+        properties:
+          created:
+            type: string
+            example: "2025-02-18T16:33:54Z"
+          creators:
+            type: array
+            items:
+              type: string
+              example: ["Tool: Claircore-<version>", "Tool: scanner-v4-matcher-<version>"]
+      packages:
+        type: array
+        items:
+          type: object
+          properties:
+            SPDXID:
+              example: "SPDXRef-Package-<id>"
+            name:
+              type: string
+              example: "example-package"
+            versionInfo:
+              type: string
+              example: "example-version"
+            packageFileName:
+              type: string
+              example: "path/to/example/file"
+            downloadLocation:
+              type: string
+              example: "NOASSERTION"
+            filesAnalyzed:
+              type: boolean
+              example: true
+            primaryPackagePurpose:
+              type: string
+              example: "APPLICATION"
+      relationships:
+        type: array
+        items:
+          type: object
+          properties:
+            spdxElementId:
+              type: string
+              example: "SPDXRef-Package-<id>"
+            relatedSpdxElement:
+              type: string
+              example: "SPDXRef-Repository-<id>"
+            relationshipType:
+              type: string
+              example: "CONTAINED_BY"
+  googlerpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+   

--- a/pkg/apiparams/sbom.go
+++ b/pkg/apiparams/sbom.go
@@ -1,6 +1,7 @@
 package apiparams
 
 // SBOMRequestBody represents the HTTP API request for generating an SBOM from an image scan.
+// Any changes to this struct should be reflected in the central/docs/api_custom_routes/image_service_swagger.yaml
 type SBOMRequestBody struct {
 	// TODO(ROX-27920): re-introduce cluster flag when SBOM generation from delegated scans is implemented.
 	// Cluster   string `json:"cluster"`


### PR DESCRIPTION
### Description

Adds a manually crafted OpenAPI / Swagger spec to the repo for the SBOM generation API that is/was used for building the associated docs - which are not generated automatically (currently).

This location may be temporary until when/if a broader strategy is defined (captured in ROX-28173)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

Via the https://editor.swagger.io/ (validates formatting, etc.), generating ascii docs using [openapi-generator-cli](https://hub.docker.com/r/openapitools/openapi-generator-cli), and further cleaning up with [rhacs-api-docs-gen](https://github.com/gaurav-nelson/rhacs-api-docs-gen)

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/6209f231-c412-4c50-a4f1-ce83e5c34982" />

![image](https://github.com/user-attachments/assets/d14c1a1c-430b-4e7d-864e-2a8ed741456a)


```
swagger_dir=~/Downloads/swag

cd $swagger_dir
docker run --rm -v "$swagger_dir:/local" openapitools/openapi-generator-cli generate -i /local/swagger.yaml -g asciidoc -o /local/out/asciidoc

# changed to the directory where I cloned Gaurav's repo: https://github.com/gaurav-nelson/rhacs-api-docs-gen
cd ~/dev/gaurav-nelson/rhacs-api-docs-gen

# copied the ascii doc generated above into dir required by Gaurav's script
cp $swagger_dir/out/asciidoc/index.adoc scripts/generate_sbom.adoc

# Cleaned up the adoc file using Gaurav's script
# (had to run `npm install` first)
node scripts/updateasciidoc.js generate_sbom.adoc 

```
Then verified the resulting adoc by comparing it to other docs and previewing it in VSCode.
