### PR TITLE
ROX-28491: Configure runtime after config validation

### DIFF
--- a/pkg/continuousprofiling/profiler_test.go
+++ b/pkg/continuousprofiling/profiler_test.go
@@ -1,0 +1,141 @@
+package continuousprofiling
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/grafana/pyroscope-go"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stretchr/testify/suite"
+)
+
+type ContinuousProfilingSuite struct {
+	suite.Suite
+}
+
+func (s *ContinuousProfilingSuite) TearDownTest() {
+	runtime.SetBlockProfileRate(0)
+	runtime.SetMutexProfileFraction(0)
+}
+
+func (s *ContinuousProfilingSuite) SetupTest() {
+	s.T().Setenv(env.ContinuousProfiling.EnvVar(), "true")
+	runtime.SetBlockProfileRate(0)
+	runtime.SetMutexProfileFraction(0)
+}
+
+var _ suite.SetupTestSuite = (*ContinuousProfilingSuite)(nil)
+var _ suite.TearDownTestSuite = (*ContinuousProfilingSuite)(nil)
+
+func TestContinuousProfiling(t *testing.T) {
+	suite.Run(t, new(ContinuousProfilingSuite))
+}
+
+func (s *ContinuousProfilingSuite) TestDefaultValues() {
+	s.T().Setenv(env.ContinuousProfilingAppName.EnvVar(), "test")
+	cfg := DefaultConfig()
+	s.Assert().NoError(SetupClient(cfg))
+	s.Assert().Equal(*cfg, *DefaultConfig())
+	s.Assert().Equal(mutexProfileFraction, runtime.SetMutexProfileFraction(-1))
+}
+
+func (s *ContinuousProfilingSuite) TestProfileValidation() {
+	s.T().Setenv(env.ContinuousProfilingServerAddress.EnvVar(), "")
+	cases := map[string]struct {
+		config                pyroscope.Config
+		expectedConfig        pyroscope.Config
+		expectedMutexFraction int
+		expectedError         error
+	}{
+		"no app name": {
+			config:        pyroscope.Config{},
+			expectedError: ErrApplicationName,
+		},
+		"no server address": {
+			config: pyroscope.Config{
+				ApplicationName: "test",
+			},
+			expectedError: ErrServerAddress,
+		},
+		"invalid server address": {
+			config: pyroscope.Config{
+				ApplicationName: "test",
+				ServerAddress:   "https:// invalid",
+			},
+			expectedError: ErrUnableToParseServerAddress,
+		},
+		"no profiles defined": {
+			config: pyroscope.Config{
+				ApplicationName: "test",
+				ServerAddress:   "https://valid",
+			},
+			expectedError: ErrAtLeastOneProfileIsNeeded,
+		},
+		"no mutex profile": {
+			config: pyroscope.Config{
+				ApplicationName: "test",
+				ServerAddress:   "https://valid",
+				ProfileTypes: []pyroscope.ProfileType{
+					pyroscope.ProfileCPU,
+				},
+			},
+			expectedConfig: pyroscope.Config{
+				ApplicationName: "test",
+				ServerAddress:   "https://valid",
+				ProfileTypes: []pyroscope.ProfileType{
+					pyroscope.ProfileCPU,
+				},
+			},
+			expectedMutexFraction: 0,
+		},
+		"with default profiles": {
+			config: pyroscope.Config{
+				ApplicationName: "test",
+				ServerAddress:   "https://valid",
+				ProfileTypes:    DefaultProfiles,
+			},
+			expectedConfig: pyroscope.Config{
+				ApplicationName: "test",
+				ServerAddress:   "https://valid",
+				ProfileTypes:    DefaultProfiles,
+			},
+			expectedMutexFraction: mutexProfileFraction,
+		},
+	}
+	for tName, tCase := range cases {
+		s.Run(tName, func() {
+			err := SetupClient(&tCase.config)
+			if tCase.expectedError == nil {
+				s.Assert().NoError(err)
+				s.Assert().Equal(tCase.expectedMutexFraction, runtime.SetMutexProfileFraction(-1))
+				s.Assert().Equal(tCase.config, tCase.expectedConfig)
+			} else {
+				s.Assert().ErrorIs(err, tCase.expectedError)
+			}
+		})
+	}
+}
+
+func (s *ContinuousProfilingSuite) TestOptions() {
+	s.Run("with default name", func() {
+		defaultName := "default-name"
+		cfg := DefaultConfig()
+		s.Assert().NoError(SetupClient(cfg, WithDefaultAppName(defaultName)))
+		s.Assert().Equal(defaultName, cfg.ApplicationName)
+	})
+	s.Run("with profiles", func() {
+		s.T().Setenv(env.ContinuousProfilingAppName.EnvVar(), "test")
+		profiles := []pyroscope.ProfileType{
+			pyroscope.ProfileCPU,
+		}
+		cfg := DefaultConfig()
+		s.Assert().NoError(SetupClient(cfg, WithProfiles(profiles...)))
+		s.Assert().Equal(profiles, cfg.ProfileTypes)
+	})
+	s.Run("with logging", func() {
+		s.T().Setenv(env.ContinuousProfilingAppName.EnvVar(), "test")
+		cfg := DefaultConfig()
+		s.Assert().NoError(SetupClient(cfg, WithLogging()))
+		s.Assert().Equal(log, cfg.Logger)
+	})
+}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The runtime configuration should be done after the client validation, otherwise we might enable mutex/block profiles when we shouldn't.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [ ] Unit tests
