### PR TITLE
chore(sac): Create resource for Vulnerability Request store access

### DIFF
--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
@@ -65,7 +65,8 @@ func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
 		return false, sac.ErrResourceAccessDenied
 	}
 
-	return ds.store.Exists(ctx, id)
+	storeCtx := getStoreAccessContext(ctx, storage.Access_READ_ACCESS)
+	return ds.store.Exists(storeCtx, id)
 }
 
 func (ds *datastoreImpl) Get(ctx context.Context, id string) (*storage.VulnerabilityRequest, bool, error) {
@@ -78,7 +79,8 @@ func (ds *datastoreImpl) Get(ctx context.Context, id string) (*storage.Vulnerabi
 		return nil, false, sac.ErrResourceAccessDenied
 	}
 
-	return ds.store.Get(ctx, id)
+	storeCtx := getStoreAccessContext(ctx, storage.Access_READ_ACCESS)
+	return ds.store.Get(storeCtx, id)
 }
 
 func (ds *datastoreImpl) GetMany(ctx context.Context, ids []string) ([]*storage.VulnerabilityRequest, error) {
@@ -88,7 +90,8 @@ func (ds *datastoreImpl) GetMany(ctx context.Context, ids []string) ([]*storage.
 		return nil, sac.ErrResourceAccessDenied
 	}
 
-	ret, _, err := ds.store.GetMany(ctx, ids)
+	storeCtx := getStoreAccessContext(ctx, storage.Access_READ_ACCESS)
+	ret, _, err := ds.store.GetMany(storeCtx, ids)
 	return ret, err
 }
 
@@ -100,7 +103,8 @@ func (ds *datastoreImpl) AddRequest(ctx context.Context, request *storage.Vulner
 		return sac.ErrResourceAccessDenied
 	}
 
-	return ds.store.Upsert(ctx, request)
+	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	return ds.store.Upsert(storeWriteCtx, request)
 }
 
 func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message string, status storage.RequestStatus) (*storage.VulnerabilityRequest, error) {
@@ -121,7 +125,8 @@ func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message st
 		return nil, sac.ErrResourceAccessDenied
 	}
 
-	req, found, err := ds.store.Get(ctx, id)
+	storeReadWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	req, found, err := ds.store.Get(storeReadWriteCtx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +171,7 @@ func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message st
 		req.Expired = true
 	}
 
