### PR TITLE
ROX-8844: Allow conditionally leaving out empty rows

### DIFF
--- a/pkg/gjson/row.go
+++ b/pkg/gjson/row.go
@@ -268,17 +268,20 @@ func (ct *columnTree) CreateColumns() [][]string {
 			}
 		}
 	}
-	for i, column := range columns {
+	var newCols [][]string
+	for _, column := range columns {
 		var purgedCol []string
-		for _, item := range column {
+		for i, item := range column {
 			if !deletionSet.Contains(i) {
 				purgedCol = append(purgedCol, item)
 			}
 		}
-		columns[i] = purgedCol
+		if len(purgedCol) > 0 {
+			newCols = append(newCols, purgedCol)
+		}
 	}
 
-	return columns
+	return newCols
 }
 
 type queryResult struct {

--- a/pkg/gjson/row.go
+++ b/pkg/gjson/row.go
@@ -3,7 +3,6 @@ package gjson
 import (
 	"encoding/json"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/stackrox/rox/pkg/errox"
@@ -248,15 +247,12 @@ func (ct *columnTree) CreateColumns() [][]string {
 	var strictColIndices []int
 	if len(ct.strictColumns) > 0 {
 		for i, r := range ct.result {
-			println("Query! ", r.query)
 			if slices.Contains(ct.strictColumns, r.query) {
 				strictColIndices = append(strictColIndices, i)
 			}
 		}
 	}
 	deletionMap := make(map[int]bool)
-	println("Strict cols: ", strings.Join(ct.strictColumns, ","))
-	println("Strict Col Indices length: ", strconv.Itoa(len(ct.strictColumns)))
 	for columnIndex := 0; columnIndex < numberOfQueries; columnIndex++ {
 		// For each query, the query ID == columnID on the node. Retrieve all values for the specific columnID
 		// and auto expand, if required, them.
@@ -266,7 +262,6 @@ func (ct *columnTree) CreateColumns() [][]string {
 		if sort.SearchInts(strictColIndices, columnIndex) != len(strictColIndices) {
 			for i, item := range newCol {
 				if item == emptyReplacement {
-					println("Added to deletionmap: ", strconv.Itoa(i))
 					deletionMap[i] = true
 				}
 			}

--- a/pkg/gjson/row_test.go
+++ b/pkg/gjson/row_test.go
@@ -309,7 +309,7 @@ func TestRowMapper_CreateRows_SimpleHierarchy(t *testing.T) {
 		{"Bilbo Baggins", "Bag End"},
 	}
 
-	runRowMapperTest(t, testJSONObject, testExpression, expectedRows)
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRows, []string{})
 }
 
 type people struct {
@@ -382,7 +382,7 @@ func TestRowMapper_Create_Rows_DeepHierarchy(t *testing.T) {
 		{"Harry Potter", "Hagrid", "Hagrid's Hut"},
 	}
 
-	runRowMapperTest(t, testJSONObject, testExpression, expectedRows)
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRows, []string{})
 }
 
 func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValues(t *testing.T) {
@@ -449,11 +449,22 @@ func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValues(t *testing.T) {
 		{"Harry Potter", "Voldemort", "-"},
 	}
 
-	runRowMapperTest(t, testJSONObject, testExpression, expectedRows)
+	expectedRowsWithStrictAddressColumn := [][]string{
+		{"LOTR", "Gandalf", "Minas Tirith"},
+		{"LOTR", "Gollum", "Gladden Fields"},
+		{"LOTR", "Aragorn", "Gondor"},
+		{"LOTR", "Bilbo Baggins", "Bag End"},
+		{"Harry Potter", "Harry Potter", "Little Whinging"},
+		{"Harry Potter", "Ron Weasley", "The Burrow"},
+		{"Harry Potter", "Hagrid", "Hagrid's Hut"},
+	}
+
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRows, []string{})
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRowsWithStrictAddressColumn, []string{"result.#.people.#.address"})
 }
 
-func runRowMapperTest(t *testing.T, obj interface{}, expression string, expectedRows [][]string) {
-	mapper, err := NewRowMapper(obj, expression)
+func runRowMapperTest(t *testing.T, obj interface{}, expression string, expectedRows [][]string, strictColumns []string) {
+	mapper, err := NewRowMapper(obj, expression, HideRowsIfColumnNotPopulated(strictColumns))
 	require.NoError(t, err)
 	rows, err := mapper.CreateRows()
 	require.NoError(t, err)

--- a/pkg/gjson/row_test.go
+++ b/pkg/gjson/row_test.go
@@ -449,18 +449,7 @@ func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValues(t *testing.T) {
 		{"Harry Potter", "Voldemort", "-"},
 	}
 
-	expectedRowsWithStrictAddressColumn := [][]string{
-		{"LOTR", "Gandalf", "Minas Tirith"},
-		{"LOTR", "Gollum", "Gladden Fields"},
-		{"LOTR", "Aragorn", "Gondor"},
-		{"LOTR", "Bilbo Baggins", "Bag End"},
-		{"Harry Potter", "Harry Potter", "Little Whinging"},
-		{"Harry Potter", "Ron Weasley", "The Burrow"},
-		{"Harry Potter", "Hagrid", "Hagrid's Hut"},
-	}
-
 	runRowMapperTest(t, testJSONObject, testExpression, expectedRows, []string{})
-	runRowMapperTest(t, testJSONObject, testExpression, expectedRowsWithStrictAddressColumn, []string{"result.#.people.#.address"})
 }
 
 func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValuesWithStrictColumns(t *testing.T) {

--- a/pkg/gjson/row_test.go
+++ b/pkg/gjson/row_test.go
@@ -463,6 +463,74 @@ func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValues(t *testing.T) {
 	runRowMapperTest(t, testJSONObject, testExpression, expectedRowsWithStrictAddressColumn, []string{"result.#.people.#.address"})
 }
 
+func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValuesWithStrictColumns(t *testing.T) {
+	testJSONObject := &deepHierarchy{
+		Result: []example{
+			{
+				Franchise: "LOTR",
+				People: []people{
+					{
+						Name:    "Gandalf",
+						Address: "Minas Tirith",
+					},
+					{
+						Name: "Gollum",
+					},
+					{
+						Name: "Aragorn",
+					},
+					{
+						Name: "Bilbo Baggins",
+					},
+					{
+						Name: "Sauron",
+					},
+				},
+			},
+			{
+				Franchise: "Harry Potter",
+				People: []people{
+					{
+						Name:    "Harry Potter",
+						Address: "Little Whinging",
+					},
+					{
+						Name: "Ron Weasley",
+					},
+					{
+						Name: "Hagrid",
+					},
+					{
+						Name: "Voldemort",
+					},
+				},
+			},
+		},
+	}
+
+	testExpression := "{result.#.franchise,result.#.people.#.name,result.#.people.#.address}"
+
+	expectedRows := [][]string{
+		{"LOTR", "Gandalf", "Minas Tirith"},
+		{"LOTR", "Gollum", "-"},
+		{"LOTR", "Aragorn", "-"},
+		{"LOTR", "Bilbo Baggins", "-"},
+		{"LOTR", "Sauron", "-"},
+		{"Harry Potter", "Harry Potter", "Little Whinging"},
+		{"Harry Potter", "Ron Weasley", "-"},
+		{"Harry Potter", "Hagrid", "-"},
+		{"Harry Potter", "Voldemort", "-"},
+	}
+
+	expectedRowsWithStrictAddressColumn := [][]string{
+		{"LOTR", "Gandalf", "Minas Tirith"},
+		{"Harry Potter", "Harry Potter", "Little Whinging"},
+	}
+
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRows, []string{})
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRowsWithStrictAddressColumn, []string{"result.#.people.#.address"})
+}
+
 func runRowMapperTest(t *testing.T, obj interface{}, expression string, expectedRows [][]string, strictColumns []string) {
 	mapper, err := NewRowMapper(obj, expression, HideRowsIfColumnNotPopulated(strictColumns))
 	require.NoError(t, err)

--- a/pkg/gjson/row_test.go
+++ b/pkg/gjson/row_test.go
@@ -449,18 +449,29 @@ func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValues(t *testing.T) {
 		{"Harry Potter", "Voldemort", "-"},
 	}
 
+	expectedRowsWithStrictAddressColumn := [][]string{
+		{"LOTR", "Gandalf", "Minas Tirith"},
+		{"LOTR", "Gollum", "Gladden Fields"},
+		{"LOTR", "Aragorn", "Gondor"},
+		{"LOTR", "Bilbo Baggins", "Bag End"},
+		{"Harry Potter", "Harry Potter", "Little Whinging"},
+		{"Harry Potter", "Ron Weasley", "The Burrow"},
+		{"Harry Potter", "Hagrid", "Hagrid's Hut"},
+	}
+
 	runRowMapperTest(t, testJSONObject, testExpression, expectedRows, []string{})
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRowsWithStrictAddressColumn,
+		[]string{"result.#.people.#.address"})
 }
 
-func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValuesWithStrictColumns(t *testing.T) {
+func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValuesWithStrictColumnsEmptyTable(t *testing.T) {
 	testJSONObject := &deepHierarchy{
 		Result: []example{
 			{
 				Franchise: "LOTR",
 				People: []people{
 					{
-						Name:    "Gandalf",
-						Address: "Minas Tirith",
+						Name: "Gandalf",
 					},
 					{
 						Name: "Gollum",
@@ -480,8 +491,7 @@ func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValuesWithStrictColumns(t *te
 				Franchise: "Harry Potter",
 				People: []people{
 					{
-						Name:    "Harry Potter",
-						Address: "Little Whinging",
+						Name: "Harry Potter",
 					},
 					{
 						Name: "Ron Weasley",
@@ -500,24 +510,22 @@ func TestRowMapper_CreateRows_DeepHierarchyAndEmptyValuesWithStrictColumns(t *te
 	testExpression := "{result.#.franchise,result.#.people.#.name,result.#.people.#.address}"
 
 	expectedRows := [][]string{
-		{"LOTR", "Gandalf", "Minas Tirith"},
+		{"LOTR", "Gandalf", "-"},
 		{"LOTR", "Gollum", "-"},
 		{"LOTR", "Aragorn", "-"},
 		{"LOTR", "Bilbo Baggins", "-"},
 		{"LOTR", "Sauron", "-"},
-		{"Harry Potter", "Harry Potter", "Little Whinging"},
+		{"Harry Potter", "Harry Potter", "-"},
 		{"Harry Potter", "Ron Weasley", "-"},
 		{"Harry Potter", "Hagrid", "-"},
 		{"Harry Potter", "Voldemort", "-"},
 	}
 
-	expectedRowsWithStrictAddressColumn := [][]string{
-		{"LOTR", "Gandalf", "Minas Tirith"},
-		{"Harry Potter", "Harry Potter", "Little Whinging"},
-	}
+	expectedRowsWithStrictAddressColumn := [][]string(nil)
 
 	runRowMapperTest(t, testJSONObject, testExpression, expectedRows, []string{})
-	runRowMapperTest(t, testJSONObject, testExpression, expectedRowsWithStrictAddressColumn, []string{"result.#.people.#.address"})
+	runRowMapperTest(t, testJSONObject, testExpression, expectedRowsWithStrictAddressColumn,
+		[]string{"result.#.people.#.address"})
 }
 
 func runRowMapperTest(t *testing.T, obj interface{}, expression string, expectedRows [][]string, strictColumns []string) {

--- a/pkg/printers/csv.go
+++ b/pkg/printers/csv.go
@@ -23,7 +23,7 @@ func WithCSVColumnHeaders(headers []string) CSVPrinterOption {
 // when those rows have an unpopulated spot from a column marked as required.
 func WithCSVHideUnpopulatedRowsOption(requiredColumns []string) CSVPrinterOption {
 	return func(p *CSVPrinter) {
-		p.columnTreeOptions = gjson.HideRowsIfColumnNotPopulated(requiredColumns)
+		p.columnTreeOptions = []gjson.ColumnTreeOptions{gjson.HideRowsIfColumnNotPopulated(requiredColumns)}
 	}
 }
 
@@ -59,7 +59,7 @@ type CSVPrinter struct {
 	columnHeaders         []string
 	rowJSONPathExpression string
 	headerPrintOption     headerPrintOption
-	columnTreeOptions     gjson.ColumnTreeOptions
+	columnTreeOptions     []gjson.ColumnTreeOptions
 }
 
 // NewCSVPrinter creates a CSVPrinter from the options set.
@@ -125,7 +125,7 @@ func NewCSVPrinter(rowJSONPathExpression string, options ...CSVPrinterOption) *C
 func (c *CSVPrinter) Print(jsonObject interface{}, out io.Writer) error {
 	csvWriter := csv.NewWriter(out)
 
-	rowMapper, err := gjson.NewRowMapper(jsonObject, c.rowJSONPathExpression, c.columnTreeOptions)
+	rowMapper, err := gjson.NewRowMapper(jsonObject, c.rowJSONPathExpression, c.columnTreeOptions...)
 	if err != nil {
 		return err
 	}

--- a/pkg/printers/csv.go
+++ b/pkg/printers/csv.go
@@ -22,7 +22,7 @@ func WithCSVColumnHeaders(headers []string) CSVPrinterOption {
 // WithCSVHideUnpopulatedRowsOption is a functional option for hiding rows of the table,
 // when those rows have an unpopulated spot from a column marked as required.
 func WithCSVHideUnpopulatedRowsOption(requiredColumns []string) CSVPrinterOption {
-	return func(p *TablePrinter) {
+	return func(p *CSVPrinter) {
 		p.columnTreeOptions = gjson.HideRowsIfColumnNotPopulated(requiredColumns)
 	}
 }

--- a/pkg/printers/csv.go
+++ b/pkg/printers/csv.go
@@ -19,6 +19,14 @@ func WithCSVColumnHeaders(headers []string) CSVPrinterOption {
 	}
 }
 
+// WithCSVHideUnpopulatedRowsOption is a functional option for hiding rows of the table,
+// when those rows have an unpopulated spot from a column marked as required.
+func WithCSVHideUnpopulatedRowsOption(requiredColumns []string) CSVPrinterOption {
+	return func(p *TablePrinter) {
+		p.columnTreeOptions = gjson.HideRowsIfColumnNotPopulated(requiredColumns)
+	}
+}
+
 // WithCSVHeaderOptions is a functional option for printing headers. Headers can be
 // either printed as comments in the CSV output or not at all.
 // By default, headers will be printed.
@@ -51,6 +59,7 @@ type CSVPrinter struct {
 	columnHeaders         []string
 	rowJSONPathExpression string
 	headerPrintOption     headerPrintOption
+	columnTreeOptions     gjson.ColumnTreeOptions
 }
 
 // NewCSVPrinter creates a CSVPrinter from the options set.
@@ -116,7 +125,7 @@ func NewCSVPrinter(rowJSONPathExpression string, options ...CSVPrinterOption) *C
 func (c *CSVPrinter) Print(jsonObject interface{}, out io.Writer) error {
 	csvWriter := csv.NewWriter(out)
 
-	rowMapper, err := gjson.NewRowMapper(jsonObject, c.rowJSONPathExpression)
+	rowMapper, err := gjson.NewRowMapper(jsonObject, c.rowJSONPathExpression, c.columnTreeOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/printers/table.go
+++ b/pkg/printers/table.go
@@ -21,6 +21,14 @@ func WithTableHeadersOption(headers []string, headersToMerge []string, noHeader 
 	}
 }
 
+// WithTableHideUnpopulatedRowsOption is a functional option for hiding rows of the table,
+// when those rows have an unpopulated spot from a column marked as required.
+func WithTableHideUnpopulatedRowsOption(requiredColumns []string) TablePrinterOptions {
+	return func(p *TablePrinter) {
+		p.columnTreeOptions = gjson.HideRowsIfColumnNotPopulated(requiredColumns)
+	}
+}
+
 // TablePrinter will print a table output from a given JSON Object.
 type TablePrinter struct {
 	headers               []string
@@ -29,6 +37,7 @@ type TablePrinter struct {
 	// There will be no precedence in any fashion applied.
 	columnIndexesToMerge []int
 	noHeader             bool
+	columnTreeOptions    gjson.ColumnTreeOptions
 }
 
 // NewTablePrinter creates a TablePrinter from the options set.
@@ -124,7 +133,7 @@ func (p *TablePrinter) Print(jsonObject interface{}, out io.Writer) error {
 	tw := p.createTableWriter(out)
 
 	// retrieve rows from JSON object via JSON path expression.
-	rowMapper, err := gjson.NewRowMapper(jsonObject, p.rowJSONPathExpression)
+	rowMapper, err := gjson.NewRowMapper(jsonObject, p.rowJSONPathExpression, p.columnTreeOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/printers/table.go
+++ b/pkg/printers/table.go
@@ -25,7 +25,7 @@ func WithTableHeadersOption(headers []string, headersToMerge []string, noHeader 
 // when those rows have an unpopulated spot from a column marked as required.
 func WithTableHideUnpopulatedRowsOption(requiredColumns []string) TablePrinterOptions {
 	return func(p *TablePrinter) {
-		p.columnTreeOptions = gjson.HideRowsIfColumnNotPopulated(requiredColumns)
+		p.columnTreeOptions = []gjson.ColumnTreeOptions{gjson.HideRowsIfColumnNotPopulated(requiredColumns)}
 	}
 }
 
@@ -37,7 +37,7 @@ type TablePrinter struct {
 	// There will be no precedence in any fashion applied.
 	columnIndexesToMerge []int
 	noHeader             bool
-	columnTreeOptions    gjson.ColumnTreeOptions
+	columnTreeOptions    []gjson.ColumnTreeOptions
 }
 
 // NewTablePrinter creates a TablePrinter from the options set.
@@ -133,7 +133,7 @@ func (p *TablePrinter) Print(jsonObject interface{}, out io.Writer) error {
 	tw := p.createTableWriter(out)
 
 	// retrieve rows from JSON object via JSON path expression.
-	rowMapper, err := gjson.NewRowMapper(jsonObject, p.rowJSONPathExpression, p.columnTreeOptions)
+	rowMapper, err := gjson.NewRowMapper(jsonObject, p.rowJSONPathExpression, p.columnTreeOptions...)
 	if err != nil {
 		return err
 	}

--- a/roxctl/common/printer/tabularprinter_factory.go
+++ b/roxctl/common/printer/tabularprinter_factory.go
@@ -190,8 +190,8 @@ func (t *TabularPrinterFactory) mapRequiredHeadersToJson() ([]string, error) {
 			strings.Join(defaultImageScanHeaders, ", "))
 	}
 	var headersJson []string
-	for i := range t.RequiredHeaders {
-		headersJson = append(headersJson, imageScanHeaderToJSONPathMap[t.RequiredHeaders[i]])
+	for _, h := range t.RequiredHeaders {
+		headersJson = append(headersJson, imageScanHeaderToJSONPathMap[h])
 	}
 	return headersJson, nil
 }

--- a/roxctl/common/printer/tabularprinter_factory.go
+++ b/roxctl/common/printer/tabularprinter_factory.go
@@ -144,11 +144,11 @@ func (t *TabularPrinterFactory) CreatePrinter(format string) (ObjectPrinter, err
 	}
 	requiredHeadersJSON, err := t.mapRequiredHeadersToJson()
 	if err != nil {
-		return nil, errox.InvalidArgs.Newf("Failed to map required headers to JSON: %v", format)
+		return nil, errox.InvalidArgs.Newf("Failed to map required headers to JSON: %v", err)
 	}
 	err = t.propagateCustomHeaders()
 	if err != nil {
-		return nil, errox.InvalidArgs.Newf("Failed to propagate custom headers: %v", format)
+		return nil, errox.InvalidArgs.Newf("Failed to propagate custom headers: %v", err)
 	}
 	// If not column is specified by merge is enabled then set all columns to merge.
 	if t.columnsToMerge == nil && t.Merge {

--- a/roxctl/common/printer/tabularprinter_factory.go
+++ b/roxctl/common/printer/tabularprinter_factory.go
@@ -26,7 +26,12 @@ var (
 	}
 
 	// Default JSON path expression representing a row within tabular output, based on the mapping above.
-	defaultImageScanJSONPathExpression, _ = createImageScanJSONPathExpression(defaultImageScanHeaders)
+	defaultImageScanJSONPathExpression = "{result.vulnerabilities.#.componentName," +
+		"result.vulnerabilities.#.componentVersion," +
+		"result.vulnerabilities.#.cveId," +
+		"result.vulnerabilities.#.cveSeverity," +
+		"result.vulnerabilities.#.cveInfo," +
+		"result.vulnerabilities.#.componentFixedVersion}"
 )
 
 // TabularPrinterFactory holds all configuration options of tabular printers, specifically CSVPrinter and TablePrinter
@@ -66,21 +71,13 @@ func NewTabularPrinterFactoryWithAutoMerge() *TabularPrinterFactory {
 // AddFlags will add all tabular printer specific flags to the cobra.Command
 func (t *TabularPrinterFactory) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&t.Merge, "merge-output", t.Merge, "Merge duplicate cells in prettified tabular output")
-	cmd.PersistentFlags().StringSliceVar(&t.Headers, "headers", defaultImageScanHeaders, "Headers to print in tabular output"+
+	cmd.PersistentFlags().StringSliceVar(&t.Headers, "headers", t.Headers, "Headers to print in tabular output. "+
 		"Will propagate headers to the table unless --row-jsonpath-expressions is also set.")
-	cmd.PersistentFlags().StringSliceVar(&t.RequiredHeaders, "required-headers", []string{}, "Headers denoted as required"+
+	cmd.PersistentFlags().StringSliceVar(&t.RequiredHeaders, "required-headers", []string{}, "Headers denoted as required "+
 		"must be present in a row of the output table, or that row will not be displayed.")
-	err := t.mapRequiredHeadersToJson()
-	if err != nil {
-		cmd.PrintErrf("%v", err)
-	}
 	cmd.PersistentFlags().StringVar(&t.RowJSONPathExpression, "row-jsonpath-expressions", t.RowJSONPathExpression,
 		"JSON Path expression to create a row from the JSON object. This leverages gJSON (https://github.com/tidwall/gjson)."+
 			" NOTE: The amount of expressions within the multi-path has to match the amount of provided headers.")
-	err = t.propagateCustomHeaders()
-	if err != nil {
-		cmd.PrintErrf("%v", err)
-	}
 	cmd.PersistentFlags().BoolVar(&t.NoHeader, "no-header", t.NoHeader, "Print no headers for tabular output")
 	cmd.PersistentFlags().BoolVar(&t.HeaderAsComment, "headers-as-comments", t.HeaderAsComment, "Print headers "+
 		"as comments in CSV tabular output")
@@ -145,6 +142,14 @@ func (t *TabularPrinterFactory) CreatePrinter(format string) (ObjectPrinter, err
 	if err := t.validate(); err != nil {
 		return nil, err
 	}
+	requiredHeadersJSON, err := t.mapRequiredHeadersToJson()
+	if err != nil {
+		return nil, errox.InvalidArgs.Newf("Failed to map required headers to JSON: %v", format)
+	}
+	err = t.propagateCustomHeaders()
+	if err != nil {
+		return nil, errox.InvalidArgs.Newf("Failed to propagate custom headers: %v", format)
+	}
 	// If not column is specified by merge is enabled then set all columns to merge.
 	if t.columnsToMerge == nil && t.Merge {
 		t.columnsToMerge = t.Headers
@@ -153,11 +158,11 @@ func (t *TabularPrinterFactory) CreatePrinter(format string) (ObjectPrinter, err
 	case "table":
 		return printers.NewTablePrinter(t.RowJSONPathExpression,
 			printers.WithTableHeadersOption(t.Headers, t.columnsToMerge, t.NoHeader),
-			printers.WithTableHideUnpopulatedRowsOption(t.RequiredHeaders)), nil
+			printers.WithTableHideUnpopulatedRowsOption(requiredHeadersJSON)), nil
 	case "csv":
 		return printers.NewCSVPrinter(t.RowJSONPathExpression,
 			printers.WithCSVColumnHeaders(t.Headers), printers.WithCSVHeaderOptions(t.NoHeader, t.HeaderAsComment),
-			printers.WithCSVHideUnpopulatedRowsOption(t.RequiredHeaders)), nil
+			printers.WithCSVHideUnpopulatedRowsOption(requiredHeadersJSON)), nil
 	default:
 		return nil, errox.InvalidArgs.Newf("invalid output format used for Tabular Printer: %q", format)
 	}
@@ -179,19 +184,20 @@ func (t *TabularPrinterFactory) validate() error {
 	return nil
 }
 
-func (t *TabularPrinterFactory) mapRequiredHeadersToJson() error {
+func (t *TabularPrinterFactory) mapRequiredHeadersToJson() ([]string, error) {
 	if !validateImageScanHeaders(t.RequiredHeaders) {
-		return errox.InvalidArgs.Newf("Invalid headers, supported headers: [%s]",
+		return nil, errox.InvalidArgs.Newf("Invalid headers, supported headers: [%s]",
 			strings.Join(defaultImageScanHeaders, ", "))
 	}
+	var headersJson []string
 	for i := range t.RequiredHeaders {
-		t.RequiredHeaders[i] = imageScanHeaderToJSONPathMap[t.RequiredHeaders[i]]
+		headersJson = append(headersJson, imageScanHeaderToJSONPathMap[t.RequiredHeaders[i]])
 	}
-	return nil
+	return headersJson, nil
 }
 
 func (t *TabularPrinterFactory) propagateCustomHeaders() error {
-	// If --headers is default OR --row-jsonpath-expressions is unset do nothing
+	// If --headers is default OR --row-jsonpath-expressions is set do nothing
 	if slices.Equal(t.Headers, defaultImageScanHeaders) || (t.RowJSONPathExpression != defaultImageScanJSONPathExpression) {
 		return nil
 	}

--- a/roxctl/maincommand/command_tree_debug.yaml
+++ b/roxctl/maincommand/command_tree_debug.yaml
@@ -1592,6 +1592,7 @@ deployment:
       - merge-output
       - no-header
       - output
+      - required-headers
       - row-jsonpath-expressions
     INHERITED_FLAGS:
       - ca
@@ -1721,6 +1722,7 @@ image:
       - merge-output
       - no-header
       - output
+      - required-headers
       - row-jsonpath-expressions
     INHERITED_FLAGS:
       - ca
@@ -1776,6 +1778,7 @@ image:
       - merge-output
       - no-header
       - output
+      - required-headers
       - row-jsonpath-expressions
     INHERITED_FLAGS:
       - ca

--- a/roxctl/maincommand/command_tree_release.yaml
+++ b/roxctl/maincommand/command_tree_release.yaml
@@ -1572,6 +1572,7 @@ deployment:
       - merge-output
       - no-header
       - output
+      - required-headers
       - row-jsonpath-expressions
     INHERITED_FLAGS:
       - ca
@@ -1682,6 +1683,7 @@ image:
       - merge-output
       - no-header
       - output
+      - required-headers
       - row-jsonpath-expressions
     INHERITED_FLAGS:
       - ca
@@ -1737,6 +1739,7 @@ image:
       - merge-output
       - no-header
       - output
+      - required-headers
       - row-jsonpath-expressions
     INHERITED_FLAGS:
       - ca


### PR DESCRIPTION
### Description

Adds an option --required-headers that marks the provided headers as required for the table that roxctl prints. If the entry for that header is empty, the whole row is not printed.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Added a test case to gjson printers, might add more tests tomorrow.
