### PR TITLE
chore(deps): upgrade go-jose to v4

### DIFF
--- a/central/auth/m2m/kube_service_account.go
+++ b/central/auth/m2m/kube_service_account.go
@@ -3,7 +3,8 @@ package m2m
 import (
 	"os"
 
-	jwt "github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	jwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/pkg/errors"
 )
 
@@ -27,7 +28,7 @@ func (k kubeServiceAccountIssuerFetcher) GetServiceAccountIssuer() (string, erro
 		return "", errors.Wrap(err, "Failed to read kube service account token")
 	}
 
-	parsedJwt, err := jwt.ParseSigned(token)
+	parsedJwt, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to parse service account JWT")
 	}

--- a/central/auth/m2m/kube_service_account.go
+++ b/central/auth/m2m/kube_service_account.go
@@ -3,9 +3,9 @@ package m2m
 import (
 	"os"
 
-	"github.com/go-jose/go-jose/v4"
-	jwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/pkg/errors"
+	pkgjwt "github.com/stackrox/rox/pkg/jwt"
 )
 
 //go:generate mockgen-wrapper
@@ -28,7 +28,7 @@ func (k kubeServiceAccountIssuerFetcher) GetServiceAccountIssuer() (string, erro
 		return "", errors.Wrap(err, "Failed to read kube service account token")
 	}
 
-	parsedJwt, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+	parsedJwt, err := pkgjwt.ParseSigned(token)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to parse service account JWT")
 	}

--- a/go.mod
+++ b/go.mod
@@ -305,7 +305,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.1 // indirect
 	github.com/go-git/go-git/v5 v5.13.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/georgysavva/scany/v2 v2.1.3
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
-	github.com/go-jose/go-jose/v3 v3.0.4
+	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/gobwas/glob v0.2.3
@@ -305,7 +305,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.6.1 // indirect
 	github.com/go-git/go-git/v5 v5.13.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect

--- a/pkg/auth/authproviders/iap/backend_impl.go
+++ b/pkg/auth/authproviders/iap/backend_impl.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"slices"
 
-	joseJwt "github.com/go-jose/go-jose/v3/jwt"
+	joseJwt "github.com/go-jose/go-jose/v4/jwt"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/auth/tokens"

--- a/pkg/auth/authproviders/validate_test.go
+++ b/pkg/auth/authproviders/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/tokens"
 	"github.com/stackrox/rox/pkg/protocompat"

--- a/pkg/auth/tokens/claims.go
+++ b/pkg/auth/tokens/claims.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 // ExternalUserClaim represents the claim that this token identifies a user from an external identity provider.

--- a/pkg/auth/tokens/issuer_factory.go
+++ b/pkg/auth/tokens/issuer_factory.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -68,7 +68,7 @@ func (f *issuerFactory) createClaims(sourceID string, roxClaims RoxClaims) *Clai
 }
 
 func (f *issuerFactory) encode(claims *Claims) (string, error) {
-	return f.builder.Claims(&claims.Claims).Claims(&claims.RoxClaims).Claims(translateExtra(claims.Extra)).CompactSerialize()
+	return f.builder.Claims(&claims.Claims).Claims(&claims.RoxClaims).Claims(translateExtra(claims.Extra)).Serialize()
 }
 
 // translateExtra converts a map[string]json.RawMessage to a map[string]interface{} expected by go-jose.

--- a/pkg/auth/tokens/options.go
+++ b/pkg/auth/tokens/options.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 // Option is an option that can transparently modify a token's claims.

--- a/pkg/cloudproviders/gcp/identity_token.go
+++ b/pkg/cloudproviders/gcp/identity_token.go
@@ -7,7 +7,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/httputil"
@@ -90,7 +91,7 @@ func getMetadataFromIdentityToken(ctx context.Context) (*gcpMetadata, error) {
 		log.Warnf("Failed to fetch Google OAuth2 certs: %v", err)
 	}
 
