### PR TITLE
ROX-20769: Use pg_upgrade in init-entrypoint

### DIFF
--- a/image/postgres/Dockerfile
+++ b/image/postgres/Dockerfile
@@ -1,4 +1,4 @@
-ARG PG_VERSION=15
+ARG PG_VERSION=13
 FROM quay.io/sclorg/postgresql-${PG_VERSION}-c8s:latest AS final
 
 USER root

--- a/image/postgres/Dockerfile
+++ b/image/postgres/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/sclorg/postgresql-13-c8s:latest AS final
+ARG PG_VERSION=15
+FROM quay.io/sclorg/postgresql-${PG_VERSION}-c8s:latest AS final
 
 USER root
 

--- a/image/postgres/scripts/init-entrypoint.sh
+++ b/image/postgres/scripts/init-entrypoint.sh
@@ -2,7 +2,113 @@
 
 set -Eeo pipefail
 
+# Inspect the file system mounted at the specified point, and tell if the
+# available disk space is more than the specified threshold. E.g. we have a
+# file system mounted at "/some/path" with available disk space 100GB, out of
+# which 20GB (2147483648) are taken. In this scenario the call:
+#
+#   check_volume_use "/some/path" 26843545600
+#
+# will fail, because the available space is less than required.
+check_available_space () {
+    MOUNT_POINT=$1
+    THRESHOLD=$2
+
+    AVAILABLE=$(df "${MOUNT_POINT}" | tail -n -1 | awk '{print $4}')
+
+    if [ -z "${AVAILABLE}" ]; then
+        echo "No volume at ${MOUNT_POINT}"
+        return 1
+    fi
+
+    if [ "${AVAILABLE}" -lt "${THRESHOLD}" ]; then
+        echo "Volume at ${MOUNT_POINT} does not have enough available disk space"
+        echo "Current value is ${AVAILABLE}, required ${THRESHOLD}"
+        return 1
+    fi
+
+    echo "Volume at ${MOUNT_POINT} has enough available disk space (${AVAILABLE})"
+    return 0
+}
+
+# Will be used by both initdb and postgresql-upgrade
+export PGSETUP_INITDB_OPTIONS="--auth-host=scram-sha-256 \
+                               --auth-local=scram-sha-256 \
+                               --pwfile /run/secrets/stackrox.io/secrets/password \
+                               --data-checksums"
+
 # Initialize DB if it does not exist
 if [ ! -s "$PGDATA/PG_VERSION" ]; then
-  initdb --auth-host=scram-sha-256 --auth-local=scram-sha-256 --pwfile /run/secrets/stackrox.io/secrets/password --data-checksums
+  initdb $PGSETUP_INITDB_OPTIONS
+else
+    # Verify if we need to perform major version upgrade
+    PG_BINARY_VERSION=$(postgres -V |\
+        sed 's/postgres (PostgreSQL) \([0-9]*\).\([0-9]*\).*/\1/')
+
+    PG_DATA_VERSION=$(cat "${PGDATA}/PG_VERSION")
+
+    if [ "$PG_DATA_VERSION" -lt "$PG_BINARY_VERSION" ]; then
+        # Binaries version is newer, upgrade the data
+
+        # This is the amount of disk space we currently consume. Normally we
+        # could use df as well, since the data will be the only disk space
+        # consumer, but in testing environment it might not be the case.
+        PG_DATA_USED=$(du -s "${PGDATA}" | awk '{print $1}')
+        PG_BACKUP_VOLUME="/backups"
+        echo "Checking backup volume space..."
+
+        # The backup volume needs to accomodate two copies of data, one is the
+        # actual backup, and one is a restored copy, which will be deleted later.
+        if ! check_available_space "${PG_BACKUP_VOLUME}" $((PG_DATA_USED * 2)); then
+            echo "Not enough space. Checking data volume space..."
+            PG_BACKUP_VOLUME="${PGDATA}/../"
+
+            # If no luck, check the main data volume. It has to accomodate two
+            # extra copies of data as well, one is the backup and one is the
+            # restored copy.
+            if ! check_available_space "${PG_BACKUP_VOLUME}" $((PG_DATA_USED * 2)); then
+                echo "Not enough disk space, upgrade is cancelled"
+                exit 1
+            fi
+        fi
+
+        # After this point we know there is enough available disk space.
+
+        BACKUP_DIR="${PG_BACKUP_VOLUME}/backups/$PG_DATA_VERSION-$PG_BINARY_VERSION/"
+        # Do not care about symlinks yet
+        if [ -d "${BACKUP_DIR}" ]; then
+          echo "An upgrade backup directory already exists, skip."
+          else
+            # Do a backup before upgrading. Since the database is stopped we
+            # may as well simple take a filesystem backup. Alternatives would
+            # be pg_dump or pg_basebackup, both require running database
+            # cluster.
+            echo "Backup..."
+            mkdir -p "${BACKUP_DIR}"
+            tar -cf "${BACKUP_DIR}/backup.tar" -C $PGDATA --checkpoint=1000 .
+            sync $BACKUP_DIR/backup.tar
+        fi
+
+        echo "Verify backup..."
+        BACKUP_VERIFY_PGDATA="${BACKUP_DIR}/backup-restore-test"
+        OLD_BINARIES="/usr/lib64/pgsql/postgresql-13/bin/"
+        mkdir -p $BACKUP_VERIFY_PGDATA
+        tar -xvf $BACKUP_DIR/backup.tar -C $BACKUP_VERIFY_PGDATA
+        $OLD_BINARIES/pg_ctl -D $BACKUP_VERIFY_PGDATA -w start
+        $OLD_BINARIES/pg_ctl -D $BACKUP_VERIFY_PGDATA -w stop
+        rm -rf $BACKUP_VERIFY_PGDATA
+
+        # Not sure how it works now, but during the upgrade group permissions
+        # are rejected.
+        chmod 0700 $PGDATA
+
+        echo "Upgrade..."
+        # Good idea to --check first
+        PGSETUP_PGUPGRADE_OPTIONS='-j 4 -k' \
+            PGPASSWORD=$(cat /run/secrets/stackrox.io/secrets/password) \
+            postgresql-upgrade "${PGDATA}"
+
+        # Need to update statistics afterwards
+        # vacuumdb --all --analyze-in-stages
+    fi
 fi


### PR DESCRIPTION
Experimental trigger for major version upgrade.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
