### PR TITLE
ROX-28200: Load monaco-editor locally instead of CDN

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@apollo/client": "^3.6.3",
                 "@lifeomic/axios-fetch": "^3.0.1",
+                "@monaco-editor/react": "^4.7.0",
                 "@patternfly/react-charts": "^7.2.2",
                 "@patternfly/react-code-editor": "^5.2.2",
                 "@patternfly/react-component-groups": "^5.2.0",
@@ -3536,27 +3537,24 @@
             }
         },
         "node_modules/@monaco-editor/loader": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
-            "integrity": "sha1-8IInBXMx7IkPoekDkSpbcRoq1Vg= sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+            "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
             "dependencies": {
                 "state-local": "^1.0.6"
-            },
-            "peerDependencies": {
-                "monaco-editor": ">= 0.21.0 < 1"
             }
         },
         "node_modules/@monaco-editor/react": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
-            "integrity": "sha1-vMaGceNYohw4FFZrhlpUsZHiQRk= sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+            "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
             "dependencies": {
-                "@monaco-editor/loader": "^1.4.0"
+                "@monaco-editor/loader": "^1.5.0"
             },
             "peerDependencies": {
                 "monaco-editor": ">= 0.25.0 < 1",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -15659,7 +15657,7 @@
         "node_modules/monaco-editor": {
             "version": "0.34.1",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
-            "integrity": "sha1-G3XErWvEwfnaZW10DZjguFCiL4c= sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
+            "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
         },
         "node_modules/monaco-editor-webpack-plugin": {
             "version": "7.1.0",
@@ -21016,7 +21014,7 @@
         "node_modules/state-local": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
-            "integrity": "sha1-2lAhHQfwV0jVMAm+5GMHo32zhtU= sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+            "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
         },
         "node_modules/statuses": {
             "version": "2.0.1",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@apollo/client": "^3.6.3",
         "@lifeomic/axios-fetch": "^3.0.1",
+        "@monaco-editor/react": "^4.7.0",
         "@patternfly/react-charts": "^7.2.2",
         "@patternfly/react-code-editor": "^5.2.2",
         "@patternfly/react-component-groups": "^5.2.0",

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -15,6 +15,7 @@ import 'css.imports';
 
 import { configure as mobxConfigure } from 'mobx';
 import * as monaco from 'monaco-editor';
+import { loader } from '@monaco-editor/react';
 import { configureMonacoYaml } from 'monaco-yaml';
 
 import ErrorBoundary from 'Components/PatternFly/ErrorBoundary/ErrorBoundary';
@@ -38,6 +39,7 @@ configureMonacoYaml(monaco, {
     format: true,
     schemas: [],
 });
+loader.config({ monaco });
 
 // We need to call this MobX utility function, to prevent the error
 //   Uncaught Error: [MobX] There are multiple, different versions of MobX active. Make sure MobX is loaded only once or use `configure({ isolateGlobalState: true })`


### PR DESCRIPTION
### Description

This PR will load the `monaco-editor` resources from a local dependency rather than through a CDN. 

A customer noticed that the CodeEditor displayed a "Loading..." text. It occurred because it didn't fetch resources for the `monaco-editor` using a CDN. The customer had a closed system. The following change will prevent it from fetching anything externally. 

References: 

https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#use-monaco-editor-as-an-npm-package

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x]  added e2e tests
- [x] added regression tests
- [x] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Before:

![Screenshot 2025-02-20 at 9 02 07 AM](https://github.com/user-attachments/assets/75eb4e10-f82d-4ba9-a83c-7d55a6c1f7ac)


After:

![Screenshot 2025-03-12 at 12 36 18 PM](https://github.com/user-attachments/assets/2a9efe49-f575-4ebd-b5b4-09320def46a0)
