### PR TITLE
ROX-28381: Add Event Filter to Policy Controller

### DIFF
--- a/config-controller/internal/controller/policy_controller.go
+++ b/config-controller/internal/controller/policy_controller.go
@@ -29,6 +29,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
@@ -199,10 +201,19 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, retErr
 }
 
+func getEventFilter() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+		},
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *SecurityPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&configstackroxiov1alpha1.SecurityPolicy{}).
+		WithEventFilter(getEventFilter()).
 		Complete(r)
 
 	if err != nil {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This adds an event filter to the Policy Controller, which should make it not trigger reconciliations when the status of the CR is updated, only when the spec of the CR is updated.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
Confirmed that creating/updating a policy only triggers one reconciliation per event, and confirmed that changes were reflected in central.
```
➜  manifests kubectl apply -f test-sp.yaml 
securitypolicy.config.stackrox.io/test-security-policy created
➜  manifests kubectl logs config-controller-865c9c6c67-64zh6 
pkg/client: 2025/03/06 20:14:40.455359 client.go:229: Error: Failed to exchange token: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 34.118.224.60:443: connect: connection refused"Failed to initialize client. Will continue to retry...
pkg/client: 2025/03/06 20:15:50.517382 client.go:320: Info: Flushing caches
main: 2025/03/06 20:15:51.186937 main.go:170: Info: Starting manager
2025-03-06T20:15:51Z    INFO    starting server {"name": "health probe", "addr": "[::]:8081"}
2025-03-06T20:15:51Z    INFO    Starting EventSource    {"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy", "source": "kind source: *v1alpha1.SecurityPolicy"}
2025-03-06T20:15:51Z    INFO    Starting Controller     {"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy"}
2025-03-06T20:15:51Z    INFO    Starting workers        {"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy", "worker count": 1}
internal/controller: 2025/03/06 20:18:19.247395 policy_controller.go:56: Info: Reconciling resource "stackrox"/"test-security-policy"
pkg/client: 2025/03/06 20:18:19.355106 client.go:260: Info: Creating policy "Test Policy"
➜  manifests kubectl edit sp test-security-policy 
securitypolicy.config.stackrox.io/test-security-policy edited
➜  manifests kubectl logs config-controller-865c9c6c67-64zh6 
pkg/client: 2025/03/06 20:14:40.455359 client.go:229: Error: Failed to exchange token: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 34.118.224.60:443: connect: connection refused"Failed to initialize client. Will continue to retry...
pkg/client: 2025/03/06 20:15:50.517382 client.go:320: Info: Flushing caches
main: 2025/03/06 20:15:51.186937 main.go:170: Info: Starting manager
2025-03-06T20:15:51Z    INFO    starting server {"name": "health probe", "addr": "[::]:8081"}
2025-03-06T20:15:51Z    INFO    Starting EventSource    {"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy", "source": "kind source: *v1alpha1.SecurityPolicy"}
2025-03-06T20:15:51Z    INFO    Starting Controller     {"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy"}
2025-03-06T20:15:51Z    INFO    Starting workers        {"controller": "securitypolicy", "controllerGroup": "config.stackrox.io", "controllerKind": "SecurityPolicy", "worker count": 1}
internal/controller: 2025/03/06 20:18:19.247395 policy_controller.go:56: Info: Reconciling resource "stackrox"/"test-security-policy"
pkg/client: 2025/03/06 20:18:19.355106 client.go:260: Info: Creating policy "Test Policy"
internal/controller: 2025/03/06 20:19:29.415919 policy_controller.go:56: Info: Reconciling resource "stackrox"/"test-security-policy"
pkg/client: 2025/03/06 20:19:29.435693 client.go:274: Info: Updating policy "Test Policy"
```