-	parsedToken, err := jwt.ParseSigned(identityToken)
+	parsedToken, err := jwt.ParseSigned(identityToken, []jose.SignatureAlgorithm{jose.RS256})
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +113,8 @@ func getMetadataFromIdentityToken(ctx context.Context) (*gcpMetadata, error) {
 	}
 
 	expectedClaims := jwt.Expected{
-		Issuer:   "https://accounts.google.com",
-		Audience: jwt.Audience{audience},
+		Issuer:      "https://accounts.google.com",
+		AnyAudience: jwt.Audience{audience},
 	}
 
 	if err := claims.Validate(expectedClaims); err != nil {

--- a/pkg/cloudproviders/gcp/identity_token.go
+++ b/pkg/cloudproviders/gcp/identity_token.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/httputil"
+	pkgjwt "github.com/stackrox/rox/pkg/jwt"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -91,7 +91,7 @@ func getMetadataFromIdentityToken(ctx context.Context) (*gcpMetadata, error) {
 		log.Warnf("Failed to fetch Google OAuth2 certs: %v", err)
 	}
 
-	parsedToken, err := jwt.ParseSigned(identityToken, []jose.SignatureAlgorithm{jose.RS256})
+	parsedToken, err := pkgjwt.ParseSigned(identityToken)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/grpc/authn/extractor.go
+++ b/pkg/grpc/authn/extractor.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"

--- a/pkg/grpc/authn/extractor_test.go
+++ b/pkg/grpc/authn/extractor_test.go
@@ -3,7 +3,7 @@ package authn
 import (
 	"testing"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"

--- a/pkg/jwt/facade.go
+++ b/pkg/jwt/facade.go
@@ -3,8 +3,8 @@ package jwt
 import (
 	"crypto/rsa"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 // CreateRS256SignerAndValidator creates a token signer and validator pair with the given properties from the

--- a/pkg/jwt/keys.go
+++ b/pkg/jwt/keys.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )

--- a/pkg/jwt/parser.go
+++ b/pkg/jwt/parser.go
@@ -1,0 +1,29 @@
+package jwt
+
+import (
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// allAlgs contains all JOSE asymmetric signing algorithm values as defined by RFC 7518
+//
+// see: https://tools.ietf.org/html/rfc7518#section-3.1
+var allowedSignatureAlgorithms = []jose.SignatureAlgorithm{
+	jose.ES256,
+	jose.ES384,
+	jose.ES512,
+	jose.EdDSA,
+	jose.HS256,
+	jose.HS384,
+	jose.HS512,
+	jose.PS256,
+	jose.PS384,
+	jose.PS512,
+	jose.RS256,
+	jose.RS384,
+	jose.RS512,
+}
+
+func ParseSigned(token string) (*jwt.JSONWebToken, error) {
+	return jwt.ParseSigned(token, allowedSignatureAlgorithms)
+}

--- a/pkg/jwt/tokens.go
+++ b/pkg/jwt/tokens.go
@@ -4,8 +4,8 @@ package jwt
 import (
 	"time"
 
-	"github.com/go-jose/go-jose/v3"
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/logging"
 )
@@ -26,7 +26,7 @@ type validator struct {
 func NewRS256Validator(keys KeyGetter, issuer string, audience jwt.Audience) Validator {
 	return validator{
 		keyGetter: keys,
-		expected:  jwt.Expected{Issuer: issuer, Audience: audience},
+		expected:  jwt.Expected{Issuer: issuer, AnyAudience: audience},
 		algorithm: string(jose.RS256),
 	}
 }
@@ -35,7 +35,7 @@ func NewRS256Validator(keys KeyGetter, issuer string, audience jwt.Audience) Val
 func NewES256Validator(keys KeyGetter, issuer string, audience jwt.Audience) Validator {
 	return validator{
 		keyGetter: keys,
-		expected:  jwt.Expected{Issuer: issuer, Audience: audience},
+		expected:  jwt.Expected{Issuer: issuer, AnyAudience: audience},
 		algorithm: string(jose.ES256),
 	}
 }
@@ -57,7 +57,7 @@ var (
 
 // Validate validates the token or returns an error.
 func (v validator) Validate(rawToken string, claims *jwt.Claims, extraClaims ...interface{}) error {
-	token, err := jwt.ParseSigned(rawToken)
+	token, err := jwt.ParseSigned(rawToken, []jose.SignatureAlgorithm{jose.RS256})
 	if err != nil {
 		return err
 	}

--- a/pkg/jwt/tokens.go
+++ b/pkg/jwt/tokens.go
@@ -57,7 +57,7 @@ var (
 
 // Validate validates the token or returns an error.
 func (v validator) Validate(rawToken string, claims *jwt.Claims, extraClaims ...interface{}) error {
-	token, err := jwt.ParseSigned(rawToken, []jose.SignatureAlgorithm{jose.RS256})
+	token, err := ParseSigned(rawToken)
 	if err != nil {
 		return err
 	}

--- a/sensor/common/certdistribution/service_impl.go
+++ b/sensor/common/certdistribution/service_impl.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
-	pkgjwt "github.com/stackrox/rox/pkg/jwt"
+	"github.com/stackrox/rox/pkg/jwt"
 	"github.com/stackrox/rox/pkg/services"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"golang.org/x/time/rate"
@@ -69,7 +69,7 @@ func (s *service) AuthFuncOverride(ctx context.Context, fullMethodName string) (
 }
 
 func (s *service) verifyToken(ctx context.Context, token string, expectedSubject string) error {
-	parsedToken, err := pkgjwt.ParseSigned(token)
+	parsedToken, err := jwt.ParseSigned(token)
 	if err != nil {
 		return errors.Wrapf(errox.InvalidArgs, "invalid JWT: %s", err)
 	}

--- a/sensor/common/certdistribution/service_impl.go
+++ b/sensor/common/certdistribution/service_impl.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-jose/go-jose/v4"
-	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
@@ -17,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	pkgjwt "github.com/stackrox/rox/pkg/jwt"
 	"github.com/stackrox/rox/pkg/services"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"golang.org/x/time/rate"
@@ -70,7 +69,7 @@ func (s *service) AuthFuncOverride(ctx context.Context, fullMethodName string) (
 }
 
 func (s *service) verifyToken(ctx context.Context, token string, expectedSubject string) error {
-	parsedToken, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+	parsedToken, err := pkgjwt.ParseSigned(token)
 	if err != nil {
 		return errors.Wrapf(errox.InvalidArgs, "invalid JWT: %s", err)
 	}

--- a/sensor/common/certdistribution/service_impl.go
+++ b/sensor/common/certdistribution/service_impl.go
@@ -6,7 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
@@ -69,7 +70,7 @@ func (s *service) AuthFuncOverride(ctx context.Context, fullMethodName string) (
 }
 
 func (s *service) verifyToken(ctx context.Context, token string, expectedSubject string) error {
-	parsedToken, err := jwt.ParseSigned(token)
+	parsedToken, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
 	if err != nil {
 		return errors.Wrapf(errox.InvalidArgs, "invalid JWT: %s", err)
 	}

--- a/sensor/kubernetes/sensor/deployment_identification.go
+++ b/sensor/kubernetes/sensor/deployment_identification.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
-	pkgjwt "github.com/stackrox/rox/pkg/jwt"
+	"github.com/stackrox/rox/pkg/jwt"
 	"github.com/stackrox/rox/pkg/namespaces"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -35,7 +35,7 @@ func populateFromServiceAccountTokenFile(out *storage.SensorDeploymentIdentifica
 		return errors.Wrapf(err, "reading token from file %s", tokenFile)
 	}
 
-	saToken, err := pkgjwt.ParseSigned(string(bytes.TrimSpace(tokenBytes)))
+	saToken, err := jwt.ParseSigned(string(bytes.TrimSpace(tokenBytes)))
 	if err != nil {
 		return errors.Wrapf(err, "parsing service account JWT from file %s", tokenFile)
 	}

--- a/sensor/kubernetes/sensor/deployment_identification.go
+++ b/sensor/kubernetes/sensor/deployment_identification.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-jose/go-jose/v4"
-	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	pkgjwt "github.com/stackrox/rox/pkg/jwt"
 	"github.com/stackrox/rox/pkg/namespaces"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -36,7 +35,7 @@ func populateFromServiceAccountTokenFile(out *storage.SensorDeploymentIdentifica
 		return errors.Wrapf(err, "reading token from file %s", tokenFile)
 	}
 
-	saToken, err := jwt.ParseSigned(string(bytes.TrimSpace(tokenBytes)), []jose.SignatureAlgorithm{jose.RS256})
+	saToken, err := pkgjwt.ParseSigned(string(bytes.TrimSpace(tokenBytes)))
 	if err != nil {
 		return errors.Wrapf(err, "parsing service account JWT from file %s", tokenFile)
 	}

--- a/sensor/kubernetes/sensor/deployment_identification.go
+++ b/sensor/kubernetes/sensor/deployment_identification.go
@@ -6,7 +6,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
@@ -35,7 +36,7 @@ func populateFromServiceAccountTokenFile(out *storage.SensorDeploymentIdentifica
 		return errors.Wrapf(err, "reading token from file %s", tokenFile)
 	}
 
-	saToken, err := jwt.ParseSigned(string(bytes.TrimSpace(tokenBytes)))
+	saToken, err := jwt.ParseSigned(string(bytes.TrimSpace(tokenBytes)), []jose.SignatureAlgorithm{jose.RS256})
 	if err != nil {
 		return errors.Wrapf(err, "parsing service account JWT from file %s", tokenFile)
 	}


### PR DESCRIPTION
### Description

Currently we have both v3 and v4 in our dependencies. This will fix this.

> Version 3, in this repo, is still receiving security fixes but not functionality updates.
https://github.com/go-jose/go-jose?tab=readme-ov-file#versions

Refs: 
- https://github.com/stackrox/stackrox/pull/10480
- https://github.com/sigstore/sigstore/pull/2000 – once it will be merged and released we will drop v3 requirement

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
