### PR TITLE
ROX-28102: Set curl to retry on any error

### DIFF
--- a/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
@@ -36,7 +36,7 @@ teardown() {
 }
 
 @test "[zip] roxctl scanner upload-db" {
-  run curl --retry 30 --retry-max-time 300 --retry-connrefused --show-error --fail --output "${temp_dir}/test-scanner-vuln-updates.zip" --location 'https://install.stackrox.io/scanner/scanner-vuln-updates.zip'
+  run curl --retry 30 --retry-max-time 600 --retry-all-errors --show-error --fail --output "${temp_dir}/test-scanner-vuln-updates.zip" --location 'https://install.stackrox.io/scanner/scanner-vuln-updates.zip'
   assert_success
 
   run roxctl_authenticated scanner upload-db --scanner-db-file "${temp_dir}/test-scanner-vuln-updates.zip"


### PR DESCRIPTION
### Description

We simply have problems with downloads. Test does not run for long, `~30sec` to download and upload zip. This also tests full flow and validates that central works properly with generated vulnerability definitions.

This PR is trying to improve the curl call to be stable.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] tested command locally
- [x] run test several times (~5) in order to see how it works
