### PR TITLE
feat(PG): create RunCursorQueryForSchemaFn

### DIFF
--- a/central/alert/datastore/internal/store/postgres/bench_test.go
+++ b/central/alert/datastore/internal/store/postgres/bench_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkMany(b *testing.B) {
@@ -50,6 +51,17 @@ func BenchmarkMany(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
+			}
+		})
+		b.Run(fmt.Sprintf("walk %d alerts", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				count := 0
+				err := store.Walk(ctx, func(obj *storeType) error {
+					count++
+					return nil
+				})
+				assert.NoError(b, err)
+				assert.Equal(b, alertsNum, count)
 			}
 		})
 	}

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -189,26 +189,7 @@ func (s *genericStore[T, PT]) Search(ctx context.Context, q *v1.Query) ([]search
 }
 
 func (s *genericStore[T, PT]) walkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
-	fetcher, closer, err := RunCursorQueryForSchema[T, PT](ctx, s.schema, query, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return RunCursorQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
 }
 
 // Walk iterates over all the objects in the store and applies the closure.


### PR DESCRIPTION
### Description

This PR adds a function that do not do batching in RunCursorQueryForSchemaFn and instead call callback once row is scanned. This PR also uses this function in generic store and deprecate `RunCursorQueryForSchema`

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
