### PR TITLE
chore(deps): remove lz4 and bzip2

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -55,6 +55,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf -y upgrade --nobest && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
+    microdnf install --setopt=install_weak_deps=0 --nodocs -y util-linux && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -55,7 +55,6 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf -y upgrade --nobest && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
-    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -55,7 +55,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf -y upgrade --nobest && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
-    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 util-linux && \
+    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities


### PR DESCRIPTION
### Description

lz4 and bzip2 were added to support rocksdb since we do not use it anymore we can remove them.

- https://github.com/stackrox/rox/pull/5611

---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [ ] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
