### PR TITLE
ROX-26663: dele scan tests flake: no connection

### DIFF
--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -893,6 +893,14 @@ func (ts *DelegatedScanningSuite) scanWithRetries(ctx context.Context, service v
 		// ex:
 		// - unable to check TLS for registry "icsp.invalid": dial tcp: lookup icsp.invalid on <ip>:53: no such host
 		"no such host",
+
+		// Central's cluster API is used to report the health of secured clusters, this cluster status is on a delay
+		// and may not represent actual state leading to flakes. When the actual connection to a cluster fails during
+		// delegation, the scan attempt should be retried.
+		//
+		// ex:
+		// - no connection to "a21b168a-280e-40d1-a175-e84d14ed8232"
+		"no connection to",
 	}
 
 	retryFunc := func() error {
@@ -910,7 +918,7 @@ func (ts *DelegatedScanningSuite) scanWithRetries(ctx context.Context, service v
 		return err
 	}
 
-	err = ts.withRetries(retryFunc, "Timeout or too many parallel scans")
+	err = ts.withRetries(retryFunc, "Scan failed")
 	return img, err
 }
 
@@ -1165,8 +1173,13 @@ func (ts *DelegatedScanningSuite) withRetries(retryFunc func() error, statusMsg 
 	t := ts.T()
 
 	betweenAttemptsFunc := func(num int) {
-		logf(t, "%s, trying again in %s, attempt %d/%d", statusMsg, deleScanDefaultRetryDelay, num, deleScanDefaultMaxRetries)
+		logf(t, "Trying again in %s, attempt %d/%d", deleScanDefaultRetryDelay, num, deleScanDefaultMaxRetries)
 		time.Sleep(deleScanDefaultRetryDelay)
+	}
+
+	onFailedAttemptsFunc := func(err error) {
+		// Log the error for each attempt to assist troubleshooting.
+		logf(t, "%s: %v", statusMsg, err)
 	}
 
 	return retry.WithRetry(retryFunc,
@@ -1174,6 +1187,7 @@ func (ts *DelegatedScanningSuite) withRetries(retryFunc func() error, statusMsg 
 		retry.Tries(deleScanDefaultMaxRetries),
 		retry.WithExponentialBackoff(),
 		retry.OnlyRetryableErrors(),
+		retry.OnFailedAttempts(onFailedAttemptsFunc),
 	)
 }
 


### PR DESCRIPTION
### Description

Addresses Delegated Scanning Test failures caused by Central incorrectly reporting an active connection to a cluster. When a delegated scan is attempted, if Central reports there is `no connection` to the cluster, the scan will be retried.

Also adds to the test output logs for the actual error returned from the Central API.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI