### PR TITLE
chore(perf): Made pruning more performant

### DIFF
--- a/central/blob/datastore/test_utils.go
+++ b/central/blob/datastore/test_utils.go
@@ -3,13 +3,17 @@ package datastore
 import (
 	"testing"
 
+	"github.com/stackrox/rox/central/blob/datastore/search"
 	"github.com/stackrox/rox/central/blob/datastore/store"
 	pgPkg "github.com/stackrox/rox/pkg/postgres"
 )
 
 // NewTestDatastore creates the data store for testing.
 func NewTestDatastore(_ *testing.T, db pgPkg.DB) Datastore {
+	datastore := store.New(db)
+	searcher := search.New(datastore)
 	return &datastoreImpl{
-		store: store.New(db),
+		store:    datastore,
+		searcher: searcher,
 	}
 }

--- a/central/pod/datastore/datastore.go
+++ b/central/pod/datastore/datastore.go
@@ -28,6 +28,7 @@ type DataStore interface {
 	UpsertPod(ctx context.Context, pod *storage.Pod) error
 
 	RemovePod(ctx context.Context, id string) error
+	RemovePods(ctx context.Context, ids []string) error
 }
 
 // NewPostgresDB creates a pod datastore based on Postgres

--- a/central/pod/datastore/internal/store/mocks/store.go
+++ b/central/pod/datastore/internal/store/mocks/store.go
@@ -72,6 +72,20 @@ func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
 }
 
