### PR TITLE
feat(operator): support verbatim overlay values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stackrox/external-network-pusher v0.0.0-20231115153210-b82d72f500a2
 	github.com/stackrox/helmtest v0.0.1
-	github.com/stackrox/k8s-overlay-patch v0.0.0-20250224082933-b9894e9f5158
+	github.com/stackrox/k8s-overlay-patch v0.0.0-20250224110925-13b5b47fd812
 	github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d
 	github.com/stackrox/scanner v0.0.0-20240830165150-d133ba942d59
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stackrox/external-network-pusher v0.0.0-20231115153210-b82d72f500a2
 	github.com/stackrox/helmtest v0.0.1
-	github.com/stackrox/k8s-overlay-patch v0.0.0-20250219071755-4ea89cb53e4c
+	github.com/stackrox/k8s-overlay-patch v0.0.0-20250224082933-b9894e9f5158
 	github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d
 	github.com/stackrox/scanner v0.0.0-20240830165150-d133ba942d59
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -125,7 +125,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stackrox/external-network-pusher v0.0.0-20231115153210-b82d72f500a2
 	github.com/stackrox/helmtest v0.0.1
-	github.com/stackrox/k8s-overlay-patch v0.0.0-20240610103501-74a2a4fd2bae
+	github.com/stackrox/k8s-overlay-patch v0.0.0-20250219071755-4ea89cb53e4c
 	github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d
 	github.com/stackrox/scanner v0.0.0-20240830165150-d133ba942d59
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1439,8 +1439,8 @@ github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8 h1:rUIvoAHokPc
 github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8/go.mod h1:ZF7mH4kH1G+82HxR3uFDHvyLG8eCOdrh1RDyQcTGkBA=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d h1:88Iui7fSMKgXvpyfBlbP3qosrqyv3qMgOJ6JJ4V4tFQ=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d/go.mod h1:GJwFpFwCxiYhgpJWrAkM+v9Z9gpgtyWxkRdK4JjsOIg=
-github.com/stackrox/k8s-overlay-patch v0.0.0-20240610103501-74a2a4fd2bae h1:8E4Rq2kqSP8Jh/cNEg90OAdnVDN98j+1h3lH8//ilT8=
-github.com/stackrox/k8s-overlay-patch v0.0.0-20240610103501-74a2a4fd2bae/go.mod h1:u7v87z34sjtlcaEaHXknpnrzXutdM//Vb3yyhXllQp0=
+github.com/stackrox/k8s-overlay-patch v0.0.0-20250219071755-4ea89cb53e4c h1:zjGIn2XjvKTr6O4fPCa8axfFNJiFvWfdJVmTqY8/ayw=
+github.com/stackrox/k8s-overlay-patch v0.0.0-20250219071755-4ea89cb53e4c/go.mod h1:u7v87z34sjtlcaEaHXknpnrzXutdM//Vb3yyhXllQp0=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e h1:hLHHK1pGLpRvEbER2cJZekLeMnL+nMn3C37CVUhameM=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e/go.mod h1:Kh55SAWnjckS96TBSrXI99KrEKH4iB0OJby3N8GRJO4=
 github.com/stackrox/oauth2 v0.0.0-20240521152739-4d3f7e4f6b49 h1:FUX/fzXDu/TkYZQCk0TFGc5QUAv7m4GtvaRutyZCk4Y=

--- a/go.sum
+++ b/go.sum
@@ -1439,8 +1439,8 @@ github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8 h1:rUIvoAHokPc
 github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8/go.mod h1:ZF7mH4kH1G+82HxR3uFDHvyLG8eCOdrh1RDyQcTGkBA=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d h1:88Iui7fSMKgXvpyfBlbP3qosrqyv3qMgOJ6JJ4V4tFQ=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d/go.mod h1:GJwFpFwCxiYhgpJWrAkM+v9Z9gpgtyWxkRdK4JjsOIg=
