### PR TITLE
ROX-19276: set adhoc roxctl scan semaphore

### DIFF
--- a/pkg/env/max_parallel_scans.go
+++ b/pkg/env/max_parallel_scans.go
@@ -5,9 +5,7 @@ var (
 	// and GetImageVulnerabilitiesInternal endpoints and separately sets the max active local scans in a secured cluster
 	MaxParallelImageScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_IMAGE_SCAN_INTERNAL", 30)
 
-	// MaxParallelDelegatedScanInternal defines the maximum number of parallel delegated scans initiated from Central.
-	// Since it consumes a portion of the total maximum parallel scans, it must be set lower than the collective limit
-	// for ScanImageInternal, EnrichLocalImageInternal, and GetImageVulnerabilitiesInternal endpoints.
-	// It separately configures the maximum number of active local scans within a secured cluster.
-	MaxParallelDelegatedScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_DELEGATED_SCAN_INTERNAL", 5)
+	// MaxParallelAdHocScanInternal defines the maximum number of parallel ad-hoc roxctl delegated scans initiated from Central.
+	// It must be set lower than the collective limit for ScanImageInternal, EnrichLocalImageInternal, and GetImageVulnerabilitiesInternal endpoints.
+	MaxParallelAdHocScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_ADHOC_SCAN_INTERNAL", 5)
 )

--- a/pkg/env/max_parallel_scans.go
+++ b/pkg/env/max_parallel_scans.go
@@ -4,4 +4,10 @@ var (
 	// MaxParallelImageScanInternal sets the max number of parallel scans collectively on the ScanImageInternal, EnrichLocalImageInternal,
 	// and GetImageVulnerabilitiesInternal endpoints and separately sets the max active local scans in a secured cluster
 	MaxParallelImageScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_IMAGE_SCAN_INTERNAL", 30)
+
+	// MaxParallelDelegatedScanInternal defines the maximum number of parallel delegated scans initiated from Central.
+	// Since it consumes a portion of the total maximum parallel scans, it must be set lower than the collective limit
+	// for ScanImageInternal, EnrichLocalImageInternal, and GetImageVulnerabilitiesInternal endpoints.
+	// It separately configures the maximum number of active local scans within a secured cluster.
+	MaxParallelDelegatedScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_DELEGATED_SCAN_INTERNAL", 5)
 )

--- a/pkg/env/max_parallel_scans.go
+++ b/pkg/env/max_parallel_scans.go
@@ -6,6 +6,8 @@ var (
 	MaxParallelImageScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_IMAGE_SCAN_INTERNAL", 30)
 
 	// MaxParallelAdHocScan defines the maximum number of parallel ad-hoc roxctl delegated scans initiated from Central.
-	// It must be set lower than the collective limit for ScanImageInternal, EnrichLocalImageInternal, and GetImageVulnerabilitiesInternal endpoints.
+	// The value is subtracted from MaxParallelImageScanInternal and must be less than MaxParallelImageScanInternal.
+	// This ensures that ad-hoc requests can always be handled.
+	// If this value exceeds MaxParallelImageScanInternal, MaxParallelImageScanInternal will be set to 10 higher than this value to prevent scan failures.
 	MaxParallelAdHocScan = RegisterIntegerSetting("ROX_MAX_PARALLEL_ADHOC_SCAN_INTERNAL", 5)
 )

--- a/pkg/env/max_parallel_scans.go
+++ b/pkg/env/max_parallel_scans.go
@@ -9,5 +9,5 @@ var (
 	// The value is subtracted from MaxParallelImageScanInternal and must be less than MaxParallelImageScanInternal.
 	// This ensures that ad-hoc requests can always be handled.
 	// If this value exceeds MaxParallelImageScanInternal, MaxParallelImageScanInternal will be set to 10 higher than this value to prevent scan failures.
-	MaxParallelAdHocScan = RegisterIntegerSetting("ROX_MAX_PARALLEL_ADHOC_SCAN_INTERNAL", 5)
+	MaxParallelAdHocScan = RegisterIntegerSetting("ROX_MAX_PARALLEL_AD_HOC_SCAN_INTERNAL", 5)
 )

