### PR TITLE
ROC-28224: wait longer for compliance

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ComplianceManagementService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ComplianceManagementService.groovy
@@ -36,7 +36,7 @@ class ComplianceManagementService extends BaseService {
         log.debug "waiting for the run${standardId ? "" : "s"} to finish..."
         Long startTime = System.currentTimeMillis()
         while (complianceRuns.any { it.state != ComplianceRun.State.FINISHED } &&
-                (System.currentTimeMillis() - startTime) < 300000) {
+                (System.currentTimeMillis() - startTime) < 600000) {
             sleep 1000
             complianceRuns = getRunStatuses(complianceRuns*.id).runsList
         }


### PR DESCRIPTION
### Description

Double the waiting time.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