-github.com/stackrox/k8s-overlay-patch v0.0.0-20250224082933-b9894e9f5158 h1:6DDfgvD18Z6wKapY/kBWxl1Z84sZaO2+2lTGYJg1Xqs=
-github.com/stackrox/k8s-overlay-patch v0.0.0-20250224082933-b9894e9f5158/go.mod h1:u7v87z34sjtlcaEaHXknpnrzXutdM//Vb3yyhXllQp0=
+github.com/stackrox/k8s-overlay-patch v0.0.0-20250224110925-13b5b47fd812 h1:ZWFTDuh/FomlOeVGfrxec7YENH9p4r6PQ4X/2so6C1M=
+github.com/stackrox/k8s-overlay-patch v0.0.0-20250224110925-13b5b47fd812/go.mod h1:u7v87z34sjtlcaEaHXknpnrzXutdM//Vb3yyhXllQp0=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e h1:hLHHK1pGLpRvEbER2cJZekLeMnL+nMn3C37CVUhameM=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e/go.mod h1:Kh55SAWnjckS96TBSrXI99KrEKH4iB0OJby3N8GRJO4=
 github.com/stackrox/oauth2 v0.0.0-20240521152739-4d3f7e4f6b49 h1:FUX/fzXDu/TkYZQCk0TFGc5QUAv7m4GtvaRutyZCk4Y=

--- a/go.sum
+++ b/go.sum
@@ -1439,8 +1439,8 @@ github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8 h1:rUIvoAHokPc
 github.com/stackrox/istio-cves v0.0.0-20221007013142-0bde9b541ec8/go.mod h1:ZF7mH4kH1G+82HxR3uFDHvyLG8eCOdrh1RDyQcTGkBA=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d h1:88Iui7fSMKgXvpyfBlbP3qosrqyv3qMgOJ6JJ4V4tFQ=
 github.com/stackrox/k8s-cves v0.0.0-20220818200547-7d0d1420c58d/go.mod h1:GJwFpFwCxiYhgpJWrAkM+v9Z9gpgtyWxkRdK4JjsOIg=
-github.com/stackrox/k8s-overlay-patch v0.0.0-20250219071755-4ea89cb53e4c h1:zjGIn2XjvKTr6O4fPCa8axfFNJiFvWfdJVmTqY8/ayw=
-github.com/stackrox/k8s-overlay-patch v0.0.0-20250219071755-4ea89cb53e4c/go.mod h1:u7v87z34sjtlcaEaHXknpnrzXutdM//Vb3yyhXllQp0=
+github.com/stackrox/k8s-overlay-patch v0.0.0-20250224082933-b9894e9f5158 h1:6DDfgvD18Z6wKapY/kBWxl1Z84sZaO2+2lTGYJg1Xqs=
+github.com/stackrox/k8s-overlay-patch v0.0.0-20250224082933-b9894e9f5158/go.mod h1:u7v87z34sjtlcaEaHXknpnrzXutdM//Vb3yyhXllQp0=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e h1:hLHHK1pGLpRvEbER2cJZekLeMnL+nMn3C37CVUhameM=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e/go.mod h1:Kh55SAWnjckS96TBSrXI99KrEKH4iB0OJby3N8GRJO4=
 github.com/stackrox/oauth2 v0.0.0-20240521152739-4d3f7e4f6b49 h1:FUX/fzXDu/TkYZQCk0TFGc5QUAv7m4GtvaRutyZCk4Y=

--- a/operator/api/v1alpha1/overlay_types.go
+++ b/operator/api/v1alpha1/overlay_types.go
@@ -58,9 +58,8 @@ package v1alpha1
 //	kind: ConfigMap
 //	name: central-endpoints
 //	patches:
-//	- path: data
-//	  value: |
-//	    endpoints.yaml: |
+//	- path: data.endpoints\.yaml:
+//	  verbatim: |
 //	    disableDefault: false
 //
 // ## Adding a container to a deployment
