### PR TITLE
chore: Mark more places to be reviewed by `rhtap-maintainers`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,8 @@ operator/**/* @stackrox/install
 /sensor/kubernetes/listener/resources/secrets*            @stackrox/scanner
 /SCANNER_VERSION                                          @stackrox/scanner
 
-# The RHTAP maintainers for ACS review all changes related to the RHTAP pipelines, such as new pipelines,
-# parameter changes or automated task updates.
-/.tekton/   @stackrox/rhtap-maintainers
+# The RHTAP maintainers for ACS review all changes related to the Konflux (f.k.a. RHTAP) pipelines, such as new
+# pipelines, parameter changes or automated task updates as well as Dockerfile updates.
+**/konflux.*Dockerfile  @stackrox/rhtap-maintainers
+/.konflux/              @stackrox/rhtap-maintainers
+/.tekton/               @stackrox/rhtap-maintainers


### PR DESCRIPTION
### Description

We (co-)author these files so it's natural if we are tagged for reviewing changes to them.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No change.

#### How I validated my change

None, I don't know how to test this upfront.
GitHub shows `This CODEOWNERS file is valid` badge.