### PR TITLE
ROX-21497: Re-fech image if the scan was updated

### DIFF
--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -339,6 +339,17 @@ func (l *loopImpl) reprocessImage(id string, fetchOpt imageEnricher.FetchOption,
 				logging.ImageName(image.GetName().GetFullName()), logging.Err(err))
 			return nil, false
 		}
+		// We need to fetch the image again to make sure all fields are populated.
+		// GetImage will internally call a Merge function which will use the CVEEdges table to enrich fields like
+		// FirstImageOccurrence and FirstSystemOccurrence.
+		image, exists, err = l.images.GetImage(allAccessCtx, id)
+		if err != nil {
+			log.Errorw("Error fetching image from database", logging.ImageID(id), logging.Err(err))
+			return nil, false
+		}
+		if !exists {
+			return nil, false
+		}
 	}
 	return image, true
 }

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -348,6 +348,7 @@ func (l *loopImpl) reprocessImage(id string, fetchOpt imageEnricher.FetchOption,
 			return nil, false
 		}
 		if !exists {
+			log.Errorw("The image was not found after enrichement", logging.ImageID(id), logging.Err(err))
 			return nil, false
 		}
 	}

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -342,15 +342,16 @@ func (l *loopImpl) reprocessImage(id string, fetchOpt imageEnricher.FetchOption,
 		// We need to fetch the image again to make sure all fields are populated.
 		// GetImage will internally call a Merge function which will use the CVEEdges table to enrich fields like
 		// FirstImageOccurrence and FirstSystemOccurrence.
-		image, exists, err = l.images.GetImage(allAccessCtx, id)
+		newImage, exists, err := l.images.GetImage(allAccessCtx, id)
 		if err != nil {
-			log.Errorw("Error fetching image from database", logging.ImageID(id), logging.Err(err))
+			log.Errorw("Error fetching image from database", logging.ImageName(image.GetName().GetFullName()), logging.Err(err))
 			return nil, false
 		}
 		if !exists {
-			log.Errorw("The image was not found after enrichement", logging.ImageID(id), logging.Err(err))
+			log.Errorw("The image was not found after enrichement", logging.ImageName(image.GetName().GetFullName()))
 			return nil, false
 		}
+		return newImage, true
 	}
 	return image, true
 }

--- a/central/reprocessor/reprocessor_unit_test.go
+++ b/central/reprocessor/reprocessor_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	mockImageDataStore "github.com/stackrox/rox/central/image/datastore/mocks"
 	nodeDatastoreMocks "github.com/stackrox/rox/central/node/datastore/mocks"
 	riskManagerMocks "github.com/stackrox/rox/central/risk/manager/mocks"
 	"github.com/stackrox/rox/generated/storage"
