### PR TITLE
test: Emit time profiling data in scanner-v4-install test suite

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -108,8 +108,12 @@ _step() {
 
 export TEST_SUITE_ABORTED="false"
 
+export test_suite_begin_timestamp=""
+
 setup_file() {
+    test_suite_begin_timestamp=$(date +%s)
     _begin "setup-file"
+
 
     cat <<'EOT'
     _    ____ ____    ___           _        _ _       _   _               _____         _
@@ -202,6 +206,13 @@ EOT
     # have any logs for investigation the situation.
     export BATS_TEST_TIMEOUT=1800 # Seconds
 
+    _end
+}
+
+teardown_file() {
+    local test_suite_end_timestamp=$(date +%s)
+    _begin "teardown-file"
+    emit_timing_data "" "test-suite" "$test_suite_begin_timestamp" "$test_suite_end_timestamp"
     _end
 }
 


### PR DESCRIPTION
This change allows for some simple time profiling introspection to learn which test steps take within the test suite take particularly long.

I don't know yet where to put this, but here's a small Python script (portable through Nix), which creates bar plots from a run log:

```python
#! /usr/bin/env nix-shell
#! nix-shell -i python3 -p python3 python3Packages.matplotlib python3Packages.pandas python3Packages.seaborn

import json
import pandas
import matplotlib.pyplot as plt
import seaborn
import re
from itertools import chain
import sys

TIMING_DATA_PATTERN = re.compile(r"INFO: .*: .*TIMING_DATA: (.*)")

def extract_timing(line):
    if match := TIMING_DATA_PATTERN.match(line):
        return [json.loads(match.group(1))]
    return []

def load_data(input_stream):
    return pandas.DataFrame(list(chain.from_iterable(extract_timing(line) for line in input_stream)))

def plot(df):
    df["test_step"] = df["test"] + ":" + df["step"]
    df["minutes_spent"] = df["seconds_spent"] / 60.0
    plt.figure(figsize=(30, 20))
    seaborn.barplot(x="test_step", y="minutes_spent", data=df, palette="viridis")
    plt.xticks(rotation=45, ha="right")
    plt.xlabel("Test Step")
    plt.ylabel("Time Spent (Minutes)")
    plt.title("Test Step Execution Times")
    plt.tight_layout()
    plt.savefig(sys.stdout.buffer, format="png")

plot(load_data(sys.stdin))
```

