### PR TITLE
ROX-26663: add log when registry store cleared

### DIFF
--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -127,6 +127,8 @@ func (rs *Store) Cleanup() {
 	rs.tlsCheckCache.Cleanup()
 
 	metrics.ResetRegistryMetrics()
+
+	log.Info("Registry store cleared.")
 }
 
 func (rs *Store) cleanupRegistries() {


### PR DESCRIPTION
### Description

Adds a log for when Sensor's registry store is cleared. This store holds the delegated registry config which is used to determine if images should be indexed by Sensor or sent to Central.

This log will help troubleshoot future CI failures like [this one](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-ocp-4-18-nongroovy-e2e-tests/1896356824681025536) in which a scan should have been handled by Sensor but was instead sent to Central.

```
image "icsp.invalid/rhacs-eng/qa@sha256:68b418b74715000e41a894428bd787442945592486a08d4cbea89a9b4fa03302" not flagged as cluster local which is expected for any delegated scans, most likely the scan was NOT delegated, check Central/Sensor logs to confirm}
```
The decision on whether or not to scan an image locally is made here:

https://github.com/stackrox/stackrox/blob/27a7aa0a2ae063d311ddf42ff47c83bd5528beaf/sensor/common/registry/registry_store.go#L308-L341

In the linked run above, the correct delegated registry config was successfully upserted into the registry store, however the scan was still sent to Central - leading theory is the stored config was erased somewhere between when the config was upserted and the deployment detected.

```
common/delegatedregistry: 2025/03/03 02:45:08.332157 delegated_registry_handler.go:98: Info: Upserted delegated registry config: "enabled_for:SPECIFIC  registries:{path:\"icsp.invalid\"}  registries:{path:\"idms.invalid\"}  registries:{path:\"itms.invalid\"}"
...
common/detector: 2025/03/03 02:46:05.854742 enricher.go:175: Debug: Sending scan to central for image "icsp.invalid/rhacs-eng/qa@sha256:68b418b74715000e41a894428bd787442945592486a08d4cbea89a9b4fa03302"
```

This log will help prove/disprove the above theory and lead to a fix.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No tests added.

#### How I validated my change

CI