### PR TITLE
test: Improved logic for detecting deletion of deployments

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -798,12 +798,12 @@ EOT
 }
 
 verify_deployment_deletion() {
+    local deployment_names_file="$1"; shift
     local namespace="$1"; shift
     local deployment_names="$@"
 
     echo "Waiting for the following deployments in namespace ${namespace} to be deleted: $deployment_names"
 
-    local deployment_names_file; deployment_names_file=$(mktemp)
     echo "$deployment_names" | tr ' ' '\n' >> "$deployment_names_file"
 
     local deleted
@@ -832,9 +832,11 @@ export -f verify_deployment_deletion
 
 verify_deployment_deletion_with_timeout() {
     local timeout_duration="$1"; shift
+    local deployment_names_file; deployment_names_file=$(mktemp)
 
-    timeout "$timeout_duration" bash -c "verify_deployment_deletion $*"
+    timeout "$timeout_duration" bash -c "verify_deployment_deletion \"$deployment_names_file\" $*"
     ret=$?
+    rm -f "$deployment_names_file"
 
     case $ret in
     0)

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -834,8 +834,10 @@ verify_deployment_deletion_with_timeout() {
     local timeout_duration="$1"; shift
     local deployment_names_file; deployment_names_file=$(mktemp)
 
-    timeout "$timeout_duration" bash -c "verify_deployment_deletion \"$deployment_names_file\" $*"
-    ret=$?
+    local ret=0
+    if ! timeout "$timeout_duration" bash -c "verify_deployment_deletion \"$deployment_names_file\" $*"; then
+        ret=$?
+    fi
     rm -f "$deployment_names_file"
 
     case $ret in

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -835,9 +835,7 @@ verify_deployment_deletion_with_timeout() {
     local deployment_names_file; deployment_names_file=$(mktemp)
 
     local ret=0
-    if ! timeout "$timeout_duration" bash -c "verify_deployment_deletion \"$deployment_names_file\" $*"; then
-        ret=$?
-    fi
+    timeout "$timeout_duration" bash -c "verify_deployment_deletion \"$deployment_names_file\" $*" || ret=$?
     rm -f "$deployment_names_file"
 
     case $ret in

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -806,19 +806,19 @@ verify_deployment_deletion() {
     local deployment_names_file; deployment_names_file=$(mktemp)
     echo "$deployment_names" | tr ' ' '\n' >> "$deployment_names_file"
 
-    local delete
+    local deleted
     while [[ -s "$deployment_names_file" ]]; do
         active_deployments=$("${ORCH_CMD}" -n "$namespace" get deployments -o json)
         deployment_names=$(cat "$deployment_names_file")
 
         for deployment_name in $deployment_names; do
-            delete=false
+            deleted=false
             if ! jq -e ".items[] | select (.metadata.name == \"$deployment_name\")" <<< "$active_deployments" > /dev/null 2>&1; then
-                delete=true
+                deleted=true
             elif jq -e ".items[] | select (.metadata.name == \"$deployment_name\") | .metadata.deletionTimestamp" > /dev/null 2>&1 <<<"$active_deployments"; then
-                delete=true
+                deleted=true
             fi
-            if [[ "$delete" == "true" ]]; then
+            if [[ "$deleted" == "true" ]]; then
                 echo "Deployment ${namespace}/$deployment_name deleted."
                 sed -ie "/^${deployment_name}$/d" "$deployment_names_file"
             fi


### PR DESCRIPTION
Previously the test simple checked "is there a deployment by the name so and so?", which makes sense, for example, after having deployed the stack initially and checking if this ACS deployment also includes specific Kubernetes deployments or not.

But currently we are also using the same function after we are disabling a component (scanner V4) through a CR and we want to make confirm that this change yields a deletion of the existing deployments. Currently we are waiting for either 30 seconds or two minutes (in the operator case) and expect this to be sufficient. But I have seen CI failures due to this *not* being sufficient. It is likely that the deletion of the respective Kubernetes deployments has been initiated but not completed.

The easy (and not so nice) "solution" would be to just increase the waiting time and hope that it will be sufficient then. Major drawback: it will slow-down all CI runs of this test suite, even those, where deployment deletion is snappy.

This PR implements a more reliable solution without waiting for a fixed time. Hence it should be quicker in most cases while also being less flaky in outlier situations where the deployment deletion takes longer than expected.

What it does is the following: It includes a new function (shell), which takes a list of deployments, which are expected to be become deleted, as input. Let's call this the deployment-watch-list. It then periodically retrieves the list of all existing deployments and removes from the deployment-watch-list all those deployments which are not present in the current deployment listing. Furthermore, it removes all deployments from the watch-list which carry a `metadata.deletionTimestamp` in the latest deployment listing.

It does this until the watch list is empty or an externally provided timeout is reached.

