### PR TITLE
ROX-26504: Add explicit Edit button to delegated image scanning

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -43,6 +43,8 @@ describe('Delegated Image Scanning', () => {
         cy.get('label:contains("All registries")').should('not.be.checked');
         cy.get('label:contains("Specified registries")').should('not.be.checked');
 
+        cy.get('button:contains("Edit")').click();
+
         // Enable delegate scanning with default
         getInputByLabel('All registries').click();
 

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
@@ -23,6 +23,7 @@ type DelegatedRegistriesListProps = {
     registries: DelegatedRegistry[];
     clusters: DelegatedRegistryCluster[];
     selectedClusterId: string;
+    isEditing: boolean;
     addRegistryRow: () => void;
     deleteRow: (number) => void;
     handlePathChange: (number, string) => void;
@@ -35,6 +36,7 @@ function DelegatedRegistriesList({
     registries,
     clusters,
     selectedClusterId,
+    isEditing,
     handlePathChange,
     handleClusterChange,
     addRegistryRow,
@@ -52,6 +54,7 @@ function DelegatedRegistriesList({
                         registries={registries}
                         clusters={clusters}
                         selectedClusterId={selectedClusterId}
+                        isEditing={isEditing}
                         handlePathChange={handlePathChange}
                         handleClusterChange={handleClusterChange}
                         deleteRow={deleteRow}
@@ -61,11 +64,17 @@ function DelegatedRegistriesList({
                         updateRegistriesOrder={updateRegistriesOrder}
                         key="delegated-registries-table"
                     />
-                    <CardFooter>
-                        <Button variant="link" icon={<PlusCircleIcon />} onClick={addRegistryRow}>
-                            Add registry
-                        </Button>
-                    </CardFooter>
+                    {isEditing && (
+                        <CardFooter>
+                            <Button
+                                variant="link"
+                                icon={<PlusCircleIcon />}
+                                onClick={addRegistryRow}
+                            >
+                                Add registry
+                            </Button>
+                        </CardFooter>
+                    )}
                 </>
             ) : (
                 <Bullseye className="pf-v5-u-flex-grow-1">
@@ -75,11 +84,13 @@ function DelegatedRegistriesList({
                             <p>All scans will be delegated to the default cluster.</p>
                             <p>You can override this for specific registries.</p>
                         </EmptyStateBody>
-                        <EmptyStateFooter>
-                            <Button variant="primary" onClick={addRegistryRow}>
-                                Add registry
-                            </Button>
-                        </EmptyStateFooter>
+                        {isEditing && (
+                            <EmptyStateFooter>
+                                <Button variant="primary" onClick={addRegistryRow}>
+                                    Add registry
+                                </Button>
+                            </EmptyStateFooter>
+                        )}
                     </EmptyState>
                 </Bullseye>
             )}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -23,6 +23,7 @@ type DelegatedRegistriesTableProps = {
     registries: DelegatedRegistry[];
     clusters: DelegatedRegistryCluster[];
     selectedClusterId: string;
+    isEditing: boolean;
     handlePathChange: (number, string) => void;
     handleClusterChange: (number, string) => void;
     deleteRow: (number) => void;
@@ -38,6 +39,7 @@ function DelegatedRegistriesTable({
     registries,
     clusters,
     selectedClusterId,
+    isEditing,
     handlePathChange,
     handleClusterChange,
     deleteRow,
@@ -223,9 +225,11 @@ function DelegatedRegistriesTable({
                     {/* <Th>Order</Th> */}
                     <Th width={40}>Source registry</Th>
                     <Th width={40}>Destination cluster (CLI/API only)</Th>
-                    <Th>
-                        <span className="pf-v5-screen-reader">Row action</span>
-                    </Th>
+                    {isEditing && (
+                        <Th>
+                            <span className="pf-v5-screen-reader">Row action</span>
+                        </Th>
+                    )}
                 </Tr>
             </Thead>
             <Tbody
@@ -258,6 +262,7 @@ function DelegatedRegistriesTable({
                             <Td dataLabel="Source registry">
                                 <TextInput
                                     isRequired
+                                    isDisabled={!isEditing}
                                     type="text"
                                     id={`${registry.uuid as string}-path-input`}
                                     name={`${registry.uuid as string}-path-input`}
@@ -277,6 +282,7 @@ function DelegatedRegistriesTable({
                                     onToggle={() => toggleSelect(rowIndex)}
                                     onSelect={(_, value) => onSelect(rowIndex, value)}
                                     isOpen={openRow === rowIndex}
+                                    isDisabled={!isEditing}
                                     selections={selectedClusterName}
                                 >
                                     <SelectOption key="no-cluster-selected" value="" isPlaceholder>
@@ -285,18 +291,20 @@ function DelegatedRegistriesTable({
                                     <>{clusterSelectOptions}</>
                                 </Select>
                             </Td>
-                            <Td dataLabel="Row action" className="pf-v5-u-text-align-right">
-                                <Button
-                                    variant="link"
-                                    isInline
-                                    icon={
-                                        <MinusCircleIcon color="var(--pf-v5-global--danger-color--100)" />
-                                    }
-                                    onClick={() => deleteRow(rowIndex)}
-                                >
-                                    Delete row
-                                </Button>
-                            </Td>
+                            {isEditing && (
+                                <Td dataLabel="Row action" className="pf-v5-u-text-align-right">
+                                    <Button
+                                        variant="link"
+                                        isInline
+                                        icon={
+                                            <MinusCircleIcon color="var(--pf-v5-global--danger-color--100)" />
+                                        }
+                                        onClick={() => deleteRow(rowIndex)}
+                                    >
+                                        Delete row
+                                    </Button>
+                                </Td>
+                            )}
                         </Tr>
                     );
                 })}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -8,12 +8,14 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
 type DelegatedScanningSettingsProps = {
     clusters?: DelegatedRegistryCluster[];
+    isEditing: boolean;
     selectedClusterId?: string;
     setSelectedClusterId: (newClusterId: string) => void;
 };
 
 function DelegatedScanningSettings({
     clusters = [],
+    isEditing,
     selectedClusterId,
     setSelectedClusterId,
 }: DelegatedScanningSettingsProps) {
@@ -61,6 +63,7 @@ function DelegatedScanningSettings({
                                 toggleAriaLabel="Select a cluster"
                                 onToggle={(_e, v) => toggleIsClusterOpen(v)}
                                 onSelect={onClusterSelect}
+                                isDisabled={!isEditing}
                                 isOpen={isClusterOpen}
                                 selections={selectedClusterName}
                             >

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
@@ -6,10 +6,15 @@ import { DelegatedRegistryConfigEnabledFor } from 'services/DelegatedRegistryCon
 
 type ToggleDelegatedScanningProps = {
     enabledFor: DelegatedRegistryConfigEnabledFor;
+    isEditing: boolean;
     onChangeEnabledFor: (newEnabledState: DelegatedRegistryConfigEnabledFor) => void;
 };
 
-function ToggleDelegatedScanning({ enabledFor, onChangeEnabledFor }: ToggleDelegatedScanningProps) {
+function ToggleDelegatedScanning({
+    enabledFor,
+    isEditing,
+    onChangeEnabledFor,
+}: ToggleDelegatedScanningProps) {
     return (
         <Card className="pf-v5-u-mb-lg">
             <CardBody>
@@ -24,6 +29,7 @@ function ToggleDelegatedScanning({ enabledFor, onChangeEnabledFor }: ToggleDeleg
                             <Radio
                                 label="None"
                                 isChecked={enabledFor === 'NONE'}
+                                isDisabled={!isEditing}
                                 id="choose-none"
                                 name="enabledFor"
                                 onChange={() => {
@@ -35,6 +41,7 @@ function ToggleDelegatedScanning({ enabledFor, onChangeEnabledFor }: ToggleDeleg
                             <Radio
                                 label="All registries"
                                 isChecked={enabledFor === 'ALL'}
+                                isDisabled={!isEditing}
                                 id="choose-all-registries"
                                 name="enabledFor"
                                 onChange={() => {
@@ -46,6 +53,7 @@ function ToggleDelegatedScanning({ enabledFor, onChangeEnabledFor }: ToggleDeleg
                             <Radio
                                 label="Specified registries"
                                 isChecked={enabledFor === 'SPECIFIC'}
+                                isDisabled={!isEditing}
                                 id="chose-specified-registries"
                                 name="enabledFor"
                                 onChange={() => {


### PR DESCRIPTION
### Description


Changes are careful not to cause merge conflict with #14493

### Problem

**Cancel** button of delegated image scanning page has no effect.

### Analysis

This page does not follow patterns for forms:
1. Table like access control.
    * **Edit** row action goes to page in edit mode, and then **Cancel** or successful **Save** goes back (to table).
    * Row link goes to page in view mode, **Edit** page action renders as form, and then **Cancel** or successful **Save** goes back (to page in view mode).
2. System Configuration page.
    * **Edit** button renders page in edit mode, and then **Cancel** or successful **Save** renders page in view mode.

### Solution

Apply (half of) the pattern from System Configuration.
1. Initial visit to the page in view mode.
2. Add conditional rendering for **Edit** button at upper right.
3. Instead of different form and view elements, add `isEditing` prop for components.

### Residue

1. Integration tests.
2. Make text more correct, clear, and complete for the primary audience.
3. Replace imperative labels that assume edit mode with descriptive labels that are balanced for either edit or view mode.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4646307 - 
        total 474 = 11567238 - 11566764
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

### Manual testing

1. Visit /main/clusters/delegated-image-scanning with role that has `'READ_ACCESS'` for `'Administration'` resource.

    * Before changes, see presence of **Save** button.
        Select **All registries** and then click **Save**.

        PUT /v1/delegatedregistryconfig has 403 Forbidden status
        ![Save_403_presence](https://github.com/user-attachments/assets/4a24577b-0cf5-4af4-a87f-0c98c9e08dca)

    * After changes, see absence of **Save** button.

2. Visit /main/clusters/delegated-image-scanning with role that has `'READ_WRITE_ACCESS'` for `'Administration'` resource.

    * Before changes, see absence of **Edit** button.

    * After changes, see presence of **Edit** button.
        ![Edit](https://github.com/user-attachments/assets/23227b09-3e0b-48ca-8aae-915b5f58b4fc)

3. Click **Edit**, click **Specified registries**, click **Add registry**, type a registry, and then click **Save**.

    PUT /v1/delegatedregistryconfig has 200 OK status

    See presence of **Edit** button and absence of **Save** button.
    See disabled form fields.
    ![Save_200](https://github.com/user-attachments/assets/2ae903bd-34dd-4ca4-a00b-822282a22e03)

