### PR TITLE
ROX-28322: Render hyphen for no advisory

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AdvisoryLinkOrText.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AdvisoryLinkOrText.tsx
@@ -41,7 +41,7 @@ function AdvisoryLinkOrText({ advisory }: AdvisoryLinkOrTextProps): ReactNode {
         }
     }
 
-    return 'No advisory';
+    return '-';
 }
 
 export default AdvisoryLinkOrText;


### PR DESCRIPTION
### Description

Thank you **Shubha** for observing during demo that **No advisory** has potential problems:
* **Not applicable** is more accurate for non Red Hat images.
* **No advisory** even for Red Hat images means no Red Hat advisory, but could be misunderstand as no advisory from any source (for example, GitHub Security Advisory).

Therefore:
* Retain empty string in API response and report CSV file.
* Replace with hyphen as the conventional absence value in UI, which has 48 results in 33 files.

### Residue

Time will tell whether we also replace **No advisories** for the count.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change