### PR TITLE
ROX-28409: install securitypolicies CRD for upgrade test

### DIFF
--- a/.github/workflows/scripts/prepare-upgrade-test.sh
+++ b/.github/workflows/scripts/prepare-upgrade-test.sh
@@ -31,6 +31,15 @@ deploy_central() {
         --image-defaults development_build \
         --output-dir bundle-test1
 
+    # Install the securitypolicies CRD since this is not done automatically when using roxctl install method
+    crd_path=$(realpath "./bundle-test1/helm/chart/crds/config.stackrox.io_securitypolicies.yaml")
+    if [ -f "$crd_path" ]; then
+        kubectl apply -f "$crd_path"
+    else
+        # This case is for compatibility with roxctl versions <4.6
+        echo "No securitypolicies.config.stackrox.io CRD file found at path: $crd_path. Install it manually if required."
+    fi
+
     ./bundle-test1/central/scripts/setup.sh
     kubectl apply -R -f bundle-test1/central
     ./bundle-test1/scanner/scripts/setup.sh


### PR DESCRIPTION
### Description

This PR adds a step to the `prepare-upgrade-test.sh` function to install the securitypolicies.config.stackrox.io CRD to the upgrade cluster.

Manual install of the CRD is required when installing central via the manifest method.

This should fix the issue that config-controller is in CrashLoopBackoff until the CRD is installed that we had in with recent releases.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
