### PR TITLE
chore(tests): use testing.TB instead of *testing.T

### DIFF
--- a/central/authprovider/datastore/datastore.go
+++ b/central/authprovider/datastore/datastore.go
@@ -17,7 +17,7 @@ func New(storage store.Store) authproviders.Store {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) authproviders.Store {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) authproviders.Store {
 	return &datastoreImpl{
 		storage: pgStore.New(pool),
 	}

--- a/central/cluster/datastore/datastore_test_constructors.go
+++ b/central/cluster/datastore/datastore_test_constructors.go
@@ -28,7 +28,7 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error) {
 	clusterdbstore := clusterPostgresStore.New(pool)
 	clusterhealthdbstore := clusterHealthPostgresStore.New(pool)
 	alertStore, err := alertDataStore.GetTestPostgresDataStore(t, pool)

--- a/central/clustercveedge/datastore/datastore.go
+++ b/central/clustercveedge/datastore/datastore.go
@@ -37,7 +37,7 @@ func New(storage store.Store, searcher search.Searcher) (DataStore, error) {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	storage := pgStore.New(pool)
 	searcher := search.NewV2(storage)
 	return New(storage, searcher)

--- a/central/complianceoperator/v2/benchmarks/datastore/datastore.go
+++ b/central/complianceoperator/v2/benchmarks/datastore/datastore.go
@@ -34,7 +34,7 @@ func New(benchmarkStorage pgStore.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	return New(store)
 }

--- a/central/complianceoperator/v2/integration/datastore/datastore.go
+++ b/central/complianceoperator/v2/integration/datastore/datastore.go
@@ -44,7 +44,7 @@ func New(complianceIntegrationStorage pgStore.Store, pool postgres.DB) DataStore
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	return New(store, pool)
 }

--- a/central/complianceoperator/v2/profiles/datastore/datastore.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore.go
@@ -53,7 +53,7 @@ func New(complianceProfileStorage pgStore.Store, pool postgres.DB, searcher sear
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB, searcher search.Searcher) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB, searcher search.Searcher) DataStore {
 	store := pgStore.New(pool)
 	return New(store, pool, searcher)
 }

