### PR TITLE
ROX-20769: Update everything to stackrox-test-0.4.6

### DIFF
--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -11,7 +11,7 @@ jobs:
   batch-load-test-metrics:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,7 @@ jobs:
       UI_PKG_INSTALL_EXTRA_ARGS: --ignore-scripts
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -244,7 +244,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -350,7 +350,7 @@ jobs:
       GO_BINARIES_BUILD_ARTIFACT: ""
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -546,7 +546,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -638,7 +638,7 @@ jobs:
     needs:
       - define-job-matrix
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -738,7 +738,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     needs:
     - pre-build-cli
     - pre-build-go-binaries

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -14,7 +14,7 @@ jobs:
   report-e2e-failures-to-slack:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -80,7 +80,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).pre_build_scanner_go_binary }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
     needs: pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
@@ -191,7 +191,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push_scanner }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -263,7 +263,7 @@ jobs:
       # race-condition-debug
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_scanner_manifests }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -108,7 +108,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp
@@ -188,7 +188,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,7 +20,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
       volumes:
       - /usr:/mnt/usr
       - /opt:/mnt/opt
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 240
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -144,7 +144,7 @@ jobs:
   go-bench:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -187,7 +187,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -264,7 +264,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -298,7 +298,7 @@ jobs:
   openshift-ci-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -146,6 +146,10 @@ jobs:
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
     steps:
+    - name: Set Postgres version
+      run: |
+        echo "/usr/pgsql-15/bin" >> "${GITHUB_PATH}"
+
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.5
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.6
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -148,7 +148,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6 "$@"
     exit 0
 fi
 


### PR DESCRIPTION
### Description

PR #14259 has introduced new version of stackrox-test image, but only for go-postgres tests. Switch everything else as well.


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI is sufficient.