### PR TITLE
ROX-28324: Delete frontend-only uuid property from delegated scanning

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -1,18 +1,8 @@
 import React, { useState } from 'react';
 import { Button, TextInput } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
-import {
-    Table,
-    Tbody,
-    // TbodyProps,
-    Td,
-    Th,
-    Thead,
-    Tr,
-    // TrProps,
-} from '@patternfly/react-table';
-// import styles from '@patternfly/react-styles/css/components/Table/table';
-import MinusCircleIcon from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { MinusCircleIcon } from '@patternfly/react-icons';
 
 import {
     DelegatedRegistry,
@@ -26,15 +16,9 @@ type DelegatedRegistriesTableProps = {
     handlePathChange: (number, string) => void;
     handleClusterChange: (number, string) => void;
     deleteRow: (number) => void;
-    // TODO: re-enable next type after @typescript-eslint deps can be resolved to ^5.2.x
-    // updateRegistriesOrder: (DelegatedRegistry[]) => void;
 };
 
 function DelegatedRegistriesTable({
-    // TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // updateRegistriesOrder,
     registries,
     clusters,
     selectedClusterId,
@@ -42,14 +26,6 @@ function DelegatedRegistriesTable({
     handleClusterChange,
     deleteRow,
 }: DelegatedRegistriesTableProps) {
-    // const [draggedItemId, setDraggedItemId] = React.useState<string | null>(null);
-    // const [draggingToItemIndex, setDraggingToItemIndex] = React.useState<number | null>(null);
-    // const [isDragging, setIsDragging] = React.useState(false);
-
-    // const initialOrderIds = registries.map((reg) => reg.uuid as string);
-    // const [itemOrder, setItemOrder] = React.useState(initialOrderIds);
-    // const [tempItemOrder, setTempItemOrder] = React.useState<string[]>([]);
-
     const [openRow, setRowOpen] = useState<number>(-1);
     function toggleSelect(rowToToggle: number) {
         setRowOpen((prev) => (rowToToggle === prev ? -1 : rowToToggle));
@@ -58,11 +34,6 @@ function DelegatedRegistriesTable({
         handleClusterChange(rowIndex, value);
         setRowOpen(-1);
     }
-
-    // useEffect(() => {
-    //     const orderIds = registries.map((reg) => reg.uuid as string);
-    //     setItemOrder(orderIds);
-    // }, [registries]);
 
     const clusterSelectOptions: JSX.Element[] = clusters.map((cluster) => {
         const optionLabel =
@@ -74,153 +45,10 @@ function DelegatedRegistriesTable({
         );
     });
 
-    // TODO (https://issues.redhat.com/browse/ROX-19275):
-    // Temporarily disabling reordering because of buggy behavior in PF drag-and-drop table variant
-    // Start PatternFly template for drag and drop
-    const bodyRef = React.useRef<HTMLTableSectionElement>();
-
-    // const onDragStart: TrProps['onDragStart'] = (evt) => {
-    //     evt.dataTransfer.effectAllowed = 'move';
-    //     evt.dataTransfer.setData('text/plain', evt.currentTarget.id);
-    //     // eslint-disable-next-line @typescript-eslint/no-shadow
-    //     const draggedItemId = evt.currentTarget.id;
-
-    //     evt.currentTarget.classList.add(styles.modifiers.ghostRow);
-    //     evt.currentTarget.setAttribute('aria-pressed', 'true');
-
-    //     setDraggedItemId(draggedItemId);
-    //     setIsDragging(true);
-    // };
-
-    // const moveItem = (arr: string[], i1: string, toIndex: number) => {
-    //     const fromIndex = arr.indexOf(i1);
-    //     if (fromIndex === toIndex) {
-    //         return arr;
-    //     }
-    //     const temp = arr.splice(fromIndex, 1);
-    //     arr.splice(toIndex, 0, temp[0]);
-
-    //     return arr;
-    // };
-
-    // const move = (itemOrder: string[]) => {
-    //     const ulNode = bodyRef.current;
-    //     if (ulNode?.children) {
-    //         const nodes = Array.from(ulNode.children);
-    //         if (nodes.map((node) => node.id).every((id, i) => id === itemOrder[i])) {
-    //             return;
-    //         }
-    //         while (ulNode?.firstChild) {
-    //             if (ulNode.lastChild) {
-    //                 ulNode.removeChild(ulNode.lastChild);
-    //             }
-    //         }
-
-    //         itemOrder.forEach((id) => {
-    //             if (nodes.find((n) => n.id === id)) {
-    //                 ulNode.appendChild(nodes.find((n) => n.id === id) as Element);
-    //             }
-    //         });
-    //     }
-    // };
-
-    // const onDragCancel = () => {
-    //     if (bodyRef?.current?.children) {
-    //         Array.from(bodyRef.current.children).forEach((el) => {
-    //             el.classList.remove(styles.modifiers.ghostRow);
-    //             el.setAttribute('aria-pressed', 'false');
-    //         });
-    //         setDraggedItemId(null);
-    //         setDraggingToItemIndex(null);
-    //         setIsDragging(false);
-    //     }
-    // };
-
-    // const onDragLeave: TbodyProps['onDragLeave'] = (evt) => {
-    //     if (!isValidDrop(evt)) {
-    //         move(itemOrder);
-    //         setDraggingToItemIndex(null);
-    //     }
-    // };
-
-    // function isValidDrop(evt: React.DragEvent<HTMLTableSectionElement | HTMLTableRowElement>) {
-    //     if (bodyRef?.current?.getBoundingClientRect()) {
-    //         const ulRect = bodyRef.current.getBoundingClientRect();
-    //         return (
-    //             evt.clientX > ulRect.x &&
-    //             evt.clientX < ulRect.x + ulRect.width &&
-    //             evt.clientY > ulRect.y &&
-    //             evt.clientY < ulRect.y + ulRect.height
-    //         );
-    //     }
-    //     return false;
-    // }
-
-    // const onDrop: TrProps['onDrop'] = (evt) => {
-    //     if (isValidDrop(evt)) {
-    //         setItemOrder(tempItemOrder);
-
-    //         // the rest of this block was added to the PF drag and drop paradigm,
-    //         // in order to keep the form data in sync with PF's visual drop order
-    //         const newRegistries: DelegatedRegistry[] = tempItemOrder.map((tempItem) => {
-    //             const newIndex = registries.findIndex((reg) => reg.uuid === tempItem) || 0;
-    //             return registries[newIndex];
-    //         });
-
-    //        updateRegistriesOrder(newRegistries);
-    //     } else {
-    //         onDragCancel();
-    //     }
-    // };
-
-    // function onDragOver(evt): TbodyProps['onDragOver'] {
-    //     evt.preventDefault();
-
-    //     const curListItem = (evt.target as HTMLTableSectionElement).closest('tr');
-    //     if (
-    //         !curListItem ||
-    //         !bodyRef?.current?.contains(curListItem) ||
-    //         curListItem.id === draggedItemId
-    //     ) {
-    //         return undefined;
-    //     }
-    //     const dragId = curListItem.id;
-    //     const newDraggingToItemIndex = Array.from(bodyRef.current.children).findIndex(
-    //         (item) => item.id === dragId
-    //     );
-    //     if (newDraggingToItemIndex !== draggingToItemIndex) {
-    //         const tempItemOrder = moveItem(
-    //             [...itemOrder],
-    //             draggedItemId || '',
-    //             newDraggingToItemIndex
-    //         );
-    //         move(tempItemOrder);
-    //         setDraggingToItemIndex(newDraggingToItemIndex);
-    //         setTempItemOrder(tempItemOrder);
-    //     }
-
-    //     return undefined;
-    // }
-
-    // const onDragEnd: TrProps['onDragEnd'] = (evt) => {
-    //     const target = evt.target as HTMLTableRowElement;
-    //     target.classList.remove(styles.modifiers.ghostRow);
-    //     target.setAttribute('aria-pressed', 'false');
-    //     setDraggedItemId(null);
-    //     setDraggingToItemIndex(null);
-    //     setIsDragging(false);
-    // };
-    // End PatternFly template for drag and drop
-    // end of TODO section (https://issues.redhat.com/browse/ROX-19275):
-
     return (
-        <Table
-            aria-label="Delegated registry exceptions table"
-            // className={(isDragging && styles.modifiers.dragOver) || ''}
-        >
+        <Table aria-label="Delegated registry exceptions table">
             <Thead>
                 <Tr>
-                    {/* <Th>Order</Th> */}
                     <Th width={40}>Source registry</Th>
                     <Th width={40}>Destination cluster (CLI/API only)</Th>
                     <Th>
@@ -228,39 +56,21 @@ function DelegatedRegistriesTable({
                     </Th>
                 </Tr>
             </Thead>
-            <Tbody
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                ref={bodyRef}
-                // onDragOver={onDragOver}
-                // onDrop={onDragOver}
-                // onDragLeave={onDragLeave}
-            >
+            <Tbody>
                 {registries.map((registry, rowIndex) => {
                     const selectedClusterName =
                         clusters.find((cluster) => registry.clusterId === cluster.id)?.name ??
                         'None';
 
+                    // Even path and clusterId combined is not a unique key.
+                    /* eslint-disable react/no-array-index-key */
                     return (
-                        <Tr
-                            key={registry.uuid}
-                            id={registry.uuid}
-                            // draggable
-                            // onDrop={onDrop}
-                            // onDragEnd={onDragEnd}
-                            // onDragStart={onDragStart}
-                        >
-                            {/* <Td
-                                draggableRow={{
-                                    id: `draggable-row-${registry.path}`,
-                                }}
-                            /> */}
+                        <Tr key={rowIndex}>
                             <Td dataLabel="Source registry">
                                 <TextInput
+                                    aria-label="registry"
                                     isRequired
                                     type="text"
-                                    id={`${registry.uuid as string}-path-input`}
-                                    name={`${registry.uuid as string}-path-input`}
                                     value={registry.path}
                                     onChange={(_event, value) => handlePathChange(rowIndex, value)}
                                 />
@@ -303,6 +113,7 @@ function DelegatedRegistriesTable({
             </Tbody>
         </Table>
     );
+    /* eslint-ensable react/no-array-index-key */
 }
 
 export default DelegatedRegistriesTable;

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -37,33 +37,6 @@ const initialDelegatedState: DelegatedRegistryConfig = {
     registries: [],
 };
 
-function getUuid() {
-    const MAX_RANDOM = 1000000;
-
-    const uuid = self?.crypto?.randomUUID() ?? Math.floor(Math.random() * MAX_RANDOM).toString();
-
-    return uuid;
-}
-
-function addUuidstoRegistries(config: DelegatedRegistryConfig) {
-    const newRegistries = config.registries.map((registry) => {
-        const uuid = getUuid();
-
-        return {
-            path: registry.path,
-            clusterId: registry.clusterId,
-            uuid,
-        };
-    });
-
-    const newState: DelegatedRegistryConfig = {
-        ...config,
-        registries: newRegistries,
-    };
-
-    return newState;
-}
-
 function DelegateScanningPage() {
     const displayedPageTitle = 'Delegated Image Scanning';
     const [delegatedRegistryConfig, setDedicatedRegistryConfig] =
@@ -81,10 +54,7 @@ function DelegateScanningPage() {
     function fetchConfig() {
         setAlertObj(null);
         fetchDelegatedRegistryConfig()
-            .then((configFetched) => {
-                const configWithUuids = addUuidstoRegistries(configFetched);
-                setDedicatedRegistryConfig(configWithUuids);
-            })
+            .then(setDedicatedRegistryConfig)
             .catch((error) => {
                 const newErrorObj: AlertObj = {
                     type: 'danger',
@@ -146,12 +116,9 @@ function DelegateScanningPage() {
     function addRegistryRow() {
         const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
 
-        const uuid = getUuid();
-
         newState.registries.push({
             path: '',
             clusterId: '',
-            uuid,
         });
 
         setDedicatedRegistryConfig(newState);
@@ -175,7 +142,6 @@ function DelegateScanningPage() {
                 return {
                     path: value,
                     clusterId: registry.clusterId,
-                    uuid: registry.uuid,
                 };
             }
 
@@ -195,20 +161,11 @@ function DelegateScanningPage() {
                 return {
                     path: registry.path,
                     clusterId: value,
-                    uuid: registry.uuid,
                 };
             }
 
             return registry;
         });
-
-        newState.registries = newRegistries;
-
-        setDedicatedRegistryConfig(newState);
-    }
-
-    function updateRegistriesOrder(newRegistries) {
-        const newState: DelegatedRegistryConfig = { ...delegatedRegistryConfig };
 
         newState.registries = newRegistries;
 
@@ -300,10 +257,6 @@ function DelegateScanningPage() {
                                 handleClusterChange={handleClusterChange}
                                 addRegistryRow={addRegistryRow}
                                 deleteRow={deleteRow}
-                                // TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
-                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                                // @ts-ignore
-                                updateRegistriesOrder={updateRegistriesOrder}
                                 key="delegated-registries-list"
                             />
                         </>

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactElement, ReactFragment } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import {
     Alert,
     Breadcrumb,
@@ -29,7 +29,7 @@ import DelegatedRegistriesList from './Components/DelegatedRegistriesList';
 type AlertObj = {
     type: 'danger' | 'success';
     title: string;
-    body: ReactElement | ReactFragment;
+    body: ReactNode;
 };
 const initialDelegatedState: DelegatedRegistryConfig = {
     enabledFor: 'NONE',

--- a/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
+++ b/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
@@ -6,15 +6,7 @@ import axios from './instance';
 // Scan images that match registries or are from the OCP integrated registry via the secured clusters otherwise scan via central services.
 export type DelegatedRegistryConfigEnabledFor = 'NONE' | 'ALL' | 'SPECIFIC';
 
-// Note:
-// In order to make each row of registry/cluster exceptions work
-// with PatternFly's drag-and-drag Table variant
-// we need to add stable surrogate UUIDs to each entry
-//
-// see description in https://github.com/stackrox/stackrox/pull/7341
-// for more details
 export type DelegatedRegistry = {
-    uuid?: string; // not in API response
     path: string;
     clusterId: string;
 };


### PR DESCRIPTION
### Description

Prerequisite to clean up delegated scanning interactions.

The drag-and-drop interaction was abandoned.

### Problem

* `DelegatedRegistry` type has extra frontend-only `uuid` property.
* Page component has extra code to add it to response data.
* The value is random.

### Analysis

David Caravello explains:

> If a path is duplicated, the back-end will ignore subsequent registry entries regardless if they have a different cluster ID or not.

> The back-end logic looks for the ‘first path’ matching the image being scanned (prefix match), once a match is found the the loop exits.

### Solution

Because even `path` and `clusterId` combined is not a unique key, fall back to simple (although less than ideal) item index as key (with eslint ignore comment).

David Caravello explains:

> Once the config is setup it generally isn’t touched again (few exceptions).

While we are at it:

1. Replace unique `import` source of `MinusCircleIcon` element.
2. Replace `ReactElement | ReactFragment` with `ReactNode` especially because `ReactFragment` is deprecated.
3. Fix accessibility issue reported by axe DevTools
    https://dequeuniversity.com/rules/axe/4.10/label

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR\ is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4646307 - 4646307
        total -582 = 11566184 - 11566766
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

### Manual testing

1. Visit /main/clusters/delegated-image-scanning, click **Specified registries**, and then click **Add registry**.

    Before changes, see presence of accessibility issue.
    ![accessibility_label_presence](https://github.com/user-attachments/assets/0ea9a3fc-8730-4e6d-87ee-3f76f04c4f07)

2. Add two rows to the table.

    After changes, see absence of accessibility issue.
    ![accessibility_label_absence](https://github.com/user-attachments/assets/845e3ec5-51e7-4ef3-a941-33877b89c58d)

3. Click **Save**.
    PUT /v1/delegatedregistryconfig see 2 items in the response.
    ![put_registries_2](https://github.com/user-attachments/assets/931bbf14-87ad-48ff-90af-7a86a6267ece)

4. Delete the first row, and then click **Save**
    PUT /v1/delegatedregistryconfig see 1 item in the response.
    ![put_registries_1](https://github.com/user-attachments/assets/3646677a-b030-4c94-834c-3407f62da5fc)

5. Delete the other row, select **None**, and then click **Save**.
    PUT /v1/delegatedregistryconfig see 0 items in the response.
    ![put_registries_0](https://github.com/user-attachments/assets/209857f6-57bc-4938-bee1-cf934db81fb0)