+// DeleteMany mocks base method.
+func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMany indicates an expected call of DeleteMany.
+func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+}
+
 // Get mocks base method.
 func (m *MockStore) Get(ctx context.Context, id string) (*storage.Pod, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/pod/datastore/internal/store/store.go
+++ b/central/pod/datastore/internal/store/store.go
@@ -23,4 +23,5 @@ type Store interface {
 
 	Upsert(ctx context.Context, pod *storage.Pod) error
 	Delete(ctx context.Context, id string) error
+	DeleteMany(ctx context.Context, ids []string) error
 }

--- a/central/pod/datastore/mocks/datastore.go
+++ b/central/pod/datastore/mocks/datastore.go
@@ -88,6 +88,20 @@ func (mr *MockDataStoreMockRecorder) RemovePod(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePod", reflect.TypeOf((*MockDataStore)(nil).RemovePod), ctx, id)
 }
 
+// RemovePods mocks base method.
+func (m *MockDataStore) RemovePods(ctx context.Context, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemovePods", ctx, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemovePods indicates an expected call of RemovePods.
+func (mr *MockDataStoreMockRecorder) RemovePods(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePods", reflect.TypeOf((*MockDataStore)(nil).RemovePods), ctx, ids)
+}
+
 // Search mocks base method.
 func (m *MockDataStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -32,6 +32,7 @@ type DataStore interface {
 	GetProcessIndicators(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, bool, error)
 	AddProcessIndicators(context.Context, ...*storage.ProcessIndicator) error
 	RemoveProcessIndicatorsByPod(ctx context.Context, id string) error
+	RemoveProcessIndicatorsByPods(ctx context.Context, ids []string) error
 	RemoveProcessIndicators(ctx context.Context, ids []string) error
 	PruneProcessIndicators(ctx context.Context, ids []string) (int, error)
 

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -195,6 +195,17 @@ func (ds *datastoreImpl) RemoveProcessIndicatorsByPod(ctx context.Context, id st
 	return storeErr
 }
 
+func (ds *datastoreImpl) RemoveProcessIndicatorsByPods(ctx context.Context, ids []string) error {
+	if ok, err := deploymentExtensionSAC.WriteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+	q := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.PodUID, ids...).ProtoQuery()
+	_, storeErr := ds.storage.DeleteByQuery(ctx, q)
+	return storeErr
+}
+
 func (ds *datastoreImpl) prunePeriodically(ctx context.Context) {
 	defer ds.stopper.Flow().ReportStopped()
 

--- a/central/processindicator/datastore/mocks/datastore.go
+++ b/central/processindicator/datastore/mocks/datastore.go
@@ -153,6 +153,20 @@ func (mr *MockDataStoreMockRecorder) RemoveProcessIndicatorsByPod(ctx, id any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveProcessIndicatorsByPod", reflect.TypeOf((*MockDataStore)(nil).RemoveProcessIndicatorsByPod), ctx, id)
 }
 
+// RemoveProcessIndicatorsByPods mocks base method.
+func (m *MockDataStore) RemoveProcessIndicatorsByPods(ctx context.Context, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveProcessIndicatorsByPods", ctx, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveProcessIndicatorsByPods indicates an expected call of RemoveProcessIndicatorsByPods.
+func (mr *MockDataStoreMockRecorder) RemoveProcessIndicatorsByPods(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveProcessIndicatorsByPods", reflect.TypeOf((*MockDataStore)(nil).RemoveProcessIndicatorsByPods), ctx, ids)
+}
+
 // Search mocks base method.
 func (m *MockDataStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/processlisteningonport/datastore/datastore.go
+++ b/central/processlisteningonport/datastore/datastore.go
@@ -31,6 +31,7 @@ type DataStore interface {
 	WalkAll(ctx context.Context, fn WalkFn) error
 	RemoveProcessListeningOnPort(ctx context.Context, ids []string) error
 	RemovePlopsByPod(ctx context.Context, id string) error
+	RemovePlopsByPods(ctx context.Context, ids []string) error
 	PruneOrphanedPLOPs(ctx context.Context, orphanWindow time.Duration) int64
 	PruneOrphanedPLOPsByProcessIndicators(ctx context.Context, orphanWindow time.Duration)
 	RemovePLOPsWithoutProcessIndicatorOrProcessInfo(ctx context.Context) (int64, error)

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -546,6 +546,21 @@ func (ds *datastoreImpl) RemovePlopsByPod(ctx context.Context, id string) error 
 	return storeErr
 }
 
+func (ds *datastoreImpl) RemovePlopsByPods(ctx context.Context, ids []string) error {
+	if ok, err := plopSAC.WriteAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return sac.ErrResourceAccessDenied
+	}
+
+	ds.mutex.Lock()
+	defer ds.mutex.Unlock()
+
+	q := search.NewQueryBuilder().AddExactMatches(search.PodUID, ids...).ProtoQuery()
+	_, storeErr := ds.storage.DeleteByQuery(ctx, q)
+	return storeErr
+}
+
 // PruneOrphanedPLOPs prunes old closed PLOPs and those without deployments or pods
 func (ds *datastoreImpl) PruneOrphanedPLOPs(ctx context.Context, orphanWindow time.Duration) int64 {
 	ds.mutex.Lock()

--- a/central/processlisteningonport/datastore/mocks/datastore.go
+++ b/central/processlisteningonport/datastore/mocks/datastore.go
@@ -132,6 +132,20 @@ func (mr *MockDataStoreMockRecorder) RemovePlopsByPod(ctx, id any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePlopsByPod", reflect.TypeOf((*MockDataStore)(nil).RemovePlopsByPod), ctx, id)
 }
 
+// RemovePlopsByPods mocks base method.
+func (m *MockDataStore) RemovePlopsByPods(ctx context.Context, ids []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemovePlopsByPods", ctx, ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemovePlopsByPods indicates an expected call of RemovePlopsByPods.
+func (mr *MockDataStoreMockRecorder) RemovePlopsByPods(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePlopsByPods", reflect.TypeOf((*MockDataStore)(nil).RemovePlopsByPods), ctx, ids)
+}
+
 // RemoveProcessListeningOnPort mocks base method.
 func (m *MockDataStore) RemoveProcessListeningOnPort(ctx context.Context, ids []string) error {
 	m.ctrl.T.Helper()

--- a/pkg/process/filter/mocks/filter.go
+++ b/pkg/process/filter/mocks/filter.go
@@ -79,6 +79,18 @@ func (mr *MockFilterMockRecorder) DeleteByPod(pod any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByPod", reflect.TypeOf((*MockFilter)(nil).DeleteByPod), pod)
 }
 
+// DeleteByPods mocks base method.
+func (m *MockFilter) DeleteByPods(pods []*storage.Pod) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteByPods", pods)
+}
+
+// DeleteByPods indicates an expected call of DeleteByPods.
+func (mr *MockFilterMockRecorder) DeleteByPods(pods any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByPods", reflect.TypeOf((*MockFilter)(nil).DeleteByPods), pods)
+}
+
 // UpdateByGivenContainers mocks base method.
 func (m *MockFilter) UpdateByGivenContainers(deploymentID string, liveContainerSet set.StringSet) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Description

This PR aims to make pruning more performant by batching out removals of pods and alerts, as well as multithreading them by using goroutines.

There are a couple of concerns I have with this off the top that I hope somebody with more knowledge than I can speak to which are
- Is this going to steamroll the DB while it's trying to prune large amounts of data?
- Are there other aspects of pruning that need to be looked at to be tuned more?
- 

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

This PR also contains a test (which is in my todo to make non-default to run) which creates massive amounts of pods/alerts and then attempts to prune them. In testing, the changes contained in this PR brought down the time to remove 100,000 alerts and 100,000 pods from 10s to 500ms, in larger tests of 100,000 pods and 10,000,000 it brought the time down from 5-10 minutes to 1 minute. Obviously in a production cluster these numbers would vary due to other factors such as latency, db load from other sources, etc, but I did see marked improvements in my naive testing environment.
