### PR TITLE
ROX-27402: CVE data model image store pr 5

### DIFF
--- a/central/cve/converter/utils/convert_utils_v2.go
+++ b/central/cve/converter/utils/convert_utils_v2.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ImageCVEV2ToEmbeddedVulnerability coverts a `*storage.ImageCVEV2` to an `*storage.EmbeddedVulnerability`.
@@ -71,6 +72,16 @@ func EmbeddedVulnerabilityToImageCVEV2(imageID string, componentID string, cveIn
 		impactScore = from.GetCvssV2().GetImpactScore()
 	}
 
+	createdAt := from.GetFirstSystemOccurrence()
+	if createdAt == nil {
+		createdAt = timestamppb.Now()
+	}
+
+	firstImageOccurrence := from.GetFirstImageOccurrence()
+	if firstImageOccurrence == nil {
+		firstImageOccurrence = timestamppb.Now()
+	}
+
 	ret := &storage.ImageCVEV2{
 		Id:          cve.IDV2(from.GetCve(), componentID, strconv.Itoa(cveIndex)),
 		ComponentId: componentID,
@@ -79,7 +90,7 @@ func EmbeddedVulnerabilityToImageCVEV2(imageID string, componentID string, cveIn
 			Summary:      from.GetSummary(),
 			Link:         from.GetLink(),
 			PublishedOn:  from.GetPublishedOn(),
-			CreatedAt:    from.GetFirstSystemOccurrence(),
+			CreatedAt:    createdAt,
 			LastModified: from.GetLastModified(),
 			CvssV2:       from.GetCvssV2(),
 			CvssV3:       from.GetCvssV3(),
@@ -92,7 +103,7 @@ func EmbeddedVulnerabilityToImageCVEV2(imageID string, componentID string, cveIn
 		NvdScoreVersion:      nvdVersion,
 		Severity:             from.GetSeverity(),
 		ImageId:              imageID,
-		FirstImageOccurrence: from.GetFirstImageOccurrence(),
+		FirstImageOccurrence: firstImageOccurrence,
 		State:                from.GetState(),
 		IsFixable:            from.GetFixedBy() != "",
 		ImpactScore:          impactScore,

--- a/central/image/datastore/singleton.go
+++ b/central/image/datastore/singleton.go
@@ -3,9 +3,12 @@ package datastore
 import (
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/image/datastore/keyfence"
+	"github.com/stackrox/rox/central/image/datastore/store"
 	pgStore "github.com/stackrox/rox/central/image/datastore/store/postgres"
+	pgStoreV2 "github.com/stackrox/rox/central/image/datastore/store/v2/postgres"
 	"github.com/stackrox/rox/central/ranking"
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -16,7 +19,12 @@ var (
 )
 
 func initialize() {
-	storage := pgStore.New(globaldb.GetPostgres(), false, keyfence.ImageKeyFenceSingleton())
+	var storage store.Store
+	if features.FlattenCVEData.Enabled() {
+		storage = pgStoreV2.New(globaldb.GetPostgres(), false, keyfence.ImageKeyFenceSingleton())
+	} else {
+		storage = pgStore.New(globaldb.GetPostgres(), false, keyfence.ImageKeyFenceSingleton())
+	}
 	ad = NewWithPostgres(storage, riskDS.Singleton(), ranking.ImageRanker(), ranking.ComponentRanker())
 }
 

--- a/central/image/datastore/store/common/metrics.go
+++ b/central/image/datastore/store/common/metrics.go
@@ -1,4 +1,4 @@
-package postgres
+package common
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/central/image/datastore/store/common/v2/metrics.go
+++ b/central/image/datastore/store/common/v2/metrics.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	sensorEventsDeduperCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	SensorEventsDeduperCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "image_upsert_deduper",
@@ -15,5 +15,5 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(sensorEventsDeduperCounter)
+	prometheus.MustRegister(SensorEventsDeduperCounter)
 }

--- a/central/image/datastore/store/postgres/store_test.go
+++ b/central/image/datastore/store/postgres/store_test.go
@@ -49,7 +49,6 @@ func (s *ImagesStoreSuite) TestStore() {
 			vuln.NvdCvss = 0
 			vuln.Epss = nil
 		}
-		// TODO(ROX-27402) remove this
 		comp.Architecture = ""
 	}
 

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -56,7 +56,6 @@ type imagePartsAsSlice struct {
 type timeFields struct {
 	createdAt            time.Time
 	firstImageOccurrence time.Time
-	publishedOn          time.Time
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -93,15 +92,10 @@ func (s *storeImpl) insertIntoImages(
 				log.Infof("CVE 2")
 				val.firstImageOccurrence = cve.GetFirstImageOccurrence().AsTime()
 			}
-			if val.publishedOn.After(cve.GetCveBaseInfo().GetPublishedOn().AsTime()) {
-				log.Infof("CVE 3")
-				val.publishedOn = cve.GetCveBaseInfo().GetPublishedOn().AsTime()
-			}
 		} else {
 			cveTimeMap[cve.GetCveBaseInfo().GetCve()] = &timeFields{
 				createdAt:            cve.GetCveBaseInfo().GetCreatedAt().AsTime(),
 				firstImageOccurrence: cve.GetFirstImageOccurrence().AsTime(),
-				publishedOn:          cve.GetCveBaseInfo().GetPublishedOn().AsTime(),
 			}
 		}
 	}
@@ -132,10 +126,6 @@ func (s *storeImpl) insertIntoImages(
 				if val.firstImageOccurrence.After(cve.GetFirstImageOccurrence().AsTime()) {
 					log.Infof("CVE 5")
 					val.firstImageOccurrence = cve.GetFirstImageOccurrence().AsTime()
-				}
-				if val.publishedOn.After(cve.GetCveBaseInfo().GetPublishedOn().AsTime()) {
-					log.Infof("CVE 6")
-					val.publishedOn = cve.GetCveBaseInfo().GetPublishedOn().AsTime()
 				}
 			}
 		}
@@ -355,7 +345,6 @@ func copyFromImageComponentV2Cves(ctx context.Context, tx *postgres.Tx, iTime ti
 			log.Infof("SHREWS -- found existing CVE %q Using its times", obj.GetCveBaseInfo().GetCve())
 			obj.CveBaseInfo.CreatedAt = protocompat.ConvertTimeToTimestampOrNil(&cveTimes.createdAt)
 			obj.FirstImageOccurrence = protocompat.ConvertTimeToTimestampOrNil(&cveTimes.firstImageOccurrence)
-			obj.CveBaseInfo.PublishedOn = protocompat.ConvertTimeToTimestampOrNil(&cveTimes.publishedOn)
 		} else {
 			log.Infof("SHREWS -- not foud existing CVE %q Using iTime", obj.GetCveBaseInfo().GetCve())
 			if obj.GetCveBaseInfo().GetCreatedAt() == nil {

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackrox/rox/central/image/datastore/store"
 	"github.com/stackrox/rox/central/image/datastore/store/common/v2"
 	common2 "github.com/stackrox/rox/central/image/datastore/store/common/v2"
-	componentStore "github.com/stackrox/rox/central/imagecomponent/v2/datastore/store/postgres"
 	"github.com/stackrox/rox/central/metrics"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -61,12 +60,11 @@ type timeFields struct {
 // TODO(ROX-28222): Refactor logic operating on other tables out and up to the datastore layer.
 
 // New returns a new Store instance using the provided sql instance.
-func New(db postgres.DB, noUpdateTimestamps bool, keyFence concurrency.KeyFence, componentV2Store componentStore.Store) store.Store {
+func New(db postgres.DB, noUpdateTimestamps bool, keyFence concurrency.KeyFence) store.Store {
 	return &storeImpl{
 		db:                 db,
 		noUpdateTimestamps: noUpdateTimestamps,
 		keyFence:           keyFence,
-		componentV2Store:   componentV2Store,
 	}
 }
 
@@ -74,7 +72,6 @@ type storeImpl struct {
 	db                 postgres.DB
 	noUpdateTimestamps bool
 	keyFence           concurrency.KeyFence
-	componentV2Store   componentStore.Store
 }
 
 func (s *storeImpl) insertIntoImages(
@@ -1100,5 +1097,5 @@ func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImagesStmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageComponentV2Stmt)
 	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageCvesV2Stmt)
-	return New(db, noUpdateTimestamps, concurrency.NewKeyFence(), componentStore.New(db))
+	return New(db, noUpdateTimestamps, concurrency.NewKeyFence())
 }

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -10,12 +10,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/central/image/datastore/store"
 	"github.com/stackrox/rox/central/image/datastore/store/common/v2"
+	componentStore "github.com/stackrox/rox/central/imagecomponent/v2/datastore/store/postgres"
 	"github.com/stackrox/rox/central/metrics"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -26,25 +26,16 @@ import (
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/set"
 	"gorm.io/gorm"
 )
 
 const (
-	imagesTable              = pkgSchema.ImagesTableName
-	imageComponentEdgesTable = pkgSchema.ImageComponentEdgesTableName
-	imageComponentsTable     = pkgSchema.ImageComponentsTableName
-	componentCVEEdgesTable   = pkgSchema.ImageComponentCveEdgesTableName
-	imageCVEsTable           = pkgSchema.ImageCvesTableName
-	imageCVEEdgesTable       = pkgSchema.ImageCveEdgesTableName
+	imagesTable                = pkgSchema.ImagesTableName
+	imageComponentsV2Table     = pkgSchema.ImageComponentV2TableName
+	imageComponentsV2CVEsTable = pkgSchema.ImageCvesV2TableName
 
 	getImageMetaStmt = "SELECT serialized FROM " + imagesTable + " WHERE Id = $1"
 	getImageIDsStmt  = "SELECT Id FROM " + imagesTable
-
-	// using copyFrom, we may not even want to batch.  It would probably be simpler
-	// to deal with failures if we just sent it all.  Something to think about as we
-	// proceed and move into more e2e and larger performance testing
-	batchSize = 500
 
 	cursorBatchSize = 50
 )
@@ -56,25 +47,18 @@ var (
 )
 
 type imagePartsAsSlice struct {
-	image               *storage.Image
-	components          []*storage.ImageComponent
-	vulns               []*storage.ImageCVE
-	imageComponentEdges []*storage.ImageComponentEdge
-	componentCVEEdges   []*storage.ComponentCVEEdge
-	imageCVEEdges       []*storage.ImageCVEEdge
+	image        *storage.Image
+	componentsV2 []*storage.ImageComponentV2
+	cveV2        []*storage.ImageCVEV2
 }
 
 // New returns a new Store instance using the provided sql instance.
-func New(db postgres.DB, noUpdateTimestamps bool, keyFence concurrency.KeyFence) store.Store {
-	// Need to only use one data model at a time.
-	if features.FlattenCVEData.Enabled() {
-		return nil
-	}
-
+func New(db postgres.DB, noUpdateTimestamps bool, keyFence concurrency.KeyFence, componentV2Store componentStore.Store) store.Store {
 	return &storeImpl{
 		db:                 db,
 		noUpdateTimestamps: noUpdateTimestamps,
 		keyFence:           keyFence,
+		componentV2Store:   componentV2Store,
 	}
 }
 
@@ -82,6 +66,7 @@ type storeImpl struct {
 	db                 postgres.DB
 	noUpdateTimestamps bool
 	keyFence           concurrency.KeyFence
+	componentV2Store   componentStore.Store
 }
 
 func (s *storeImpl) insertIntoImages(
@@ -90,6 +75,26 @@ func (s *storeImpl) insertIntoImages(
 	metadataUpdated, scanUpdated bool,
 	iTime time.Time,
 ) error {
+	// Grab all the components and CVEs that exist.
+	existingComponents, err := getImageComponents(ctx, tx, parts.image.GetId())
+	if err != nil {
+		return err
+	}
+
+	componentCVEMap := make(map[string]map[string]*storage.ImageCVEV2)
+	for _, component := range existingComponents {
+		existingCVEs, err := getImageComponentCVEs(ctx, tx, component.GetId())
+		if err != nil {
+			return err
+		}
+
+		cveMap := make(map[string]*storage.ImageCVEV2)
+		for _, cve := range existingCVEs {
+			cveMap[cve.GetId()] = cve
+		}
+		componentCVEMap[component.GetId()] = cveMap
+	}
+
 	cloned := parts.image
 	if cloned.GetScan().GetComponents() != nil {
 		cloned = parts.image.CloneVT()
@@ -127,7 +132,7 @@ func (s *storeImpl) insertIntoImages(
 	}
 
 	finalStr := "INSERT INTO " + imagesTable + " (Id, Name_Registry, Name_Remote, Name_Tag, Name_FullName, Metadata_V1_Created, Metadata_V1_User, Metadata_V1_Command, Metadata_V1_Entrypoint, Metadata_V1_Volumes, Metadata_V1_Labels, Scan_ScanTime, Scan_OperatingSystem, Signature_Fetched, Components, Cves, FixableCves, LastUpdated, Priority, RiskScore, TopCvss, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, Name_Registry = EXCLUDED.Name_Registry, Name_Remote = EXCLUDED.Name_Remote, Name_Tag = EXCLUDED.Name_Tag, Name_FullName = EXCLUDED.Name_FullName, Metadata_V1_Created = EXCLUDED.Metadata_V1_Created, Metadata_V1_User = EXCLUDED.Metadata_V1_User, Metadata_V1_Command = EXCLUDED.Metadata_V1_Command, Metadata_V1_Entrypoint = EXCLUDED.Metadata_V1_Entrypoint, Metadata_V1_Volumes = EXCLUDED.Metadata_V1_Volumes, Metadata_V1_Labels = EXCLUDED.Metadata_V1_Labels, Scan_ScanTime = EXCLUDED.Scan_ScanTime, Scan_OperatingSystem = EXCLUDED.Scan_OperatingSystem, Signature_Fetched = EXCLUDED.Signature_Fetched, Components = EXCLUDED.Components, Cves = EXCLUDED.Cves, FixableCves = EXCLUDED.FixableCves, LastUpdated = EXCLUDED.LastUpdated, Priority = EXCLUDED.Priority, RiskScore = EXCLUDED.RiskScore, TopCvss = EXCLUDED.TopCvss, serialized = EXCLUDED.serialized"
-	_, err := tx.Exec(ctx, finalStr, values...)
+	_, err = tx.Exec(ctx, finalStr, values...)
 	if err != nil {
 		return err
 	}
@@ -153,55 +158,32 @@ func (s *storeImpl) insertIntoImages(
 	}
 	common.SensorEventsDeduperCounter.With(prometheus.Labels{"status": "passed"}).Inc()
 
-	// DO NOT CHANGE THE ORDER.
-	if err := copyFromImageComponentEdges(ctx, tx, cloned.GetId(), parts.imageComponentEdges...); err != nil {
+	err = copyFromImageComponentsV2(ctx, tx, iTime, componentCVEMap, parts.componentsV2...)
+	if err != nil {
 		return err
 	}
-	if err := copyFromImageComponents(ctx, tx, parts.components...); err != nil {
-		return err
-	}
-	if err := copyFromImageComponentCVEEdges(ctx, tx, parts.componentCVEEdges...); err != nil {
-		return err
-	}
-	if err := copyFromImageCves(ctx, tx, iTime, parts.vulns...); err != nil {
-		return err
-	}
-	return copyFromImageCVEEdges(ctx, tx, iTime, false, parts.imageCVEEdges...)
+
+	return copyFromImageComponentV2Cves(ctx, tx, iTime, componentCVEMap, parts.cveV2...)
 }
 
 func getPartsAsSlice(parts common.ImageParts) *imagePartsAsSlice {
-	components := make([]*storage.ImageComponent, 0, len(parts.Children))
-	imageComponentEdges := make([]*storage.ImageComponentEdge, 0, len(parts.Children))
-	vulnMap := make(map[string]*storage.ImageCVE)
-	var componentCVEEdges []*storage.ComponentCVEEdge
+	componentsV2 := make([]*storage.ImageComponentV2, 0, len(parts.Children))
+	// TODO:  Add sizing
+	vulns := make([]*storage.ImageCVEV2, 0)
 	for _, child := range parts.Children {
-		components = append(components, child.Component)
-		imageComponentEdges = append(imageComponentEdges, child.Edge)
+		componentsV2 = append(componentsV2, child.ComponentV2)
 		for _, gChild := range child.Children {
-			componentCVEEdges = append(componentCVEEdges, gChild.Edge)
-			vulnMap[gChild.CVE.GetId()] = gChild.CVE
+			vulns = append(vulns, gChild.CVEV2)
 		}
 	}
-	vulns := make([]*storage.ImageCVE, 0, len(vulnMap))
-	for _, vuln := range vulnMap {
-		vulns = append(vulns, vuln)
-	}
-	imageCVEEdges := make([]*storage.ImageCVEEdge, 0, len(parts.ImageCVEEdges))
-	for _, imageCVEEdge := range parts.ImageCVEEdges {
-		imageCVEEdges = append(imageCVEEdges, imageCVEEdge)
-	}
 	return &imagePartsAsSlice{
-		image:               parts.Image,
-		components:          components,
-		vulns:               vulns,
-		imageComponentEdges: imageComponentEdges,
-		componentCVEEdges:   componentCVEEdges,
-		imageCVEEdges:       imageCVEEdges,
+		image:        parts.Image,
+		componentsV2: componentsV2,
+		cveV2:        vulns,
 	}
 }
 
 func insertIntoImagesLayers(ctx context.Context, tx *postgres.Tx, obj *storage.ImageLayer, imageID string, idx int) error {
-
 	values := []interface{}{
 		// parent primary keys start
 		imageID,
@@ -219,27 +201,34 @@ func insertIntoImagesLayers(ctx context.Context, tx *postgres.Tx, obj *storage.I
 	return nil
 }
 
-func copyFromImageComponents(ctx context.Context, tx *postgres.Tx, objs ...*storage.ImageComponent) error {
-	inputRows := [][]interface{}{}
+// Basically a copy of the generated method in imagecomponent/v2/datastore/store/postgres.  But we need to pass some additional information
+// around to ensure times and things are updated appropriately.  So we must have this method here.
+func copyFromImageComponentsV2(ctx context.Context, tx *postgres.Tx, iTime time.Time, componentCVEMap map[string]map[string]*storage.ImageCVEV2, objs ...*storage.ImageComponentV2) error {
+	batchSize := pgSearch.MaxBatchSize
+	if len(objs) < batchSize {
+		batchSize = len(objs)
+	}
+	inputRows := make([][]interface{}, 0, batchSize)
 
-	var err error
-
-	var deletes []string
+	// This is a copy, so first we must delete the rows and re-add them
+	// Which is essentially the desired behaviour of an upsert.
+	deletes := make([]string, 0, batchSize)
 
 	copyCols := []string{
 		"id",
 		"name",
 		"version",
-		"operatingsystem",
 		"priority",
 		"source",
 		"riskscore",
 		"topcvss",
+		"operatingsystem",
+		"imageid",
+		"location",
 		"serialized",
 	}
 
 	for idx, obj := range objs {
-
 		serialized, marshalErr := obj.MarshalVT()
 		if marshalErr != nil {
 			return marshalErr
@@ -249,205 +238,80 @@ func copyFromImageComponents(ctx context.Context, tx *postgres.Tx, objs ...*stor
 			obj.GetId(),
 			obj.GetName(),
 			obj.GetVersion(),
-			obj.GetOperatingSystem(),
 			obj.GetPriority(),
 			obj.GetSource(),
 			obj.GetRiskScore(),
 			obj.GetTopCvss(),
+			obj.GetOperatingSystem(),
+			obj.GetImageId(),
+			obj.GetLocation(),
 			serialized,
 		})
 
-		// Add the id to be deleted.
+		// Add the ID to be deleted.
 		deletes = append(deletes, obj.GetId())
 
 		// if we hit our batch size we need to push the data
 		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
-			// Copy does not upsert so have to delete first.
-			_, err = tx.Exec(ctx, "DELETE FROM "+imageComponentsTable+" WHERE id = ANY($1::text[])", deletes)
+			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
+			// delete for the top level parent
+			_, err := tx.Exec(ctx, "DELETE FROM "+imageComponentsV2Table+" WHERE id = ANY($1::text[])", deletes)
 			if err != nil {
 				return err
 			}
+			// clear the inserts and vals for the next batch
+			deletes = deletes[:0]
 
-			// clear the inserts for the next batch
-			deletes = nil
-
-			_, err = tx.CopyFrom(ctx, pgx.Identifier{imageComponentsTable}, copyCols, pgx.CopyFromRows(inputRows))
-
-			if err != nil {
+			if _, err := tx.CopyFrom(ctx, pgx.Identifier{imageComponentsV2Table}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
 				return err
 			}
-
 			// clear the input rows for the next batch
 			inputRows = inputRows[:0]
 		}
 	}
-	return removeOrphanedImageComponent(ctx, tx)
+
+	return nil
 }
 
-func copyFromImageComponentEdges(ctx context.Context, tx *postgres.Tx, imageID string, objs ...*storage.ImageComponentEdge) error {
-	inputRows := [][]interface{}{}
-	var err error
+// Basically a copy of the generated method in imagecomponent/v2/datastore/store/postgres.  But we need to pass some additional information
+// around to ensure times and things are updated appropriately.  So we must have this method here.
+func copyFromImageComponentV2Cves(ctx context.Context, tx *postgres.Tx, iTime time.Time, componentCVEMap map[string]map[string]*storage.ImageCVEV2, objs ...*storage.ImageCVEV2) error {
+	batchSize := pgSearch.MaxBatchSize
+	if len(objs) < batchSize {
+		batchSize = len(objs)
+	}
+	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"id",
-		"location",
 		"imageid",
-		"imagecomponentid",
-		"serialized",
-	}
-
-	// Copy does not upsert so have to delete first. This also cleans up orphaned edges.
-	_, err = tx.Exec(ctx, "DELETE FROM "+imageComponentEdgesTable+" WHERE imageid = $1", imageID)
-	if err != nil {
-		return err
-	}
-
-	if len(objs) == 0 {
-		return nil
-	}
-
-	for idx, obj := range objs {
-		serialized, marshalErr := obj.MarshalVT()
-		if marshalErr != nil {
-			return marshalErr
-		}
-
-		inputRows = append(inputRows, []interface{}{
-			obj.GetId(),
-			obj.GetLocation(),
-			obj.GetImageId(),
-			obj.GetImageComponentId(),
-			serialized,
-		})
-
-		// if we hit our batch size we need to push the data
-		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
-			_, err = tx.CopyFrom(ctx, pgx.Identifier{imageComponentEdgesTable}, copyCols, pgx.CopyFromRows(inputRows))
-			if err != nil {
-				return err
-			}
-
-			// clear the input rows for the next batch
-			inputRows = inputRows[:0]
-		}
-	}
-
-	return err
-}
-
-func copyFromImageCves(ctx context.Context, tx *postgres.Tx, iTime time.Time, objs ...*storage.ImageCVE) error {
-	inputRows := [][]interface{}{}
-
-	var err error
-
-	// This is a copy so first we must delete the rows and re-add them
-	var deletes []string
-
-	copyCols := []string{
-		"id",
 		"cvebaseinfo_cve",
 		"cvebaseinfo_publishedon",
 		"cvebaseinfo_createdat",
+		"cvebaseinfo_epss_epssprobability",
 		"operatingsystem",
 		"cvss",
-		"nvdcvss",
 		"severity",
 		"impactscore",
-		"snoozed",
-		"snoozeexpiry",
-		"serialized",
-		"cvebaseinfo_epss_epssprobability",
-	}
-
-	ids := set.NewStringSet()
-	for _, obj := range objs {
-		ids.Add(obj.GetId())
-	}
-	existingCVEs, err := getCVEs(ctx, tx, ids.AsSlice())
-	if err != nil {
-		return err
-	}
-
-	for idx, obj := range objs {
-		if storedCVE := existingCVEs[obj.GetId()]; storedCVE != nil {
-			obj.CveBaseInfo.CreatedAt = storedCVE.GetCveBaseInfo().GetCreatedAt()
-			obj.Snoozed = storedCVE.GetSnoozed()
-			obj.SnoozeStart = storedCVE.GetSnoozeStart()
-			obj.SnoozeExpiry = storedCVE.GetSnoozeExpiry()
-		} else {
-			obj.CveBaseInfo.CreatedAt = protocompat.ConvertTimeToTimestampOrNil(&iTime)
-		}
-
-		serialized, marshalErr := obj.MarshalVT()
-		if marshalErr != nil {
-			return marshalErr
-		}
-
-		row := []interface{}{
-			obj.GetId(),
-			obj.GetCveBaseInfo().GetCve(),
-			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
-			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
-			obj.GetOperatingSystem(),
-			obj.GetCvss(),
-			obj.GetNvdcvss(),
-			obj.GetSeverity(),
-			obj.GetImpactScore(),
-			obj.GetSnoozed(),
-			protocompat.NilOrTime(obj.GetSnoozeExpiry()),
-			serialized,
-		}
-
-		if epss := obj.GetCveBaseInfo().GetEpss(); epss != nil {
-			row = append(row, epss.GetEpssProbability())
-		} else {
-			row = append(row, nil)
-		}
-
-		inputRows = append(inputRows, row)
-
-		// Add the id to be deleted.
-		deletes = append(deletes, obj.GetId())
-
-		// if we hit our batch size we need to push the data
-		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
-			// Copy does not upsert so have to delete first.
-			_, err = tx.Exec(ctx, "DELETE FROM "+imageCVEsTable+" WHERE id = ANY($1::text[])", deletes)
-			if err != nil {
-				return err
-			}
-			// Clear the inserts for the next batch.
-			deletes = nil
-
-			_, err = tx.CopyFrom(ctx, pgx.Identifier{imageCVEsTable}, copyCols, pgx.CopyFromRows(inputRows))
-
-			if err != nil {
-				return err
-			}
-
-			// Clear the input rows for the next batch
-			inputRows = inputRows[:0]
-		}
-	}
-
-	return removeOrphanedImageCVEs(ctx, tx)
-}
-
-func copyFromImageComponentCVEEdges(ctx context.Context, tx *postgres.Tx, objs ...*storage.ComponentCVEEdge) error {
-	inputRows := [][]interface{}{}
-	var err error
-	deletes := set.NewStringSet()
-
-	copyCols := []string{
-		"id",
+		"nvdcvss",
+		"firstimageoccurrence",
+		"state",
 		"isfixable",
 		"fixedby",
-		"imagecomponentid",
-		"imagecveid",
+		"componentid",
 		"serialized",
 	}
 
 	for idx, obj := range objs {
+		existingCVEs := componentCVEMap[obj.GetComponentId()]
+		if storedCVE := existingCVEs[obj.GetId()]; storedCVE != nil {
+			obj.CveBaseInfo.CreatedAt = storedCVE.GetCveBaseInfo().GetCreatedAt()
+			obj.FirstImageOccurrence = storedCVE.GetFirstImageOccurrence()
+		} else {
+			obj.CveBaseInfo.CreatedAt = protocompat.ConvertTimeToTimestampOrNil(&iTime)
+			obj.FirstImageOccurrence = protocompat.ConvertTimeToTimestampOrNil(&iTime)
+		}
+
 		serialized, marshalErr := obj.MarshalVT()
 		if marshalErr != nil {
 			return marshalErr
@@ -455,215 +319,37 @@ func copyFromImageComponentCVEEdges(ctx context.Context, tx *postgres.Tx, objs .
 
 		inputRows = append(inputRows, []interface{}{
 			obj.GetId(),
+			obj.GetImageId(),
+			obj.GetCveBaseInfo().GetCve(),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
+			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetOperatingSystem(),
+			obj.GetCvss(),
+			obj.GetSeverity(),
+			obj.GetImpactScore(),
+			obj.GetNvdcvss(),
+			protocompat.NilOrTime(obj.GetFirstImageOccurrence()),
+			obj.GetState(),
 			obj.GetIsFixable(),
 			obj.GetFixedBy(),
-			obj.GetImageComponentId(),
-			obj.GetImageCveId(),
+			obj.GetComponentId(),
 			serialized,
 		})
 
-		// Add the id to be deleted.
-		deletes.Add(obj.GetId())
-
 		// if we hit our batch size we need to push the data
 		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
-			// Copy does not upsert so have to delete first.
-			_, err = tx.Exec(ctx, "DELETE FROM "+componentCVEEdgesTable+" WHERE id = ANY($1::text[])", deletes.AsSlice())
-			if err != nil {
+			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
+			// delete for the top level parent
+
+			if _, err := tx.CopyFrom(ctx, pgx.Identifier{imageComponentsV2CVEsTable}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
 				return err
 			}
-
-			// Clear the inserts for the next batch
-			deletes = nil
-
-			_, err = tx.CopyFrom(ctx, pgx.Identifier{componentCVEEdgesTable}, copyCols, pgx.CopyFromRows(inputRows))
-
-			if err != nil {
-				return err
-			}
-
-			// Clear the input rows for the next batch
+			// clear the input rows for the next batch
 			inputRows = inputRows[:0]
 		}
 	}
 
-	// Due to referential constraints, orphaned component-cve edges are removed when orphaned image components are removed.
-	return nil
-}
-
-func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime time.Time, vulnStateUpdate bool,
-	objs ...*storage.ImageCVEEdge) error {
-
-	if vulnStateUpdate {
-		return copyFromImageCVEEdgesWithVulnStateUpdates(ctx, tx, objs)
-	}
-
-	var err error
-	var oldEdgeIDs set.Set[string]
-
-	var imageIDs []string
-	for _, obj := range objs {
-		imageIDs = append(imageIDs, obj.GetImageId())
-	}
-
-	// Collect the existing edges for the images to skip re-inserting existing edges.
-	oldEdgeIDs, err = getImageCVEEdgeIDs(ctx, tx, imageIDs...)
-	if err != nil {
-		return err
-	}
-
-	inputRows := [][]interface{}{}
-	for _, edge := range objs {
-		// Since the edge only maintains states enriched by ACS, if the edge already exists, then it should skip copy from.
-		if oldEdgeIDs.Remove(edge.GetId()) {
-			continue
-		}
-		edge.FirstImageOccurrence = protocompat.ConvertTimeToTimestampOrNil(&iTime)
-
-		inputRow, err := getImageCVEEdgeRowToInsert(edge)
-		if err != nil {
-			return err
-		}
-		inputRows = append(inputRows, inputRow)
-
-		// if we hit our batch size or end of slice, push the edges
-		if len(inputRows) > 0 && len(inputRows)%batchSize == 0 {
-			err = execCopyFromImageCVEEdges(ctx, tx, inputRows)
-			if err != nil {
-				return err
-			}
-
-			// Clear the input rows for the next batch
-			inputRows = inputRows[:0]
-		}
-	}
-
-	if len(inputRows) > 0 {
-		err = execCopyFromImageCVEEdges(ctx, tx, inputRows)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Remove orphaned edges.
-	return removeOrphanedImageCVEEdges(ctx, tx, oldEdgeIDs.AsSlice())
-}
-
-func copyFromImageCVEEdgesWithVulnStateUpdates(ctx context.Context, tx *postgres.Tx, edges []*storage.ImageCVEEdge) error {
-	inputRows := [][]interface{}{}
-	deletes := set.NewStringSet()
-
-	for _, edge := range edges {
-		// Add the id to be deleted.
-		deletes.Add(edge.GetId())
-
-		inputRow, err := getImageCVEEdgeRowToInsert(edge)
-		if err != nil {
-			return err
-		}
-		inputRows = append(inputRows, inputRow)
-
-		// if we hit our batch size or end of slice, delete old edges and push new ones
-		if len(inputRows) > 0 && len(inputRows)%batchSize == 0 {
-			// Copy does not upsert so have to delete first.
-			err = execDeleteFromImageCVEEdges(ctx, tx, deletes)
-			if err != nil {
-				return err
-			}
-
-			// Clear the inserts for the next batch
-			deletes = nil
-
-			err = execCopyFromImageCVEEdges(ctx, tx, inputRows)
-			if err != nil {
-				return err
-			}
-
-			// Clear the input rows for the next batch
-			inputRows = inputRows[:0]
-		}
-	}
-
-	if len(inputRows) > 0 {
-		err := execDeleteFromImageCVEEdges(ctx, tx, deletes)
-		if err != nil {
-			return err
-		}
-
-		err = execCopyFromImageCVEEdges(ctx, tx, inputRows)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func getImageCVEEdgeRowToInsert(edge *storage.ImageCVEEdge) ([]interface{}, error) {
-	serialized, marshalErr := edge.MarshalVT()
-	if marshalErr != nil {
-		return nil, marshalErr
-	}
-
-	return []interface{}{
-		edge.GetId(),
-		protocompat.NilOrTime(edge.GetFirstImageOccurrence()),
-		edge.GetState(),
-		edge.GetImageId(),
-		edge.GetImageCveId(),
-		serialized,
-	}, nil
-}
-
-func execCopyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, inputRows [][]interface{}) error {
-	copyCols := []string{
-		"id",
-		"firstimageoccurrence",
-		"state",
-		"imageid",
-		"imagecveid",
-		"serialized",
-	}
-
-	_, err := tx.CopyFrom(ctx, pgx.Identifier{imageCVEEdgesTable}, copyCols, pgx.CopyFromRows(inputRows))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func execDeleteFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, deletes set.Set[string]) error {
-	_, err := tx.Exec(ctx, "DELETE FROM "+imageCVEEdgesTable+" WHERE id = ANY($1::text[])", deletes.AsSlice())
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func removeOrphanedImageComponent(ctx context.Context, tx *postgres.Tx) error {
-	_, err := tx.Exec(ctx, "DELETE FROM "+imageComponentsTable+" WHERE not exists (select "+imageComponentEdgesTable+".imagecomponentid from "+imageComponentEdgesTable+" where "+imageComponentsTable+".id = "+imageComponentEdgesTable+".imagecomponentid)")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func removeOrphanedImageCVEs(ctx context.Context, tx *postgres.Tx) error {
-	_, err := tx.Exec(ctx, "DELETE FROM "+imageCVEsTable+" WHERE not exists (select "+componentCVEEdgesTable+".imagecveid from "+componentCVEEdgesTable+" where "+imageCVEsTable+".id = "+componentCVEEdgesTable+".imagecveid)")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func removeOrphanedImageCVEEdges(ctx context.Context, tx *postgres.Tx, orphanedEdgeIDs []string) error {
-	if len(orphanedEdgeIDs) == 0 {
-		return nil
-	}
-
-	_, err := tx.Exec(ctx, "DELETE FROM "+imageCVEEdgesTable+" WHERE id = ANY($1::text[])", orphanedEdgeIDs)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -840,65 +526,23 @@ func (s *storeImpl) retryableGet(ctx context.Context, id string) (*storage.Image
 }
 
 func (s *storeImpl) populateImage(ctx context.Context, tx *postgres.Tx, image *storage.Image) error {
-	imageCVEEdgeMap, err := getImageCVEEdges(ctx, tx, image.GetId())
+	components, err := getImageComponents(ctx, tx, image.Id)
 	if err != nil {
 		return err
-	}
-	cveIDs := make([]string, 0, len(imageCVEEdgeMap))
-	for _, val := range imageCVEEdgeMap {
-		cveIDs = append(cveIDs, val.GetImageCveId())
-	}
-
-	componentEdgeMap, err := getImageComponentEdges(ctx, tx, image.GetId())
-	if err != nil {
-		return err
-	}
-	componentIDs := make([]string, 0, len(componentEdgeMap))
-	for _, val := range componentEdgeMap {
-		componentIDs = append(componentIDs, val.GetImageComponentId())
-	}
-
-	componentMap, err := getImageComponents(ctx, tx, componentIDs)
-	if err != nil {
-		return err
-	}
-
-	componentCVEEdgeMap, err := getComponentCVEEdges(ctx, tx, componentIDs)
-	if err != nil {
-		return err
-	}
-
-	cveMap, err := getCVEs(ctx, tx, cveIDs)
-	if err != nil {
-		return err
-	}
-
-	if len(componentEdgeMap) != len(componentMap) {
-		log.Errorf("Number of component (%d) in image-component edges is not equal to number of stored components (%d) for image %s (imageID=%s)",
-			len(componentEdgeMap), len(componentMap), image.GetName().GetFullName(), image.GetId())
 	}
 
 	imageParts := common.ImageParts{
-		Image:         image,
-		Children:      []common.ComponentParts{},
-		ImageCVEEdges: imageCVEEdgeMap,
+		Image:    image,
+		Children: []common.ComponentParts{},
 	}
-	for componentID, component := range componentMap {
+	for _, component := range components {
 		child := common.ComponentParts{
-			Edge:      componentEdgeMap[componentID],
-			Component: component,
-			Children:  []common.CVEParts{},
-		}
-
-		for _, edge := range componentCVEEdgeMap[componentID] {
-			child.Children = append(child.Children, common.CVEParts{
-				Edge: edge,
-				CVE:  cveMap[edge.GetImageCveId()],
-			})
+			ComponentV2: component,
+			Children:    []common.CVEParts{},
 		}
 		imageParts.Children = append(imageParts.Children, child)
 	}
-	common.Merge(imageParts)
+	common.MergeV2(imageParts)
 	return nil
 }
 
@@ -929,133 +573,54 @@ func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*po
 	return conn, conn.Release, nil
 }
 
-func getImageComponentEdges(ctx context.Context, tx *postgres.Tx, imageID string) (map[string]*storage.ImageComponentEdge, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "ImageComponentEdges")
-
-	rows, err := tx.Query(ctx, "SELECT serialized FROM "+imageComponentEdgesTable+" WHERE imageid = $1", imageID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	componentIDToEdgeMap := make(map[string]*storage.ImageComponentEdge)
-	for rows.Next() {
-		var data []byte
-		if err := rows.Scan(&data); err != nil {
-			return nil, err
-		}
-		msg := &storage.ImageComponentEdge{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
-			return nil, err
-		}
-		componentIDToEdgeMap[msg.GetImageComponentId()] = msg
-	}
-	return componentIDToEdgeMap, rows.Err()
-}
-
-func getImageCVEEdgeIDs(ctx context.Context, tx *postgres.Tx, imageIDs ...string) (set.StringSet, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "ImageCVEEdges")
-
-	rows, err := tx.Query(ctx, "SELECT id FROM "+imageCVEEdgesTable+" WHERE imageid = ANY($1::text[])", imageIDs)
-	if err != nil {
-		return nil, err
-	}
-	ids, err := scanIDs(rows)
-	if err != nil {
-		return nil, err
-	}
-	return set.NewStringSet(ids...), nil
-}
-
-func getImageCVEEdges(ctx context.Context, tx *postgres.Tx, imageID string) (map[string]*storage.ImageCVEEdge, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "ImageCVEEdges")
-
-	rows, err := tx.Query(ctx, "SELECT serialized FROM "+imageCVEEdgesTable+" WHERE imageid = $1", imageID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	cveIDToEdgeMap := make(map[string]*storage.ImageCVEEdge)
-	for rows.Next() {
-		var data []byte
-		if err := rows.Scan(&data); err != nil {
-			return nil, err
-		}
-		msg := &storage.ImageCVEEdge{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
-			return nil, err
-		}
-		cveIDToEdgeMap[msg.GetImageCveId()] = msg
-	}
-	return cveIDToEdgeMap, rows.Err()
-}
-
-func getImageComponents(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string]*storage.ImageComponent, error) {
+func getImageComponents(ctx context.Context, tx *postgres.Tx, imageID string) ([]*storage.ImageComponentV2, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageComponents")
 
-	rows, err := tx.Query(ctx, "SELECT serialized FROM "+imageComponentsTable+" WHERE id = ANY($1::text[])", componentIDs)
+	// Using this method instead of accessing the component store to ensure the query is in the same transaction as
+	// the updates.  That may prove to not matter, but for now doing it this way.
+	rows, err := tx.Query(ctx, "SELECT serialized FROM "+imageComponentsV2Table+" WHERE imageid = $1", imageID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	idToComponentMap := make(map[string]*storage.ImageComponent)
+	components := make([]*storage.ImageComponentV2, 0)
 	for rows.Next() {
 		var data []byte
 		if err := rows.Scan(&data); err != nil {
 			return nil, err
 		}
-		msg := &storage.ImageComponent{}
+		msg := &storage.ImageComponentV2{}
 		if err := msg.UnmarshalVTUnsafe(data); err != nil {
 			return nil, err
 		}
-		idToComponentMap[msg.GetId()] = msg
+		components = append(components, msg)
 	}
-	return idToComponentMap, rows.Err()
+	return components, rows.Err()
 }
 
-func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string][]*storage.ComponentCVEEdge, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "ImageComponentCVEEdges")
+func getImageComponentCVEs(ctx context.Context, tx *postgres.Tx, componentID string) ([]*storage.ImageCVEV2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageCVEs")
 
-	rows, err := tx.Query(ctx, "SELECT serialized FROM "+componentCVEEdgesTable+" WHERE imagecomponentid = ANY($1::text[])", componentIDs)
+	// Using this method instead of accessing the component store to ensure the query is in the same transaction as
+	// the updates.  That may prove to not matter, but for now doing it this way.
+	rows, err := tx.Query(ctx, "SELECT serialized FROM "+imageComponentsV2CVEsTable+" WHERE componentid = $1", componentID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	componentIDToEdgeMap := make(map[string][]*storage.ComponentCVEEdge)
+	cves := make([]*storage.ImageCVEV2, 0)
 	for rows.Next() {
 		var data []byte
 		if err := rows.Scan(&data); err != nil {
 			return nil, err
 		}
-		msg := &storage.ComponentCVEEdge{}
+		msg := &storage.ImageCVEV2{}
 		if err := msg.UnmarshalVTUnsafe(data); err != nil {
 			return nil, err
 		}
-		componentIDToEdgeMap[msg.GetImageComponentId()] = append(componentIDToEdgeMap[msg.GetImageComponentId()], msg)
+		cves = append(cves, msg)
 	}
-	return componentIDToEdgeMap, rows.Err()
-}
-
-func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]*storage.ImageCVE, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "ImageCVEs")
-
-	rows, err := tx.Query(ctx, "SELECT serialized FROM "+imageCVEsTable+" WHERE id = ANY($1::text[])", cveIDs)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	idToCVEMap := make(map[string]*storage.ImageCVE)
-	for rows.Next() {
-		var data []byte
-		if err := rows.Scan(&data); err != nil {
-			return nil, err
-		}
-		msg := &storage.ImageCVE{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
-			return nil, err
-		}
-		idToCVEMap[msg.GetId()] = msg
-	}
-	return idToCVEMap, rows.Err()
+	return cves, rows.Err()
 }
 
 // Delete removes the specified ID from the store.
@@ -1094,15 +659,11 @@ func (s *storeImpl) deleteImageTree(ctx context.Context, tx *postgres.Tx, imageI
 		return err
 	}
 
-	// Delete orphaned image components.
-	if _, err := tx.Exec(ctx, "delete from "+imageComponentsTable+" where not exists (select "+imageComponentEdgesTable+".imagecomponentid FROM "+imageComponentEdgesTable+" where "+imageComponentsTable+".id = "+imageComponentEdgesTable+".imagecomponentid)"); err != nil {
+	// Delete image components for this image
+	if _, err := tx.Exec(ctx, "delete from "+imageComponentsV2Table+" where imageid = $1", imageID); err != nil {
 		return err
 	}
 
-	// Delete orphaned cves.
-	if _, err := tx.Exec(ctx, "delete from "+imageCVEsTable+" where not exists (select "+componentCVEEdgesTable+".imagecveid FROM "+componentCVEEdgesTable+" where "+imageCVEsTable+".id = "+componentCVEEdgesTable+".imagecveid)"); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -1230,58 +791,6 @@ func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(image 
 	return nil
 }
 
-//// Used for testing
-
-func dropAllTablesInImageTree(ctx context.Context, db postgres.DB) {
-	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS images CASCADE")
-	dropTableImagesLayers(ctx, db)
-	dropTableImageComponents(ctx, db)
-	dropTableImageCVEs(ctx, db)
-	dropTableImageCVEEdges(ctx, db)
-	dropTableComponentCVEEdges(ctx, db)
-	dropTableImageComponentEdges(ctx, db)
-}
-
-func dropTableImagesLayers(ctx context.Context, db postgres.DB) {
-	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS images_Layers CASCADE")
-}
-
-func dropTableImageComponents(ctx context.Context, db postgres.DB) {
-	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+imageComponentsTable+" CASCADE")
-}
-
-func dropTableImageCVEs(ctx context.Context, db postgres.DB) {
-	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+imageCVEsTable+" CASCADE")
-}
-
-func dropTableImageCVEEdges(ctx context.Context, db postgres.DB) {
-	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+imageCVEEdgesTable+" CASCADE")
-}
-
-func dropTableComponentCVEEdges(ctx context.Context, db postgres.DB) {
-	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+componentCVEEdgesTable+" CASCADE")
-}
-
-func dropTableImageComponentEdges(ctx context.Context, db postgres.DB) {
-	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+imageComponentEdgesTable+" CASCADE")
-}
-
-// Destroy drops image table.
-func Destroy(ctx context.Context, db postgres.DB) {
-	dropAllTablesInImageTree(ctx, db)
-}
-
-// CreateTableAndNewStore returns a new Store instance for testing
-func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB, noUpdateTimestamps bool) store.Store {
-	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImagesStmt)
-	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageComponentsStmt)
-	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageCvesStmt)
-	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageComponentEdgesStmt)
-	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageComponentCveEdgesStmt)
-	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageCveEdgesStmt)
-	return New(db, noUpdateTimestamps, concurrency.NewKeyFence())
-}
-
 // GetImageMetadata returns the image without scan/component data.
 func (s *storeImpl) GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageMetadata")
