### PR TITLE
ROX-28141: fix race with scanner integration registration

### DIFF
--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -6,6 +6,7 @@ import util.Cert
 import spock.lang.Tag
 import spock.lang.IgnoreIf
 import util.Env
+import util.Helpers
 
 @Tag("BAT")
 @Tag("COMPATIBILITY")
@@ -33,7 +34,10 @@ class CertExpiryTest extends BaseSpecification {
         assert shellCmdExitValue("./scripts/ci/is-scanner-v2-available.sh stackrox") == 0
         def scannerTLSSecret = orchestrator.getSecret("scanner-tls", "stackrox")
         assert scannerTLSSecret
-        def scannerCertExpiryFromCentral = new Date(CredentialExpiryService.getScannerCertExpiry().getSeconds() * 1000)
+        // Retry since scanner integration registration happens asynchronously.
+        def scannerCertExpiryFromCentral = Helpers.evaluateWithRetry(5, 5) {
+            return new Date(CredentialExpiryService.getScannerCertExpiry().getSeconds() * 1000)
+        }
         assert scannerCertExpiryFromCentral
 
         then:


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Scanner integration registration can take another while after scanner pod is up and healthy.
Retry 5x with 5 second delay.
Details in the ticket.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] checked gke-version-compatibility-tests log