@@ -16,7 +17,9 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 )
 
 func Test_loopImpl_reprocessNode(t *testing.T) {
@@ -137,5 +140,120 @@ func TestReprocessWatchedImageDelegation(t *testing.T) {
 
 		loop := &loopImpl{imageEnricher: enricher}
 		loop.reprocessWatchedImage("example.com/repo/path:tag")
+	})
+}
+
+func TestReprocessImage(t *testing.T) {
+	newTestLoop := func(tt *testing.T) (*loopImpl, *mockImageDataStore.MockDataStore, *riskManagerMocks.MockManager) {
+		ctrl := gomock.NewController(t)
+		imageDS := mockImageDataStore.NewMockDataStore(ctrl)
+		riskManager := riskManagerMocks.NewMockManager(ctrl)
+		testLoop := &loopImpl{
+			images: imageDS,
+			risk:   riskManager,
+		}
+		return testLoop, imageDS, riskManager
+	}
+	reprocessFuncError := func(_ context.Context, _ imageEnricher.EnrichmentContext, _ *storage.Image) (imageEnricher.EnrichmentResult, error) {
+		return imageEnricher.EnrichmentResult{}, errors.New("some error")
+	}
+	reprocessFuncUpdate := func(_ context.Context, _ imageEnricher.EnrichmentContext, _ *storage.Image) (imageEnricher.EnrichmentResult, error) {
+		return imageEnricher.EnrichmentResult{ImageUpdated: true}, nil
+	}
+	reprocessFuncNoUpdate := func(_ context.Context, _ imageEnricher.EnrichmentContext, _ *storage.Image) (imageEnricher.EnrichmentResult, error) {
+		return imageEnricher.EnrichmentResult{ImageUpdated: false}, nil
+	}
+	imageID := "id"
+	t.Run("error retrieving the image", func(tt *testing.T) {
+		testLoop, imageDS, _ := newTestLoop(tt)
+		imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(nil, false, errors.New("some error"))
+		image, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, nil)
+		assert.Nil(tt, image)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("image does not exist", func(tt *testing.T) {
+		testLoop, imageDS, _ := newTestLoop(tt)
+		imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(nil, false, nil)
+		image, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, nil)
+		assert.Nil(tt, image)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("image is not pullable", func(tt *testing.T) {
+		testLoop, imageDS, _ := newTestLoop(tt)
+		imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(&storage.Image{NotPullable: true}, true, nil)
+		image, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, nil)
+		assert.Nil(tt, image)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("image is cluster local", func(tt *testing.T) {
+		testLoop, imageDS, _ := newTestLoop(tt)
+		imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(&storage.Image{IsClusterLocal: true}, true, nil)
+		image, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, nil)
+		assert.Nil(tt, image)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("reprocessingFunc error", func(tt *testing.T) {
+		testLoop, imageDS, _ := newTestLoop(tt)
+		imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(&storage.Image{}, true, nil)
+		image, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, reprocessFuncError)
+		assert.Nil(tt, image)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("reprocessingFunc update calculate risk and upsert error", func(tt *testing.T) {
+		testLoop, imageDS, riskManager := newTestLoop(tt)
+		image := &storage.Image{}
+		imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(image, true, nil)
+		riskManager.EXPECT().CalculateRiskAndUpsertImage(gomock.Eq(image)).Times(1).Return(errors.New("some error"))
+		retImage, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, reprocessFuncUpdate)
+		assert.Nil(tt, retImage)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("re-fetch error", func(tt *testing.T) {
+		testLoop, imageDS, riskManager := newTestLoop(tt)
+		image := &storage.Image{}
+		gomock.InOrder(
+			imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(image, true, nil),
+			riskManager.EXPECT().CalculateRiskAndUpsertImage(gomock.Eq(image)).Times(1).Return(nil),
+			imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(nil, false, errors.New("some error")),
+		)
+		retImage, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, reprocessFuncUpdate)
+		assert.Nil(tt, retImage)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("re-fetch not found", func(tt *testing.T) {
+		testLoop, imageDS, riskManager := newTestLoop(tt)
+		image := &storage.Image{}
+		gomock.InOrder(
+			imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(image, true, nil),
+			riskManager.EXPECT().CalculateRiskAndUpsertImage(gomock.Eq(image)).Times(1).Return(nil),
+			imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(nil, false, nil),
+		)
+		retImage, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, reprocessFuncUpdate)
+		assert.Nil(tt, retImage)
+		assert.False(tt, reprocessed)
+	})
+	t.Run("re-fetch image", func(tt *testing.T) {
+		testLoop, imageDS, riskManager := newTestLoop(tt)
+		initialImage := &storage.Image{}
+		secondImage := &storage.Image{Scan: &storage.ImageScan{}}
+		gomock.InOrder(
+			imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(initialImage, true, nil),
+			riskManager.EXPECT().CalculateRiskAndUpsertImage(gomock.Eq(initialImage)).Times(1).Return(nil),
+			imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(secondImage, true, nil),
+		)
+		retImage, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, reprocessFuncUpdate)
+		assert.NotNil(tt, retImage)
+		assert.False(tt, proto.Equal(initialImage, retImage))
+		assert.True(tt, proto.Equal(secondImage, retImage))
+		assert.True(tt, reprocessed)
+	})
+	t.Run("reprocessingFunc no scan update", func(tt *testing.T) {
+		testLoop, imageDS, _ := newTestLoop(tt)
+		image := &storage.Image{}
+		imageDS.EXPECT().GetImage(gomock.Any(), gomock.Eq(imageID)).Times(1).Return(image, true, nil)
+		retImage, reprocessed := testLoop.reprocessImage(imageID, imageEnricher.UseCachesIfPossible, reprocessFuncNoUpdate)
+		assert.NotNil(tt, retImage)
+		assert.True(tt, proto.Equal(image, retImage))
+		assert.True(tt, reprocessed)
 	})
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

We need to fetch the image again to make sure all fields are populated. `GetImage` will internally call a `Merge` function which will use the CVEEdges table to enrich fields like `FirstImageOccurrence` and `FirstSystemOccurrence`.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit test
- [x] Manual test
  - Deploy ACS
  - Deploy a nginx
  - Create a System Policy with the `Days since CVE was first discovered in image` criteria set to `0`
  - ☝️ This should generate violations for the nginx deployment
  - To speed up the test set `ROX_REPROCESSING_INTERVAL` to 10 minutes in central
  - Observe the violations do not get resolved after the reprocessor is triggered
