### PR TITLE
ROX-28253: drop cursor in RunCursorQueryForSchemaFn

### DIFF
--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -189,7 +189,7 @@ func (s *genericStore[T, PT]) Search(ctx context.Context, q *v1.Query) ([]search
 }
 
 func (s *genericStore[T, PT]) walkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
-	return RunCursorQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
+	return RunGetQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
 }
 
 // Walk iterates over all the objects in the store and applies the closure.


### PR DESCRIPTION
### Description

Cursor was introduced to prevent memory usage but in the meantime we improved how stores handles row and we don't need cursors at all and we can drop them and use normal queries instead.

- https://github.com/stackrox/stackrox/pull/2157
- https://github.com/jackc/pgx/discussions/1391

---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