--- a/pkg/env/max_parallel_scans.go
+++ b/pkg/env/max_parallel_scans.go
@@ -5,7 +5,7 @@ var (
 	// and GetImageVulnerabilitiesInternal endpoints and separately sets the max active local scans in a secured cluster
 	MaxParallelImageScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_IMAGE_SCAN_INTERNAL", 30)
 
-	// MaxParallelAdHocScanInternal defines the maximum number of parallel ad-hoc roxctl delegated scans initiated from Central.
+	// MaxParallelAdHocScan defines the maximum number of parallel ad-hoc roxctl delegated scans initiated from Central.
 	// It must be set lower than the collective limit for ScanImageInternal, EnrichLocalImageInternal, and GetImageVulnerabilitiesInternal endpoints.
-	MaxParallelAdHocScanInternal = RegisterIntegerSetting("ROX_MAX_PARALLEL_ADHOC_SCAN_INTERNAL", 5)
+	MaxParallelAdHocScan = RegisterIntegerSetting("ROX_MAX_PARALLEL_ADHOC_SCAN_INTERNAL", 5)
 )

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -139,8 +139,7 @@ func (s *LocalScan) EnrichLocalImageInNamespace(ctx context.Context, centralClie
 
 	// Throttle the # of active scans.
 	scanLimitSemaphore := s.scanSemaphore
-
-	// ad-hoc requests
+	// Ad hoc requests have a request ID.
 	if req.ID != "" {
 		scanLimitSemaphore = s.adHocScanSemaphore
 	}

--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -139,13 +139,15 @@ func (s *LocalScan) EnrichLocalImageInNamespace(ctx context.Context, centralClie
 	if s.scannerClientSingleton() == nil {
 		return nil, errors.Join(ErrNoLocalScanner, ErrEnrichNotStarted)
 	}
+
+	// Throttle the # of active scans.
 	scanLimitSemaphore := s.scanSemaphore
 
 	// Delegated requests
 	if req.ID != "" && !env.DelegatedScanningDisabled.BooleanSetting() {
 		scanLimitSemaphore = s.adHocScanSemaphore
 	}
-	// Throttle the # of active scans.
+
 	semaphoreCtx, cancel := context.WithTimeout(ctx, s.maxSemaphoreWaitTime)
 	defer cancel()
 	if err := scanLimitSemaphore.Acquire(semaphoreCtx, 1); err != nil {

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -373,7 +373,7 @@ func (suite *scanTestSuite) TestAdHocScanThrottle() {
 	}
 
 	img := &storage.ContainerImage{Name: &storage.ImageName{Registry: "fake"}}
-	req := genScanReq(img, "", "some-id", false) // "makes it an ad-hoc delegated request
+	req := genScanReq(img, "", "some-id", false) // "setting up request ID to make it an ad-hoc delegated request
 
 	_, err := ls.EnrichLocalImageInNamespace(context.Background(), nil, req)
 	suite.Require().ErrorIs(err, ErrTooManyParallelScans)

--- a/sensor/common/scan/scan_test.go
+++ b/sensor/common/scan/scan_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/fs"
 	"testing"
+	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -354,7 +355,7 @@ func (suite *scanTestSuite) TestEnrichThrottle() {
 	scan := LocalScan{
 		scannerClientSingleton: emptyScannerClientSingleton,
 		scanSemaphore:          semaphore.NewWeighted(0),
-		maxSemaphoreWaitTime:   defaultMaxSemaphoreWaitTime,
+		maxSemaphoreWaitTime:   1 * time.Millisecond,
 	}
 
 	img := &storage.ContainerImage{Name: &storage.ImageName{Registry: "fake"}}
@@ -363,11 +364,12 @@ func (suite *scanTestSuite) TestEnrichThrottle() {
 	suite.Require().ErrorIs(err, ErrEnrichNotStarted)
 }
 
-func (suite *scanTestSuite) TestCentralDelegatedScanThrottle() {
+func (suite *scanTestSuite) TestAdHocScanThrottle() {
 	ls := LocalScan{
 		scannerClientSingleton: emptyScannerClientSingleton,
 		scanSemaphore:          semaphore.NewWeighted(5),
 		adHocScanSemaphore:     semaphore.NewWeighted(0),
+		maxSemaphoreWaitTime:   1 * time.Millisecond,
 	}
 
 	img := &storage.ContainerImage{Name: &storage.ImageName{Registry: "fake"}}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Currently, delegated scans share a rate limiter/semaphore with sensor reprocessing and sensor-observed workloads. This can lead to issues when running scans (e.g., via CI/CD) if the sensor is simultaneously reprocessing or has been restarted.
To mitigate this, we are considering modifying the Sensor to allow a separate pool for ad-hoc roxctl requests by creating a distinct semaphore. This would ensure that a certain number of these requests can be processed independently, reducing contention with sensor reprocessing.


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

1. Create a new OCP cluster
2. Deploy ACS with deploy script
3. `kubectl set env -n=stackrox deploy/sensor ROX_LOCAL_IMAGE_SCANNING_ENABLED=true`
4. remove and restart sensor pod `kubectl delete pod -lapp=sensor -n stackrox`
5. `./roxctl image scan --force --insecure-skip-tls-verify --endpoint <endpoint> --image=<image> --cluster=<cluster>`
6. No `too many parallel scans` errors
