### PR TITLE
fix(ci): more permissive cleanup in job preamble

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -27,9 +27,9 @@ runs:
           /opt/hostedtoolcache/Ruby
         )
         for d in "${cleanup[@]}"; do
-          if [[ -d "/mnt${d}" ]]; then
+          if [[ -e "/mnt${d}" ]]; then
             rm -rf "/mnt${d}"
-          elif [[ -d "$d" ]]; then
+          elif [[ -e "$d" ]]; then
             rm -rf "$d" \
               || sudo rm -rf "$d"
           fi

--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -27,12 +27,10 @@ runs:
           /opt/hostedtoolcache/Ruby
         )
         for d in "${cleanup[@]}"; do
-          if [[ -e "/mnt${d}" ]]; then
-            rm -rf "/mnt${d}"
-          elif [[ -e "$d" ]]; then
-            rm -rf "$d" \
-              || sudo rm -rf "$d"
-          fi
+          rm -rf "/mnt${d}" \
+            || sudo rm -rf "/mnt${d}"
+          rm -rf "$d" \
+            || sudo rm -rf "$d"
         done
         df --si /
 


### PR DESCRIPTION
### Description

Our `Scanner versioned vulnerabilities update` GitHub Action has been failing pretty consistently since last Friday. It could purely be a coincidence, but I have a hypothesis that it was due to https://github.com/stackrox/stackrox/pull/14545 since that was the latest related change. The only difference I could figure out is that the check is more strict, checking for the existence of the FILE and making sure they're directories before deleting them. This change makes that check more permissive.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

Tested with the `pr-update-scanner-vulns` label; however, these changes won't be fully validated until this PR is merged.
