### PR TITLE
ROX-27875: Change "Exposed port" from number to text input type

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -864,7 +864,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         shortName: 'Exposed port',
         negatedName: 'Exposed port doesn’t match',
         category: policyCriteriaCategories.NETWORKING,
-        type: 'text',
+        type: 'text', // Use 'text' instead of 'number', as this field supports range qualifiers (>, >=, <, <=)
         placeholder: '22',
         canBooleanLogic: true,
         lifecycleStages: ['DEPLOY', 'RUNTIME'],

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -864,7 +864,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         shortName: 'Exposed port',
         negatedName: 'Exposed port doesn’t match',
         category: policyCriteriaCategories.NETWORKING,
-        type: 'number',
+        type: 'text',
         placeholder: '22',
         canBooleanLogic: true,
         lifecycleStages: ['DEPLOY', 'RUNTIME'],


### PR DESCRIPTION
### Description

Changes the Policy field "Exposed port" from a number to a text type. This allows adding range characters, which
are supported by the backend and allowed for other similar policy fields. At long last...

Fixes https://github.com/stackrox/stackrox/issues/12932

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![image](https://github.com/user-attachments/assets/1338f50f-c32b-4828-8084-db96a06d10f1)
![image](https://github.com/user-attachments/assets/3e118cf9-350e-4cb4-a491-c254b12ab2ba)
