### PR TITLE
ROX-27885: Align data in old Compliance across tables and widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - ROX-28263: New `roxctl` help formatting.
 - ROX-24500: Certificate validation failure in `roxctl` is now an error.
+- ROX-27885: Aligned data in old Compliance across tables and widgets
 
 ## [4.7.0]
 

--- a/ui/apps/platform/cypress/integration/compliance/Compliance.selectors.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.selectors.js
@@ -6,6 +6,8 @@ export const selectors = {
             firstRow: 'div.rt-tr-group > .rt-tr.-odd:first',
             firstRowName: 'div.rt-tr-group > .rt-tr.-odd:first .rt-td a',
             secondRowName: 'div.rt-tr-group > .rt-tr.-even:first .rt-td a',
+            firstStandard: 'div.rt-table .rt-thead .rt-th:nth-child(3)',
+            firstPercentage: 'div.rt-tr-group > .rt-tr.-odd > .rt-td:nth-child(3)',
         },
     },
 };

--- a/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
@@ -57,6 +57,25 @@ describe('Compliance entities list', () => {
             });
     });
 
+    it('should have the same percentage from list to entity widget', () => {
+        visitComplianceEntities('clusters');
+
+        cy.get(selectors.list.table.firstRow).click();
+        cy.get(selectors.list.table.firstStandard)
+            .invoke('text')
+            .then((firstStandard) => {
+                cy.get(selectors.list.table.firstPercentage)
+                    .invoke('text')
+                    .then((firstTablePercentage) => {
+                        cy.get(`[data-testid="${firstStandard}-compliance"] div.rv-sunburst text`)
+                            .invoke('text')
+                            .then((firstWidgetPercentage) =>
+                                expect(firstTablePercentage).to.equal(firstWidgetPercentage)
+                            );
+                    });
+            });
+    });
+
     it('should link to entity page when clicking on side panel header', () => {
         visitComplianceEntities('clusters');
 

--- a/ui/apps/platform/src/queries/table.js
+++ b/ui/apps/platform/src/queries/table.js
@@ -4,7 +4,7 @@ export const CLUSTERS_QUERY = gql`
     query clustersList($where: String) {
         results: aggregatedResults(
             groupBy: [CLUSTER, STANDARD]
-            unit: CHECK
+            unit: CONTROL
             where: $where
             collapseBy: CLUSTER
         ) {
@@ -35,7 +35,7 @@ export const NAMESPACES_QUERY = gql`
     query namespaceList($where: String) {
         results: aggregatedResults(
             groupBy: [NAMESPACE, STANDARD]
-            unit: CHECK
+            unit: CONTROL
             where: $where
             collapseBy: NAMESPACE
         ) {
@@ -70,7 +70,7 @@ export const NODES_QUERY = gql`
     query nodesList($where: String) {
         results: aggregatedResults(
             groupBy: [NODE, STANDARD]
-            unit: CHECK
+            unit: CONTROL
             where: $where
             collapseBy: NODE
         ) {
@@ -103,7 +103,7 @@ export const DEPLOYMENTS_QUERY = gql`
     query deploymentsList($where: String) {
         results: aggregatedResults(
             groupBy: [DEPLOYMENT, STANDARD]
-            unit: CHECK
+            unit: CONTROL
             where: $where
             collapseBy: DEPLOYMENT
         ) {


### PR DESCRIPTION
### Description

Changing aggregation unit in Compliance tables to use controls instead of checks to match the widgets. choosing `CONTROL` over `CHECK` since we don't show check level of detail anyways in the UI. the ticket specified only for clusters but i found this to be an issue across namespaces/deployments/nodes, so i made the changes in those queries as well.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

clicking on the old compliance dashboard lists (clusters, namespaces, deployments, nodes) and subsequently clicking a row should show the standard percentage match the table data & the widgets in the side panel

cluster:
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/eedf8bce-1b90-43a6-821c-36f26ad6aa8a" />
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/ea8f7dc9-c7aa-4ff0-accb-126c97dea2f6" />
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/2ece7779-5a84-4951-85d1-9766f7cea5cd" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/2f17f677-0bb8-45a2-9775-e48e2fbabdae" />
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/8609a48d-a979-48b4-9061-c985c0c21385" />

namespace:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/16817c18-61dd-49a8-9609-61d9d2a32789" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c09bd850-a170-471f-a068-95bae2e395a1" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4a7f44fc-d3a2-43f5-a621-3247039b713d" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/023d4e55-49d9-471c-9ded-9aad576fe5fe" />

deployment:
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/33a3175e-c18f-4ee8-936d-48a538889038" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/bac07892-eff3-491c-8abc-24c2874385f5" />
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/6d1b8b99-4301-4849-8076-06916c41946c" />
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/14185384-2f81-430b-94cf-d521a6139430" />

node:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4b6bb1ce-360a-4a58-8b7d-6a235395ef7f" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c59370b6-625e-4580-9b6f-233e0e544b09" />


- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
