### PR TITLE
ci: delete unused tools to free space for builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -400,7 +400,7 @@ jobs:
           set +e
           set -x
           df -h
-          for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /mnt/opt/hostedtoolcache/Ruby; do
+          for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Ruby; do
             du -hs "/mnt${delete:?}"
             rm -rf "/mnt${delete:?}"
           done
@@ -657,7 +657,7 @@ jobs:
           set +e
           set -x
           df -h
-          for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /mnt/opt/hostedtoolcache/Ruby; do
+          for delete in /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Ruby; do
             du -hs "/mnt${delete:?}"
             rm -rf "/mnt${delete:?}"
           done


### PR DESCRIPTION
### Description

The build action failed with out-of-space on a PR and appears to be close to failing on master. 

out-of-space PR https://github.com/stackrox/stackrox/actions/runs/13571460063/job/37938128868?pr=14425#step:5:27

Latest commit on master shows a starting available space of 23G: https://github.com/stackrox/stackrox/actions/runs/13573282948/job/37944128197#step:5:22

Disk available after successful build on master: 
```
Filesystem      Size  Used Avail Use% Mounted on
overlay          77G   74G  3.4G  96% /
```
https://github.com/stackrox/stackrox/actions/runs/13575488867/job/37951198058#step:30:24

### Testing and quality

- [ ] CI results are inspected

#### How I validated my change
