### PR TITLE
chore(ui): Reduce effort to add search filter config in ui

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/searchFilterConfig.ts
@@ -2,16 +2,14 @@ import { clusterAttributes } from 'Components/CompoundSearchFilter/attributes/cl
 import { profileCheckAttributes } from 'Components/CompoundSearchFilter/attributes/profileCheck';
 import { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
 
-const profileCheckSearchFilterConfig: CompoundSearchFilterEntity = {
+export const profileCheckSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Profile check',
     searchCategory: 'COMPLIANCE',
     attributes: profileCheckAttributes,
 };
 
-const clusterSearchFilterConfig: CompoundSearchFilterEntity = {
+export const clusterSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Cluster',
     searchCategory: 'CLUSTERS',
     attributes: clusterAttributes,
 };
-
-export { profileCheckSearchFilterConfig, clusterSearchFilterConfig };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -10,75 +10,62 @@ import { nodeCVEAttributes } from 'Components/CompoundSearchFilter/attributes/no
 import { nodeComponentAttributes } from 'Components/CompoundSearchFilter/attributes/nodeComponent';
 import { platformCVEAttributes } from 'Components/CompoundSearchFilter/attributes/platformCVE';
 
-const nodeSearchFilterConfig: CompoundSearchFilterEntity = {
+export const nodeSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Node',
     searchCategory: 'NODES',
     attributes: nodeAttributes,
 };
 
-const nodeCVESearchFilterConfig: CompoundSearchFilterEntity = {
+export const nodeCVESearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'CVE',
     searchCategory: 'NODE_VULNERABILITIES',
     attributes: nodeCVEAttributes,
 };
 
-const nodeComponentSearchFilterConfig: CompoundSearchFilterEntity = {
+export const nodeComponentSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Node component',
     searchCategory: 'NODE_COMPONENTS',
     attributes: nodeComponentAttributes,
 };
 
-const imageSearchFilterConfig: CompoundSearchFilterEntity = {
+export const imageSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Image',
     searchCategory: 'IMAGES',
     attributes: imageAttributes,
 };
 
-const imageCVESearchFilterConfig: CompoundSearchFilterEntity = {
+export const imageCVESearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'CVE',
     searchCategory: 'IMAGE_VULNERABILITIES',
     attributes: imageCVEAttributes,
 };
 
-const imageComponentSearchFilterConfig: CompoundSearchFilterEntity = {
+export const imageComponentSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Image component',
     searchCategory: 'IMAGE_COMPONENTS',
     attributes: imageComponentAttributes,
 };
 
-const deploymentSearchFilterConfig: CompoundSearchFilterEntity = {
+export const deploymentSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Deployment',
     searchCategory: 'DEPLOYMENTS',
     attributes: deploymentAttributes,
 };
 
-const namespaceSearchFilterConfig: CompoundSearchFilterEntity = {
+export const namespaceSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Namespace',
     searchCategory: 'NAMESPACES',
     attributes: namespaceAttributes,
 };
 
-const clusterSearchFilterConfig: CompoundSearchFilterEntity = {
+export const clusterSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Cluster',
     searchCategory: 'CLUSTERS',
     attributes: clusterAttributes,
 };
 
-const platformCVESearchFilterConfig: CompoundSearchFilterEntity = {
+export const platformCVESearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'CVE',
     searchCategory: 'CLUSTER_VULNERABILITIES',
     attributes: platformCVEAttributes,
-};
-
-export {
-    nodeSearchFilterConfig,
-    nodeCVESearchFilterConfig,
-    nodeComponentSearchFilterConfig,
-    imageSearchFilterConfig,
-    imageCVESearchFilterConfig,
-    imageComponentSearchFilterConfig,
-    deploymentSearchFilterConfig,
-    namespaceSearchFilterConfig,
-    clusterSearchFilterConfig,
-    platformCVESearchFilterConfig,
 };


### PR DESCRIPTION
### Description

Found during planning for potential future `Advisory ID` search filter config.

#### Problem

Two changes to add another search filter config:
1. Add module-scope assignment.
2. And then corresponding variable in `export { … };` statement.

#### Analysis

All references are one or more via `import { … }` statement, never all of them.

#### Solution

One change to add another search filter config: 
1. Add `export const whateverElseSearchConfig` assignment statement.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4646307 - 4646307
        total 0 = 11566078 - 11566078 so neutral after webpack
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/compliance/coverage/profiles and then test search filter.

2. Visit /main/vulnerabilities/user-workloads and then test search filter.