### PR TITLE
ROX-28479: Add external IPs to fake workload generation

### DIFF
--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -121,15 +121,15 @@ func generateIP() string {
 	return fmt.Sprintf("10.%d.%d.%d", rand.Intn(256), rand.Intn(256), rand.Intn(256))
 }
 
-// Generate IP addresses from 11.0.0.0 to 126.255.255.255 which are all public
+// Generate IP addresses from 11.0.0.0 to 99.255.255.255 which are all public
 func generateExternalIP() string {
-	return fmt.Sprintf("%d.%d.%d.%d", rand.Intn(116)+11, rand.Intn(256), rand.Intn(256), rand.Intn(256))
+	return fmt.Sprintf("%d.%d.%d.%d", rand.Intn(89)+11, rand.Intn(256), rand.Intn(256), rand.Intn(256))
 }
 
 // We want to reuse some external IPs, so we test the cases where multiple
 // entities connect to the same external IP, but we also want many external IPs
 // that are only used once.
-func (w *WorkloadManager) generateExternalIPPool() {
+func generateExternalIPPool() {
 	for range 1000 {
 		ip := generateExternalIP()
 		for !externalIpPool.add(ip) {
@@ -355,7 +355,7 @@ func (w *WorkloadManager) manageFlows(ctx context.Context, workload NetworkWorkl
 	ticker := time.NewTicker(workload.FlowInterval)
 	defer ticker.Stop()
 
-	w.generateExternalIPPool()
+	generateExternalIPPool()
 
 	for {
 		select {

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -126,7 +126,7 @@ func generateExternalIP() string {
 	return fmt.Sprintf("%d.%d.%d.%d", rand.Intn(171)+11, rand.Intn(256), rand.Intn(256), rand.Intn(256))
 }
 
-// We want to reuse some external IPs, so we test the cases where muliple
+// We want to reuse some external IPs, so we test the cases where multiple
 // entities connect to the same external IP, but we also want many external IPs
 // that are only used once.
 func (w *WorkloadManager) generateExternalIPPool() {
@@ -230,7 +230,7 @@ func makeNetworkConnection(src string, dst string, containerID string, closeTime
 
 // Randomly decide to get an interal or external IP, with an 80% chance of the IP
 // being internal and 20% of being external. If the IP is external randomly decide
-// to pick it from a pool of external IPs or a new exteranl IP, with a 50/50 chance
+// to pick it from a pool of external IPs or a new external IP, with a 50/50 chance
 // of being from the pool or a newly generated IP address. We want to have cases
 // where multiple different entities connect to the same external IP, but we also
 // want a large number of unique external IPs.
@@ -238,21 +238,15 @@ func (w *WorkloadManager) getRandomInternalExternalIP() (string, bool, bool) {
 	ip := ""
 	var ok bool
 
-	p := rand.Float32()
-	probInternal := float32(0.8)
-	var internal bool
-	if p < probInternal {
-		internal = true
+	internal := rand.Intn(100) < 80
+	if internal {
 		ip, ok = ipPool.randomElem()
 		if !ok {
 			log.Error("found no IPs in pool")
 			return "", internal, false
 		}
 	} else {
-		probPool := float32(0.5)
-		p := rand.Float32()
-		if p < probPool {
-			internal = false
+		if rand.Intn(100) < 50 {
 			ip, ok = externalIpPool.randomElem()
 			if !ok {
 				log.Error("found no IPs in pool")
@@ -273,7 +267,7 @@ func (w *WorkloadManager) getRandomSrcDst() (string, string, bool) {
 	}
 	var dst string
 	// If the src is internal, the dst can be internal or external, but
-	// if the src is external, the dst cannot also be external.
+	// if the src is external, the dst must be internal.
 	if internal {
 		dst, _, ok = w.getRandomInternalExternalIP()
 		if !ok {

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -131,7 +131,7 @@ func generateExternalIP() string {
 // that are only used once.
 func generateExternalIPPool() {
 	ip := []int{11, 0, 0, 0}
-	for _ = range 1000 {
+	for range 1000 {
 		for j := 3; j >= 0; j-- {
 			ip[j]++
 			if ip[j] > 255 {

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -130,11 +130,18 @@ func generateExternalIP() string {
 // entities connect to the same external IP, but we also want many external IPs
 // that are only used once.
 func generateExternalIPPool() {
-	for range 1000 {
-		ip := generateExternalIP()
-		for !externalIpPool.add(ip) {
-			ip = generateExternalIP()
+	ip := []int{11, 0, 0, 0}
+	for _ = range 1000 {
+		for j := 3; j >= 0; j-- {
+			ip[j]++
+			if ip[j] > 255 {
+				ip[j] = 0
+			} else {
+				break
+			}
 		}
+		ipString := fmt.Sprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3])
+		externalIpPool.add(ipString)
 	}
 }
 

--- a/sensor/kubernetes/fake/flows_test.go
+++ b/sensor/kubernetes/fake/flows_test.go
@@ -1,7 +1,6 @@
 package fake
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stackrox/rox/pkg/net"
@@ -18,21 +17,29 @@ func TestFlowsSuite(t *testing.T) {
 
 func (s *flowsSuite) TestGetRandomInternalExternalIP() {
 	var w WorkloadManager
+
+	_, _, ok := w.getRandomInternalExternalIP()
+	s.False(ok)
+
+	_, _, ok = w.getRandomSrcDst()
+	s.False(ok)
+
 	for range 1000 {
 		generateAndAddIPToPool()
 	}
+
 	generateExternalIPPool()
 
 	for range 1000 {
 		ip, internal, ok := w.getRandomInternalExternalIP()
-		if internal == net.ParseIP(ip).IsPublic() {
-			fmt.Println()
-			fmt.Println(ip)
-			fmt.Println(internal)
-			fmt.Println(net.ParseIP(ip).IsPublic())
-			fmt.Println()
-		}
-		s.Equal(true, ok)
+		s.True(ok)
 		s.Equal(internal, !net.ParseIP(ip).IsPublic())
+	}
+
+	for range 1000 {
+		src, dst, ok := w.getRandomSrcDst()
+		// At least one has to be internal
+		s.True(!net.ParseIP(src).IsPublic() || !net.ParseIP(dst).IsPublic())
+		s.True(ok)
 	}
 }

--- a/sensor/kubernetes/fake/flows_test.go
+++ b/sensor/kubernetes/fake/flows_test.go
@@ -18,10 +18,7 @@ func TestFlowsSuite(t *testing.T) {
 func (s *flowsSuite) TestGetRandomInternalExternalIP() {
 	var w WorkloadManager
 
-	_, _, ok := w.getRandomInternalExternalIP()
-	s.False(ok)
-
-	_, _, ok = w.getRandomSrcDst()
+	_, _, ok := w.getRandomSrcDst()
 	s.False(ok)
 
 	for range 1000 {

--- a/sensor/kubernetes/fake/flows_test.go
+++ b/sensor/kubernetes/fake/flows_test.go
@@ -9,21 +9,21 @@ import (
 )
 
 type flowsSuite struct {
-        suite.Suite
+	suite.Suite
 }
 
 func TestFlowsSuite(t *testing.T) {
-        suite.Run(t, new(flowsSuite))
+	suite.Run(t, new(flowsSuite))
 }
 
-func (s* flowsSuite) TestGetRandomInternalExternalIP() {
+func (s *flowsSuite) TestGetRandomInternalExternalIP() {
 	var w WorkloadManager
-	for _ = range 1000 {
+	for range 1000 {
 		generateAndAddIPToPool()
 	}
 	generateExternalIPPool()
 
-	for _ = range 1000 {
+	for range 1000 {
 		ip, internal, ok := w.getRandomInternalExternalIP()
 		if internal == net.ParseIP(ip).IsPublic() {
 			fmt.Println()
@@ -36,4 +36,3 @@ func (s* flowsSuite) TestGetRandomInternalExternalIP() {
 		s.Equal(internal, !net.ParseIP(ip).IsPublic())
 	}
 }
-

--- a/sensor/kubernetes/fake/flows_test.go
+++ b/sensor/kubernetes/fake/flows_test.go
@@ -1,0 +1,39 @@
+package fake
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/net"
+	"github.com/stretchr/testify/suite"
+)
+
+type flowsSuite struct {
+        suite.Suite
+}
+
+func TestFlowsSuite(t *testing.T) {
+        suite.Run(t, new(flowsSuite))
+}
+
+func (s* flowsSuite) TestGetRandomInternalExternalIP() {
+	var w WorkloadManager
+	for _ = range 1000 {
+		generateAndAddIPToPool()
+	}
+	generateExternalIPPool()
+
+	for _ = range 1000 {
+		ip, internal, ok := w.getRandomInternalExternalIP()
+		if internal == net.ParseIP(ip).IsPublic() {
+			fmt.Println()
+			fmt.Println(ip)
+			fmt.Println(internal)
+			fmt.Println(net.ParseIP(ip).IsPublic())
+			fmt.Println()
+		}
+		s.Equal(true, ok)
+		s.Equal(internal, !net.ParseIP(ip).IsPublic())
+	}
+}
+


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds external IPs to fake workload generation. We need to be able to test the external IPs feature using the existing scale tests, in which Sensor creates fake data that it itself consumes. This will enable us to find bugs that might cause crashes, scalability issues, and leaks. This will be part of the long running cluster. It will also be run with K6 load testing, though at the current moment the API endpoints relevant to external IPs is not called by K6 load testing. That change can be made later.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
~~- [ ] added e2e tests~~
~~- [ ] added regression tests~~
~~- [ ] added compatibility tests~~
~~- [ ] modified existing tests~~

No code that runs in production is modified, so no testing is needed. The fake workload generation currently does not have any testing.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Scale testing was run using the following commands from the root of the stackrox/stackrox repository.

```
cd scale/dev
./cluster.sh jv-0311-exip-scale
infractl artifacts jv-0311-exip-scale --download-dir /tmp/artifacts-jv-0311-exip-scale
export KUBECONFIG=/tmp/artifacts-jv-0311-exip-scale/kubeconfig
export ROX_EXTERNAL_IPS=true
./run-many.sh long-running 10
```

The following script was run to get metadata on the external entities.

```
#!/usr/bin/env bash
set -eou pipefail

ROX_ENDPOINT=${1:-localhost:8000}


clusters_json="$(curl --location --silent --request GET "https://${ROX_ENDPOINT}/v1/clusters" -k --header "Authorization: Bearer $ROX_API_TOKEN")"

cluster_id="$(echo "$clusters_json" | jq -r '.clusters[0].id')"

metadata="$(curl --location --silent --request GET "https://${ROX_ENDPOINT}/v1/networkgraph/cluster/$cluster_id/externalentities/metadata" -k --header "Authorization: Bearer $ROX_API_TOKEN")"

echo "$metadata" | jq
```

Part of the output is shown bellow

```
{
  "entities": [ 
    {
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "__MC41NC4yMTMuMTk3LzMy",
        "externalSource": {
          "name": "0.54.213.197",
          "cidr": "0.54.213.197/32",
          "default": false,
          "discovered": true
        }
      },
      "flowsCount": 1
    },
    {
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "__MC41NS45MS4yNS8zMg",
        "externalSource": {
          "name": "0.55.91.25",
          "cidr": "0.55.91.25/32",
          "default": false,
          "discovered": true
        }
      },
      "flowsCount": 1
    },

....

   { 
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "__OTkuMjQuNjguNjIvMzI",
        "externalSource": {
          "name": "99.24.68.62",
          "cidr": "99.24.68.62/32",
          "default": false,
          "discovered": true
        } 
      },  
      "flowsCount": 1
    },
    { 
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "__OTkuNi44Ny44My8zMg",
        "externalSource": {
          "name": "99.6.87.83",
          "cidr": "99.6.87.83/32",
          "default": false,
          "discovered": true
        } 
      },  
      "flowsCount": 1
    } 
  ],  
  "totalEntities": 2585
```

The script was run a few times and the value of `totalEntities` was seen to fluctuate.

#### Long running cluster

A long running cluster was also created, which essentially does the same thing as above, except that it is triggered through a github action and runs for much longer.

The following was done to run the github action.

```
git commit -m "Empty commit" --allow-empty
git tag -a 0.0.1 -m “Test tag for long running cluster"
git push origin 0.0.1
git push origin HEAD
```

The commit used for this tag was 8436aaab2e5ecc9bb8e7d2bca0a1f0960ee43993. The tag was later deleted.

The images were then built by CI.

Went to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml


Clicked on “Run workflow”. Set the image tag in “Version of the images” to 0.0.1. Selected “Create a long-running cluster on RC1” and clicked on the green button that says “Run workflow”.

```
infractl artifacts long-fake-load-0-0-1 --download-dir /tmp/artifacts-long-fake-load-0-0-1
export KUBECONFIG=/tmp/artifacts-long-fake-load-0-0-1/kubeconfig
```

Set the `ROX_EXTERNAL_IPS` environment variable by editing the central deployment manually. 

Obtained the password and API token.

Ran the script from the first testing section and saw the following

```
{
  "entities": [
    {
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "1de6b523-4a36-4082-8fa9-51dc670990c7__MTA0LjE0Mi4xNjkuMTQ4LzMy",
        "externalSource": {
          "name": "104.142.169.148",
          "cidr": "104.142.169.148/32",
          "default": false,
          "discovered": true
        }
      },
      "flowsCount": 1
    },
    {
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "1de6b523-4a36-4082-8fa9-51dc670990c7__MTA0LjE0NS42LjQwLzMy",
        "externalSource": {
          "name": "104.145.6.40",
          "cidr": "104.145.6.40/32",
          "default": false,
          "discovered": true
        }
      },
      "flowsCount": 1
    },


...


    {
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "1de6b523-4a36-4082-8fa9-51dc670990c7__OTkuMjkuMTg2LjE1Mi8zMg",
        "externalSource": {
          "name": "99.29.186.152",
          "cidr": "99.29.186.152/32",
          "default": false,
          "discovered": true
        }
      },
      "flowsCount": 4
    },
    {
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "1de6b523-4a36-4082-8fa9-51dc670990c7__OTkuNDAuNzkuMjA2LzMy",
        "externalSource": {
          "name": "99.40.79.206",
          "cidr": "99.40.79.206/32",
          "default": false,
          "discovered": true
        }
      },
      "flowsCount": 1
    },
    {
      "entity": {
        "type": "EXTERNAL_SOURCE",
        "id": "1de6b523-4a36-4082-8fa9-51dc670990c7__OTkuNjcuMTc5LjU4LzMy",
        "externalSource": {
          "name": "99.67.179.58",
          "cidr": "99.67.179.58/32",
          "default": false,
          "discovered": true
        }
      },
      "flowsCount": 1
    }
  ],
  "totalEntities": 2697
}
```

Here are some screen shots from the long running cluster.


![Screenshot from 2025-03-17 08-27-52](https://github.com/user-attachments/assets/9ebb6cbc-f4c4-47d9-b0c4-4afb4909d9d9)

![Screenshot from 2025-03-17 08-28-04](https://github.com/user-attachments/assets/34c5bbc7-d5c3-449f-8235-876a7fc2acd4)

![Screenshot from 2025-03-17 08-28-19](https://github.com/user-attachments/assets/c2de2149-1e04-4b1e-96a8-4615a302db8f)

![Screenshot from 2025-03-17 08-28-28](https://github.com/user-attachments/assets/73387f6b-8cfd-4e19-a4de-965131f46091)

![Screenshot from 2025-03-17 08-28-33](https://github.com/user-attachments/assets/9382f126-47cb-4918-956d-2dc1b242c405)

