### PR TITLE
ROX-27626: DeploymentTest CI Flakes

### DIFF
--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -94,8 +94,7 @@ class CSVTest extends BaseSpecification {
         ImageService.scanImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
         orchestrator.createDeployment(CVE_DEPLOYMENT)
         assert Services.waitForDeployment(CVE_DEPLOYMENT)
-        // wait for all image CVEs to be discovered and added to db
-        sleep(5000)
+        assert Services.waitForVulnerabilitiesForImage(CVE_DEPLOYMENT)
     }
 
     def cleanupSpec() {

--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -46,6 +46,7 @@ class DeploymentTest extends BaseSpecification {
     def setupSpec() {
         orchestrator.createDeployment(DEPLOYMENT)
         ImageService.scanImage(DEPLOYMENT_IMAGE_NAME)
+        assert Services.waitForVulnerabilitiesForImage(DEPLOYMENT)
     }
 
     def cleanupSpec() {

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -535,6 +535,21 @@ class Services extends BaseService {
         return false
     }
 
+    static waitForVulnerabilitiesForImage(objects.Deployment deployment, int retries = 30, int interval = 2) {
+        def imageName = deployment.image.contains(":") ? deployment.image : deployment.image + ":latest"
+        Timer t = new Timer(retries, interval)
+        while (t.IsValid()) {
+            def found = ImageService.getImages().find{ it.name.endsWith(imageName) }
+            if (found.hasCves() || found.hasFixableCves()) {
+                LOG.info "SR found vulnerabilities for the image ${imageName} within ${t.SecondsSince()}s"
+                return true
+            }
+            LOG.info "SR has not found vulnerabilities for the image ${imageName} yet"
+        }
+        LOG.info "SR did not detect vulnerabilities for the image ${imageName} in ${t.SecondsSince()} seconds"
+        return false
+    }
+
     static cleanupNetworkPolicies(List<NetworkPolicy> policies) {
         policies.each {
             if (it.uid) {

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -539,7 +539,7 @@ class Services extends BaseService {
         def imageName = deployment.image.contains(":") ? deployment.image : deployment.image + ":latest"
         Timer t = new Timer(retries, interval)
         while (t.IsValid()) {
-            def found = ImageService.getImages().find{ it.name.endsWith(imageName) }
+            def found = ImageService.getImages().find { it.name.endsWith(imageName) }
             if (found.hasCves() || found.hasFixableCves()) {
                 LOG.info "SR found vulnerabilities for the image ${imageName} within ${t.SecondsSince()}s"
                 return true

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -538,20 +538,13 @@ class Services extends BaseService {
     static waitForVulnerabilitiesForImage(objects.Deployment deployment, int retries = 30, int interval = 2) {
         def imageName = deployment.image.contains(":") ? deployment.image : deployment.image + ":latest"
         Timer t = new Timer(retries, interval)
-        int i = 1
         while (t.IsValid()) {
-            try {
-                def found = ImageService.getImages().find { it.name.endsWith(imageName) }
-                if (found.hasCves() || found.hasFixableCves()) {
-                    LOG.info "SR found vulnerabilities for the image ${imageName} within ${t.SecondsSince()}s"
-                    return true
-                }
-                LOG.info "SR has not found vulnerabilities for the image ${imageName} yet"
-            } catch (Exception e) {
-                LOG.debug("Caught exception while waiting for vulnerabilities to populate for the image ${imageName}. Retrying in ${interval}s (attempt ${i} of ${retries}): " + e)
-            } finally {
-                i++
+            def found = ImageService.getImages().find { it.name.endsWith(imageName) }
+            if (found.hasCves() || found.hasFixableCves()) {
+                LOG.info "SR found vulnerabilities for the image ${imageName} within ${t.SecondsSince()}s"
+                return true
             }
+            LOG.info "SR has not found vulnerabilities for the image ${imageName} yet"
         }
         LOG.info "SR did not detect vulnerabilities for the image ${imageName} in ${t.SecondsSince()} seconds"
         return false


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This will (hopefully) fix some CI flakes that occur with the Groovy `DeploymentTest`. The issue may have been caused by the fact that the test does not wait for scanner to actually complete the scan of the image, just that scanner was able to successfully initiate a scan, this should hopefully rectify that by making it wait for vulnerabilities to be found before it proceeds out of the test setup.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Re-ran the groovy tests a few times, `DeploymentTest` seems to be passing, though it wasn't a common CI failure before. At the very least, this change doesn't seem to have made the flakes any worse or created any new ones.