### PR TITLE
ROX-28100: retry grpc call

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -21,6 +21,11 @@ import org.junit.AssumptionViolatedException
 @Slf4j
 @CompileStatic
 class Helpers {
+    static <V> V evaluateWithRetry(int retries, int pauseSecs, String name, Closure<V> closure) {
+        log.debug("Calling ${name} with ${retries} retries")
+        return evaluateWithRetry(retries, pauseSecs, closure)
+    }
+
     static <V> V evaluateWithRetry(int retries, int pauseSecs, Closure<V> closure) {
         for (int i = 0; i < retries; i++) {
             try {

--- a/qa-tests-backend/src/main/groovy/util/Retry.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Retry.groovy
@@ -88,6 +88,7 @@ class RetryASTTransformation extends AbstractASTTransformation {
                         new ArgumentListExpression(
                                 new ConstantExpression(attempts),
                                 new ConstantExpression(delay),
+                                new ConstantExpression("${clazz.name}.${method.name}".toString()),
                                 closureExpression
                         )
                 ))

--- a/qa-tests-backend/src/main/groovy/util/Retry.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Retry.groovy
@@ -1,0 +1,97 @@
+package util
+
+import java.lang.annotation.Documented
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+import groovy.transform.CompileStatic
+import org.codehaus.groovy.ast.ASTNode
+import org.codehaus.groovy.ast.AnnotationNode
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.ast.Parameter
+import org.codehaus.groovy.ast.VariableScope
+import org.codehaus.groovy.ast.expr.ArgumentListExpression
+import org.codehaus.groovy.ast.expr.ClosureExpression
+import org.codehaus.groovy.ast.expr.ConstantExpression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.StaticMethodCallExpression
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codehaus.groovy.ast.stmt.ReturnStatement
+import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.transform.AbstractASTTransformation
+import org.codehaus.groovy.transform.GroovyASTTransformation
+import org.codehaus.groovy.transform.GroovyASTTransformationClass
+
+/**
+ * Retry the method in case of exception. Using Helpers.evaluateWithRetry
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@GroovyASTTransformationClass(classes = RetryASTTransformation)
+@interface Retry {
+
+    /**
+     * How many times to retry.
+     * @return Number of attempts
+     */
+    int attempts() default 3
+
+    /**
+     * Delay in seconds between attempts, in time units.
+     * @return Delay
+     */
+    long delay() default 1
+}
+
+@GroovyASTTransformation
+class RetryASTTransformation extends AbstractASTTransformation {
+
+    @Override
+    @CompileStatic
+    void visit(ASTNode[] nodes, SourceUnit sourceUnit) {
+        AnnotationNode annotation = (AnnotationNode) nodes[0]
+        MethodNode method = (MethodNode) nodes[1]
+
+        def clazz = method.declaringClass
+        def methodName = method.name + "_with_retry"
+        clazz.addMethod(
+                methodName,
+                method.modifiers,
+                method.returnType,
+                method.parameters,
+                method.exceptions,
+                method.code
+        )
+
+        int attempts = getMemberIntValue(annotation, "attempts")
+        int delay = getMemberIntValue(annotation, "delay")
+
+        def argumentListExpression = new ArgumentListExpression(method.parameters)
+        def funcCall = new MethodCallExpression(new VariableExpression("this"), methodName, argumentListExpression)
+
+        def closureExpression = new ClosureExpression(Parameter.EMPTY_ARRAY, new ReturnStatement(funcCall))
+        def variableScope = new VariableScope()
+        method.parameters.each {
+            variableScope.putReferencedLocalVariable(it)
+            it.setClosureSharedVariable(true)
+        }
+        closureExpression.setVariableScope(variableScope)
+
+        def retryCall = new ReturnStatement(
+                new StaticMethodCallExpression(
+                        ClassHelper.make(Helpers),
+                        "evaluateWithRetry",
+                        new ArgumentListExpression(
+                                new ConstantExpression(attempts),
+                                new ConstantExpression(delay),
+                                closureExpression
+                        )
+                ))
+
+        method.setCode(retryCall)
+    }
+}

--- a/qa-tests-backend/src/main/groovy/util/Retry.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Retry.groovy
@@ -41,7 +41,7 @@ import org.codehaus.groovy.transform.GroovyASTTransformationClass
     int attempts() default 3
 
     /**
-     * Delay in seconds between attempts, in time units.
+     * Delay in seconds between attempts.
      * @return Delay
      */
     long delay() default 1

--- a/qa-tests-backend/src/test/groovy/RetryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RetryTest.groovy
@@ -1,0 +1,22 @@
+import util.Retry
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class RetryTest extends Specification {
+    def test() {
+        expect:
+        fail("called", 1)
+    }
+
+    @Shared
+    private int i = 0
+
+    @Retry(attempts = 3, delay = 0)
+    def fail(def text, int x) {
+        assert text
+        assert x == 1
+        assert i++ > 2,  "I was $text $i"
+        return true
+    }
+}

--- a/qa-tests-backend/src/test/groovy/RetryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RetryTest.groovy
@@ -14,7 +14,7 @@ class RetryTest extends Specification {
     def fail(def text, int x) {
         assert text
         assert x == 1
-        assert i++ > 2, "I was $text $i"
+        assert i++ > 2, "I was $text $i times"
         return true
     }
 }

--- a/qa-tests-backend/src/test/groovy/RetryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RetryTest.groovy
@@ -1,6 +1,5 @@
 import util.Retry
 
-import spock.lang.Shared
 import spock.lang.Specification
 
 class RetryTest extends Specification {
@@ -9,14 +8,13 @@ class RetryTest extends Specification {
         fail("called", 1)
     }
 
-    @Shared
     private int i = 0
 
     @Retry(attempts = 3, delay = 0)
     def fail(def text, int x) {
         assert text
         assert x == 1
-        assert i++ > 2,  "I was $text $i"
+        assert i++ > 2, "I was $text $i"
         return true
     }
 }


### PR DESCRIPTION
### Description

This PR creates `@Retry` annotation that wraps annotated method with `Helpers.evaluateWithRetry`.
This is done to help retrying on grpc after set of failures to configure it on grpc level. Eventually most of the service methods will be annotated.

- https://github.com/stackrox/stackrox/pull/11821

https://github.com/stackrox/stackrox/blob/d22867428080ff0928788095ec7e634b43b863f0/qa-tests-backend/src/main/groovy/services/BaseService.groovy#L131-L137

Unfortunately there is no easy to use auto retry annotation. I found:
1. https://aspects.jcabi.com/annotation-retryonfailure.html – requires magic to enable aspects in gradle and spock tests
2. https://resilience4j.readme.io/docs/retry – too complex, good for services not for tests
3. https://github.com/spring-projects/spring-retry – too complex and rather to use with spring

Tutorial: https://youtu.be/GVfrNwTBpUM?si=hMCJGsBOGAf44cFb

---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