--- a/central/complianceoperator/v2/pruner/pruner.go
+++ b/central/complianceoperator/v2/pruner/pruner.go
@@ -98,7 +98,7 @@ func (p *pruneImpl) RemoveComplianceResourcesByCluster(ctx context.Context, clus
 // Testing
 
 // GetTestPruner provides a pruner connected to postgres for testing purposes.
-func GetTestPruner(t *testing.T, pool postgres.DB) Pruner {
+func GetTestPruner(t testing.TB, pool postgres.DB) Pruner {
 	scanSettingDataStore := compScanSetting.GetTestPostgresDataStore(t, pool)
 	integrationDataStore := compIntegration.GetTestPostgresDataStore(t, pool)
 	scanResultDataStore := scanResult.GetTestPostgresDataStore(t, pool)

--- a/central/complianceoperator/v2/remediations/datastore/datastore.go
+++ b/central/complianceoperator/v2/remediations/datastore/datastore.go
@@ -41,7 +41,7 @@ func New(remediationStorage pgStore.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	return New(store)
 }

--- a/central/complianceoperator/v2/rules/datastore/datastore.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore.go
@@ -42,7 +42,7 @@ func New(complianceRuleStorage pgStore.Store, db postgres.DB) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	return New(store, pool)
 }

--- a/central/complianceoperator/v2/scans/datastore/datastore.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore.go
@@ -41,7 +41,7 @@ func New(complianceScanStorage pgStore.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	return New(store)
 }

--- a/central/complianceoperator/v2/scansettingbindings/datastore/datastore.go
+++ b/central/complianceoperator/v2/scansettingbindings/datastore/datastore.go
@@ -41,7 +41,7 @@ func New(scanSettingBindingStorage pgStore.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	return New(store)
 }

--- a/central/complianceoperator/v2/suites/datastore/datastore.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore.go
@@ -45,7 +45,7 @@ func New(complianceSuiteStorage pgStore.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	return New(store)
 }

--- a/central/componentcveedge/datastore/datastore.go
+++ b/central/componentcveedge/datastore/datastore.go
@@ -36,7 +36,7 @@ func New(storage store.Store, searcher search.Searcher) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
 	searcher := search.NewV2(dbstore)
 	return New(dbstore, searcher)

--- a/central/cve/cluster/datastore/datastore_test_constructors.go
+++ b/central/cve/cluster/datastore/datastore_test_constructors.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	dbstore := pgStore.NewFullStore(pool)
 	searcher := search.New(dbstore)
 	return New(dbstore, searcher)

--- a/central/cve/image/datastore/datastore.go
+++ b/central/cve/image/datastore/datastore.go
@@ -54,7 +54,7 @@ func New(storage store.Store, searcher search.Searcher, kf concurrency.KeyFence)
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
 	searcher := search.New(dbstore)
 	return New(dbstore, searcher, concurrency.NewKeyFence())

--- a/central/cve/node/datastore/datastore.go
+++ b/central/cve/node/datastore/datastore.go
@@ -55,7 +55,7 @@ func New(storage store.Store, searcher search.Searcher, kf concurrency.KeyFence)
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	dbstore := pgStore.New(pool)
 	searcher := search.New(dbstore)
 	return New(dbstore, searcher, concurrency.NewKeyFence())

--- a/central/declarativeconfig/health/datastore/datastore.go
+++ b/central/declarativeconfig/health/datastore/datastore.go
@@ -29,6 +29,6 @@ func New(storage store.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	return New(pgStore.New(pool))
 }

--- a/central/group/datastore/datastore.go
+++ b/central/group/datastore/datastore.go
@@ -41,7 +41,7 @@ func New(storage store.Store, roleDatastore datastore.DataStore, authProviderDat
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB, roleDatastore datastore.DataStore,
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB, roleDatastore datastore.DataStore,
 	authProviderDatastore authproviders.Store) DataStore {
 	return &dataStoreImpl{
 		storage:               pgStore.New(pool),

--- a/central/group/datastore/filter/filter_test_constructors.go
+++ b/central/group/datastore/filter/filter_test_constructors.go
@@ -16,7 +16,7 @@ type RetrieverFactory interface {
 
 // GetTestPostgresGroupFilterGenerator returns a generator for filtered group
 // retrieval connected to a postgres database.
-func GetTestPostgresGroupFilterGenerator(_ *testing.T, db postgres.DB) RetrieverFactory {
+func GetTestPostgresGroupFilterGenerator(_ testing.TB, db postgres.DB) RetrieverFactory {
 	groupStore := postgresStore.New(db)
 	return &factoryImpl{
 		store: groupStore,

--- a/central/hash/datastore/datastore_test_constructors.go
+++ b/central/hash/datastore/datastore_test_constructors.go
@@ -8,6 +8,6 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (Datastore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (Datastore, error) {
 	return NewDatastore(pgStore.New(pool)), nil
 }

--- a/central/imagecomponent/datastore/datastore.go
+++ b/central/imagecomponent/datastore/datastore.go
@@ -43,7 +43,7 @@ func New(storage store.Store, searcher search.Searcher, risks riskDataStore.Data
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
 	searcher := search.NewV2(dbstore)
 	riskStore := riskDataStore.GetTestPostgresDataStore(t, pool)

--- a/central/imagecomponent/v2/datastore/datastore.go
+++ b/central/imagecomponent/v2/datastore/datastore.go
@@ -42,7 +42,7 @@ func New(storage pgStore.Store, searcher search.Searcher, risks riskDataStore.Da
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
 	searcher := search.NewV2(dbstore)
 	riskStore := riskDataStore.GetTestPostgresDataStore(t, pool)

--- a/central/imagecveedge/datastore/datastore_test_constructors.go
+++ b/central/imagecveedge/datastore/datastore_test_constructors.go
@@ -9,6 +9,6 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	return New(pgStore.New(pool), search.NewV2(pgStore.New(pool)))
 }

--- a/central/imageintegration/datastore/datastore.go
+++ b/central/imageintegration/datastore/datastore.go
@@ -52,7 +52,7 @@ func NewForTestOnly(imageIntegrationStorage store.Store, searcher search.Searche
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	store := pgStore.New(pool)
 	searcher := search.New(store)
 	return New(store, searcher), nil

--- a/central/logimbue/store/singleton.go
+++ b/central/logimbue/store/singleton.go
@@ -24,6 +24,6 @@ func Singleton() Store {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) Store {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) Store {
 	return pgStore.New(pool)
 }

--- a/central/namespace/datastore/datastore_test_constructors.go
+++ b/central/namespace/datastore/datastore_test_constructors.go
@@ -21,7 +21,7 @@ func NewTestDataStore(t testing.TB, testDB *pgtest.TestPostgres, deploymentDataS
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error) {
 	dbStore := pgStore.New(pool)
 	deploymentStore, err := deploymentDataStore.GetTestPostgresDataStore(t, pool)
 	if err != nil {

--- a/central/networkbaseline/datastore/datastore_impl.go
+++ b/central/networkbaseline/datastore/datastore_impl.go
@@ -30,13 +30,7 @@ func newNetworkBaselineDataStore(storage store.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
-	dbstore := pgStore.New(pool)
-	return newNetworkBaselineDataStore(dbstore), nil
-}
-
-// GetBenchPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetBenchPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	dbstore := pgStore.New(pool)
 	return newNetworkBaselineDataStore(dbstore), nil
 }

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -956,7 +956,7 @@ func New(
 }
 
 // GetTestPostgresManager provides a network baseline manager connected to postgres for testing purposes.
-func GetTestPostgresManager(t *testing.T, pool postgres.DB) (Manager, error) {
+func GetTestPostgresManager(t testing.TB, pool postgres.DB) (Manager, error) {
 	networkBaselineStore, err := datastore.GetTestPostgresDataStore(t, pool)
 	if err != nil {
 		return nil, err

--- a/central/networkbaseline/manager/manager_impl_bench_test.go
+++ b/central/networkbaseline/manager/manager_impl_bench_test.go
@@ -40,11 +40,11 @@ func BenchmarkInitFromStore(b *testing.B) {
 	pgtestbase := pgtest.ForT(b)
 	require.NotNil(b, pgtestbase)
 
-	nbStore, err := nbDS.GetBenchPostgresDataStore(b, pgtestbase.DB)
+	nbStore, err := nbDS.GetTestPostgresDataStore(b, pgtestbase.DB)
 	require.NoError(b, err)
-	npStore, err := npDS.GetBenchPostgresDataStore(b, pgtestbase.DB)
+	npStore, err := npDS.GetTestPostgresDataStore(b, pgtestbase.DB)
 	require.NoError(b, err)
-	networkEntityStore, err := networkEntityDS.GetBenchPostgresDataStore(b, pgtestbase.DB)
+	networkEntityStore, err := networkEntityDS.GetTestPostgresDataStore(b, pgtestbase.DB)
 	require.NoError(b, err)
 
 	deploymentDS := deploymentMocks.NewMockDataStore(mockCtrl)

--- a/central/networkgraph/entity/datastore/datastore_impl.go
+++ b/central/networkgraph/entity/datastore/datastore_impl.go
@@ -65,21 +65,9 @@ func NewEntityDataStore(storage store.EntityStore, graphConfig graphConfigDS.Dat
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (EntityDataStore, error) {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (EntityDataStore, error) {
 	dbstore := pgStore.New(pool)
 	graphConfigStore, err := graphConfigDS.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	treeMgr := networktree.Singleton()
-	sensorCnxMgr := connection.ManagerSingleton()
-	return NewEntityDataStore(dbstore, graphConfigStore, treeMgr, sensorCnxMgr), nil
-}
-
-// GetBenchPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetBenchPostgresDataStore(t testing.TB, pool postgres.DB) (EntityDataStore, error) {
-	dbstore := pgStore.New(pool)
-	graphConfigStore, err := graphConfigDS.GetBenchPostgresDataStore(t, pool)
 	if err != nil {
 		return nil, err
 	}

--- a/central/networkpolicies/datastore/datastore.go
+++ b/central/networkpolicies/datastore/datastore.go
@@ -58,18 +58,10 @@ func New(storage store.Store, searcher search.Searcher, undoStorage undostore.Un
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	dbstore := pgStore.New(pool)
 	searcher := search.New(dbstore)
 	undodbstore := undopostgres.New(pool)
 	undodeploymentdbstore := undoDeploymentPostgres.New(pool)
 	return New(dbstore, searcher, undodbstore, undodeploymentdbstore), nil
-}
-
-// GetBenchPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetBenchPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
-	dbstore := pgStore.New(pool)
-	undodbstore := undopostgres.New(pool)
-	undodeploymentdbstore := undoDeploymentPostgres.New(pool)
-	return New(dbstore, nil, undodbstore, undodeploymentdbstore), nil
 }

--- a/central/nodecomponent/datastore/datastore.go
+++ b/central/nodecomponent/datastore/datastore.go
@@ -42,7 +42,7 @@ func New(storage pgStore.Store, searcher search.Searcher, risks riskDataStore.Da
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
 	searcher := search.New(dbstore)
 	riskStore := riskDataStore.GetTestPostgresDataStore(t, pool)

--- a/central/nodecomponentedge/datastore/datastore_test_constructors.go
+++ b/central/nodecomponentedge/datastore/datastore_test_constructors.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	storage := postgresStore.New(pool)
 	searcher := search.New(storage)
 	return New(storage, searcher), nil

--- a/central/notifier/datastore/datastore.go
+++ b/central/notifier/datastore/datastore.go
@@ -36,6 +36,6 @@ func New(storage store.Store) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	return New(pgStore.New(pool))
 }

--- a/central/reports/config/datastore/datastore.go
+++ b/central/reports/config/datastore/datastore.go
@@ -38,7 +38,7 @@ func New(reportConfigStore store.Store, searcher search.Searcher) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	searcher := search.New(store)
 

--- a/central/reports/snapshot/datastore/datastore.go
+++ b/central/reports/snapshot/datastore/datastore.go
@@ -43,7 +43,7 @@ func New(storage pgStore.Store, searcher search.Searcher) DataStore {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
 	searcher := search.New(store)
 

--- a/central/role/datastore/datastore_test_constructors.go
+++ b/central/role/datastore/datastore_test_constructors.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error) {
 	permissionStore := permissionSetPostgresStore.New(pool)
 	roleStore := rolePostgresStore.New(pool)
 	scopeStore := accessScopePostgresStore.New(pool)

--- a/central/secret/datastore/datastore.go
+++ b/central/secret/datastore/datastore.go
@@ -39,7 +39,7 @@ func New(secretStore store.Store, searcher search.Searcher) (DataStore, error) {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	dbstore := pgStore.New(pool)
 	searcher := search.New(dbstore)
 	return New(dbstore, searcher)

--- a/central/serviceaccount/datastore/datastore.go
+++ b/central/serviceaccount/datastore/datastore.go
@@ -37,7 +37,7 @@ func New(saStore store.Store, searcher search.Searcher) (DataStore, error) {
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	dbstore := pgStore.New(pool)
 	searcher := search.New(dbstore)
 	return New(dbstore, searcher)


### PR DESCRIPTION
### Description

Makes use of testing.TB instead of testing.T to allow datastore construction from benchmark context as well as test context.

### Testing and quality

- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

I've run the tests, which should cover all of this relatively small change. And CI should confirm.
