### PR TITLE
chore(ui): Add better error handling to debug CI failures in old VM

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { Bullseye } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import Raven from 'raven-js';
 
 import Loader from 'Components/Loader';
 import PageNotFound from 'Components/PageNotFound';
@@ -85,6 +86,7 @@ const WorkflowEntityPage = ({
         return <Loader />;
     }
     if (error) {
+        Raven.captureException(error);
         return (
             <Bullseye>
                 <EmptyStateTemplate

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import Raven from 'raven-js';
+
 import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
 
@@ -32,6 +34,11 @@ const VulnMgmtEntityList = (props) => {
     const { entityListType } = props;
     const Component = entityComponentMap[entityListType];
     if (!Component) {
+        Raven.captureException(
+            new Error(
+                `DEVELOPER ERROR A component could not be found for entity type ${entityListType} for use case ${useCases.VULN_MANAGEMENT}`
+            )
+        );
         return <PageNotFound resourceType={entityListType} useCase={useCases.VULN_MANAGEMENT} />;
     }
     return <Component {...props} />;


### PR DESCRIPTION
### Description

Additional debugging information for the failure in ROX-20173 and possibly dozens of other CI failures. Captures error information in the logimbue file for all error points in the old VM component list page. This also renders an error UI instead of a "Not Found" UI when an error is detected in the query.

The error manifests as a "PageNotFound" error when visiting a VM list page, usually deployments, even though previous and following tests that visit the same page succeed without issue:
![image](https://github.com/user-attachments/assets/00e1799c-6946-495d-853f-da792ac0d8d1)



### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Modify the code locally to create an erroneous GraphQL request and see the display of the error component:
![image](https://github.com/user-attachments/assets/6940f234-e6c0-4c6c-bfd9-1c35886a070e)
