### PR TITLE
ROX-28249: Fix roxctl usage in deploy script and scanner tests

### DIFF
--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -278,7 +278,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() || !containers.IsRunningInContainer() {
+	if roxctl.InMainImage() || (!containers.IsRunningInContainer() && flags.OutputDirManuallySet) {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -278,7 +278,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() || (!containers.IsRunningInContainer() && flags.OutputDirManuallySet) {
+	if roxctl.InMainImage() || (!containers.IsRunningInContainer() && !flags.OutputDirManuallySet) {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/certgen"
+	"github.com/stackrox/rox/pkg/containers"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
@@ -277,7 +278,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() {
+	if roxctl.InMainImage() || !containers.IsRunningInContainer() {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -80,6 +80,7 @@ func orchestratorCommand(shortName, _ string) *cobra.Command {
 	}
 	if !roxctl.InMainImage() {
 		c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, defaultBundlePath), "output-dir", "The directory to output the deployment bundle to")
+		flags.OutputDirManuallySet = c.PersistentFlags().Changed("output-dir")
 	}
 	return c
 }

--- a/roxctl/common/flags/annotations.go
+++ b/roxctl/common/flags/annotations.go
@@ -17,3 +17,8 @@ const (
 	// PasswordKey allows an echoless prompt.
 	PasswordKey = "password"
 )
+
+var (
+	// OutputDirManuallySet returns true iff --output-dir was manually set in the roxctl command
+	OutputDirManuallySet = false
+)


### PR DESCRIPTION
### Description

It's a somewhat ugly solution, but it seems that the best way to not break existing behavior while also making `roxctl central generate...` output zip files is to add another flag.

Currently we have an `--output-dir` flag which specifies which file to write the bundle to, this defaults to `central-bundle`. The usage of this flag is overridden iff `ROX_ROXCTL_IN_MAIN_IMAGE` is set to `false`, in which case the output happens in `STDOUT`. However in ROX-28249 it's pointed out that the default should be a zip output into `STDOUT`, not a file, according to decoumentation.

I've added a flag that is true iff `output-dir` is set *manually* only. Otherwise the default value would make it so we won't have zip outputs even when we don't set it. This should also make the deploy script not break because there it's explicitly set as `--output-dir="central-bundle"`.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Will try the deploy script and scanner v4 install tests (that use the deploy script) and make sure the zip no longer appears in `STDOUT`
