### PR TITLE
ROX-27943: Fix link to the docs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -198,7 +198,7 @@ function NodeCvesOverviewPage() {
                             <a
                                 href={getVersionedDocs(
                                     version,
-                                    'operating/manage-vulnerabilities/scan-rhcos-node-host#understanding-node-cves-scanner-v4_scan-rhcos-node-host'
+                                    'operating/managing-vulnerabilities#understanding-node-cves-scanner-v4_scan-rhcos-node-host'
                                 )}
                                 target="_blank"
                                 rel="noopener noreferrer"


### PR DESCRIPTION
### Description

Apparently some URLs were changed in the docs 4.7 and many links are 404 now. This fixes the link for Node scanning with scanner V4.

Currently, the link is generated as ([click](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.7/html/operating/manage-vulnerabilities/scan-rhcos-node-host#understanding-node-cves-scanner-v4_scan-rhcos-node-host)):

```
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.7/html/operating/manage-vulnerabilities/scan-rhcos-node-host#understanding-node-cves-scanner-v4_scan-rhcos-node-host
```

whereas the working link (for 4.6 and 4.7) is ([click](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.6/html/operating/managing-vulnerabilities#understanding-node-cves-scanner-v4_scan-rhcos-node-host)):

```
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.6/html/operating/managing-vulnerabilities#understanding-node-cves-scanner-v4_scan-rhcos-node-host
```

After this change, the link renders as ([click (changed 4.8 to 4.7)](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.7/html/operating/managing-vulnerabilities#understanding-node-cves-scanner-v4_scan-rhcos-node-host)):

```
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.8/html/operating/managing-vulnerabilities#understanding-node-cves-scanner-v4_scan-rhcos-node-host

^ Change "4.8" to 4.6 or 4.7 and it would work
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- [x] Deploying to cluster manually, clicking on the link, ensuring that it is not 404
