### PR TITLE
ROX-28192: skip TLS verification for insecure registries

### DIFF
--- a/scanner/internal/httputil/doc.go
+++ b/scanner/internal/httputil/doc.go
@@ -1,0 +1,5 @@
+// Package httputil defines utility HTTP functions built specifically for Scanner's use cases.
+//
+// It is possible other StackRox components may benefit from these functions,
+// but that will be considered at a future time.
+package httputil

--- a/scanner/internal/httputil/transport.go
+++ b/scanner/internal/httputil/transport.go
@@ -1,0 +1,48 @@
+package httputil
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// InsecureSkipTLSVerifyHeader specifies the custom header used to
+// identify when to skip TLS verification.
+const InsecureSkipTLSVerifyHeader = `StackRox-Insecure-Skip-TLS-Verify`
+
+var _ http.RoundTripper = (*insecureCapableTransport)(nil)
+
+// insecureCapableTransport is a http.RoundTripper
+// which supports communication with servers with untrusted certificates
+// via presence of the header InsecureSkipTLSVerifyHeader.
+type insecureCapableTransport struct {
+	transport         http.RoundTripper
+	insecureTransport http.RoundTripper
+}
+
+// NewInsecureCapableTransport creates a http.RoundTripper based on the given transport.
+//
+// The given transport is used for all requests unless the request has the InsecureSkipTLSVerifyHeader
+// header. In that case, a copy of the given transport which skips client-side TLS certificate verification
+// is used.
+func NewInsecureCapableTransport(transport *http.Transport) http.RoundTripper {
+	insecure := transport.Clone()
+	if insecure.TLSClientConfig == nil {
+		insecure.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	} else {
+		insecure.TLSClientConfig.InsecureSkipVerify = true
+	}
+	return &insecureCapableTransport{
+		transport:         transport,
+		insecureTransport: insecure,
+	}
+}
+
+func (t *insecureCapableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get(InsecureSkipTLSVerifyHeader) == "true" {
+		req.Header.Del(InsecureSkipTLSVerifyHeader)
+		return t.insecureTransport.RoundTrip(req)
+	}
+	return t.transport.RoundTrip(req)
+}

--- a/scanner/internal/httputil/transport_mux.go
+++ b/scanner/internal/httputil/transport_mux.go
@@ -1,7 +1,3 @@
-// Package httputil defines utility HTTP functions built specifically for Scanner's use cases.
-//
-// It is possible other StackRox components may benefit from these functions,
-// but that will be considered at a future time.
 package httputil
 
 import (

--- a/scanner/internal/httputil/transport_test.go
+++ b/scanner/internal/httputil/transport_test.go
@@ -1,0 +1,36 @@
+package httputil
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTransport(t *testing.T) {
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "", r.Header.Get(InsecureSkipTLSVerifyHeader))
+	}))
+	testServer.StartTLS()
+	t.Cleanup(testServer.Close)
+
+	client := testServer.Client()
+	client.Transport = NewInsecureCapableTransport(http.DefaultTransport.(*http.Transport))
+
+	// Secure transport.
+	// Because we overwrote the transport, we will not know about the server's certs.
+	// Therefore, this is expected to fail.
+	_, err := client.Get(testServer.URL)
+	assert.ErrorAs(t, err, &x509.UnknownAuthorityError{})
+
+	// Insecure transport.
+	req, err := http.NewRequest("GET", testServer.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set(InsecureSkipTLSVerifyHeader, "true")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -171,6 +171,8 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 		}
 	}()
 
+	// Using http.DefaultTransport instead of httputil.DefaultTransport, as the Matcher
+	// should never have a need to reach out to a server with untrusted certificates.
 	// Note: http.DefaultTransport has already been modified to handle configured proxies.
 	// See scanner/cmd/scanner/main.go.
 	defaultTransport := http.DefaultTransport


### PR DESCRIPTION
### Description

This completes what https://github.com/stackrox/stackrox/pull/10680 originally hoped to complete. The original solution did ensure Scanner V4 Indexer could reach registries with untrusted certificates; however, it did not account for Claircore being unable to handle it.

Scanner V4 Indexer uses a single instance of a `libindex.Libindex` which is initialized upon startup. The issue is that this struct requires an `http.Client` upon initialization. Before this change, this client was completely unaware of the possibility of an insecure registry, so it did not skip TLS verification, even though Scanner V4 Indexer did skip it in steps prior to passing the request down to Claircore.

This change updates the client we give to `libindex.Libindex` to one which can handle insecure registries as well as the typical secure registries.

This is done via intercepting the request and looking for the presence of a custom header: `StackRox-Insecure-Skip-TLS-Verify`. If this header is found in the request, it is removed and we use a client which knows to skip TLS verification. If it's not found, the usual client is used.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests

#### How I validated my change

CI + test artifactory

Once I had an instance of Artifactory running, and you have set up a Docker repository called `docker-local`, run:
```
$ podman tag nginx:latest <TEST-ARTIFACTORY-IP>/docker-local/nginx:latest
$ podman push --creds='<USERNAME>:<PASSWORD>' --tls-verify=false <ARTIFACTORY-IP>/docker-local/nginx:latest
```

From there, I installed StackRox version `4.8.x-144-g75d7eac09e` with Scanner V4 into an OpenShift cluster. From there, I added a new registry integration for the Artifactory instance I created:

Without skipping TLS verification:

<img width="1237" alt="screenshot-fail" src="https://github.com/user-attachments/assets/b7bb581c-aa34-4b04-b0bc-0c1c4af51ca2" />

With skipping TLS verification:

<img width="1239" alt="screenshot-success" src="https://github.com/user-attachments/assets/747d0179-af42-4837-8e33-430e5f7f4bb2" />

Finally, I scanned the image (note the `--insecure-skip-tls-verify` is for connecting to Central):

```
$ roxctl -e <CENTRAL-ENDPOINT> --insecure-skip-tls-verify image scan -i <ARTIFACTORY-IP>/docker-local/nginx:latest | jq '.cves'
WARN:	Flag --format has been deprecated, please use --output/-o to specify the output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.
95
```