### PR TITLE
ROX-28477: Add feature flag for vulnerability ad hoc reports

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -118,7 +118,7 @@ var (
 	FlattenCVEData = registerFeature("Uses a flattened CVE Data Model improved accuracy and performance", "ROX_FLATTEN_CVE_DATA")
 
 	// Adds the ability to generate vulnerability reports based on filter views
-	VulnerabilityAdHocReports = registerFeature("Adds the ability to generate vulnerability reports based on filter views", "ROX_VULNERABILITY_AD_HOC_REPORTS",enabled)
+	VulnerabilityAdHocReports = registerFeature("Adds the ability to generate vulnerability reports based on filter views", "ROX_VULNERABILITY_AD_HOC_REPORTS", enabled)
 )
 
 // The following feature flags are related to Scanner V4.

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -118,7 +118,7 @@ var (
 	FlattenCVEData = registerFeature("Uses a flattened CVE Data Model improved accuracy and performance", "ROX_FLATTEN_CVE_DATA")
 
 	// Adds the ability to generate vulnerability reports based on filter views
-	VulnerabilityAdHocReports = registerFeature("Adds the ability to generate vulnerability reports based on filter views", "ROX_VULNERABILITY_AD_HOC_REPORTS", enabled)
+	VulnerabilityAdHocReports = registerFeature("Adds the ability to generate vulnerability reports based on filter views", "ROX_VULNERABILITY_AD_HOC_REPORTS")
 )
 
 // The following feature flags are related to Scanner V4.

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -116,6 +116,9 @@ var (
 
 	// Flattens CVE Data Model for improved accuracy and performance
 	FlattenCVEData = registerFeature("Uses a flattened CVE Data Model improved accuracy and performance", "ROX_FLATTEN_CVE_DATA")
+
+	// Adds the ability to generate vulnerability reports based on filter views
+	VulnerabilityAdHocReports = registerFeature("Adds the ability to generate vulnerability reports based on filter views", "ROX_VULNERABILITY_AD_HOC_REPORTS",enabled)
 )
 
 // The following feature flags are related to Scanner V4.

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -182,6 +182,7 @@ export_test_environment() {
     ci_export ROX_EXTERNAL_IPS "${ROX_EXTERNAL_IPS:-true}"
     ci_export ROX_NETWORK_GRAPH_EXTERNAL_IPS "${ROX_NETWORK_GRAPH_EXTERNAL_IPS:-false}"
     ci_export ROX_FLATTEN_CVE_DATA "${ROX_FLATTEN_CVE_DATA:-false}"
+    ci_export ROX_VULNERABILITY_AD_HOC_REPORTS "${ROX_VULNERABILITY_AD_HOC_REPORTS:-true}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
@@ -325,6 +326,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_FLATTEN_CVE_DATA'
     customize_envVars+=$'\n        value: "false"'
+    customize_envVars+=$'\n      - name: ROX_VULNERABILITY_AD_HOC_REPORTS'
+    customize_envVars+=$'\n        value: "true"'
 
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -14,4 +14,5 @@ export type FeatureFlagEnvVar =
     | 'ROX_SCAN_SCHEDULE_REPORT_JOBS'
     | 'ROX_SCANNER_V4'
     | 'ROX_VULN_MGMT_LEGACY_SNOOZE'
+    | 'ROX_VULNERABILITY_AD_HOC_REPORTS'
     ;


### PR DESCRIPTION
### Description

This PR adds a feature flag for the work related to allowing the generation of vulnerability reports using filter views.

### User-facing documentation

- [x] ~CHANGELOG is updated **OR** update is not needed~
- [x] ~[documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] ~added unit tests~
- [x] ~added e2e tests~
- [x] ~added regression tests~
- [x] ~added compatibility tests~
- [x] ~modified existing tests~

#### How I validated my change

Used the same process as other feature flags