@@ -112,4 +111,9 @@ type K8sObjectOverlayPatch struct {
 	// All values are strings but are converted into appropriate type based on schema.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Value",order=2
 	Value string `json:"value,omitempty"`
+	// Verbatim value to add, delete or replace.
+	// Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
+	// At least one of Value and Verbatim must be empty.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verbatim",order=3
+	Verbatim string `json:"verbatim,omitempty"`
 }

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -834,7 +834,7 @@ spec:
                     spec.ingress[-1]\n\t  value: |\n\t    ports:\n\t    - port: 999\n\t
                     \     protocol: TCP\n\n## Changing the value of a configMap\n\n\tapiVersion:
                     v1\n\tkind: ConfigMap\n\tname: central-endpoints\n\tpatches:\n\t-
-                    path: data\n\t  value: |\n\t    endpoints.yaml: |\n\t    disableDefault:
+                    path: data.endpoints\\.yaml:\n\t  verbatim: |\n\t    disableDefault:
                     false\n\n## Adding a container to a deployment\n\n\tapiVersion:
                     apps/v1\n\tkind: Deployment\n\tname: central\n\tpatches:\n\t  -
                     path: spec.template.spec.containers[-1]\n\t    value: |\n\t      name:
@@ -876,6 +876,12 @@ spec:
                               For delete, value should be unset.
                               For replace, path should reference an existing node.
                               All values are strings but are converted into appropriate type based on schema.
+                            type: string
+                          verbatim:
+                            description: |-
+                              Verbatim value to add, delete or replace.
+                              Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
+                              At least one of Value and Verbatim must be empty.
                             type: string
                         type: object
                       type: array

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -474,7 +474,7 @@ spec:
                     spec.ingress[-1]\n\t  value: |\n\t    ports:\n\t    - port: 999\n\t
                     \     protocol: TCP\n\n## Changing the value of a configMap\n\n\tapiVersion:
                     v1\n\tkind: ConfigMap\n\tname: central-endpoints\n\tpatches:\n\t-
-                    path: data\n\t  value: |\n\t    endpoints.yaml: |\n\t    disableDefault:
+                    path: data.endpoints\\.yaml:\n\t  verbatim: |\n\t    disableDefault:
                     false\n\n## Adding a container to a deployment\n\n\tapiVersion:
                     apps/v1\n\tkind: Deployment\n\tname: central\n\tpatches:\n\t  -
                     path: spec.template.spec.containers[-1]\n\t    value: |\n\t      name:
@@ -516,6 +516,12 @@ spec:
                               For delete, value should be unset.
                               For replace, path should reference an existing node.
                               All values are strings but are converted into appropriate type based on schema.
+                            type: string
+                          verbatim:
+                            description: |-
+                              Verbatim value to add, delete or replace.
+                              Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
+                              At least one of Value and Verbatim must be empty.
                             type: string
                         type: object
                       type: array

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -549,6 +549,14 @@ spec:
           schema.'
         displayName: Value
         path: overlays[0].patches[0].value
+      - description: 'Verbatim value to add, delete or replace.
+
+          Same as Value, however the content is not interpreted as YAML, but treated
+          as literal string instead.
+
+          At least one of Value and Verbatim must be empty.'
+        displayName: Verbatim
+        path: overlays[0].patches[0].verbatim
       - description: 'If you do not want to deploy the Red Hat Advanced Cluster Security
           Scanner, you can disable it here
 
@@ -1123,6 +1131,14 @@ spec:
           schema.'
         displayName: Value
         path: overlays[0].patches[0].value
