### PR TITLE
chore(CI): notify about top flaky unit tests

### DIFF
--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -36,3 +36,4 @@ jobs:
         slack_top_n_failures ${n} "operator-e2e" ":operator: Top ${n} Operator E2E Test failures in this and previous week" "${{github.event.inputs.test}}"
         slack_top_n_failures ${n} "ui-e2e" ":computer: Top ${n} UI E2E Test failures in this and previous week" "${{github.event.inputs.test}}"
         slack_top_n_failures ${n} "nongroovy-e2e" ":go: Top ${n} NonGroovy E2E Test failures in this and previous week" "${{github.event.inputs.test}}"
+        slack_top_n_failures ${n} "go" ":github: Top ${n} unit test failures in this and previous week" "${{github.event.inputs.test}}"

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -145,7 +145,9 @@ slack_top_n_failures() {
     sql='
 SELECT
     FORMAT("%6.2f", 100 * COUNTIF(Status="failed") / COUNT(*)) AS `%`,
-    IF(LENGTH(Classname) > 28, CONCAT(RPAD(Classname, 25), "..."), Classname) AS `Suite`,
+    IF(LENGTH(REPLACE(Classname, "github.com/stackrox/rox/", "")) > 28,
+        CONCAT(RPAD(REPLACE(Classname, "github.com/stackrox/rox/", ""), 25), "..."),
+        REPLACE(Classname, "github.com/stackrox/rox/", "")) AS `Suite`,
     IF(LENGTH(Name) > 123, CONCAT(RPAD(Name, 120), "..."), Name) AS `Case`
 FROM
     `acs-san-stackroxci.ci_metrics.stackrox_tests__extended_view`


### PR DESCRIPTION
### Description

Since we have more and more flaky unit test let's add them to our weekly news. 
Because all of unit tests leaves in our repo we can replace common prefix with `./`


- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change

https://github.com/stackrox/stackrox/actions/runs/13816471195/job/38650854104
