### PR TITLE
chore(deps): bump Go to 1.23.6

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5",
+	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8",
 	"containerEnv":{
 		"CI":"true"
 	},

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -11,7 +11,7 @@ jobs:
   batch-load-test-metrics:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,7 @@ jobs:
       UI_PKG_INSTALL_EXTRA_ARGS: --ignore-scripts
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -244,7 +244,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -350,7 +350,7 @@ jobs:
       GO_BINARIES_BUILD_ARTIFACT: ""
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -546,7 +546,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -638,7 +638,7 @@ jobs:
     needs:
       - define-job-matrix
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -738,7 +738,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     needs:
     - pre-build-cli
     - pre-build-go-binaries

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -14,7 +14,7 @@ jobs:
   report-e2e-failures-to-slack:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/fixxx' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
 
     - name: Fetch PR metadata

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -80,7 +80,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).pre_build_scanner_go_binary }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
     needs: pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
@@ -191,7 +191,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push_scanner }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -263,7 +263,7 @@ jobs:
       # race-condition-debug
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_scanner_manifests }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -108,7 +108,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp
@@ -188,7 +188,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,7 +20,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       volumes:
       - /usr:/mnt/usr
       - /opt:/mnt/opt
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 240
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Set Postgres version
       run: |
@@ -144,7 +144,7 @@ jobs:
   go-bench:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Set Postgres version
       run: |
@@ -191,7 +191,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -227,7 +227,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -302,7 +302,7 @@ jobs:
   openshift-ci-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,4 +1,4 @@
-# These versions should match those used in the current CI test image (stackrox-test-0.4.5).
+# These versions should match those used in the current CI test image (stackrox-test-0.4.8).
 # See .github/workflows/{lint,style}.yaml for that.
 # And the stackrox/rox-ci-image repo for the original source and pinned versions.
 pycodestyle==2.10.0

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.4.5
+stackrox-build-0.4.8

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.23.2
 
 require (
 	cloud.google.com/go/artifactregistry v1.16.1

--- a/operator/bundle_helpers/requirements-gha.txt
+++ b/operator/bundle_helpers/requirements-gha.txt
@@ -1,5 +1,5 @@
 # TODO(ROX-26860): remove this file and use just requirements.txt once the GHA operator build runs with Python 3.9.
 # PyYAML > 6.0 requires Python > 3.6.
 PyYAML==6.0
-# pytest==7.0.1 is the latest available for the quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.5 job container's Python.
+# pytest==7.0.1 is the latest available for the quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8 job container's Python.
 pytest==7.0.1

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.6
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.8
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -148,7 +148,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.6 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8 "$@"
     exit 0
 fi
 


### PR DESCRIPTION
### Description

This PR bumps Go version in builder/test images to allow upgrading cosign:
- https://github.com/stackrox/stackrox/pull/14430

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
