### PR TITLE
ROX-27727: Use dedicated priority class for collector pods

### DIFF
--- a/deploy/common/env.sh
+++ b/deploy/common/env.sh
@@ -115,3 +115,5 @@ elif [[ -n "$ROX_DEFAULT_TLS_KEY_FILE" ]]; then
 else
 	echo "No default TLS certificates provided"
 fi
+
+export DEDICATED_COLLECTOR_PRIORITY_CLASS="${DEDICATED_COLLECTOR_PRIORITY_CLASS:-true}"

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -603,17 +603,16 @@ function launch_central {
 function ensure_collector_priority_class {
     local priority_class_name="$1"
     ${ORCH_CMD} get priorityclass -o=name "$priority_class_name" >/dev/null 2>&1 && return 0
-    ${ORCH_CMD} apply -f <(cat <<EOT | sed -e "s|\$PRIORITY_CLASS_NAME|$priority_class_name|g;"
+    ${ORCH_CMD} apply -f - <<EOT
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: \$PRIORITY_CLASS_NAME
+  name: ${priority_class_name}
 value: 1000000
 preemptionPolicy: PreemptLowerPriority
 globalDefault: false
 description: "This priority class shall be used for collector pods, which must be able to preempt other pods to fit exactly one collector on each node."
 EOT
-)
 }
 
 function launch_sensor {

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -625,7 +625,7 @@ function launch_sensor {
     local extra_json_config=''
     local extra_helm_config=()
 
-    local collector_priority_class_name="stackrox-collector"
+    local collector_priority_class_name="stackrox-collector-dev"
 
     verify_orch
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -600,6 +600,22 @@ function launch_central {
     echo "Access the UI at: https://${API_ENDPOINT}"
 }
 
+function ensure_collector_priority_class {
+    local priority_class_name="$1"
+    ${ORCH_CMD} get priorityclass -o=name "$priority_class_name" >/dev/null 2>&1 && return 0
+    ${ORCH_CMD} apply -f <(cat <<EOT | sed -e "s|\$PRIORITY_CLASS_NAME|$priority_class_name|g;"
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: \$PRIORITY_CLASS_NAME
+value: 1000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "This priority class shall be used for collector pods, which must be able to preempt other pods to fit exactly one collector on each node."
+EOT
+)
+}
+
 function launch_sensor {
     local k8s_dir="$1"
     local sensor_namespace=${SENSOR_NAMESPACE:-stackrox}
@@ -609,6 +625,8 @@ function launch_sensor {
     local scanner_extra_config=()
     local extra_json_config=''
     local extra_helm_config=()
+
+    local collector_priority_class_name="stackrox-collector"
 
     verify_orch
 
@@ -830,6 +848,11 @@ function launch_sensor {
       if [[ "${FORCE_COLLECTION_METHOD:-false}" == "true" ]]; then
         echo "Forcing collection method"
         extra_helm_config+=(--set "collector.forceCollectionMethod=true")
+      fi
+
+      if [[ "${DEDICATED_COLLECTOR_PRIORITY_CLASS:-}" == "true" ]]; then
+        ensure_collector_priority_class "$collector_priority_class_name"
+        extra_helm_config+=(--set "collector.priorityClassName=$collector_priority_class_name")
       fi
 
       if [[ -n "$CI" ]]; then


### PR DESCRIPTION
### Description

Use dedicated priority class for collector pods.

### The problem as observed in CI

We have two worker nodes -- A & B -- and most StackRox workloads have been -- for some reason -- scheduled on node A. Later in the deployment flow, when the collector DaemonSet was about to be deployed, there were no resources left for deploying a collector pod on node A. Hence the deployment and consequently the scanner V4 install test suite failed.

### Solution

Use pod priority classes and configure the collector pods to be of higher priority class allowing preemption of lower-prio class pods to free up resources on full nodes.

I have enabled using prio classes by default in our deployment scripts.  But it can be disabled explicitly.




