### PR TITLE
fix: use different token for fixxxer

### DIFF
--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -59,6 +59,7 @@ jobs:
       with:
         ref: ${{ steps.pr-metadata.outputs.branch }}
         fetch-depth: 0
+        token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
 
     - name: Configure Git
       run: |
@@ -72,4 +73,4 @@ jobs:
     - uses: ad-m/github-push-action@v0.8.0
       with:
         branch: ${{ steps.pr-metadata.outputs.branch }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

[Work around](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs) for the [problem](https://github.com/orgs/community/discussions/25702) of GH disallowing triggering of workflows on pushes done using the default `GITHUB_TOKEN`.

In theory only the change on `github-push-action` call is needed, but I had seen reports where people saw this action reusing the credentials left in place by the checkout action, so let's keep it safe.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no test changes

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

No easy way to test if this works 100% correctly without merging first 😢 
Let's YOLO it in and check. Nobody will suffer if it does not from the start.

