### PR TITLE
ROX-28249: Disable new roxctl zip output

### DIFF
--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/certgen"
-	"github.com/stackrox/rox/pkg/containers"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
@@ -278,7 +277,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() || !containers.IsRunningInContainer() {
+	if roxctl.InMainImage() {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")


### PR DESCRIPTION
### Description

Fixing the behavior of `roxctl central generate k8s pvc` in https://issues.redhat.com/browse/ROX-20811 lead to unexpected consequences of our `deploy` script dumping the zip file into STDOUT like this:
```INFO:   Generating deployment bundle...
INFO:   Deployment bundle does not include PodSecurityPolicies (PSPs).
INFO:   This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.
INFO:   Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.
PK^C^D^T^@^H^@^@^@<B1>]ZZ^@^@^@^@^@^@^@^@^@^@^@^@^]^@   ^@helm/chart/templates/_psp.tplUT^E^@^A<CE><F0<F0><BE>g{{/*
    srox.autoSensePodSecurityPolicies $
  */}}

{{ define "srox.autoSensePodSecurityPolicies" }}

{{ $ := index . 0 }}
{{ $system := $._rox.system }}

{{ if kindIs "invalid" $system.enablePodSecurityPolicies }}
  {{ $_ := set $system "enablePodSecurityPolicies" (has "policy/v1beta1" $._rox._apiServer.apiResources) }}
  {{ if $system.enablePodSecurityPolicies }}
[...] 
```

This PR is to revert this behavior. A proper fix to reintroduce the behavior and make the deploy script play ball will be in a followup.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I'll run the deploy script and look at the output once the build is ready.