+      - description: 'Verbatim value to add, delete or replace.
+
+          Same as Value, however the content is not interpreted as YAML, but treated
+          as literal string instead.
+
+          At least one of Value and Verbatim must be empty.'
+        displayName: Verbatim
+        path: overlays[0].patches[0].verbatim
       - description: 'Settings for the Collector container, which is responsible for
           collecting process and networking
 

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -834,7 +834,7 @@ spec:
                     spec.ingress[-1]\n\t  value: |\n\t    ports:\n\t    - port: 999\n\t
                     \     protocol: TCP\n\n## Changing the value of a configMap\n\n\tapiVersion:
                     v1\n\tkind: ConfigMap\n\tname: central-endpoints\n\tpatches:\n\t-
-                    path: data\n\t  value: |\n\t    endpoints.yaml: |\n\t    disableDefault:
+                    path: data.endpoints\\.yaml:\n\t  verbatim: |\n\t    disableDefault:
                     false\n\n## Adding a container to a deployment\n\n\tapiVersion:
                     apps/v1\n\tkind: Deployment\n\tname: central\n\tpatches:\n\t  -
                     path: spec.template.spec.containers[-1]\n\t    value: |\n\t      name:
@@ -876,6 +876,12 @@ spec:
                               For delete, value should be unset.
                               For replace, path should reference an existing node.
                               All values are strings but are converted into appropriate type based on schema.
+                            type: string
+                          verbatim:
+                            description: |-
+                              Verbatim value to add, delete or replace.
+                              Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
+                              At least one of Value and Verbatim must be empty.
                             type: string
                         type: object
                       type: array

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -474,7 +474,7 @@ spec:
                     spec.ingress[-1]\n\t  value: |\n\t    ports:\n\t    - port: 999\n\t
                     \     protocol: TCP\n\n## Changing the value of a configMap\n\n\tapiVersion:
                     v1\n\tkind: ConfigMap\n\tname: central-endpoints\n\tpatches:\n\t-
-                    path: data\n\t  value: |\n\t    endpoints.yaml: |\n\t    disableDefault:
+                    path: data.endpoints\\.yaml:\n\t  verbatim: |\n\t    disableDefault:
                     false\n\n## Adding a container to a deployment\n\n\tapiVersion:
                     apps/v1\n\tkind: Deployment\n\tname: central\n\tpatches:\n\t  -
                     path: spec.template.spec.containers[-1]\n\t    value: |\n\t      name:
@@ -516,6 +516,12 @@ spec:
                               For delete, value should be unset.
                               For replace, path should reference an existing node.
                               All values are strings but are converted into appropriate type based on schema.
+                            type: string
+                          verbatim:
+                            description: |-
+                              Verbatim value to add, delete or replace.
+                              Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
+                              At least one of Value and Verbatim must be empty.
                             type: string
                         type: object
                       type: array

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -357,6 +357,12 @@ spec:
       - description: Name of resource.
         displayName: Name
         path: overlays[0].name
+      - description: |-
+          Verbatim value to add, delete or replace.
+          Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
+          At least one of Value and Verbatim must be empty.
+        displayName: Verbatim
+        path: overlays[0].patches[0].verbatim
       - displayName: Autoscaling Minimum Replicas
         path: scanner.analyzer.scaling.minReplicas
         x-descriptors:
@@ -965,6 +971,12 @@ spec:
       - description: Name of resource.
         displayName: Name
         path: overlays[0].name
+      - description: |-
+          Verbatim value to add, delete or replace.
+          Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
+          At least one of Value and Verbatim must be empty.
+        displayName: Verbatim
+        path: overlays[0].patches[0].verbatim
       - description: Deprecated field. This field will be removed in a future release.
         displayName: Force Collection
         path: perNode.collector.forceCollection

--- a/operator/internal/overlays/postrenderer.go
+++ b/operator/internal/overlays/postrenderer.go
@@ -83,8 +83,9 @@ func mapOverlayPatches(patches []*v1alpha1.K8sObjectOverlayPatch) []*types.K8sOb
 	out := make([]*types.K8sObjectOverlayPatch, len(patches))
 	for i, p := range patches {
 		out[i] = &types.K8sObjectOverlayPatch{
-			Path:  p.Path,
-			Value: p.Value,
+			Path:     p.Path,
+			Value:    p.Value,
+			Verbatim: p.Verbatim,
 		}
 	}
 	return out


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Solves https://issues.redhat.com/browse/ROX-27333

