### PR TITLE
chore(image): remove libxml2 from release

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -59,7 +59,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities
-    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd) && \
+    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd libxml2 libarchive librepo) && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=mappings /mappings/repository-to-cpe.json /mappings/container-name-r
 RUN microdnf upgrade --nobest && \
     microdnf clean all && \
     # (Optional) Remove line below to keep package management utilities
-    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd) && \
+    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd libxml2 libarchive librepo) && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     chown -R 65534:65534 /tmp && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -66,7 +66,7 @@ COPY .konflux/scanner-data/repository-to-cpe.json .konflux/scanner-data/containe
 RUN microdnf upgrade --nobest && \
     microdnf clean all && \
     # (Optional) Remove line below to keep package management utilities
-    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd) && \
+    rpm -v -e $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' libmodulemd libxml2 libarchive librepo) && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     chown -R 65534:65534 /tmp && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved


### PR DESCRIPTION
### Description

This PR removes libxml2 and packages that depends on it. It's done to fix following reports:

```
|          libarchive           |     3.3.3-5.el8     | CVE-2024-57970 | MODERATE  |       -       |           https://access.redhat.com/security/cve/CVE-2024-57970            |
+-------------------------------+---------------------+----------------+-----------+---------------+----------------------------------------------------------------------------+
|            libxml2            |  2.9.7-18.el8_10.2  | CVE-2024-56171 | IMPORTANT |       -       |           https://access.redhat.com/security/cve/CVE-2024-56171            |
+                               +                     +----------------+-----------+---------------+----------------------------------------------------------------------------+
|                               |                     | CVE-2025-24928 | IMPORTANT |       -       |           https://access.redhat.com/security/cve/CVE-2025-24928            |
```


- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
