### PR TITLE
test: (scanner-v4-install) Simplify handling of old roxctl version

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -95,10 +95,12 @@ setup_file() {
     if [[ -z "${EARLIER_ROXCTL_PATH:-}" ]]; then
         EARLIER_ROXCTL_PATH=$(mktemp -d "early_roxctl.XXXXXX" -p /tmp)
     fi
-    echo "EARLIER_ROXCTL_PATH=$EARLIER_ROXCTL_PATH"
+    echo "For tests requiring an older roxctl version, $EARLIER_ROXCTL_PATH will be used."
     export EARLIER_ROXCTL_PATH
     if [[ ! -e "${EARLIER_ROXCTL_PATH}/roxctl" ]]; then
-        curl --retry 5 --retry-connrefused -sL "https://mirror.openshift.com/pub/rhacs/assets/${EARLIER_MAIN_IMAGE_TAG}/bin/${OS}/roxctl" --output "${EARLIER_ROXCTL_PATH}/roxctl"
+        local ROXCTL_URL="https://mirror.openshift.com/pub/rhacs/assets/${EARLIER_MAIN_IMAGE_TAG}/bin/${OS}/roxctl"
+        echo "Downloading roxctl from ${ROXCTL_URL}..."
+        curl --retry 5 --retry-connrefused -sL "$ROXCTL_URL" --output "${EARLIER_ROXCTL_PATH}/roxctl"
         chmod +x "${EARLIER_ROXCTL_PATH}/roxctl"
     fi
 
@@ -237,7 +239,6 @@ teardown() {
 }
 
 teardown_file() {
-    remove_earlier_roxctl_binary
 }
 
 @test "Upgrade from old Helm chart to HEAD Helm chart with Scanner v4 enabled" {
@@ -884,14 +885,6 @@ wait_for_ready_pods() {
     done
 
     echo "Pod(s) within deployment ${namespace}/${deployment} ready."
-}
-
-remove_earlier_roxctl_binary() {
-    if [[ -d "${EARLIER_ROXCTL_PATH}" ]]; then
-      rm -f "${EARLIER_ROXCTL_PATH}/roxctl"
-      rmdir "${EARLIER_ROXCTL_PATH}"
-      echo "Removed earlier roxctl binary"
-    fi
 }
 
 # Waits until ValidationWebhook is completely functional.


### PR DESCRIPTION
### Description

The current behaviour wrt handling of old roxctl's was bogus: if a user passed a path containing an existing old copy of roxctl to prevent re-downloading and thus speed up the test suite invocation, at the end this (pre-existing!) roxctl version was deleted. To keep things simple I have removed the deletion entirely. Alternative would have been to keep track of whether is has been downloaded or not but I doubt this would be worth the effort. This file is downloaded into a tmp directory and thus it should not persist for particularly long on host systems (host system being either CI or a local dev workstation).

This also fixes a bug in the test suite where an access to `EARLIER_ROXCTL_PATH` could happen during `teardown_file()` if, for some reason, `setup_file()` threw an error before that environment variable was properly initialized. Interestingly this would confuse Bats entirely, causing it not produce any helpful error messages even though it terminated with error. 

(I'd like to keep the `teardown_file()` function, it will most likely be re-populated in a follow-up PR.)
