### PR TITLE
chore(image): remove packages with dependencies

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -55,7 +55,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf -y upgrade --nobest && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
-    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 util-linux && \
+    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -59,7 +59,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities
-    rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd) && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=mappings /mappings/repository-to-cpe.json /mappings/container-name-r
 RUN microdnf upgrade --nobest && \
     microdnf clean all && \
     # (Optional) Remove line below to keep package management utilities
-    rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd) && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     chown -R 65534:65534 /tmp && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -66,7 +66,7 @@ COPY .konflux/scanner-data/repository-to-cpe.json .konflux/scanner-data/containe
 RUN microdnf upgrade --nobest && \
     microdnf clean all && \
     # (Optional) Remove line below to keep package management utilities
-    rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd) && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     chown -R 65534:65534 /tmp && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved


### PR DESCRIPTION
### Description

Currently we do remove package managers but without dependencies (`--nodeps`).
This PR forces removal with dependencies as they are not needed since package is removed.
This resulted in additional removal of `libmodulemd` which is not required since we remove
package manager.

- https://github.com/fedora-modularity/libmodulemd

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
