### PR TITLE
ROX-28196: CVE data model search framework updates

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -289,7 +290,7 @@ func (q *query) AsSQL() string {
 		querySB.WriteString(join.rightTable)
 		querySB.WriteString(" on")
 
-		if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+		if env.ImageCVEEdgeCustomJoin.BooleanSetting() && !features.FlattenCVEData.Enabled() {
 			if (i == len(q.Joins)-1) && (join.rightTable == pkgSchema.ImageCveEdgesTableName) {
 				// Step 4: Join image_cve_edges table such that both its ImageID and ImageCveId columns are matched with the joins so far
 				imageIDTable := findImageIDTableAndField(q.Joins)
@@ -421,7 +422,7 @@ func standardizeQueryAndPopulatePath(ctx context.Context, q *v1.Query, schema *w
 	joins, dbFields := getJoinsAndFields(schema, q)
 
 	var err error
-	if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+	if env.ImageCVEEdgeCustomJoin.BooleanSetting() && !features.FlattenCVEData.Enabled() {
 		joins, err = handleImageCveEdgesTableInJoins(schema, joins)
 		if err != nil {
 			return nil, err

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -503,9 +503,9 @@ func TestCountQueries(t *testing.T) {
 				inner join image_cve_edges on(images.Id = image_cve_edges.ImageId and image_component_cve_edges.ImageCveId = image_cve_edges.ImageCveId)
 				where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cve_edges.State = $2)`),
 			expectedData: []interface{}{"false", "0"},
-			expectedFlattenedStatement: `select count(distinct(images.Id)) from images 
+			expectedFlattenedStatement: `select count(distinct(images.Id)) from images
 				left join deployments_containers on images.Id = deployments_containers.Image_Id
-				left join deployments on deployments_containers.deployments_Id = deployments.Id " +
+				left join deployments on deployments_containers.deployments_Id = deployments.Id
 				inner join image_cves_v2 on images.Id = image_cves_v2.ImageId
 				where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cves_v2.State = $2)`,
 		},

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -503,11 +503,11 @@ func TestCountQueries(t *testing.T) {
 				inner join image_cve_edges on(images.Id = image_cve_edges.ImageId and image_component_cve_edges.ImageCveId = image_cve_edges.ImageCveId)
 				where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cve_edges.State = $2)`),
 			expectedData: []interface{}{"false", "0"},
-			expectedFlattenedStatement: "select count(distinct(images.Id)) from images " +
-				"left join deployments_containers on images.Id = deployments_containers.Image_Id " +
-				"left join deployments on deployments_containers.deployments_Id = deployments.Id " +
-				"inner join image_cves_v2 on images.Id = image_cves_v2.ImageId " +
-				"where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cves_v2.State = $2)",
+			expectedFlattenedStatement: `select count(distinct(images.Id)) from images 
+				left join deployments_containers on images.Id = deployments_containers.Image_Id
+				left join deployments on deployments_containers.deployments_Id = deployments.Id " +
+				inner join image_cves_v2 on images.Id = image_cves_v2.ImageId
+				where ((deployments.PlatformComponent = $1 or deployments.PlatformComponent is null) and image_cves_v2.State = $2)`,
 		},
 	} {
 		t.Run(c.desc, func(it *testing.T) {

--- a/pkg/search/postgres/joins.go
+++ b/pkg/search/postgres/joins.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
@@ -176,7 +177,7 @@ type searchFieldMetadata struct {
 func getJoinsAndFields(src *walker.Schema, q *v1.Query) ([]Join, map[string]searchFieldMetadata) {
 	unreachedFields, nullableFields := collectFields(q)
 
-	if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+	if env.ImageCVEEdgeCustomJoin.BooleanSetting() && !features.FlattenCVEData.Enabled() {
 		// Step 1: If ImageCveEdgesSchema is going to be a part of joins, we want to ensure that we are able to join on both
 		//  ImageId and ImageCveId fields
 		if src != schema.ImageCveEdgesSchema &&
@@ -206,7 +207,7 @@ func getJoinsAndFields(src *walker.Schema, q *v1.Query) ([]Join, map[string]sear
 		currElem := queue[0]
 		queue = queue[1:]
 
-		if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+		if env.ImageCVEEdgeCustomJoin.BooleanSetting() && !features.FlattenCVEData.Enabled() {
 			// Step 2: Avoid using ImageCveEdgesSchema unless there is no other way to get to the required fields.
 			// If ImageCveEdgesSchema is root schema, then it is unavoidable.
 			if currElem.schema == schema.ImageCveEdgesSchema && currElem.schema != src {
@@ -268,7 +269,7 @@ func getJoinsAndFields(src *walker.Schema, q *v1.Query) ([]Join, map[string]sear
 				}
 			}
 
-			if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+			if env.ImageCVEEdgeCustomJoin.BooleanSetting() && !features.FlattenCVEData.Enabled() {
 				// We want to make sure ImageCveEdgesSchema gets added only once to queue. If there are multiple copies of
 				// ImageCveEdgesSchema in the queue, then we can enter an infinite loop trying to push one copy after another
 				// to the end of queue.

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
@@ -87,7 +88,7 @@ func standardizeSelectQueryAndPopulatePath(ctx context.Context, q *v1.Query, sch
 		return nil, nil
 	}
 
-	if env.ImageCVEEdgeCustomJoin.BooleanSetting() {
+	if env.ImageCVEEdgeCustomJoin.BooleanSetting() && !features.FlattenCVEData.Enabled() {
 		joins, err = handleImageCveEdgesTableInJoins(schema, joins)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Updates to bypass the the custom image cve and component join logic when using the new data model.  That directed join logic is no longer valid with the new model and should be completely bypassed.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Updated the unit test.  Ran it with the `ROX_FLATTEN_CVE_DATA` set `true` and with the flag set to `false`.  Further testing will occur as additional changes are implemented to get the data out of the system to support the various workflows.
