### PR TITLE
chore(release): Tweak CPU usage for Core Grafana dashboard

### DIFF
--- a/deploy/charts/monitoring/dashboards/stackrox-core-dashboard.json
+++ b/deploy/charts/monitoring/dashboards/stackrox-core-dashboard.json
@@ -47,7 +47,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Percent CPU Usage",
+            "axisLabel": "CPU Usage [Cores]",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -59,7 +59,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -70,20 +70,17 @@
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -117,7 +114,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"central\"}[1m])*100",
+          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"central\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -227,7 +224,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Percent CPU Usage",
+            "axisLabel": "CPU Usage [Cores]",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -239,7 +236,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -250,20 +247,17 @@
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -297,7 +291,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"central-db\"}[1m])*100",
+          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"central-db\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -407,7 +401,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Percent CPU Usage",
+            "axisLabel": "CPU Usage [Cores]",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -419,7 +413,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -430,20 +424,17 @@
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -477,7 +468,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"scanner\"}[1m])*100",
+          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"scanner\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -587,7 +578,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Percent CPU Usage",
+            "axisLabel": "CPU Usage [Cores]",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -599,7 +590,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -610,20 +601,17 @@
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -657,7 +645,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"scanner-db\"}[1m])*100",
+          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"scanner-db\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -767,7 +755,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Percent CPU Usage",
+            "axisLabel": "CPU Usage [Cores]",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -779,7 +767,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -790,20 +778,17 @@
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -837,7 +822,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "sum by(pod)(\n  rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=~\"(collector|compliance|node-inventory)\"}[1m])*100\n)",
+          "expr": "sum by(pod)(\n  rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=~\"(collector|compliance|node-inventory)\"}[$__rate_interval])\n)",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -947,7 +932,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Percent CPU Usage",
+            "axisLabel": "CPU Usage [Cores]",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -959,7 +944,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -970,20 +955,17 @@
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -1017,7 +999,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "sum by(pod)(\n  rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"sensor\"}[1m])*100\n)",
+          "expr": "sum by(pod)(\n  rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"sensor\"}[$__rate_interval])\n)",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -1127,7 +1109,7 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "Percent CPU Usage",
+            "axisLabel": "CPU Usage [Cores]",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1139,7 +1121,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -1150,20 +1132,17 @@
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -1197,7 +1176,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "sum by(pod)(\n  rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"admission-control\"}[1m])*100\n)",
+          "expr": "sum by(pod)(\n  rate(container_cpu_usage_seconds_total{namespace=\"stackrox\", container=\"admission-control\"}[$__rate_interval])\n)",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
### Description

This PR is tweaking CPU panels in Grafana `Core Dashboard`.

Main reason for changes are:
- we use percentage and the calculated value is a percentage of 1 vCPU. That can be misleading, because there could be an assumption that the percentage is based on the CPU limit
- when using percent for Y-axis, it's capped to 100% and CPU utilization with 1+ Cores is not visible
- we use `1m` time range for `rate` function. Better solution is to use `$__rate_interval`, a global Grafana variable that will be properly set by Grafana based on selected time range

Made changes:
- remove percentage calculation (`*100`)
- use variable rate range provided by Grafana (`$__rate_interval `)
- removed `Percent` for Y-axis, because it's not representing percentage anymore and added `[Cores]`
- changed line plotting to `linear`. This will plot lines in the most common way.
- removed `unit` type
- removed `thresholds` - because plotted value is not percentage anymore
- set start for the Y-axis to 0

**Consideration**

- Instead of using `[Cores]` on axis label, we could set `cores` for `unit`. That will render `cores` next to each number on the Y-axis and also on mouseover. On mouseover it looks good, but an additional string next to each number on the Y-axis does not look good and it pushes the plot to the right.
- We have also CPU utilization in `dataplane.json`, but I'm not sure what the intention is there, because we are using `avg(increase())` and `unit` is time. If we should adjust that, this can be done in a separate PR.

**An example**

Before:
![Screenshot 2025-03-06 at 11 47 39](https://github.com/user-attachments/assets/664bee14-323a-4048-9ee9-d9e4a9faad8e)

After:
![Screenshot 2025-03-06 at 11 49 36](https://github.com/user-attachments/assets/91773b4b-7705-4136-90ed-6c0895f3bf9a)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

We do not have automated testing for this functionality.

#### How I validated my change

- [x] imported dashboard on `long-fake-load-4-6-3-rc-4` and tested it
