### PR TITLE
fix(ci): checkout master before running preamble

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -123,15 +123,21 @@ jobs:
       SCANNER_BUNDLE_VERSION: ${{ matrix.version }}
       ROX_GIT_REF: ${{ matrix.ref }}
     steps:
+    # Checkout master to get the latest local actions
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: ./.github/actions/job-preamble
+      with:
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
     - name: Checkout specific reference
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ env.ROX_GIT_REF }}
-
-    - uses: ./.github/actions/job-preamble
-      with:
-        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Download NVD
       uses: ./.github/actions/download-artifact-with-retry
@@ -184,15 +190,21 @@ jobs:
       - /usr:/mnt/usr
       - /opt:/mnt/opt
     steps:
+    # Checkout master to get the latest local actions
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Checkout specific reference
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Authenticate with test GCS bucket
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Description

Our `Scanner versioned vulnerabilities update` GitHub Action has been failing pretty consistently since last Friday (example: https://github.com/stackrox/stackrox/actions/runs/13780455617). The changes from https://github.com/stackrox/stackrox/pull/14545 moved the storage cleanup out of this workflow and into a shared, locally referenced action (i.e., after checkout). However, in this workflow, we checkout a particular git reference that isn't the HEAD of the default branch. These changes will first checkout the default branch, run the job preamble, then checkout the specific ref we need to perform the rest of the workflow.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

Tested with the pr-update-scanner-vulns label; however, these changes won't be fully validated until this PR is merged.