@@ -1395,24 +904,33 @@ func (s *storeImpl) retryableUpdateVulnState(ctx context.Context, cve string, im
 		return err
 	}
 
-	// Collect stored edges.
-	rows, err := tx.Query(ctx, "SELECT "+imageCVEEdgesTable+".serialized FROM "+imageCVEEdgesTable+" "+
-		"inner join "+imageCVEsTable+" on "+imageCVEEdgesTable+".imagecveid = "+imageCVEsTable+".id "+
-		"WHERE "+imageCVEEdgesTable+".imageid = ANY($1::text[]) AND "+imageCVEsTable+".cvebaseinfo_cve = $2", imageIDs, cve)
+	// Collect stored cves for the image.
+	rows, err := tx.Query(ctx, "SELECT serialized FROM "+imageComponentsV2CVEsTable+" "+
+		"WHERE "+imageComponentsV2CVEsTable+".imageid = ANY($1::text[]) AND "+imageComponentsV2CVEsTable+".cvebaseinfo_cve = $2", imageIDs, cve)
 	if err != nil {
 		return err
 	}
-	var imageCVEEdges []*storage.ImageCVEEdge
-	imageCVEEdges, err = pgutils.ScanRows[storage.ImageCVEEdge](rows)
-	if err != nil || len(imageCVEEdges) == 0 {
-		return err
+	defer rows.Close()
+	var imageCVEs []*storage.ImageCVEV2
+	for rows.Next() {
+		var serialized []byte
+
+		if err := rows.Scan(&serialized); err != nil {
+			return pgutils.ErrNilIfNoRows(err)
+		}
+		var msg storage.ImageCVEV2
+		if err := msg.UnmarshalVTUnsafe(serialized); err != nil {
+			return err
+		}
+
+		imageCVEs = append(imageCVEs, &msg)
 	}
 
 	// Update state.
-	cveIDs := make([]string, 0, len(imageCVEEdges))
-	for _, edge := range imageCVEEdges {
-		edge.State = state
-		cveIDs = append(cveIDs, edge.GetImageCveId())
+	cveIDs := make([]string, 0, len(imageCVEs))
+	for _, compCVE := range imageCVEs {
+		compCVE.State = state
+		cveIDs = append(cveIDs, compCVE.GetId())
 	}
 
 	// Construct keys to lock.
@@ -1425,7 +943,7 @@ func (s *storeImpl) retryableUpdateVulnState(ctx context.Context, cve string, im
 	}
 
 	return s.keyFence.DoStatusWithLock(concurrency.DiscreteKeySet(keys...), func() error {
-		err = copyFromImageCVEEdges(ctx, tx, time.Now(), true, imageCVEEdges...)
+		err = s.updateCVEVulnState(ctx, tx, imageCVEs...)
 		if err != nil {
 			if err := tx.Rollback(ctx); err != nil {
 				return err
@@ -1436,16 +954,60 @@ func (s *storeImpl) retryableUpdateVulnState(ctx context.Context, cve string, im
 	})
 }
 
-func gatherKeys(parts *imagePartsAsSlice) [][]byte {
-	// We only need to collect image, component, and vuln keys because edges are derived from those resources and edge
-	// datastores are do not support upserts and deletes.
-	keys := make([][]byte, 0, len(parts.components)+len(parts.vulns)+1)
-	keys = append(keys, []byte(parts.image.GetId()))
-	for _, component := range parts.components {
-		keys = append(keys, []byte(component.GetId()))
+func (s *storeImpl) updateCVEVulnState(ctx context.Context, tx *postgres.Tx, objs ...*storage.ImageCVEV2) error {
+	batch := &pgx.Batch{}
+	for _, obj := range objs {
+		if err := s.insertIntoImageComponentV2Cves(batch, obj); err != nil {
+			return errors.Wrap(err, "error on insertInto")
+		}
 	}
-	for _, vuln := range parts.vulns {
-		keys = append(keys, []byte(vuln.GetId()))
+	batchResults := tx.SendBatch(ctx, batch)
+	if err := batchResults.Close(); err != nil {
+		return errors.Wrap(err, "closing batch")
+	}
+	return nil
+}
+
+// TODO, figure out if we can wrap the transaction and use the one in the image CVE store
+func (s *storeImpl) insertIntoImageComponentV2Cves(batch *pgx.Batch, obj *storage.ImageCVEV2) error {
+	serialized, marshalErr := obj.MarshalVT()
+	if marshalErr != nil {
+		return marshalErr
+	}
+
+	values := []interface{}{
+		obj.GetId(),
+		obj.GetImageId(),
+		obj.GetCveBaseInfo().GetCve(),
+		protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
+		protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
+		obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+		obj.GetOperatingSystem(),
+		obj.GetCvss(),
+		obj.GetSeverity(),
+		obj.GetImpactScore(),
+		obj.GetNvdcvss(),
+		protocompat.NilOrTime(obj.GetFirstImageOccurrence()),
+		obj.GetState(),
+		obj.GetIsFixable(),
+		obj.GetFixedBy(),
+		obj.GetComponentId(),
+		serialized,
+	}
+
+	finalStr := "INSERT INTO image_cves_v2 (Id, ImageId, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, OperatingSystem, Cvss, Severity, ImpactScore, Nvdcvss, FirstImageOccurrence, State, IsFixable, FixedBy, ComponentId, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, ImageId = EXCLUDED.ImageId, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, OperatingSystem = EXCLUDED.OperatingSystem, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Nvdcvss = EXCLUDED.Nvdcvss, FirstImageOccurrence = EXCLUDED.FirstImageOccurrence, State = EXCLUDED.State, IsFixable = EXCLUDED.IsFixable, FixedBy = EXCLUDED.FixedBy, ComponentId = EXCLUDED.ComponentId, serialized = EXCLUDED.serialized"
+	batch.Queue(finalStr, values...)
+
+	return nil
+}
+
+func gatherKeys(parts *imagePartsAsSlice) [][]byte {
+	// We only need to collect image, component keys because vulns are a child of component and the component
+	// datastore does not support upserts and deletes of vulns.
+	keys := make([][]byte, 0, len(parts.componentsV2))
+	keys = append(keys, []byte(parts.image.GetId()))
+	for _, component := range parts.componentsV2 {
+		keys = append(keys, []byte(component.GetId()))
 	}
 	return keys
 }
@@ -1462,4 +1024,37 @@ func scanIDs(rows pgx.Rows) ([]string, error) {
 		ids = append(ids, id)
 	}
 	return ids, rows.Err()
+}
+
+// // Used for testing
+func dropAllTablesInImageTree(ctx context.Context, db postgres.DB) {
+	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS images CASCADE")
+	dropTableImagesLayers(ctx, db)
+	dropTableImageComponents(ctx, db)
+	dropTableImageCVEs(ctx, db)
+}
+
+func dropTableImagesLayers(ctx context.Context, db postgres.DB) {
+	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS images_Layers CASCADE")
+}
+
+func dropTableImageComponents(ctx context.Context, db postgres.DB) {
+	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+imageComponentsV2Table+" CASCADE")
+}
+
+func dropTableImageCVEs(ctx context.Context, db postgres.DB) {
+	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+imageComponentsV2CVEsTable+" CASCADE")
+}
+
+// Destroy drops image table.
+func Destroy(ctx context.Context, db postgres.DB) {
+	dropAllTablesInImageTree(ctx, db)
+}
+
+// CreateTableAndNewStore returns a new Store instance for testing
+func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB, noUpdateTimestamps bool) store.Store {
+	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImagesStmt)
+	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageComponentV2Stmt)
+	pgutils.CreateTableFromModel(ctx, gormDB, pkgSchema.CreateTableImageCvesV2Stmt)
+	return New(db, noUpdateTimestamps, concurrency.NewKeyFence(), componentStore.New(db))
 }

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -1028,17 +1028,3 @@ func gatherKeys(parts *imagePartsAsSlice) [][]byte {
 	}
 	return keys
 }