-	if err := ds.store.Upsert(ctx, req); err != nil {
+	if err := ds.store.Upsert(storeReadWriteCtx, req); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -266,7 +271,8 @@ func (ds *datastoreImpl) UpdateRequestExpiry(ctx context.Context, id, message st
 		req.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
 	}
 
-	if err := ds.store.Upsert(ctx, req); err != nil {
+	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.Upsert(storeWriteCtx, req); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -317,7 +323,8 @@ func (ds *datastoreImpl) ensureApproverOrInitialRequestorReturningRequest(ctx co
 		return nil, sac.ErrResourceAccessDenied
 	}
 
-	req, found, err := ds.store.Get(ctx, id)
+	storeReadCtx := getStoreAccessContext(ctx, storage.Access_READ_ACCESS)
+	req, found, err := ds.store.Get(storeReadCtx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +401,8 @@ func (ds *datastoreImpl) MarkRequestInactive(ctx context.Context, id, comment st
 	req.Comments = append(req.Comments, utils.CreateRequestCommentProto(ctx, comment))
 	req.Expired = true
 
-	if err := ds.store.Upsert(ctx, req); err != nil {
+	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.Upsert(storeWriteCtx, req); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -408,7 +416,8 @@ func (ds *datastoreImpl) RemoveRequest(ctx context.Context, id string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	req, found, err := ds.store.Get(ctx, id)
+	storeReadWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	req, found, err := ds.store.Get(storeReadWriteCtx, id)
 	if err != nil {
 		return err
 	}
@@ -429,7 +438,7 @@ func (ds *datastoreImpl) RemoveRequest(ctx context.Context, id string) error {
 	// exceptions can only is cancelled and are retained in the system according to the retention configuration.
 	switch req.GetStatus() {
 	case storage.RequestStatus_PENDING:
-		if err := ds.store.Delete(ctx, id); err != nil {
+		if err := ds.store.Delete(storeReadWriteCtx, id); err != nil {
 			return errors.Wrapf(err, "could not delete vulnerability exception %s", id)
 		}
 
@@ -438,7 +447,7 @@ func (ds *datastoreImpl) RemoveRequest(ctx context.Context, id string) error {
 		// the original state, it can't be simply removed.
 		req.Status = storage.RequestStatus_APPROVED
 		req.UpdatedReq = nil
-		if err := ds.store.Upsert(ctx, req); err != nil {
+		if err := ds.store.Upsert(storeReadWriteCtx, req); err != nil {
 			return errors.Wrapf(err, "could not delete vulnerability exception %s update", id)
 		}
 	default:
@@ -454,10 +463,29 @@ func (ds *datastoreImpl) RemoveRequestsInternal(ctx context.Context, ids []strin
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-	if err := ds.store.DeleteMany(ctx, ids); err != nil {
+	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.DeleteMany(storeWriteCtx, ids); err != nil {
 		return err
 	}
 	ds.pendingReqCache.RemoveMany(ids...)
 	ds.activeReqCache.RemoveMany(ids...)
 	return nil
 }
+
+// region helpers
+
+func getStoreAccessContext(ctx context.Context, mode storage.Access) context.Context {
+	accessModes := []storage.Access{mode}
+	if mode == storage.Access_READ_WRITE_ACCESS {
+		accessModes = append(accessModes, storage.Access_READ_ACCESS)
+	}
+	return sac.WithGlobalAccessScopeChecker(
+		ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(accessModes...),
+			sac.ResourceScopeKeys(resources.VulnerabilityRequest),
+		),
+	)
+}
+
+// endregion helpers

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
@@ -309,7 +309,8 @@ func (ds *datastoreImpl) UpdateRequest(ctx context.Context, id string, update *c
 		falsePositiveUpdate(req, update.FalsePositiveUpdate)
 	}
 
-	if err := ds.store.Upsert(ctx, req); err != nil {
+	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.Upsert(storeWriteCtx, req); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl_postgres_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl_postgres_test.go
@@ -76,8 +76,6 @@ const (
 
 	fakeUserID    = "user-id-a"
 	altFakeUserID = "another users id"
-
-	notFoundFormat = "vulnerability request %s not found"
 )
 
 func TestVulnRequestPostgresDataStore(t *testing.T) {
@@ -346,7 +344,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyRequesterWithWriteCanAdd
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyApproversWithWriteCanUpdateStatus() {
-	for ix, ctx := range []context.Context{approverAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{approverWriteSac, approverAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 601).String()
 		s.injectGeneratedRequest(requestID)
 		updated, err := s.datastore.UpdateRequestStatus(ctx, requestID, approvedMessage, storage.RequestStatus_APPROVED)
@@ -355,18 +353,8 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyApproversWithWriteCanUpd
 		s.Equal(updated.Status, storage.RequestStatus_APPROVED)
 	}
 
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{approverWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 611).String()
-		s.injectGeneratedRequest(requestID)
-		updated, err := s.datastore.UpdateRequestStatus(ctx, requestID, approvedMessage, storage.RequestStatus_APPROVED)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-		s.Nil(updated)
-	}
-
 	for ix, ctx := range []context.Context{requesterReadSac, requesterWriteSac, approverReadSac, selfApproverReadSac, noVMAccessSac} {
-		requestID := uuid.NewTestUUID(ix + 621).String()
+		requestID := uuid.NewTestUUID(ix + 611).String()
 		s.injectGeneratedRequest(requestID)
 		_, err := s.datastore.UpdateRequestStatus(ctx, requestID, approvedMessage, storage.RequestStatus_APPROVED)
 		s.ErrorIs(err, sac.ErrResourceAccessDenied)
@@ -593,7 +581,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryRequiresW
 	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c")
 	req.Requestor = &storage.SlimUser{Id: fakeUserID}
 
-	for ix, ctx := range []context.Context{requesterAllSac, approverAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac, approverWriteSac, approverAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		testReq := req.CloneVT()
 		testReq.Id = uuid.NewTestUUID(ix + 1301).String()
 		testReq.Name = fmt.Sprintf("VulnerabilityRequest %s", testReq.Id)
@@ -607,26 +595,9 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryRequiresW
 		s.NoError(err)
 	}
 
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac, approverWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 1311).String()
-		testReq := req.CloneVT()
-		testReq.Id = requestID
-		testReq.Name = fmt.Sprintf("VulnerabilityRequest %s", testReq.Id)
-		s.injectRequest(testReq)
-		_, err := s.datastore.UpdateRequestExpiry(
-			authn.ContextWithIdentity(ctx, s.mockIdentity, s.T()),
-			testReq.GetId(),
-			"update comment",
-			expiry,
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-	}
-
 	for ix, ctx := range []context.Context{requesterReadSac, approverReadSac, selfApproverReadSac, noVMAccessSac} {
 		testReq := req.CloneVT()
-		testReq.Id = uuid.NewTestUUID(ix + 1321).String()
+		testReq.Id = uuid.NewTestUUID(ix + 1311).String()
 		testReq.Name = fmt.Sprintf("VulnerabilityRequest %s", testReq.Id)
 		s.injectRequest(testReq)
 		_, err := s.datastore.UpdateRequestExpiry(ctx, testReq.GetId(), "update comment", expiry)
@@ -636,7 +607,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryRequiresW
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestRequesterCannotUpdateOthersRequestExpiry() {
 	expiry := &storage.RequestExpiry{Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: protocompat.TimestampNow()}}
-	for ix, ctx := range []context.Context{requesterAllSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac} {
 		requestID := uuid.NewTestUUID(ix + 1401).String()
 		s.injectGeneratedRequest(requestID)
 		_, err := s.datastore.UpdateRequestExpiry(
@@ -647,19 +618,6 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestRequesterCannotUpdateOthersR
 		)
 		s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	}
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 1411).String()
-		s.injectGeneratedRequest(requestID)
-		_, err := s.datastore.UpdateRequestExpiry(
-			authn.ContextWithIdentity(ctx, s.altIdentity, s.T()),
-			requestID,
-			"comment",
-			expiry,
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-	}
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestApproversCanUpdateOthersRequestExpiry() {
@@ -667,7 +625,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestApproversCanUpdateOthersRequ
 	req := fixtures.GetGlobalDeferralRequest("cve-a-b-c").CloneVT()
 	req.Requestor = &storage.SlimUser{Id: "another users id"}
 
-	for ix, ctx := range []context.Context{approverAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{approverWriteSac, approverAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 1501).String()
 		testReq := req.CloneVT()
 		testReq.Id = requestID
@@ -680,23 +638,6 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestApproversCanUpdateOthersRequ
 			expiry,
 		)
 		s.NoError(err)
-	}
-
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{approverWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 1511).String()
-		testReq := req.CloneVT()
-		testReq.Id = requestID
-		testReq.Name = fmt.Sprintf("Vulnerability Request %s", testReq.Id)
-		s.injectRequest(testReq)
-		_, err := s.datastore.UpdateRequestExpiry(
-			authn.ContextWithIdentity(ctx, s.mockIdentity, s.T()),
-			requestID,
-			"comment",
-			expiry,
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
 	}
 }
 
@@ -721,7 +662,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryFailsINot
 	s.injectRequest(req)
 
 	_, err := s.datastore.UpdateRequestExpiry(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		"update comment",
 		expiry,
@@ -740,7 +681,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryFailsIfRe
 	s.injectRequest(req)
 
 	_, err := s.datastore.UpdateRequestExpiry(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		"update comment",
 		expiry,
@@ -759,7 +700,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryFailsIfRe
 	s.injectRequest(req)
 
 	_, err := s.datastore.UpdateRequestExpiry(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		"update comment",
 		expiry,
@@ -779,7 +720,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryUpdatesEx
 	s.injectRequest(req)
 
 	resp, err := s.datastore.UpdateRequestExpiry(
-		authn.ContextWithIdentity(requesterAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(requesterWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		"update comment",
 		expiry,
@@ -804,7 +745,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpiryUpdatesEx
 	s.injectRequest(req)
 
 	resp, err := s.datastore.UpdateRequestExpiry(
-		authn.ContextWithIdentity(requesterAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(requesterWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		"update comment",
 		expiry,
@@ -829,7 +770,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestExpirySetsUpdat
 	s.injectRequest(req)
 
 	resp, err := s.datastore.UpdateRequestExpiry(
-		authn.ContextWithIdentity(requesterAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(requesterWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		"update comment",
 		expiry,
@@ -862,7 +803,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestFailsIfRequestW
 	s.injectRequest(req)
 
 	_, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -891,7 +832,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestFailsIfTypeIsDi
 	s.injectRequest(req)
 
 	_, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -913,7 +854,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestFailsIfTypeIsDi
 	s.injectRequest(req)
 
 	_, err = s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -944,7 +885,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestFailsIfNoOp() {
 	s.injectRequest(req)
 
 	_, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -966,7 +907,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestFailsIfNoOp() {
 	s.injectRequest(req)
 
 	_, err = s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -992,7 +933,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestFailsIfRequestW
 	s.injectRequest(req)
 
 	_, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(approverAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(approverWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -1019,7 +960,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestSucceedsIfDefer
 	s.injectRequest(req)
 
 	resp, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(requesterAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(requesterWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -1052,7 +993,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestSucceedsIfDefer
 	s.injectRequest(req)
 
 	resp, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(requesterAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(requesterWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -1082,7 +1023,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestSucceedsIfOrigi
 	s.injectRequest(req)
 
 	resp, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(requesterAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(requesterWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -1113,7 +1054,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestSucceedsIfOrigi
 	s.injectRequest(req)
 
 	resp, err := s.datastore.UpdateRequest(
-		authn.ContextWithIdentity(requesterAllSac, s.mockIdentity, s.T()),
+		authn.ContextWithIdentity(requesterWriteSac, s.mockIdentity, s.T()),
 		requestID,
 		update,
 	)
@@ -1125,7 +1066,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestUpdateRequestSucceedsIfOrigi
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestMarkRequestInactiveRequiresWriteOnAny() {
-	for ix, ctx := range []context.Context{requesterAllSac, approverAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac, approverWriteSac, approverAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 3101).String()
 		s.injectGeneratedRequest(requestID)
 		_, err := s.datastore.MarkRequestInactive(
@@ -1136,21 +1077,8 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestMarkRequestInactiveRequiresW
 		s.NoError(err)
 	}
 
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac, approverWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 3111).String()
-		s.injectGeneratedRequest(requestID)
-		_, err := s.datastore.MarkRequestInactive(
-			authn.ContextWithIdentity(ctx, s.mockIdentity, s.T()),
-			requestID,
-			"comment",
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-	}
-
 	for ix, ctx := range []context.Context{requesterReadSac, approverReadSac, selfApproverReadSac, noVMAccessSac} {
-		requestID := uuid.NewTestUUID(ix + 3121).String()
+		requestID := uuid.NewTestUUID(ix + 3111).String()
 		s.injectGeneratedRequest(requestID)
 		_, err := s.datastore.MarkRequestInactive(ctx, requestID, "comment")
 		s.ErrorIs(err, sac.ErrResourceAccessDenied)
@@ -1158,7 +1086,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestMarkRequestInactiveRequiresW
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestRequesterCannotMarkOthersRequestInactive() {
-	for ix, ctx := range []context.Context{requesterAllSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac} {
 		requestID := uuid.NewTestUUID(ix + 3201).String()
 		s.injectGeneratedRequest(requestID)
 		_, err := s.datastore.MarkRequestInactive(
@@ -1168,22 +1096,10 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestRequesterCannotMarkOthersReq
 		)
 		s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	}
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 3211).String()
-		s.injectGeneratedRequest(requestID)
-		_, err := s.datastore.MarkRequestInactive(
-			authn.ContextWithIdentity(ctx, s.altIdentity, s.T()),
-			requestID,
-			"comment",
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-	}
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestApproversCanMarkOthersRequestInactive() {
-	for ix, ctx := range []context.Context{approverAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{approverWriteSac, approverAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 3301).String()
 		s.injectGeneratedRequest(requestID)
 		_, err := s.datastore.MarkRequestInactive(
@@ -1193,23 +1109,10 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestApproversCanMarkOthersReques
 		)
 		s.NoError(err)
 	}
-
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{approverWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 3311).String()
-		s.injectGeneratedRequest(requestID)
-		_, err := s.datastore.MarkRequestInactive(
-			authn.ContextWithIdentity(ctx, s.altIdentity, s.T()),
-			requestID,
-			"comment",
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-	}
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestMarkRequestInactiveFailsWhenAlreadyInactive() {
-	for ix, ctx := range []context.Context{requesterAllSac, approverAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac, approverWriteSac, approverAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 3401).String()
 		s.injectGeneratedExpiredRequest(requestID)
 		_, err := s.datastore.MarkRequestInactive(
@@ -1218,19 +1121,6 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestMarkRequestInactiveFailsWhen
 			"comment",
 		)
 		expectedErrorString := fmt.Sprintf("vulnerability request %s has expired. Undo is noop", requestID)
-		s.EqualError(err, expectedErrorString)
-	}
-
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac, approverWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 3411).String()
-		s.injectGeneratedExpiredRequest(requestID)
-		_, err := s.datastore.MarkRequestInactive(
-			authn.ContextWithIdentity(ctx, s.mockIdentity, s.T()),
-			requestID,
-			"comment",
-		)
-		expectedErrorString := fmt.Sprintf(notFoundFormat, requestID)
 		s.EqualError(err, expectedErrorString)
 	}
 }
@@ -1250,7 +1140,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestMarkRequestInactiveSetsComme
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyRequesterWithWriteCanRemoveOwnRequest() {
-	for ix, ctx := range []context.Context{requesterAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 3601).String()
 		s.injectGeneratedRequest(requestID)
 		err := s.datastore.RemoveRequest(
@@ -1264,25 +1154,8 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyRequesterWithWriteCanRem
 		s.Nil(rsp)
 	}
 
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 3611).String()
-		req := createPendingVulnerabilityRequest(requestID)
-		s.injectRequest(req)
-		err := s.datastore.RemoveRequest(
-			authn.ContextWithIdentity(ctx, s.mockIdentity, s.T()),
-			requestID,
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-		rsp, found, err := s.datastore.Get(selfApproverAllSac, requestID)
-		s.NoError(err)
-		s.True(found)
-		protoassert.Equal(s.T(), req, rsp)
-	}
-
 	for ix, ctx := range []context.Context{requesterReadSac, approverReadSac, approverWriteSac, approverAllSac, selfApproverReadSac, noVMAccessSac} {
-		requestID := uuid.NewTestUUID(ix + 3621).String()
+		requestID := uuid.NewTestUUID(ix + 3611).String()
 		req := createPendingVulnerabilityRequest(requestID)
 		s.injectRequest(req)
 		err := s.datastore.RemoveRequest(ctx, requestID)
@@ -1295,7 +1168,7 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyRequesterWithWriteCanRem
 }
 
 func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyRequesterWithWriteCannotRemoveOthersRequests() {
-	for ix, ctx := range []context.Context{requesterAllSac, selfApproverAllSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 3701).String()
 		req := createPendingVulnerabilityRequest(requestID)
 		s.injectRequest(req)
@@ -1309,24 +1182,8 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyRequesterWithWriteCannot
 		s.True(found)
 		protoassert.Equal(s.T(), req, rsp)
 	}
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac, selfApproverWriteSac} {
+	for ix, ctx := range []context.Context{requesterWriteSac, requesterAllSac, selfApproverWriteSac, selfApproverAllSac} {
 		requestID := uuid.NewTestUUID(ix + 3711).String()
-		req := createPendingVulnerabilityRequest(requestID)
-		s.injectRequest(req)
-		err := s.datastore.RemoveRequest(
-			authn.ContextWithIdentity(ctx, s.altIdentity, s.T()),
-			requestID,
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-		rsp, found, err := s.datastore.Get(selfApproverAllSac, requestID)
-		s.NoError(err)
-		s.True(found)
-		protoassert.Equal(s.T(), req, rsp)
-	}
-	for ix, ctx := range []context.Context{requesterAllSac, selfApproverAllSac} {
-		requestID := uuid.NewTestUUID(ix + 3721).String()
 		req := createPendingVulnerabilityRequest(requestID)
 		s.injectRequest(req)
 		err := s.datastore.RemoveRequest(
@@ -1338,22 +1195,6 @@ func (s *VulnRequestPostgresDataStoreTestSuite) TestOnlyRequesterWithWriteCannot
 		s.NoError(err)
 		s.False(found)
 		s.Nil(rsp)
-	}
-	// requests with AllowFixedScope write-only scopes cannot read the requests to approve
-	for ix, ctx := range []context.Context{requesterWriteSac, selfApproverWriteSac} {
-		requestID := uuid.NewTestUUID(ix + 3731).String()
-		req := createPendingVulnerabilityRequest(requestID)
-		s.injectRequest(req)
-		err := s.datastore.RemoveRequest(
-			authn.ContextWithIdentity(ctx, s.mockIdentity, s.T()),
-			requestID,
-		)
-		errorText := fmt.Sprintf(notFoundFormat, requestID)
-		s.EqualError(err, errorText)
-		rsp, found, err := s.datastore.Get(selfApproverAllSac, requestID)
-		s.NoError(err)
-		s.True(found)
-		protoassert.Equal(s.T(), req, rsp)
 	}
 }
 

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/searcher/searcher_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/searcher/searcher_impl.go
@@ -25,13 +25,28 @@ type searcherImpl struct {
 	searcher search.Searcher
 }
 
+func getStoreAccessContext(ctx context.Context) context.Context {
+	return sac.WithGlobalAccessScopeChecker(
+		ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(
+				resources.VulnerabilityRequest,
+				resources.VulnerabilityManagementApprovals,
+				resources.VulnerabilityManagementRequests,
+			),
+		),
+	)
+}
+
 // Count returns the number of search results from the query
 func (s *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	if ok, err := requesterOrApproverSAC.ReadAllowedToAny(ctx); err != nil || !ok {
 		return 0, err
 	}
 
-	return s.searcher.Count(ctx, q)
+	storeCtx := getStoreAccessContext(ctx)
+	return s.searcher.Count(storeCtx, q)
 }
 
 // Search returns the raw search results from the query
@@ -40,7 +55,8 @@ func (s *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result
 		return nil, err
 	}
 
-	return s.getSearchResults(ctx, q)
+	storeCtx := getStoreAccessContext(ctx)
+	return s.getSearchResults(storeCtx, q)
 }
 
 // SearchRequests returns the search results from indexed VulnerabilityRequest objects for the query.
@@ -49,7 +65,8 @@ func (s *searcherImpl) SearchRequests(ctx context.Context, q *v1.Query) ([]*v1.S
 		return nil, err
 	}
 
-	vulnRequests, results, err := s.searchRequests(ctx, q)
+	storeCtx := getStoreAccessContext(ctx)
+	vulnRequests, results, err := s.searchRequests(storeCtx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +79,8 @@ func (s *searcherImpl) SearchRawRequests(ctx context.Context, q *v1.Query) ([]*s
 		return nil, err
 	}
 
-	vulnReqs, _, err := s.searchRequests(ctx, q)
+	storeCtx := getStoreAccessContext(ctx)
+	vulnReqs, _, err := s.searchRequests(storeCtx, q)
 	return vulnReqs, err
 }
 

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/gen.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.VulnerabilityRequest --search-category VULN_REQUEST --permission-checker sac.NewAnyGlobalResourceAllowedPermissionChecker(resources.VulnerabilityManagementRequests,resources.VulnerabilityManagementApprovals)
+//go:generate pg-table-bindings-wrapper --type=storage.VulnerabilityRequest --search-category VULN_REQUEST

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protocompat"
-	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
@@ -28,8 +27,9 @@ const (
 )
 
 var (
-	log    = logging.LoggerForModule()
-	schema = pkgSchema.VulnerabilityRequestsSchema
+	log            = logging.LoggerForModule()
+	schema         = pkgSchema.VulnerabilityRequestsSchema
+	targetResource = resources.VulnerabilityRequest
 )
 
 type storeType = storage.VulnerabilityRequest
@@ -58,7 +58,7 @@ type Store interface {
 
 // New returns a new Store instance using the provided sql instance.
 func New(db postgres.DB) Store {
-	return pgSearch.NewGenericStoreWithPermissionChecker[storeType, *storeType](
+	return pgSearch.NewGenericStore[storeType, *storeType](
 		db,
 		schema,
 		pkGetter,
@@ -66,7 +66,8 @@ func New(db postgres.DB) Store {
 		copyFromVulnerabilityRequests,
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
-		sac.NewAnyGlobalResourceAllowedPermissionChecker(resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+		pgSearch.GloballyScopedUpsertChecker[storeType, *storeType](targetResource),
+		targetResource,
 	)
 }
 

--- a/pkg/postgres/schema/vulnerability_requests.go
+++ b/pkg/postgres/schema/vulnerability_requests.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
-	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
@@ -45,7 +44,7 @@ var (
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.VulnerabilityRequest)(nil)), "vulnerability_requests")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_VULN_REQUEST, "vulnerabilityrequest", (*storage.VulnerabilityRequest)(nil)))
-		schema.PermissionChecker = sac.NewAnyGlobalResourceAllowedPermissionChecker(resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals)
+		schema.ScopingResource = resources.VulnerabilityRequest
 		RegisterTable(schema, CreateTableVulnerabilityRequestsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_VULN_REQUEST, schema)
 		return schema

--- a/pkg/sac/resources/list.go
+++ b/pkg/sac/resources/list.go
@@ -79,11 +79,12 @@ var (
 	WorkflowAdministration = newResourceMetadata("WorkflowAdministration", permissions.GlobalScope)
 
 	// Internal Resources.
-	ComplianceOperator = newInternalResourceMetadata("ComplianceOperator", permissions.GlobalScope)
-	InstallationInfo   = newInternalResourceMetadata("InstallationInfo", permissions.GlobalScope)
-	Notifications      = newInternalResourceMetadata("Notifications", permissions.GlobalScope)
-	Version            = newInternalResourceMetadata("Version", permissions.GlobalScope)
-	Hash               = newInternalResourceMetadata("Hash", permissions.GlobalScope)
+	ComplianceOperator   = newInternalResourceMetadata("ComplianceOperator", permissions.GlobalScope)
+	Hash                 = newInternalResourceMetadata("Hash", permissions.GlobalScope)
+	InstallationInfo     = newInternalResourceMetadata("InstallationInfo", permissions.GlobalScope)
+	Notifications        = newInternalResourceMetadata("Notifications", permissions.GlobalScope)
+	Version              = newInternalResourceMetadata("Version", permissions.GlobalScope)
+	VulnerabilityRequest = newInternalResourceMetadata("VulnerabilityRequest", permissions.GlobalScope)
 
 	resourceToMetadata         = make(map[permissions.Resource]permissions.ResourceMetadata)
 	disabledResourceToMetadata = make(map[permissions.Resource]permissions.ResourceMetadata)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This change is a first step in the direction of removing the concept of Permission Checker in the postgres stores and schemas.
An internal resource is added to control store access for VulnerabilityRequest objects. The more complex access control checks are performed at datastore level, and access to the store is injected in the context by the datastore logic when applicable.

PR stack:
- #14382
   - #14384 

### User-facing documentation

- [x] CHANGELOG ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->
Refactor PR. The associated testing was added upfront in #14382 

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI should cover the change.
