### PR TITLE
feat(operator): handle istio API disappearance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -534,11 +534,18 @@ require (
 replace github.com/nxadm/tail => github.com/stackrox/tail v1.4.9-0.20240806130957-77cf33bea65f
 
 // @stackrox/install
-// github.com/stackrox/helm-operator is a modified fork of github.com/operator-framework/helm-operator-plugins that
-// we currently depend on.
-// It includes a number of features and bug fixes which we faced in StackRox. We use this fork
-// primarily to iterate faster. See https://issues.redhat.com/browse/ROX-7911
-replace github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20250211113659-1b2840226a8b
+replace (
+	// Enhanced to support removal of arbitrary resources.
+	// This change is already merged upstream and released in https://github.com/helm/helm-mapkubeapis/releases/tag/v0.6.1
+	// but this version requires go 1.24.
+	// TODO(ROX-29652): Bump the dependency above to v0.6.1 or later and remove this "replace" once we're on Go 1.24 or later.
+	github.com/helm/helm-mapkubeapis => github.com/porridge/helm-mapkubeapis v0.0.0-20250220113302-2f740596cb45
+	// github.com/stackrox/helm-operator is a modified fork of github.com/operator-framework/helm-operator-plugins that
+	// we currently depend on.
+	// It includes a number of features and bug fixes which we faced in StackRox. We use this fork
+	// primarily to iterate faster. See https://issues.redhat.com/browse/ROX-7911
+	github.com/operator-framework/helm-operator-plugins => github.com/stackrox/helm-operator v0.0.12-0.20250211113659-1b2840226a8b
+)
 
 // @stackrox/sensor-ecosystem
 replace (

--- a/go.sum
+++ b/go.sum
@@ -904,8 +904,6 @@ github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5L
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
 github.com/heimdalr/dag v1.5.0 h1:hqVtijvY776P5OKP3QbdVBRt3Xxq6BYopz3XgklsGvo=
 github.com/heimdalr/dag v1.5.0/go.mod h1:lthekrHl01dddmzqyBQ1YZbi7XcVGGzjFo0jIky5knc=
-github.com/helm/helm-mapkubeapis v0.5.2 h1:pxiy9J5CtIAH2KCBaJEvgHxeoPhgTwzF2AXa92hPUzs=
-github.com/helm/helm-mapkubeapis v0.5.2/go.mod h1:6bgWDRUOAiVk0zw8s5IqM6TIDN2knjxvYImdfqdGwLE=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -1270,6 +1268,8 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240409071808-615f978279ca/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/porridge/helm-mapkubeapis v0.0.0-20250220113302-2f740596cb45 h1:NBxeCQB+gxRMShJjjlTZ4iTN25ZGom3ganG/VceDbg8=
+github.com/porridge/helm-mapkubeapis v0.0.0-20250220113302-2f740596cb45/go.mod h1:6bgWDRUOAiVk0zw8s5IqM6TIDN2knjxvYImdfqdGwLE=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=

--- a/operator/internal/central/reconciler/reconciler.go
+++ b/operator/internal/central/reconciler/reconciler.go
@@ -57,7 +57,8 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 	if err != nil {
 		return err
 	}
-	opts = commonExtensions.AddMapKubeAPIsExtensionIfMapFileExists(opts)
+
+	opts = commonExtensions.AddMapKubeAPIsExtensionIfMapFileExists(opts, mgr.GetRESTMapper())
 
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.CentralGVK, image.CentralServicesChartPrefix,

--- a/operator/internal/common/extensions/mapkubeapis.go
+++ b/operator/internal/common/extensions/mapkubeapis.go
@@ -2,21 +2,26 @@ package extensions
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/go-logr/logr"
 	mapkubeapisCommon "github.com/helm/helm-mapkubeapis/pkg/common"
+	"github.com/helm/helm-mapkubeapis/pkg/mapping"
 	mapkubeapisV3 "github.com/helm/helm-mapkubeapis/pkg/v3"
 	"github.com/operator-framework/helm-operator-plugins/pkg/extensions"
 	pkgReconciler "github.com/operator-framework/helm-operator-plugins/pkg/reconciler"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/operator/internal/config/mapkubeapis"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // AddMapKubeAPIsExtensionIfMapFileExists conditionally adds the extension to opts if the map file exists
-func AddMapKubeAPIsExtensionIfMapFileExists(opts []pkgReconciler.Option) []pkgReconciler.Option {
+func AddMapKubeAPIsExtensionIfMapFileExists(opts []pkgReconciler.Option, mapper meta.RESTMapper) []pkgReconciler.Option {
 	mapFile := mapkubeapis.GetMapFilePath()
 	if mapFile == "" {
 		ctrl.Log.Info("mapkubeapis map file does not exist, the extension will NOT be added")
@@ -25,7 +30,15 @@ func AddMapKubeAPIsExtensionIfMapFileExists(opts []pkgReconciler.Option) []pkgRe
 	ctrl.Log.Info("mapkubeapis extension enabled", "mapFile", mapFile)
 
 	config := MapKubeAPIsExtensionConfig{
-		MapFile: mapFile,
+		MapFile:    mapFile,
+		RESTMapper: mapper,
+		DubiousAPIs: []schema.GroupVersionKind{
+			{
+				Group:   "networking.istio.io",
+				Version: "v1alpha3",
+				Kind:    "DestinationRule",
+			},
+		},
 	}
 	extension := MapKubeAPIsExtension(config)
 	return append(opts, pkgReconciler.WithPreExtension(extension))
@@ -35,11 +48,23 @@ func AddMapKubeAPIsExtensionIfMapFileExists(opts []pkgReconciler.Option) []pkgRe
 type MapKubeAPIsExtensionConfig struct {
 	KubeConfig mapkubeapisCommon.KubeConfig
 	MapFile    string
+	// List of APIs which - if missing on the cluster - should be removed from release before processing,
+	// to prevent helm upgrade errors such as:
+	//   unable to build kubernetes objects from current release manifest: [resource mapping not found for name:
+	//   "scanner-internal-no-istio -mtls" namespace: "stackrox" from "": no matches for kind "DestinationRule"
+	//   in version "networking.istio.io/v1alpha3" ensure CRDs are installed first,
+	DubiousAPIs []schema.GroupVersionKind
+	RESTMapper  meta.RESTMapper
 }
 
 // MapKubeAPIsExtension checks the latest release version for any deprecated or removed APIs and performs
 // the cleanup using helm mapkubeapis extension
 func MapKubeAPIsExtension(config MapKubeAPIsExtensionConfig) extensions.ReconcileExtension {
+	for _, api := range config.DubiousAPIs {
+		if api.Group == "" || api.Version == "" || api.Kind == "" {
+			log.Fatalf("dubious api %s group/version/kind is missing", api)
+		}
+	}
 	return func(ctx context.Context, obj *unstructured.Unstructured, statusUpdater func(statusFunc extensions.UpdateStatusFunc), log logr.Logger) error {
 		run := &mapKubeAPIsExtensionRun{
 			ctx:           ctx,
@@ -68,7 +93,18 @@ func (r *mapKubeAPIsExtensionRun) Execute() error {
 		KubeConfig:       r.config.KubeConfig,
 	}
 
-	if err := mapkubeapisV3.MapReleaseWithUnSupportedAPIs(mapOptions); err != nil {
+	var extra []*mapping.Mapping
+	for _, dubiousGVK := range r.config.DubiousAPIs {
+		if _, err := r.config.RESTMapper.RESTMapping(dubiousGVK.GroupKind(), dubiousGVK.Version); meta.IsNoMatchError(err) {
+			r.log.Info("API not present, marking for removal from release.", "GVK", dubiousGVK, "error", err)
+			extra = append(extra, &mapping.Mapping{
+				DeprecatedAPI:    fmt.Sprintf("apiVersion: %s/%s\nkind: %s\n", dubiousGVK.Group, dubiousGVK.Version, dubiousGVK.Kind),
+				RemovedInVersion: "v0.0.0",
+			})
+		}
+	}
+
+	if err := mapkubeapisV3.MapReleaseWithUnSupportedAPIs(mapOptions, extra...); err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			r.log.V(1).Info("release not found, most likely it is not installed yet", "namespace", r.obj.GetNamespace(), "name", r.obj.GetName())
 		} else {

--- a/operator/internal/common/extensions/mapkubeapis.go
+++ b/operator/internal/common/extensions/mapkubeapis.go
@@ -62,7 +62,7 @@ type MapKubeAPIsExtensionConfig struct {
 func MapKubeAPIsExtension(config MapKubeAPIsExtensionConfig) extensions.ReconcileExtension {
 	for _, api := range config.DubiousAPIs {
 		if api.Group == "" || api.Version == "" || api.Kind == "" {
-			log.Fatalf("dubious api %s group/version/kind is missing", api)
+			log.Fatalf("MapKubeAPIsExtensionConfig dubious api %s group/version/kind is missing", api)
 		}
 	}
 	return func(ctx context.Context, obj *unstructured.Unstructured, statusUpdater func(statusFunc extensions.UpdateStatusFunc), log logr.Logger) error {
@@ -86,6 +86,7 @@ type mapKubeAPIsExtensionRun struct {
 }
 
 func (r *mapKubeAPIsExtensionRun) Execute() error {
+	const allK8sVersions = "v0.0.0"
 	mapOptions := mapkubeapisCommon.MapOptions{
 		ReleaseName:      r.obj.GetName(),
 		ReleaseNamespace: r.obj.GetNamespace(),
@@ -99,7 +100,7 @@ func (r *mapKubeAPIsExtensionRun) Execute() error {
 			r.log.Info("API not present, marking for removal from release.", "GVK", dubiousGVK, "error", err)
 			extra = append(extra, &mapping.Mapping{
 				DeprecatedAPI:    fmt.Sprintf("apiVersion: %s/%s\nkind: %s\n", dubiousGVK.Group, dubiousGVK.Version, dubiousGVK.Kind),
-				RemovedInVersion: "v0.0.0",
+				RemovedInVersion: allK8sVersions,
 			})
 		}
 	}

--- a/operator/internal/securedcluster/reconciler/reconciler.go
+++ b/operator/internal/securedcluster/reconciler/reconciler.go
@@ -49,7 +49,8 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 	if err != nil {
 		return err
 	}
-	opts = commonExtensions.AddMapKubeAPIsExtensionIfMapFileExists(opts)
+
+	opts = commonExtensions.AddMapKubeAPIsExtensionIfMapFileExists(opts, mgr.GetRESTMapper())
 
 	// Using uncached UncachedClient since this is reading secrets not
 	// owned by the operator so we can't guarantee labels for cache


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Fixes https://issues.redhat.com/browse/ROX-19315 i.e. operator getting stuck if an API disappears from under a stackrox installation.

This is a PoC which uses a [slightly hacked](https://github.com/porridge/helm-mapkubeapis/pull/1) mapkubeapis plugin. This change is already merged upstream and released in https://github.com/helm/helm-mapkubeapis/releases/tag/v0.6.1 but this version requires go 1.24. Dropping the fork is tracked separately.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no test changes, see manual testing below

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

1. Applied an [istio CRD](https://github.com/istio/istio/blob/release-1.16/manifests/charts/base/crds/crd-all.gen.yaml).
2. ran the operator from `master`
3. removed the CRD
4. triggered another reconcile, operator got stuck
5. stopped it and ran it from this branch:

```
2025-02-20T12:39:47+01:00	INFO	controllers.SecuredCluster	API not present, marking for removal from release.	{"GVK": "networking.istio.io/v1alpha3, Kind=DestinationRule", "error": "no matches for kind \"DestinationRule\" in version \"networking.istio.io/v1alpha3\""}
2025-02-20T12:39:47+01:00	DEBUG	Get release 'stackrox-secured-cluster-services' latest version.
2025-02-20T12:39:47+01:00	DEBUG	Check release 'stackrox-secured-cluster-services' for deprecated or removed APIs...
2025-02-20T12:39:47+01:00	DEBUG	Found 1 instances of deprecated or removed Kubernetes API:
"apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
"
No supported API equivalent
2025-02-20T12:39:47+01:00	DEBUG	Finished checking release 'stackrox-secured-cluster-services' for deprecated or removed APIs.
2025-02-20T12:39:47+01:00	DEBUG	Deprecated or removed APIs exist, updating release: stackrox-secured-cluster-services.
2025-02-20T12:39:47+01:00	DEBUG	Set status of release version 'stackrox-secured-cluster-services.v1' to 'superseded'.
2025-02-20T12:39:47+01:00	DEBUG	Release version 'stackrox-secured-cluster-services.v1' updated successfully.
2025-02-20T12:39:47+01:00	DEBUG	Add release version 'stackrox-secured-cluster-services.v2' with updated supported APIs.
2025-02-20T12:39:47+01:00	INFO	controller-runtime.metrics	Serving metrics server	{"bindAddress": "0.0.0.0:8443", "secure": true}
2025-02-20T12:39:47+01:00	DEBUG	Release version 'stackrox-secured-cluster-services.v2' added successfully.
2025-02-20T12:39:47+01:00	DEBUG	Release 'stackrox-secured-cluster-services' with deprecated or removed APIs updated successfully to new version.
```