-
-func scanIDs(rows pgx.Rows) ([]string, error) {
-	defer rows.Close()
-	var ids []string
-
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
-	}
-	return ids, rows.Err()
-}

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 )
@@ -36,9 +35,8 @@ const (
 )
 
 var (
-	log            = logging.LoggerForModule()
-	schema         = pkgSchema.ImagesSchema
-	targetResource = resources.Image
+	log    = logging.LoggerForModule()
+	schema = pkgSchema.ImagesSchema
 )
 
 type imagePartsAsSlice struct {

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/central/image/datastore/store"
 	"github.com/stackrox/rox/central/image/datastore/store/common/v2"
+	common2 "github.com/stackrox/rox/central/image/datastore/store/common/v2"
 	componentStore "github.com/stackrox/rox/central/imagecomponent/v2/datastore/store/postgres"
 	"github.com/stackrox/rox/central/metrics"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -153,10 +154,10 @@ func (s *storeImpl) insertIntoImages(
 	}
 
 	if !scanUpdated {
-		common.SensorEventsDeduperCounter.With(prometheus.Labels{"status": "deduped"}).Inc()
+		common2.SensorEventsDeduperCounter.With(prometheus.Labels{"status": "deduped"}).Inc()
 		return nil
 	}
-	common.SensorEventsDeduperCounter.With(prometheus.Labels{"status": "passed"}).Inc()
+	common2.SensorEventsDeduperCounter.With(prometheus.Labels{"status": "passed"}).Inc()
 
 	err = copyFromImageComponentsV2(ctx, tx, iTime, componentCVEMap, parts.componentsV2...)
 	if err != nil {

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -1,0 +1,152 @@
+//go:build sql_integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	componentStore "github.com/stackrox/rox/central/imagecomponent/v2/datastore/store/postgres"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/suite"
+)
+
+type ImagesStoreSuite struct {
+	suite.Suite
+}
+
+func TestImagesStore(t *testing.T) {
+	suite.Run(t, new(ImagesStoreSuite))
+}
+
+func (s *ImagesStoreSuite) TestStore() {
+	if !features.FlattenCVEData.Enabled() {
+		s.T().Skip("FlattenCVEData is not enabled")
+	}
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	source := pgtest.GetConnectionString(s.T())
+	config, err := postgres.ParseConfig(source)
+	s.Require().NoError(err)
+	pool, err := postgres.New(ctx, config)
+	s.NoError(err)
+	defer pool.Close()
+
+	Destroy(ctx, pool)
+
+	gormDB := pgtest.OpenGormDB(s.T(), source)
+	defer pgtest.CloseGormDB(s.T(), gormDB)
+	store := CreateTableAndNewStore(ctx, pool, gormDB, false)
+
+	image := fixtures.GetImage()
+	s.NoError(testutils.FullInit(image, testutils.SimpleInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range image.GetScan().GetComponents() {
+		for _, vuln := range comp.GetVulns() {
+			vuln.NvdCvss = 0
+			vuln.Suppressed = false
+			vuln.SuppressActivation = nil
+			vuln.SuppressExpiry = nil
+		}
+	}
+
+	foundImage, exists, err := store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.False(exists)
+	s.Nil(foundImage)
+
+	s.NoError(store.Upsert(ctx, image))
+	foundImage, exists, err = store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.True(exists)
+	cloned := image.CloneVT()
+
+	protoassert.Equal(s.T(), cloned, foundImage)
+
+	imageCount, err := store.Count(ctx, search.EmptyQuery())
+	s.NoError(err)
+	s.Equal(imageCount, 1)
+
+	imageExists, err := store.Exists(ctx, image.GetId())
+	s.NoError(err)
+	s.True(imageExists)
+	s.NoError(store.Upsert(ctx, image))
+
+	foundImage, exists, err = store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.True(exists)
+
+	// Reconcile the timestamps that are set during upsert.
+	cloned.LastUpdated = foundImage.LastUpdated
+	protoassert.Equal(s.T(), cloned, foundImage)
+
+	s.NoError(store.Delete(ctx, image.GetId()))
+	foundImage, exists, err = store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.False(exists)
+	s.Nil(foundImage)
+}
+
+func (s *ImagesStoreSuite) TestNVDCVSS() {
+	if !features.FlattenCVEData.Enabled() {
+		s.T().Skip("FlattenCVEData is not enabled")
+	}
+
+	ctx := sac.WithAllAccess(context.Background())
+	source := pgtest.GetConnectionString(s.T())
+	config, err := postgres.ParseConfig(source)
+	s.Require().NoError(err)
+	pool, err := postgres.New(ctx, config)
+	s.NoError(err)
+	defer pool.Close()
+	Destroy(ctx, pool)
+
+	gormDB := pgtest.OpenGormDB(s.T(), source)
+	defer pgtest.CloseGormDB(s.T(), gormDB)
+	store := CreateTableAndNewStore(ctx, pool, gormDB, false)
+
+	image := fixtures.GetImage()
+	s.NoError(testutils.FullInit(image, testutils.SimpleInitializer(), testutils.JSONFieldsFilter))
+	nvdCvss := &storage.CVSSScore{
+		Source: storage.Source_SOURCE_NVD,
+		CvssScore: &storage.CVSSScore_Cvssv3{
+			Cvssv3: &storage.CVSSV3{
+				Score: 10,
+			},
+		},
+	}
+	for _, component := range image.GetScan().GetComponents() {
+		for _, vuln := range component.GetVulns() {
+			vuln.CvssMetrics = []*storage.CVSSScore{nvdCvss}
+		}
+
+	}
+
+	s.NoError(store.Upsert(ctx, image))
+	foundImage, exists, err := store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.NotEmpty(foundImage)
+
+	componentPgStore := componentStore.CreateTableAndNewStore(ctx, pool, gormDB)
+	components, err := componentPgStore.GetIDs(ctx)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(components)
+	id := components[0]
+	imageComponent, _, err := componentPgStore.Get(ctx, id)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(imageComponent)
+	for _, cve := range imageComponent.GetCves() {
+		s.Equal(float32(10), cve.GetNvdcvss())
+		s.Require().NotEmpty(cve.GetCvssMetrics())
+		protoassert.Equal(s.T(), nvdCvss, cve.GetCvssMetrics()[0])
+	}
+}

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -24,7 +24,6 @@ import (
 var (
 	lastWeek  = time.Now().Add(-7 * 24 * time.Hour)
 	yesterday = time.Now().Add(-24 * time.Hour)
-	now       = time.Now()
 )
 
 type ImagesStoreSuite struct {
@@ -245,11 +244,11 @@ func (s *ImagesStoreSuite) TestUpsert() {
 	log.Infof("SHREWS -- found1 %v", foundImage)
 	protoassert.Equal(s.T(), cloned, foundImage)
 
-	//s.NoError(store.Delete(ctx, image.GetId()))
-	//foundImage, exists, err = store.Get(ctx, image.GetId())
-	//s.NoError(err)
-	//s.False(exists)
-	//s.Nil(foundImage)
+	s.NoError(store.Delete(ctx, image.GetId()))
+	foundImage, exists, err = store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.False(exists)
+	s.Nil(foundImage)
 
 	s.T().Setenv("ROX_FLATTEN_CVE_DATA", "false")
 }

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"testing"
+	"time"
 
 	cveStore "github.com/stackrox/rox/central/cve/image/v2/datastore/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
@@ -13,10 +14,17 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/suite"
+)
+
+var (
+	lastWeek  = time.Now().Add(-7 * 24 * time.Hour)
+	yesterday = time.Now().Add(-24 * time.Hour)
+	now       = time.Now()
 )
 
 type ImagesStoreSuite struct {
@@ -29,7 +37,7 @@ func TestImagesStore(t *testing.T) {
 
 func (s *ImagesStoreSuite) TestStore() {
 	if !features.FlattenCVEData.Enabled() {
-		s.T().Skip("FlattenCVEData is not enabled")
+		s.T().Setenv("ROX_FLATTEN_CVE_DATA", "true")
 	}
 
 	ctx := sac.WithAllAccess(context.Background())
@@ -69,6 +77,8 @@ func (s *ImagesStoreSuite) TestStore() {
 	s.True(exists)
 	cloned := image.CloneVT()
 
+	log.Infof("SHREWS -- cloned %v", cloned)
+	log.Infof("SHREWS -- found1 %v", foundImage)
 	protoassert.Equal(s.T(), cloned, foundImage)
 
 	imageCount, err := store.Count(ctx, search.EmptyQuery())
@@ -93,11 +103,13 @@ func (s *ImagesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.False(exists)
 	s.Nil(foundImage)
+
+	s.T().Setenv("ROX_FLATTEN_CVE_DATA", "false")
 }
 
 func (s *ImagesStoreSuite) TestNVDCVSS() {
 	if !features.FlattenCVEData.Enabled() {
-		s.T().Skip("FlattenCVEData is not enabled")
+		s.T().Setenv("ROX_FLATTEN_CVE_DATA", "true")
 	}
 
 	ctx := sac.WithAllAccess(context.Background())
@@ -147,4 +159,228 @@ func (s *ImagesStoreSuite) TestNVDCVSS() {
 	s.Equal(float32(10), imageCve.GetNvdcvss())
 	s.Require().NotEmpty(imageCve.GetCveBaseInfo().GetCvssMetrics())
 	protoassert.Equal(s.T(), nvdCvss, imageCve.GetCveBaseInfo().GetCvssMetrics()[0])
+
+	s.T().Setenv("ROX_FLATTEN_CVE_DATA", "false")
+}
+
+func (s *ImagesStoreSuite) TestUpsert() {
+	if !features.FlattenCVEData.Enabled() {
+		s.T().Setenv("ROX_FLATTEN_CVE_DATA", "true")
+	}
+
+	if !features.FlattenCVEData.Enabled() {
+		s.T().Setenv("ROX_FLATTEN_CVE_DATA", "true")
+	}
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	source := pgtest.GetConnectionString(s.T())
+	config, err := postgres.ParseConfig(source)
+	s.Require().NoError(err)
+	pool, err := postgres.New(ctx, config)
+	s.NoError(err)
+	defer pool.Close()
+
+	Destroy(ctx, pool)
+
+	gormDB := pgtest.OpenGormDB(s.T(), source)
+	defer pgtest.CloseGormDB(s.T(), gormDB)
+	store := CreateTableAndNewStore(ctx, pool, gormDB, false)
+
+	image := getTestImage("image1")
+
+	s.NoError(store.Upsert(ctx, image))
+	foundImage, exists, err := store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.True(exists)
+	cloned := image.CloneVT()
+
+	// Reconcile the timestamps that are set during upsert.
+	cloned.LastUpdated = foundImage.LastUpdated
+
+	log.Infof("SHREWS -- cloned %v", cloned)
+	log.Infof("SHREWS -- found1 %v", foundImage)
+	protoassert.Equal(s.T(), cloned, foundImage)
+
+	// Add a new component with "cve1" that has new times
+	// Ensure old times are associated with the CVE in the new component.
+	image.Scan.Components = append(image.Scan.Components, getComponent3())
+	s.NoError(store.Upsert(ctx, image))
+	foundImage, exists, err = store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.True(exists)
+
+	// Should pull the old CVE times for CVE1 even though it just appeared in
+	// the component.  The CVE has still existed in the image even though it is
+	// new to the component.
+	cloned.LastUpdated = foundImage.LastUpdated
+	cloned.Scan.Hashoneof = &storage.ImageScan_Hash{
+		Hash: foundImage.GetScan().GetHash(),
+	}
+	cloned.Scan.Components = append(cloned.Scan.Components, getComponent3Verify())
+	log.Infof("SHREWS -- cloned %v", cloned)
+	log.Infof("SHREWS -- found1 %v", foundImage)
+	protoassert.Equal(s.T(), cloned, foundImage)
+
+	// Replace all components removing "cve2".
+	// Ensure "cve2" is not returned with the image.
+
+	s.T().Setenv("ROX_FLATTEN_CVE_DATA", "false")
+}
+
+func getTestImage(id string) *storage.Image {
+	return &storage.Image{
+		Id: id,
+		Scan: &storage.ImageScan{
+			OperatingSystem: "blah",
+			ScanTime:        protocompat.TimestampNow(),
+			Components: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:    "comp1",
+					Version: "ver1",
+					Vulns:   []*storage.EmbeddedVulnerability{},
+				},
+				{
+					Name:    "comp1",
+					Version: "ver2",
+					Vulns: []*storage.EmbeddedVulnerability{
+						{
+							Cve:                "cve1",
+							VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+							VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+							CvssV3: &storage.CVSSV3{
+								ImpactScore: 10,
+							},
+							ScoreVersion:          storage.EmbeddedVulnerability_V3,
+							PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+							FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+							FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+						},
+						{
+							Cve:                "cve2",
+							VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+							VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+								FixedBy: "ver3",
+							},
+							CvssV3: &storage.CVSSV3{
+								ImpactScore: 1,
+							},
+							ScoreVersion:          storage.EmbeddedVulnerability_V3,
+							PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+							FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+							FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+						},
+					},
+				},
+				{
+					Name:    "comp2",
+					Version: "ver1",
+					Vulns: []*storage.EmbeddedVulnerability{
+						{
+							Cve:                "cve1",
+							VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+							VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+								FixedBy: "ver2",
+							},
+							CvssV3: &storage.CVSSV3{
+								ImpactScore: 10,
+							},
+							ScoreVersion:          storage.EmbeddedVulnerability_V3,
+							PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+							FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+							FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+						},
+						{
+							Cve:                "cve2",
+							VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+							VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+							CvssV3: &storage.CVSSV3{
+								ImpactScore: 1,
+							},
+							ScoreVersion:          storage.EmbeddedVulnerability_V3,
+							PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+							FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+							FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+						},
+					},
+				},
+			},
+		},
+		RiskScore: 30,
+		Priority:  1,
+	}
+}
+
+func getComponent3() *storage.EmbeddedImageScanComponent {
+	return &storage.EmbeddedImageScanComponent{
+		Name:    "comp3",
+		Version: "ver1",
+		Vulns: []*storage.EmbeddedVulnerability{
+			{
+				Cve:                "cve1",
+				VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+				VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+				SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+					FixedBy: "ver2",
+				},
+				CvssV3: &storage.CVSSV3{
+					ImpactScore: 10,
+				},
+				ScoreVersion:          storage.EmbeddedVulnerability_V3,
+				PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+				FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+				FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+			},
+			{
+				Cve:                "cve3",
+				VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+				VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+				CvssV3: &storage.CVSSV3{
+					ImpactScore: 1,
+				},
+				ScoreVersion:          storage.EmbeddedVulnerability_V3,
+				PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+				FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+				FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+			},
+		},
+	}
+}
+
+func getComponent3Verify() *storage.EmbeddedImageScanComponent {
+	return &storage.EmbeddedImageScanComponent{
+		Name:    "comp3",
+		Version: "ver1",
+		Vulns: []*storage.EmbeddedVulnerability{
+			{
+				Cve:                "cve1",
+				VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+				VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+				SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+					FixedBy: "ver2",
+				},
+				CvssV3: &storage.CVSSV3{
+					ImpactScore: 10,
+				},
+				ScoreVersion:          storage.EmbeddedVulnerability_V3,
+				PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+				FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+				FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+			},
+			{
+				Cve:                "cve3",
+				VulnerabilityType:  storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+				VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+				CvssV3: &storage.CVSSV3{
+					ImpactScore: 1,
+				},
+				ScoreVersion:          storage.EmbeddedVulnerability_V3,
+				PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+				FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+				FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&yesterday),
+			},
+		},
+	}
 }

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -225,6 +225,12 @@ func (s *ImagesStoreSuite) TestUpsert() {
 	// Replace all components removing "cve2".
 	// Ensure "cve2" is not returned with the image.
 
+	s.NoError(store.Delete(ctx, image.GetId()))
+	foundImage, exists, err = store.Get(ctx, image.GetId())
+	s.NoError(err)
+	s.False(exists)
+	s.Nil(foundImage)
+
 	s.T().Setenv("ROX_FLATTEN_CVE_DATA", "false")
 }
 
@@ -365,7 +371,7 @@ func getComponent3Verify() *storage.EmbeddedImageScanComponent {
 					ImpactScore: 10,
 				},
 				ScoreVersion:          storage.EmbeddedVulnerability_V3,
-				PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
+				PublishedOn:           protocompat.ConvertTimeToTimestampOrNil(&yesterday),
 				FirstImageOccurrence:  protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
 				FirstSystemOccurrence: protocompat.ConvertTimeToTimestampOrNil(&lastWeek),
 			},

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -76,8 +76,6 @@ func (s *ImagesStoreSuite) TestStore() {
 	s.True(exists)
 	cloned := image.CloneVT()
 
-	log.Infof("SHREWS -- cloned %v", cloned)
-	log.Infof("SHREWS -- found1 %v", foundImage)
 	protoassert.Equal(s.T(), cloned, foundImage)
 
 	imageCount, err := store.Count(ctx, search.EmptyQuery())
@@ -167,10 +165,6 @@ func (s *ImagesStoreSuite) TestUpsert() {
 		s.T().Setenv("ROX_FLATTEN_CVE_DATA", "true")
 	}
 
-	if !features.FlattenCVEData.Enabled() {
-		s.T().Setenv("ROX_FLATTEN_CVE_DATA", "true")
-	}
-
 	ctx := sac.WithAllAccess(context.Background())
 
 	source := pgtest.GetConnectionString(s.T())
@@ -200,8 +194,6 @@ func (s *ImagesStoreSuite) TestUpsert() {
 	// for first image occurrence and first system time of a CVE
 	cloned.Scan.Components = getTestImageComponentsVerify()
 
-	log.Infof("SHREWS -- cloned %v", cloned)
-	log.Infof("SHREWS -- found1 %v", foundImage)
 	protoassert.Equal(s.T(), cloned, foundImage)
 
 	// Add a new component with "cve1" that has new times
@@ -220,8 +212,6 @@ func (s *ImagesStoreSuite) TestUpsert() {
 		Hash: foundImage.GetScan().GetHash(),
 	}
 	cloned.Scan.Components = append(cloned.Scan.Components, getComponent3Verify())
-	log.Infof("SHREWS -- cloned %v", cloned)
-	log.Infof("SHREWS -- found1 %v", foundImage)
 	protoassert.Equal(s.T(), cloned, foundImage)
 
 	// Replace all components removing "cve1".
@@ -240,8 +230,6 @@ func (s *ImagesStoreSuite) TestUpsert() {
 	cloned.Scan.Hashoneof = &storage.ImageScan_Hash{
 		Hash: foundImage.GetScan().GetHash(),
 	}
-	log.Infof("SHREWS -- cloned %v", cloned)
-	log.Infof("SHREWS -- found1 %v", foundImage)
 	protoassert.Equal(s.T(), cloned, foundImage)
 
 	s.NoError(store.Delete(ctx, image.GetId()))

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	componentStore "github.com/stackrox/rox/central/imagecomponent/v2/datastore/store/postgres"
+	cveStore "github.com/stackrox/rox/central/cve/image/v2/datastore/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
@@ -136,17 +136,15 @@ func (s *ImagesStoreSuite) TestNVDCVSS() {
 	s.True(exists)
 	s.NotEmpty(foundImage)
 
-	componentPgStore := componentStore.CreateTableAndNewStore(ctx, pool, gormDB)
-	components, err := componentPgStore.GetIDs(ctx)
+	cvePgStore := cveStore.CreateTableAndNewStore(ctx, pool, gormDB)
+	cves, err := cvePgStore.GetIDs(ctx)
 	s.Require().NoError(err)
-	s.Require().NotEmpty(components)
-	id := components[0]
-	imageComponent, _, err := componentPgStore.Get(ctx, id)
+	s.Require().NotEmpty(cves)
+	id := cves[0]
+	imageCve, _, err := cvePgStore.Get(ctx, id)
 	s.Require().NoError(err)
-	s.Require().NotEmpty(imageComponent)
-	for _, cve := range imageComponent.GetCves() {
-		s.Equal(float32(10), cve.GetNvdcvss())
-		s.Require().NotEmpty(cve.GetCvssMetrics())
-		protoassert.Equal(s.T(), nvdCvss, cve.GetCvssMetrics()[0])
-	}
+	s.Require().NotEmpty(imageCve)
+	s.Equal(float32(10), imageCve.GetNvdcvss())
+	s.Require().NotEmpty(imageCve.GetCveBaseInfo().GetCvssMetrics())
+	protoassert.Equal(s.T(), nvdCvss, imageCve.GetCveBaseInfo().GetCvssMetrics()[0])
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Updates to the image store to populate the data for the updated model.  This is absolutely based off the existing image store.  The CVE and Components are tied to the image.  Thus there is a lot of logic to make sure things are updated correctly and that all the updates are done under a transaction.  I did however write https://issues.redhat.com/browse/ROX-28222 to look at refactoring this so that all the logic isn't buried in a bespoke store and perhaps bubble the logic up to the datastore later if we have time.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Updated and expanded unit test.  Executed clusters locally with the feature flag enabled to ensure the data is getting populated as expected as data is scanned.