### PR TITLE
test: (scanner-v4-install) Use ORCH_CMD instead of kubectl

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -744,7 +744,7 @@ _deploy_central() {
     if [[ "${CI:-}" != "true" ]]; then
         info "Creating namespace and image pull secrets..."
         "${ORCH_CMD}" </dev/null create namespace "$central_namespace" || true
-        "${ROOT}/deploy/common/pull-secret.sh" stackrox quay.io | kubectl -n "$central_namespace" apply -f -
+        "${ROOT}/deploy/common/pull-secret.sh" stackrox quay.io | "${ORCH_CMD}" -n "$central_namespace" apply -f -
     fi
     deploy_central "${central_namespace}"
     patch_down_central "${central_namespace}"
@@ -801,8 +801,8 @@ _deploy_sensor() {
     if [[ "${CI:-}" != "true" ]]; then
         info "Creating image pull secrets..."
         "${ORCH_CMD}" </dev/null create namespace "$sensor_namespace" || true
-        "${ROOT}/deploy/common/pull-secret.sh" stackrox quay.io | kubectl -n "$sensor_namespace" apply -f -
-        "${ROOT}/deploy/common/pull-secret.sh" collector-stackrox quay.io | kubectl -n "$sensor_namespace" apply -f -
+        "${ROOT}/deploy/common/pull-secret.sh" stackrox quay.io | "${ORCH_CMD}" -n "$sensor_namespace" apply -f -
+        "${ROOT}/deploy/common/pull-secret.sh" collector-stackrox quay.io | "${ORCH_CMD}" -n "$sensor_namespace" apply -f -
     fi
     deploy_sensor "${sensor_namespace}" "${central_namespace}"
     patch_down_sensor "${sensor_namespace}"


### PR DESCRIPTION
### Description

For test stability, replace remaining occurrences of plain `kubectl` with `ORCH_CMD`, which points to the retrying `kubectl` wrapper.

