### PR TITLE
chore(deps): bump oauth2 fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/mod v0.23.0
 	golang.org/x/net v0.35.0
-	golang.org/x/oauth2 v0.26.0
+	golang.org/x/oauth2 v0.27.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.29.0
@@ -559,7 +559,7 @@ replace (
 	//       there is a mix of header auth and body auth in existence, which
 	//       the library solves with autosensing + caching, and what we don't
 	//       want to reimplement in our code.
-	golang.org/x/oauth2 => github.com/stackrox/oauth2 v0.0.0-20240521152739-4d3f7e4f6b49
+	golang.org/x/oauth2 => github.com/stackrox/oauth2 v0.27.1-0.20250303074527-ab111a926f2a
 
 	// Both github.com/go-yaml/yaml/v2 and github.com/go-yaml/yaml/v3 do not provide go.sum
 	// so dependabot is not able to check dependecies.

--- a/go.sum
+++ b/go.sum
@@ -1444,8 +1444,8 @@ github.com/stackrox/k8s-overlay-patch v0.0.0-20250224110925-13b5b47fd812 h1:ZWFT
 github.com/stackrox/k8s-overlay-patch v0.0.0-20250224110925-13b5b47fd812/go.mod h1:u7v87z34sjtlcaEaHXknpnrzXutdM//Vb3yyhXllQp0=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e h1:hLHHK1pGLpRvEbER2cJZekLeMnL+nMn3C37CVUhameM=
 github.com/stackrox/nvdtools v0.0.0-20231111002313-57e262e4797e/go.mod h1:Kh55SAWnjckS96TBSrXI99KrEKH4iB0OJby3N8GRJO4=
-github.com/stackrox/oauth2 v0.0.0-20240521152739-4d3f7e4f6b49 h1:FUX/fzXDu/TkYZQCk0TFGc5QUAv7m4GtvaRutyZCk4Y=
-github.com/stackrox/oauth2 v0.0.0-20240521152739-4d3f7e4f6b49/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+github.com/stackrox/oauth2 v0.27.1-0.20250303074527-ab111a926f2a h1:wZu1eOLttRfg2YgIWC1HKerDOb/ZGeHPpfxk36L9DLg=
+github.com/stackrox/oauth2 v0.27.1-0.20250303074527-ab111a926f2a/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d h1:aLCTq23tpBhbmrLa/3+21rESx7VXgkrjIKJpbhcrvVk=
 github.com/stackrox/pkcs7 v0.0.0-20240314170115-841ca6b5f88d/go.mod h1:zwEXo3PEZZb6QQZBrBORMX0Hvnnwst3PduSaTQZMFYc=
 github.com/stackrox/scanner v0.0.0-20240830165150-d133ba942d59 h1:XrOPpgBpAnwTXGbyAYSOongfFeVJJBWPTdWEgYw+Uck=


### PR DESCRIPTION
### Description

Fixes [`CVE-2025-22868`](https://access.redhat.com/security/cve/cve-2025-22868)

- https://github.com/golang/go/issues/71490

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
