### PR TITLE
fix(CI): do not cache go modules

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -7,15 +7,7 @@ runs:
       id: cache-paths
       run: |
         echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-        echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
       shell: bash
-
-    - name: Cache Go Dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ steps.cache-paths.outputs.GOMODCACHE }}
-        key: go-mod-v1-${{ hashFiles('**/go.sum') }}
 
     - name: Cache Go Build
       uses: actions/cache@v4
@@ -24,6 +16,8 @@ runs:
           ${{ steps.cache-paths.outputs.GOCACHE }}
         key: go-build-v1-${{ github.job }}-${{ hashFiles('**/go.sum') }}
 
-    - name: Download Go modules
-      run: make deps --always-make
+    - name: Set GOPROXY
+      id: set-goproxy
+      run: |
+        echo "GOPROXY=https://proxy.golang.org|https://goproxy.io|direct" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
### Description

This PR aims to solve problem with no space left on CI that causes failures in builds.
Instead of downloading all deps from cache, let's download lazy from proxies.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
