### PR TITLE
chore(govulncheck): remove fixed stdlib vulns

### DIFF
--- a/govulncheck-allowlist.json
+++ b/govulncheck-allowlist.json
@@ -5,15 +5,6 @@
     },
     "GO-2022-0646": {
       "reason": "Unused portion of the SDK"
-    },
-    "GO-2024-3105": {
-      "reason": "Requires Go 1.22.7 or 1.23.1"
-    },
-    "GO-2024-3106": {
-      "reason": "Requires Go 1.22.7 or 1.23.1"
-    },
-    "GO-2024-3107": {
-      "reason": "Requires Go 1.22.7 or 1.23.1"
     }
   }
 }


### PR DESCRIPTION
### Description

These vulns have been fixed since updating to go1.23.2. We are now on go1.23.6, so these are definitely resolved.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

CI