- actual support was added in https://github.com/stackrox/k8s-overlay-patch/pull/25
- this just adds the field to our types and adjusts some docs

Docs will be added in scope of related https://issues.redhat.com/browse/ROX-27332

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no tests changed, the core functionality is tested in https://github.com/stackrox/k8s-overlay-patch/pull/25

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->


##### Manual inspection of operator UI

This is not visible in the form view. The help text in the YAML view looks reasonable:

![image](https://github.com/user-attachments/assets/ffc45c5c-09ee-479e-9c11-2d72e03009b4)

##### Manual testing

Tested manually with roughly:

```
$ cd operator
$ make install run

# in another window
$ kubectl apply -n stackrox -f operator/tests/common/central-cr.yaml
$ oc get cm -n stackrox -o jsonpath='{.data.postgresql\.conf}' central-db-config|grep max_connections
max_connections = 100
$ kubectl edit -n stackrox centrals.platform.stackrox.io stackrox-central-services
# add something like below right above `status`
$ oc get cm -n stackrox -o jsonpath='{.data.postgresql\.conf}' central-db-config|grep max_connections
max_connections = 99

# Also checked that comments are retained.
```

```
  overlays:
  - apiVersion: v1
    kind: ConfigMap
    name: central-db-config
    patches:
    - path: data.postgresql\.conf
      verbatim: |
        hba_file = '/etc/stackrox.d/config/pg_hba.conf'
        listen_addresses = '*'
        max_connections = 99
        password_encryption = scram-sha-256

        ssl = on
        ssl_ca_file = '/run/secrets/stackrox.io/certs/root.crt'
        ssl_cert_file = '/run/secrets/stackrox.io/certs/server.crt'
        ssl_key_file = '/run/secrets/stackrox.io/certs/server.key'

        shared_buffers = 2GB
        work_mem = 40MB
        maintenance_work_mem = 512MB
        effective_cache_size = 4GB
        hash_mem_multiplier = 2.0

        dynamic_shared_memory_type = posix
        max_wal_size = 5GB
        min_wal_size = 80MB

        log_timezone = 'Etc/UTC'
        datestyle = 'iso, mdy'
        timezone = 'Etc/UTC'
        lc_messages = 'en_US.utf8'
        lc_monetary = 'en_US.utf8'          # locale for monetary formatting
        lc_numeric = 'en_US.utf8'           # locale for number formatting
        lc_time = 'en_US.utf8'              # locale for time formatting

        default_text_search_config = 'pg_catalog.english'
        shared_preload_libraries = 'pg_stat_statements'     # StackRox customized

        # Logging. For more details, see
        # https://www.postgresql.org/docs/current/runtime-config-logging.html

        # It's convenienv for troubleshooting to log which client has connected and
        # disconnected and when.
        log_connections = 'on'
        log_disconnections = 'on'

        # Checkpoints might affect IO throughput.
        log_checkpoints = 'on'

        # Make excessive locking visible, since it could affect query latency.
        log_lock_waits = 'on'

        # It's useful for troubleshooting to log any query, that took longer than
        # 500ms. Just in case if there is any sensitive information in the query
        # parameters, do not log them, only the query itself.
        log_min_duration_statement = 500
        log_parameter_max_length = 0

        # Creating temporary files might indicate switching query plan to a worse one
        # due to lack of memory. Log any activity with temporary files larger than 1024 bytes.
        log_temp_files = 1024

        # Autovacuum has to keep up with the data growth. Log any autovacuum activity,
        # that took longer than 500ms.
        log_autovacuum_min_duration = 500
        autovacuum_max_workers = 5
        autovacuum_vacuum_scale_factor = 0.05
        autovacuum_analyze_scale_factor = 0.02
```
