### PR TITLE
ROX-28742: Fix deduplication of connections for external IPs

### DIFF
--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -180,12 +180,6 @@ func (a *aggregateExternalConnByNameImpl) Aggregate(flows []*storage.NetworkFlow
 			continue
 		}
 
-		// If the entity is discovered, anonymize it to avoid overloading
-		// the graph with many nodes (external IP details are still accessible
-		// via other APIs)
-		flowProps.SrcEntity = anonymizeDiscoveredEntity(flowProps.SrcEntity)
-		flowProps.DstEntity = anonymizeDiscoveredEntity(flowProps.DstEntity)
-
 		srcEntity, dstEntity = flowProps.SrcEntity, flowProps.DstEntity
 
 		// If both endpoints are not known external sources, skip processing.
@@ -193,6 +187,12 @@ func (a *aggregateExternalConnByNameImpl) Aggregate(flows []*storage.NetworkFlow
 			ret = append(ret, flow)
 			continue
 		}
+
+		// If the entity is discovered, anonymize it to avoid overloading
+		// the graph with many nodes (external IP details are still accessible
+		// via other APIs)
+		flowProps.SrcEntity = anonymizeDiscoveredEntity(flowProps.SrcEntity)
+		flowProps.DstEntity = anonymizeDiscoveredEntity(flowProps.DstEntity)
 
 		updateDupNameExtSrcTracker(srcEntity, dupNameExtSrcTracker)
 		updateDupNameExtSrcTracker(dstEntity, dupNameExtSrcTracker)

--- a/central/networkgraph/aggregator/aggregator_test.go
+++ b/central/networkgraph/aggregator/aggregator_test.go
@@ -313,20 +313,19 @@ func TestAggregateExtConnsByNameAnonymizeDiscoveredExtEntities(t *testing.T) {
 	detailed_flow2 := testutils.GetNetworkFlow(d1, discovered_entity2, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts2)
 	anonymized_flow := testutils.GetNetworkFlow(d1, internet, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts1)
 
-
 	for _, testCase := range []struct {
-		name	 string
-		flows	 []*storage.NetworkFlow
+		name     string
+		flows    []*storage.NetworkFlow
 		expected []*storage.NetworkFlow
 	}{
 		{
-			name: "Single flow with discovered entity",
-			flows: []*storage.NetworkFlow{detailed_flow1},
+			name:     "Single flow with discovered entity",
+			flows:    []*storage.NetworkFlow{detailed_flow1},
 			expected: []*storage.NetworkFlow{anonymized_flow},
 		},
 		{
-			name: "Two flows with discovered entities are aggregated",
-			flows: []*storage.NetworkFlow{detailed_flow1, detailed_flow2},
+			name:     "Two flows with discovered entities are aggregated",
+			flows:    []*storage.NetworkFlow{detailed_flow1, detailed_flow2},
 			expected: []*storage.NetworkFlow{anonymized_flow},
 		},
 	} {

--- a/central/networkgraph/aggregator/aggregator_test.go
+++ b/central/networkgraph/aggregator/aggregator_test.go
@@ -57,12 +57,12 @@ func TestSubnetToSupernetAggregator(t *testing.T) {
 	id5, _ := externalsrcs.NewClusterScopedID("1", cidr5)
 	id6, _ := externalsrcs.NewClusterScopedID("1", cidr6)
 
-	e1 := testutils.GetExtSrcNetworkEntityInfo(id1.String(), "1", cidr1, true)  // -> e2
-	e2 := testutils.GetExtSrcNetworkEntityInfo(id2.String(), "2", cidr2, false) // -> e3
-	e3 := testutils.GetExtSrcNetworkEntityInfo(id3.String(), "3", cidr3, false) // -> internet
-	e4 := testutils.GetExtSrcNetworkEntityInfo(id4.String(), "4", cidr4, true)  // -> e1
-	e5 := testutils.GetExtSrcNetworkEntityInfo(id5.String(), "5", cidr5, false) // -> e6
-	e6 := testutils.GetExtSrcNetworkEntityInfo(id6.String(), "6", cidr6, true)  // -> internet
+	e1 := testutils.GetExtSrcNetworkEntityInfo(id1.String(), "1", cidr1, true, false)  // -> e2
+	e2 := testutils.GetExtSrcNetworkEntityInfo(id2.String(), "2", cidr2, false, false) // -> e3
+	e3 := testutils.GetExtSrcNetworkEntityInfo(id3.String(), "3", cidr3, false, false) // -> internet
+	e4 := testutils.GetExtSrcNetworkEntityInfo(id4.String(), "4", cidr4, true, false)  // -> e1
+	e5 := testutils.GetExtSrcNetworkEntityInfo(id5.String(), "5", cidr5, false, false) // -> e6
+	e6 := testutils.GetExtSrcNetworkEntityInfo(id6.String(), "6", cidr6, true, false)  // -> internet
 
 	tree1, err := tree.NewNetworkTreeWrapper([]*storage.NetworkEntityInfo{e2, e3})
 	assert.NoError(t, err)
@@ -157,12 +157,12 @@ func TestHideDefaultExtSrcsAggregator(t *testing.T) {
 	id5, _ := externalsrcs.NewClusterScopedID("1", cidr5)
 	id6, _ := externalsrcs.NewGlobalScopedScopedID(cidr6)
 
-	e1 := testutils.GetExtSrcNetworkEntityInfo(id1.String(), "1", cidr1, true)
-	e2 := testutils.GetExtSrcNetworkEntityInfo(id2.String(), "2", cidr2, false)
-	e3 := testutils.GetExtSrcNetworkEntityInfo(id3.String(), "3", cidr3, false)
-	e4 := testutils.GetExtSrcNetworkEntityInfo(id4.String(), "4", cidr4, true)
-	e5 := testutils.GetExtSrcNetworkEntityInfo(id5.String(), "5", cidr5, false)
-	e6 := testutils.GetExtSrcNetworkEntityInfo(id6.String(), "6", cidr6, true)
+	e1 := testutils.GetExtSrcNetworkEntityInfo(id1.String(), "1", cidr1, true, false)
+	e2 := testutils.GetExtSrcNetworkEntityInfo(id2.String(), "2", cidr2, false, false)
+	e3 := testutils.GetExtSrcNetworkEntityInfo(id3.String(), "3", cidr3, false, false)
+	e4 := testutils.GetExtSrcNetworkEntityInfo(id4.String(), "4", cidr4, true, false)
+	e5 := testutils.GetExtSrcNetworkEntityInfo(id5.String(), "5", cidr5, false, false)
+	e6 := testutils.GetExtSrcNetworkEntityInfo(id6.String(), "6", cidr6, true, false)
 	internet := networkgraph.InternetEntity().ToProto()
 
 	networkTree, err := tree.NewNetworkTreeWrapper([]*storage.NetworkEntityInfo{e1, e2, e3, e4, e5, e6})
@@ -241,12 +241,12 @@ func TestAggregateExtConnsByName(t *testing.T) {
 	d1 := testutils.GetDeploymentNetworkEntity("d1", "d1")
 	d2 := testutils.GetDeploymentNetworkEntity("d2", "d2")
 
-	e1 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e1", "google", "net1", false)
-	e2 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e2", "google", "net2", false)
-	e3 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e3", "google", "net3", false)
-	e4 := testutils.GetExtSrcNetworkEntityInfo("cluster1__id4", "e4", "", false)
-	e5 := testutils.GetExtSrcNetworkEntityInfo("cluster1__nameless", "", "", false)
-	e6 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e6", "extSrc6", "net6", false)
+	e1 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e1", "google", "net1", false, false)
+	e2 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e2", "google", "net2", false, false)
+	e3 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e3", "google", "net3", false, false)
+	e4 := testutils.GetExtSrcNetworkEntityInfo("cluster1__id4", "e4", "", false, false)
+	e5 := testutils.GetExtSrcNetworkEntityInfo("cluster1__nameless", "", "", false, false)
+	e6 := testutils.GetExtSrcNetworkEntityInfo("cluster1__e6", "extSrc6", "net6", false, false)
 
 	f1 := testutils.GetNetworkFlow(d1, e1, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts1)
 	f2 := testutils.GetNetworkFlow(d1, e2, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts2)
@@ -273,7 +273,7 @@ func TestAggregateExtConnsByName(t *testing.T) {
 			},
 		},
 	}
-	e5x := testutils.GetExtSrcNetworkEntityInfo("cluster1__nameless", "unnamed external source #1", "", false)
+	e5x := testutils.GetExtSrcNetworkEntityInfo("cluster1__nameless", "unnamed external source #1", "", false, false)
 
 	/*
 		f1 -> f2x
@@ -353,8 +353,8 @@ func TestAnonymizeDiscoveredEntity(t *testing.T) {
 		},
 		{
 			name:     "NonDiscoveredExternalEntity",
-			input:    testutils.GetExtSrcNetworkEntityInfo("cluster1__e1", "google", "net1", false),
-			expected: testutils.GetExtSrcNetworkEntityInfo("cluster1__e1", "google", "net1", false),
+			input:    testutils.GetExtSrcNetworkEntityInfo("cluster1__e1", "google", "net1", false, false),
+			expected: testutils.GetExtSrcNetworkEntityInfo("cluster1__e1", "google", "net1", false, false),
 		},
 		{
 			name:     "DiscoveredExternalEntity",

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -115,17 +115,17 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 	}{
 		{
 			// Valid entity
-			entity: testutils.GetExtSrcNetworkEntity(entity1ID.String(), "cidr1", "192.0.2.0/24", true, ""),
+			entity: testutils.GetExtSrcNetworkEntity(entity1ID.String(), "cidr1", "192.0.2.0/24", true, "", false),
 			pass:   true,
 		},
 		{
 			// Valid entity-no name
-			entity: testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/30", false, cluster1),
+			entity: testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/30", false, cluster1, false),
 			pass:   true,
 		},
 		{
 			// Invalid external source-invalid network
-			entity: testutils.GetExtSrcNetworkEntity(entity3ID.String(), "cidr1", "300.0.2.0/24", false, cluster1),
+			entity: testutils.GetExtSrcNetworkEntity(entity3ID.String(), "cidr1", "300.0.2.0/24", false, cluster1, false),
 			pass:   false,
 		},
 		{
@@ -152,18 +152,18 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
 		},
 		{
 			// Valid entity
-			entity: testutils.GetExtSrcNetworkEntity(entity5ID.String(), "", "192.0.2.0/24", false, cluster2),
+			entity: testutils.GetExtSrcNetworkEntity(entity5ID.String(), "", "192.0.2.0/24", false, cluster2, false),
 			pass:   true,
 		},
 		{
 			// Invalid entity-update CIDR block
-			entity:  testutils.GetExtSrcNetworkEntity(entity5ID.String(), "", "192.0.2.0/29", false, cluster2),
+			entity:  testutils.GetExtSrcNetworkEntity(entity5ID.String(), "", "192.0.2.0/29", false, cluster2, false),
 			pass:    false,
 			skipGet: true,
 		},
 		{
 			// Valid entity
-			entity: testutils.GetExtSrcNetworkEntity(entity6ID.String(), "", "192.0.2.0/29", false, cluster2),
+			entity: testutils.GetExtSrcNetworkEntity(entity6ID.String(), "", "192.0.2.0/29", false, cluster2, false),
 			pass:   true,
 		},
 	}
@@ -271,9 +271,9 @@ func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntitiesBatchOps() {
 	suite.NoError(err)
 
 	entities := []*storage.NetworkEntity{
-		testutils.GetExtSrcNetworkEntity(entity1ID.String(), "", "192.0.2.0/30", false, cluster1),
-		testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/24", false, cluster1),
-		testutils.GetExtSrcNetworkEntity(entity3ID.String(), "", "192.0.2.0/29", false, cluster1),
+		testutils.GetExtSrcNetworkEntity(entity1ID.String(), "", "192.0.2.0/30", false, cluster1, false),
+		testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/24", false, cluster1, false),
+		testutils.GetExtSrcNetworkEntity(entity3ID.String(), "", "192.0.2.0/29", false, cluster1, false),
 	}
 
 	// Batch Create
@@ -312,11 +312,11 @@ func (suite *NetworkEntityDataStoreTestSuite) TestSAC() {
 	entity4ID, _ := externalsrcs.NewClusterScopedID(cluster2, "192.0.2.0/29")
 	defaultEntityID, _ := externalsrcs.NewGlobalScopedScopedID("192.0.2.0/30")
 
-	entity1 := testutils.GetExtSrcNetworkEntity(entity1ID.String(), "", "192.0.2.0/24", false, cluster1)
-	entity2 := testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/29", false, cluster1)
-	entity3 := testutils.GetExtSrcNetworkEntity(entity3ID.String(), "", "192.0.2.0/24", false, cluster2)
-	entity4 := testutils.GetExtSrcNetworkEntity(entity4ID.String(), "", "192.0.2.0/29", false, cluster2)
-	defaultEntity := testutils.GetExtSrcNetworkEntity(defaultEntityID.String(), "default", "192.0.2.0/30", true, "")
+	entity1 := testutils.GetExtSrcNetworkEntity(entity1ID.String(), "", "192.0.2.0/24", false, cluster1, false)
+	entity2 := testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/29", false, cluster1, false)
+	entity3 := testutils.GetExtSrcNetworkEntity(entity3ID.String(), "", "192.0.2.0/24", false, cluster2, false)
+	entity4 := testutils.GetExtSrcNetworkEntity(entity4ID.String(), "", "192.0.2.0/29", false, cluster2, false)
+	defaultEntity := testutils.GetExtSrcNetworkEntity(defaultEntityID.String(), "default", "192.0.2.0/30", true, "", false)
 
 	cluster1ReadCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
@@ -545,8 +545,8 @@ func (suite *NetworkEntityDataStoreTestSuite) TestDefaultGraphSetting() {
 	entity1ID, _ := externalsrcs.NewGlobalScopedScopedID("192.0.2.0/24")
 	entity2ID, _ := externalsrcs.NewClusterScopedID(cluster1, "192.0.2.0/30")
 
-	entity1 := testutils.GetExtSrcNetworkEntity(entity1ID.String(), "cidr1", "192.0.2.0/24", true, "")
-	entity2 := testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/30", false, cluster1)
+	entity1 := testutils.GetExtSrcNetworkEntity(entity1ID.String(), "cidr1", "192.0.2.0/24", true, "", false)
+	entity2 := testutils.GetExtSrcNetworkEntity(entity2ID.String(), "", "192.0.2.0/30", false, cluster1, false)
 	entities := []*storage.NetworkEntity{entity1, entity2}
 
 	for _, entity := range entities {

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -449,45 +449,45 @@ func (s *serviceImpl) enhanceWithNetworkPolicyIsolationInfo(ctx context.Context,
 }
 
 func aggregateExternal(conns []*storage.NetworkFlow) []*storage.NetworkFlow {
-        normalizedConns := make(map[networkgraph.NetworkConnIndicator]*storage.NetworkFlow)
-        ret := make([]*storage.NetworkFlow, 0, len(conns))
+	normalizedConns := make(map[networkgraph.NetworkConnIndicator]*storage.NetworkFlow)
+	ret := make([]*storage.NetworkFlow, 0, len(conns))
 
-        for _, conn := range conns {
-                srcEntity, dstEntity := conn.GetProps().GetSrcEntity(), conn.GetProps().GetDstEntity()
-                // This is essentially an invalid connection.
-                if srcEntity == nil || dstEntity == nil {
-                        utils.Should(errors.Errorf("network conn %s without endpoints is unexpected", networkgraph.GetNetworkConnIndicator(conn).String()))
-                        continue
-                }
+	for _, conn := range conns {
+		srcEntity, dstEntity := conn.GetProps().GetSrcEntity(), conn.GetProps().GetDstEntity()
+		// This is essentially an invalid connection.
+		if srcEntity == nil || dstEntity == nil {
+			utils.Should(errors.Errorf("network conn %s without endpoints is unexpected", networkgraph.GetNetworkConnIndicator(conn).String()))
+			continue
+		}
 
-                if networkgraph.IsExternal(srcEntity) && networkgraph.IsExternal(dstEntity) {
-                        utils.Should(errors.Errorf("network conn %s with all external endpoints is unexpected", networkgraph.GetNetworkConnIndicator(conn).String()))
-                        continue
-                }
+		if networkgraph.IsExternal(srcEntity) && networkgraph.IsExternal(dstEntity) {
+			utils.Should(errors.Errorf("network conn %s with all external endpoints is unexpected", networkgraph.GetNetworkConnIndicator(conn).String()))
+			continue
+		}
 
-                conn = conn.CloneVT()
-                srcEntity, dstEntity = conn.GetProps().GetSrcEntity(), conn.GetProps().GetDstEntity()
+		conn = conn.CloneVT()
+		srcEntity, dstEntity = conn.GetProps().GetSrcEntity(), conn.GetProps().GetDstEntity()
 
-                // If both endpoints are not external (including INTERNET), skip processing.
-                if !networkgraph.IsExternal(srcEntity) && !networkgraph.IsExternal(dstEntity) {
-                        ret = append(ret, conn)
-                        continue
-                }
+		// If both endpoints are not external (including INTERNET), skip processing.
+		if !networkgraph.IsExternal(srcEntity) && !networkgraph.IsExternal(dstEntity) {
+			ret = append(ret, conn)
+			continue
+		}
 
 		connID := networkgraph.GetNetworkConnIndicator(conn)
-                if storedFlow := normalizedConns[connID]; storedFlow != nil {
-                        if protocompat.CompareTimestamps(storedFlow.GetLastSeenTimestamp(), conn.GetLastSeenTimestamp()) < 0 {
-                                storedFlow.LastSeenTimestamp = conn.GetLastSeenTimestamp()
-                        }
-                } else {
-                        normalizedConns[connID] = conn
-                }
-        }
+		if storedFlow := normalizedConns[connID]; storedFlow != nil {
+			if protocompat.CompareTimestamps(storedFlow.GetLastSeenTimestamp(), conn.GetLastSeenTimestamp()) < 0 {
+				storedFlow.LastSeenTimestamp = conn.GetLastSeenTimestamp()
+			}
+		} else {
+			normalizedConns[connID] = conn
+		}
+	}
 
-        for _, conn := range normalizedConns {
-                ret = append(ret, conn)
-        }
-        return ret
+	for _, conn := range normalizedConns {
+		ret = append(ret, conn)
+	}
+	return ret
 }
 
 func (s *serviceImpl) addDeploymentFlowsToGraph(

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -448,48 +448,6 @@ func (s *serviceImpl) enhanceWithNetworkPolicyIsolationInfo(ctx context.Context,
 	return nil
 }
 
-func aggregateExternal(conns []*storage.NetworkFlow) []*storage.NetworkFlow {
-	normalizedConns := make(map[networkgraph.NetworkConnIndicator]*storage.NetworkFlow)
-	ret := make([]*storage.NetworkFlow, 0, len(conns))
-
-	for _, conn := range conns {
-		srcEntity, dstEntity := conn.GetProps().GetSrcEntity(), conn.GetProps().GetDstEntity()
-		// This is essentially an invalid connection.
-		if srcEntity == nil || dstEntity == nil {
-			utils.Should(errors.Errorf("network conn %s without endpoints is unexpected", networkgraph.GetNetworkConnIndicator(conn).String()))
-			continue
-		}
-
-		if networkgraph.IsExternal(srcEntity) && networkgraph.IsExternal(dstEntity) {
-			utils.Should(errors.Errorf("network conn %s with all external endpoints is unexpected", networkgraph.GetNetworkConnIndicator(conn).String()))
-			continue
-		}
-
-		conn = conn.CloneVT()
-		srcEntity, dstEntity = conn.GetProps().GetSrcEntity(), conn.GetProps().GetDstEntity()
-
-		// If both endpoints are not external (including INTERNET), skip processing.
-		if !networkgraph.IsExternal(srcEntity) && !networkgraph.IsExternal(dstEntity) {
-			ret = append(ret, conn)
-			continue
-		}
-
-		connID := networkgraph.GetNetworkConnIndicator(conn)
-		if storedFlow := normalizedConns[connID]; storedFlow != nil {
-			if protocompat.CompareTimestamps(storedFlow.GetLastSeenTimestamp(), conn.GetLastSeenTimestamp()) < 0 {
-				storedFlow.LastSeenTimestamp = conn.GetLastSeenTimestamp()
-			}
-		} else {
-			normalizedConns[connID] = conn
-		}
-	}
-
-	for _, conn := range normalizedConns {
-		ret = append(ret, conn)
-	}
-	return ret
-}
-
 func (s *serviceImpl) addDeploymentFlowsToGraph(
 	ctx context.Context,
 	request *v1.NetworkGraphRequest,
@@ -582,7 +540,6 @@ func (s *serviceImpl) addDeploymentFlowsToGraph(
 	// Aggregate all external flows by node names to control the number of external nodes.
 	flows = aggregator.NewDuplicateNameExtSrcConnAggregator().Aggregate(flows)
 	missingInfoFlows = aggregator.NewDuplicateNameExtSrcConnAggregator().Aggregate(missingInfoFlows)
-	flows = aggregateExternal(flows)
 	graphBuilder.AddFlows(flows)
 
 	filteredFlows, visibleNeighbors, maskedDeployments, err := filterFlowsAndMaskScopeAlienDeployments(ctx,

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -157,18 +157,16 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.NetworkGraph, resources.Deployment)))
 
-	entityIDs := []string{
-			externalsrcs.NewClusterScopedID(testCluster, "192.168.1.1/32"),
-	        externalsrcs.NewClusterScopedID(testCluster, "10.0.0.2/32"),
-	        externalsrcs.NewClusterScopedID(testCluster, "1.1.1.1/32"),
-	}
+	entityID1, _ := externalsrcs.NewClusterScopedID(testCluster, "192.168.1.1/32")
+	entityID2, _ := externalsrcs.NewClusterScopedID(testCluster, "10.0.0.2/32")
+	entityID3, _ := externalsrcs.NewClusterScopedID(testCluster, "1.1.1.1/32")
 
 	isDiscovered := true
 
 	entities := []*storage.NetworkEntity{
-		testutils.GetExtSrcNetworkEntityDiscovered(entityIDs[0], "ext1", "192.168.1.1/32", false, testCluster, isDiscovered),
-		testutils.GetExtSrcNetworkEntityDiscovered(entityIDs[1], "ext2", "10.0.0.2/32", false, testCluster, isDiscovered),
-		testutils.GetExtSrcNetworkEntityDiscovered(entityIDs[2], "ext3", "10.0.100.25/32", false, testCluster, isDiscovered),
+		testutils.GetExtSrcNetworkEntityWithDiscovered(entityID1.String(), "ext1", "192.168.1.1/32", false, testCluster, isDiscovered),
+		testutils.GetExtSrcNetworkEntityWithDiscovered(entityID2.String(), "ext2", "10.0.0.2/32", false, testCluster, isDiscovered),
+		testutils.GetExtSrcNetworkEntityWithDiscovered(entityID3.String(), "ext3", "10.0.100.25/32", false, testCluster, isDiscovered),
 	}
 
 	deployment := &storage.Deployment{
@@ -180,10 +178,8 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	err := s.deploymentsDataStore.UpsertDeployment(globalWriteAccessCtx, deployment)
 	s.NoError(err)
 
-	for _, e := range entities {
-		err := s.entityDataStore.CreateExternalNetworkEntity(globalWriteAccessCtx, e, true)
-		s.NoError(err)
-	}
+
+	s.entityDataStore.CreateExtNetworkEntitiesForCluster(globalWriteAccessCtx, testCluster, entities...)
 
 	entityFlows := []*storage.NetworkFlow{
 		externalFlow(deployment, entities[0], false),

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -157,12 +157,10 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.NetworkGraph, resources.Deployment)))
 
-	entityID1, _ := externalsrcs.NewClusterScopedID(testCluster, "192.168.1.1/32")
-	entityID2, _ := externalsrcs.NewClusterScopedID(testCluster, "10.0.0.2/32")
-	entityID3, _ := externalsrcs.NewClusterScopedID(testCluster, "1.1.1.1/32")
-
 	entityIDs := []string{
-		entityID1.String(), entityID2.String(), entityID3.String(),
+			externalsrcs.NewClusterScopedID(testCluster, "192.168.1.1/32"),
+	        externalsrcs.NewClusterScopedID(testCluster, "10.0.0.2/32"),
+	        externalsrcs.NewClusterScopedID(testCluster, "1.1.1.1/32"),
 	}
 
 	isDiscovered := true

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
-
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	configDS "github.com/stackrox/rox/central/networkgraph/config/datastore"
@@ -175,9 +174,9 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	}
 
 	deployment := &storage.Deployment{
-			Id:        fixtureconsts.Deployment1,
-			ClusterId: testCluster,
-			Namespace: testNamespace,
+		Id:        fixtureconsts.Deployment1,
+		ClusterId: testCluster,
+		Namespace: testNamespace,
 	}
 
 	err := s.deploymentsDataStore.UpsertDeployment(globalWriteAccessCtx, deployment)
@@ -202,45 +201,43 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	s.NoError(err)
 
 	request := &v1.NetworkGraphRequest{
-			ClusterId: testCluster,
-		}
+		ClusterId: testCluster,
+	}
 
 	expectedResponse := &v1.NetworkGraph{
-				Nodes: []*v1.NetworkNode{
-					&v1.NetworkNode{
-						Entity:	&storage.NetworkEntityInfo{
-							Type:	storage.NetworkEntityInfo_DEPLOYMENT,
-							Id:	deployment.Id,
-							Desc: &storage.NetworkEntityInfo_Deployment_{
-								Deployment: &storage.NetworkEntityInfo_Deployment{
-									Namespace: deployment.Namespace,
-								},
-							},
+		Nodes: []*v1.NetworkNode{
+			{
+				Entity: &storage.NetworkEntityInfo{
+					Type: storage.NetworkEntityInfo_DEPLOYMENT,
+					Id:   deployment.Id,
+					Desc: &storage.NetworkEntityInfo_Deployment_{
+						Deployment: &storage.NetworkEntityInfo_Deployment{
+							Namespace: deployment.Namespace,
 						},
-						OutEdges: map[int32]*v1.NetworkEdgePropertiesBundle{
-							1: &v1.NetworkEdgePropertiesBundle{
-								Properties: []*v1.NetworkEdgeProperties{
-									&v1.NetworkEdgeProperties{
-										Port: 1234,
-										Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
-										LastActiveTimestamp: timeNow.Protobuf(),
-									},
-								},
-							},
-						},
-						QueryMatch: true,
-					},
-					&v1.NetworkNode{
-						Entity:	&storage.NetworkEntityInfo{
-							Type:	storage.NetworkEntityInfo_INTERNET,
-							Id:	networkgraph.InternetExternalSourceID,
-						},
-						OutEdges: map[int32]*v1.NetworkEdgePropertiesBundle{},
 					},
 				},
-			}
-
-
+				OutEdges: map[int32]*v1.NetworkEdgePropertiesBundle{
+					1: {
+						Properties: []*v1.NetworkEdgeProperties{
+							{
+								Port:                1234,
+								Protocol:            storage.L4Protocol_L4_PROTOCOL_TCP,
+								LastActiveTimestamp: timeNow.Protobuf(),
+							},
+						},
+					},
+				},
+				QueryMatch: true,
+			},
+			{
+				Entity: &storage.NetworkEntityInfo{
+					Type: storage.NetworkEntityInfo_INTERNET,
+					Id:   networkgraph.InternetExternalSourceID,
+				},
+				OutEdges: map[int32]*v1.NetworkEdgePropertiesBundle{},
+			},
+		},
+	}
 
 	response, err := s.service.GetNetworkGraph(ctx, request)
 	s.NoError(err)

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -196,9 +196,9 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	isDiscovered := true
 
 	entities := []*storage.NetworkEntity{
-		testutils.GetExtSrcNetworkEntityWithDiscovered(entityID1.String(), "ext1", "192.168.1.1/32", false, testCluster, isDiscovered),
-		testutils.GetExtSrcNetworkEntityWithDiscovered(entityID2.String(), "ext2", "10.0.0.2/32", false, testCluster, isDiscovered),
-		testutils.GetExtSrcNetworkEntityWithDiscovered(entityID3.String(), "ext3", "10.0.100.25/32", false, testCluster, isDiscovered),
+		testutils.GetExtSrcNetworkEntity(entityID1.String(), "ext1", "192.168.1.1/32", false, testCluster, isDiscovered),
+		testutils.GetExtSrcNetworkEntity(entityID2.String(), "ext2", "10.0.0.2/32", false, testCluster, isDiscovered),
+		testutils.GetExtSrcNetworkEntity(entityID3.String(), "ext3", "10.0.100.25/32", false, testCluster, isDiscovered),
 	}
 
 	deployment := &storage.Deployment{
@@ -210,8 +210,8 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	err := s.deploymentsDataStore.UpsertDeployment(globalWriteAccessCtx, deployment)
 	s.NoError(err)
 
-
-	s.entityDataStore.CreateExtNetworkEntitiesForCluster(globalWriteAccessCtx, testCluster, entities...)
+	_, err = s.entityDataStore.CreateExtNetworkEntitiesForCluster(globalWriteAccessCtx, testCluster, entities...)
+	s.NoError(err)
 
 	entityFlows := []*storage.NetworkFlow{
 		externalFlow(deployment, entities[0], false),
@@ -271,7 +271,7 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	// Compare the timestamps, but they just need to be similar. They don't need to be equal
 	similarTimestamps := compareTimestamps(expectedResponse, response)
 	s.Assert().True(similarTimestamps)
-	
+
 	// We don't expect the timestamps to agree perfectly so set them to the same value
 	normalizeTimestamps(response, timeNow.Protobuf())
 	normalizeTimestamps(expectedResponse, timeNow.Protobuf())
@@ -302,9 +302,9 @@ func (s *networkGraphServiceSuite) TestGetExternalNetworkFlows() {
 	}
 
 	entities := []*storage.NetworkEntity{
-		testutils.GetExtSrcNetworkEntity(entityIDs[0], "ext1", "192.168.1.1/32", false, testCluster),
-		testutils.GetExtSrcNetworkEntity(entityIDs[1], "ext2", "10.0.0.2/32", false, testCluster),
-		testutils.GetExtSrcNetworkEntity(entityIDs[2], "ext3", "10.0.100.25/32", false, testCluster),
+		testutils.GetExtSrcNetworkEntity(entityIDs[0], "ext1", "192.168.1.1/32", false, testCluster, false),
+		testutils.GetExtSrcNetworkEntity(entityIDs[1], "ext2", "10.0.0.2/32", false, testCluster, false),
+		testutils.GetExtSrcNetworkEntity(entityIDs[2], "ext3", "10.0.100.25/32", false, testCluster, false),
 	}
 
 	deployments := []*storage.Deployment{
@@ -450,9 +450,9 @@ func (s *networkGraphServiceSuite) TestGetExternalNetworkFlowsMetadata() {
 	}
 
 	entities := []*storage.NetworkEntity{
-		testutils.GetExtSrcNetworkEntity(entityIDs[0], "ext1", "192.168.1.1/32", false, testCluster),
-		testutils.GetExtSrcNetworkEntity(entityIDs[1], "ext2", "10.0.0.2/32", false, testCluster),
-		testutils.GetExtSrcNetworkEntity(entityIDs[2], "ext3", "10.0.100.25/32", false, testCluster),
+		testutils.GetExtSrcNetworkEntity(entityIDs[0], "ext1", "192.168.1.1/32", false, testCluster, false),
+		testutils.GetExtSrcNetworkEntity(entityIDs[1], "ext2", "10.0.0.2/32", false, testCluster, false),
+		testutils.GetExtSrcNetworkEntity(entityIDs[2], "ext3", "10.0.100.25/32", false, testCluster, false),
 	}
 
 	deployments := []*storage.Deployment{

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -245,6 +245,7 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	response, err := s.service.GetNetworkGraph(ctx, request)
 	s.NoError(err)
 
+	// We don't expect the timestamps to agree perfectly so set them to the same value
 	normalizeTimestamps(response, timeNow.Protobuf())
 	normalizeTimestamps(expectedResponse, timeNow.Protobuf())
 	protoassert.Equal(s.T(), expectedResponse, response)

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/protobuf/types/known/timestamppb"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	configDS "github.com/stackrox/rox/central/networkgraph/config/datastore"
@@ -30,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (

--- a/central/networkgraph/service/service_impl_test.go
+++ b/central/networkgraph/service/service_impl_test.go
@@ -162,9 +162,9 @@ func (s *NetworkGraphServiceTestSuite) TestGetExternalNetworkEntities() {
 	es1bID, _ := externalsrcs.NewClusterScopedID("mycluster", "35.187.144.0/16")
 	es1cID, _ := externalsrcs.NewClusterScopedID("mycluster", "35.187.144.0/8")
 
-	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "35.187.144.0/20", false)
-	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net1", "35.187.144.0/16", false)
-	es1c := testutils.GetExtSrcNetworkEntityInfo(es1cID.String(), "net1", "35.187.144.0/8", false)
+	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "35.187.144.0/20", false, false)
+	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net1", "35.187.144.0/16", false, false)
+	es1c := testutils.GetExtSrcNetworkEntityInfo(es1cID.String(), "net1", "35.187.144.0/8", false, false)
 
 	expected := []*storage.NetworkEntity{
 		{Info: es1a},
@@ -220,8 +220,8 @@ func (s *NetworkGraphServiceTestSuite) TestGetExternalNetworkFlows() {
 	es1aID, _ := externalsrcs.NewClusterScopedID("mycluster", "192.168.0.1/32")
 	es1bID, _ := externalsrcs.NewClusterScopedID("mycluster", "192.168.0.2/32")
 
-	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "192.168.0.1/32", false)
-	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net2", "192.168.0.2/32", false)
+	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "192.168.0.1/32", false, false)
+	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net2", "192.168.0.2/32", false, false)
 
 	entities := []*storage.NetworkEntity{
 		{
@@ -364,11 +364,11 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 	es4ID, _ := externalsrcs.NewClusterScopedID("mycluster", "10.10.10.10/8")
 	es5ID, _ := externalsrcs.NewClusterScopedID("mycluster", "36.188.144.0/30")
 
-	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "35.187.144.0/20", false)
-	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net1", "35.187.144.0/16", false)
-	es1c := testutils.GetExtSrcNetworkEntityInfo(es1cID.String(), "net1", "35.187.144.0/8", false)
-	es2 := testutils.GetExtSrcNetworkEntityInfo(es2ID.String(), "2", "35.187.144.0/23", false)
-	es3 := testutils.GetExtSrcNetworkEntityInfo(es3ID.String(), "3", "36.188.144.0/16", false)
+	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "35.187.144.0/20", false, false)
+	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net1", "35.187.144.0/16", false, false)
+	es1c := testutils.GetExtSrcNetworkEntityInfo(es1cID.String(), "net1", "35.187.144.0/8", false, false)
+	es2 := testutils.GetExtSrcNetworkEntityInfo(es2ID.String(), "2", "35.187.144.0/23", false, false)
+	es3 := testutils.GetExtSrcNetworkEntityInfo(es3ID.String(), "3", "36.188.144.0/16", false, false)
 
 	networkTree, err := tree.NewNetworkTreeWrapper([]*storage.NetworkEntityInfo{es1a, es1b, es1c, es2, es3})
 	s.NoError(err)
@@ -592,11 +592,11 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSACDeterminis
 	es4ID, _ := externalsrcs.NewClusterScopedID("mycluster", "10.10.10.10/8")
 	es5ID, _ := externalsrcs.NewClusterScopedID("mycluster", "36.188.144.0/30")
 
-	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "35.187.144.0/20", false)
-	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net1", "35.187.144.0/16", false)
-	es1c := testutils.GetExtSrcNetworkEntityInfo(es1cID.String(), "net1", "35.187.144.0/8", false)
-	es2 := testutils.GetExtSrcNetworkEntityInfo(es2ID.String(), "2", "35.187.144.0/23", false)
-	es3 := testutils.GetExtSrcNetworkEntityInfo(es3ID.String(), "3", "36.188.144.0/16", false)
+	es1a := testutils.GetExtSrcNetworkEntityInfo(es1aID.String(), "net1", "35.187.144.0/20", false, false)
+	es1b := testutils.GetExtSrcNetworkEntityInfo(es1bID.String(), "net1", "35.187.144.0/16", false, false)
+	es1c := testutils.GetExtSrcNetworkEntityInfo(es1cID.String(), "net1", "35.187.144.0/8", false, false)
+	es2 := testutils.GetExtSrcNetworkEntityInfo(es2ID.String(), "2", "35.187.144.0/23", false, false)
+	es3 := testutils.GetExtSrcNetworkEntityInfo(es3ID.String(), "3", "36.188.144.0/16", false, false)
 
 	fooBarDeploymentsOrdered := []*storage.ListDeployment{
 		{
@@ -1099,9 +1099,9 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 	es3ID, _ := externalsrcs.NewClusterScopedID("mycluster", "36.188.144.0/16")
 	es4ID, _ := externalsrcs.NewClusterScopedID("mycluster", "10.10.10.10/8")
 
-	es1 := testutils.GetExtSrcNetworkEntityInfo(es1ID.String(), "1", "35.187.144.0/20", false)
-	es2 := testutils.GetExtSrcNetworkEntityInfo(es2ID.String(), "2", "35.187.144.0/23", false)
-	es3 := testutils.GetExtSrcNetworkEntityInfo(es3ID.String(), "3", "36.188.144.0/16", false)
+	es1 := testutils.GetExtSrcNetworkEntityInfo(es1ID.String(), "1", "35.187.144.0/20", false, false)
+	es2 := testutils.GetExtSrcNetworkEntityInfo(es2ID.String(), "2", "35.187.144.0/23", false, false)
+	es3 := testutils.GetExtSrcNetworkEntityInfo(es3ID.String(), "3", "36.188.144.0/16", false, false)
 
 	networkTree, err := tree.NewNetworkTreeWrapper([]*storage.NetworkEntityInfo{es1, es2, es3})
 	s.NoError(err)

--- a/pkg/networkgraph/testutils/utils.go
+++ b/pkg/networkgraph/testutils/utils.go
@@ -27,16 +27,18 @@ func GetDeploymentNetworkEntity(id, name string) *storage.NetworkEntityInfo {
 	}
 }
 
-func GetExtSrcNetworkEntityDiscovered(id, name, cidr string, isDefault bool, clusterID string, isDiscovered bool) *storage.NetworkEntity {
+// GetExtSrcNetworkEntity returns a external source typed *storage.NetworkEntity object, where discoved can be true or false.
+func GetExtSrcNetworkEntityWithDiscovered(id, name, cidr string, isDefault bool, clusterID string, isDiscovered bool) *storage.NetworkEntity {
 	return &storage.NetworkEntity{
-		Info: GetExtSrcNetworkEntityInfoDiscovered(id, name, cidr, isDefault, isDiscovered),
+		Info: GetExtSrcNetworkEntityInfoWithDiscovered(id, name, cidr, isDefault, isDiscovered),
 		Scope: &storage.NetworkEntity_Scope{
 			ClusterId: clusterID,
 		},
 	}
 }
 
-func GetExtSrcNetworkEntityInfoDiscovered(id, name, cidr string, isDefault bool, isDiscovered bool) *storage.NetworkEntityInfo {
+// GetExtSrcNetworkEntityInfo returns a external source typed *storage.NetworkEntityInfo object, where discovered can be true or false.
+func GetExtSrcNetworkEntityInfoWithDiscovered(id, name, cidr string, isDefault bool, isDiscovered bool) *storage.NetworkEntityInfo {
 	return &storage.NetworkEntityInfo{
 		Id:   id,
 		Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
@@ -65,19 +67,8 @@ func GetExtSrcNetworkEntity(id, name, cidr string, isDefault bool, clusterID str
 
 // GetExtSrcNetworkEntityInfo returns a external source typed *storage.NetworkEntityInfo object.
 func GetExtSrcNetworkEntityInfo(id, name, cidr string, isDefault bool) *storage.NetworkEntityInfo {
-	return &storage.NetworkEntityInfo{
-		Id:   id,
-		Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
-		Desc: &storage.NetworkEntityInfo_ExternalSource_{
-			ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
-				Name: name,
-				Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
-					Cidr: cidr,
-				},
-				Default: isDefault,
-			},
-		},
-	}
+	isDiscovered := false
+	return GetExtSrcNetworkEntityInfoWithDiscovered(id, name, cidr, isDefault, isDiscovered)
 }
 
 // GetNetworkFlow returns a network flow constructed from supplied data.

--- a/pkg/networkgraph/testutils/utils.go
+++ b/pkg/networkgraph/testutils/utils.go
@@ -27,6 +27,32 @@ func GetDeploymentNetworkEntity(id, name string) *storage.NetworkEntityInfo {
 	}
 }
 
+func GetExtSrcNetworkEntityDiscovered(id, name, cidr string, isDefault bool, clusterID string, isDiscovered bool) *storage.NetworkEntity {
+	return &storage.NetworkEntity{
+		Info: GetExtSrcNetworkEntityInfoDiscovered(id, name, cidr, isDefault, isDiscovered),
+		Scope: &storage.NetworkEntity_Scope{
+			ClusterId: clusterID,
+		},
+	}
+}
+
+func GetExtSrcNetworkEntityInfoDiscovered(id, name, cidr string, isDefault bool, isDiscovered bool) *storage.NetworkEntityInfo {
+	return &storage.NetworkEntityInfo{
+		Id:   id,
+		Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+		Desc: &storage.NetworkEntityInfo_ExternalSource_{
+			ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+				Name: name,
+				Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
+					Cidr: cidr,
+				},
+				Default:    isDefault,
+				Discovered: isDiscovered,
+			},
+		},
+	}
+}
+
 // GetExtSrcNetworkEntity returns a external source typed *storage.NetworkEntity object.
 func GetExtSrcNetworkEntity(id, name, cidr string, isDefault bool, clusterID string) *storage.NetworkEntity {
 	return &storage.NetworkEntity{
@@ -48,7 +74,7 @@ func GetExtSrcNetworkEntityInfo(id, name, cidr string, isDefault bool) *storage.
 				Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
 					Cidr: cidr,
 				},
-				Default: isDefault,
+				Default:    isDefault,
 			},
 		},
 	}

--- a/pkg/networkgraph/testutils/utils.go
+++ b/pkg/networkgraph/testutils/utils.go
@@ -27,18 +27,18 @@ func GetDeploymentNetworkEntity(id, name string) *storage.NetworkEntityInfo {
 	}
 }
 
-// GetExtSrcNetworkEntity returns a external source typed *storage.NetworkEntity object, where discoved can be true or false.
-func GetExtSrcNetworkEntityWithDiscovered(id, name, cidr string, isDefault bool, clusterID string, isDiscovered bool) *storage.NetworkEntity {
+// GetExtSrcNetworkEntity returns a external source typed *storage.NetworkEntity object.
+func GetExtSrcNetworkEntity(id, name, cidr string, isDefault bool, clusterID string, isDiscovered bool) *storage.NetworkEntity {
 	return &storage.NetworkEntity{
-		Info: GetExtSrcNetworkEntityInfoWithDiscovered(id, name, cidr, isDefault, isDiscovered),
+		Info: GetExtSrcNetworkEntityInfo(id, name, cidr, isDefault, isDiscovered),
 		Scope: &storage.NetworkEntity_Scope{
 			ClusterId: clusterID,
 		},
 	}
 }
 
-// GetExtSrcNetworkEntityInfo returns a external source typed *storage.NetworkEntityInfo object, where discovered can be true or false.
-func GetExtSrcNetworkEntityInfoWithDiscovered(id, name, cidr string, isDefault bool, isDiscovered bool) *storage.NetworkEntityInfo {
+// GetExtSrcNetworkEntityInfo returns a external source typed *storage.NetworkEntityInfo object.
+func GetExtSrcNetworkEntityInfo(id, name, cidr string, isDefault bool, isDiscovered bool) *storage.NetworkEntityInfo {
 	return &storage.NetworkEntityInfo{
 		Id:   id,
 		Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
@@ -53,22 +53,6 @@ func GetExtSrcNetworkEntityInfoWithDiscovered(id, name, cidr string, isDefault b
 			},
 		},
 	}
-}
-
-// GetExtSrcNetworkEntity returns a external source typed *storage.NetworkEntity object.
-func GetExtSrcNetworkEntity(id, name, cidr string, isDefault bool, clusterID string) *storage.NetworkEntity {
-	return &storage.NetworkEntity{
-		Info: GetExtSrcNetworkEntityInfo(id, name, cidr, isDefault),
-		Scope: &storage.NetworkEntity_Scope{
-			ClusterId: clusterID,
-		},
-	}
-}
-
-// GetExtSrcNetworkEntityInfo returns a external source typed *storage.NetworkEntityInfo object.
-func GetExtSrcNetworkEntityInfo(id, name, cidr string, isDefault bool) *storage.NetworkEntityInfo {
-	isDiscovered := false
-	return GetExtSrcNetworkEntityInfoWithDiscovered(id, name, cidr, isDefault, isDiscovered)
 }
 
 // GetNetworkFlow returns a network flow constructed from supplied data.
@@ -93,7 +77,7 @@ func GenRandomExtSrcNetworkEntityInfo(family pkgNet.Family, numNetworks int) ([]
 
 	entities := make([]*storage.NetworkEntityInfo, 0, len(nets))
 	for k := range nets {
-		entities = append(entities, GetExtSrcNetworkEntityInfo(k, k, k, false))
+		entities = append(entities, GetExtSrcNetworkEntityInfo(k, k, k, false, false))
 	}
 
 	return entities, nil
@@ -110,7 +94,7 @@ func GenRandomExtSrcNetworkEntity(family pkgNet.Family, numNetworks int, cluster
 	for k := range nets {
 		id, err := externalsrcs.NewClusterScopedID(clusterID, k)
 		utils.Should(err)
-		entities = append(entities, GetExtSrcNetworkEntity(id.String(), k, k, false, clusterID))
+		entities = append(entities, GetExtSrcNetworkEntity(id.String(), k, k, false, clusterID, false))
 	}
 
 	return entities, nil

--- a/pkg/networkgraph/testutils/utils.go
+++ b/pkg/networkgraph/testutils/utils.go
@@ -74,7 +74,7 @@ func GetExtSrcNetworkEntityInfo(id, name, cidr string, isDefault bool) *storage.
 				Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
 					Cidr: cidr,
 				},
-				Default:    isDefault,
+				Default: isDefault,
 			},
 		},
 	}

--- a/pkg/networkgraph/tree/multitree_test.go
+++ b/pkg/networkgraph/tree/multitree_test.go
@@ -43,12 +43,12 @@ func TestMultiTree(t *testing.T) {
 
 	*/
 
-	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "35.187.144.0/20", true)
-	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "35.187.144.0/16", false)
-	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "35.187.144.0/8", false)
-	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/23", true)
-	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "36.188.144.0/30", false)
-	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "36.188.144.0/16", true)
+	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "35.187.144.0/20", true, false)
+	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "35.187.144.0/16", false, false)
+	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "35.187.144.0/8", false, false)
+	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/23", true, false)
+	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "36.188.144.0/30", false, false)
+	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "36.188.144.0/16", true, false)
 
 	tree1, err := NewNetworkTreeWrapper([]*storage.NetworkEntityInfo{e2, e3, e5})
 	assert.NoError(t, err)

--- a/pkg/networkgraph/tree/radix_test.go
+++ b/pkg/networkgraph/tree/radix_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestNRadixTreeIPv4(t *testing.T) {
-	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "35.187.144.0/20", true)
-	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "35.187.144.0/16", false)
-	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "35.187.144.0/8", false)
-	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/23", false)
-	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "35.188.144.0/16", true)
-	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "36.188.144.0/30", false)
-	e7 := testutils.GetExtSrcNetworkEntityInfo("7", "7", "36.188.144.0/16", true)
-	e8 := testutils.GetExtSrcNetworkEntityInfo("8", "8", "36.188.144.0/32", true)
+	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "35.187.144.0/20", true, false)
+	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "35.187.144.0/16", false, false)
+	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "35.187.144.0/8", false, false)
+	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/23", false, false)
+	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "35.188.144.0/16", true, false)
+	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "36.188.144.0/30", false, false)
+	e7 := testutils.GetExtSrcNetworkEntityInfo("7", "7", "36.188.144.0/16", true, false)
+	e8 := testutils.GetExtSrcNetworkEntityInfo("8", "8", "36.188.144.0/32", true, false)
 
 	tree, err := NewNRadixTree(pkgNet.IPv4, []*storage.NetworkEntityInfo{e1, e2, e3, e4, e5, e6, e7, e8})
 	assert.NoError(t, err)
@@ -34,7 +34,7 @@ func TestNRadixTreeIPv4(t *testing.T) {
 	protoassert.Equal(t, e7, tree.Get("7"))
 	protoassert.Equal(t, e8, tree.Get("8"))
 
-	assert.Error(t, tree.Insert(testutils.GetExtSrcNetworkEntityInfo("60", "60", "36.188.144.0/16", true)))
+	assert.Error(t, tree.Insert(testutils.GetExtSrcNetworkEntityInfo("60", "60", "36.188.144.0/16", true, false)))
 
 	protoassert.Equal(t, e2, tree.GetSupernet(e1.GetId()))
 	protoassert.Equal(t, e1, tree.GetSupernet(e4.GetId()))
@@ -68,12 +68,12 @@ func TestNRadixTreeIPv4(t *testing.T) {
 }
 
 func TestNRadixTreeIPv6(t *testing.T) {
-	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "2001:db8:3333:4444:5555:6666:7777:8888/63", true)
-	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "2001:db8:3333:4444:5555:6666:7777:8888/64", false)
-	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "2001:db8:3333:4444:5555:6666:7777:8888/100", false)
-	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "2001:db8:3333:4444:5555:6666:7777:8888/128", false)
-	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "2001:db8:2222:4444:5555:6666:7777:8888/70", true)
-	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "2001:db8:2222:4444:5555:6666:7777:8888/80", false)
+	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "2001:db8:3333:4444:5555:6666:7777:8888/63", true, false)
+	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "2001:db8:3333:4444:5555:6666:7777:8888/64", false, false)
+	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "2001:db8:3333:4444:5555:6666:7777:8888/100", false, false)
+	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "2001:db8:3333:4444:5555:6666:7777:8888/128", false, false)
+	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "2001:db8:2222:4444:5555:6666:7777:8888/70", true, false)
+	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "2001:db8:2222:4444:5555:6666:7777:8888/80", false, false)
 
 	tree, err := NewNRadixTree(pkgNet.IPv6, []*storage.NetworkEntityInfo{e1, e2, e3, e4, e5, e6})
 	assert.NoError(t, err)
@@ -86,7 +86,7 @@ func TestNRadixTreeIPv6(t *testing.T) {
 	protoassert.Equal(t, e5, tree.Get("5"))
 	protoassert.Equal(t, e6, tree.Get("6"))
 
-	assert.Error(t, tree.Insert(testutils.GetExtSrcNetworkEntityInfo("60", "60", "2001:db8:2222:4444:5555:6666:7777:8888/80", true)))
+	assert.Error(t, tree.Insert(testutils.GetExtSrcNetworkEntityInfo("60", "60", "2001:db8:2222:4444:5555:6666:7777:8888/80", true, false)))
 
 	protoassert.Equal(t, e1, tree.GetSupernet(e2.GetId()))
 	protoassert.Equal(t, networkgraph.InternetEntity().ToProto(), tree.GetSupernet(e1.GetId()))

--- a/pkg/networkgraph/tree/wrapper_test.go
+++ b/pkg/networkgraph/tree/wrapper_test.go
@@ -26,12 +26,12 @@ func TestNetworkTreeWrapper(t *testing.T) {
 
 	*/
 
-	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "35.187.144.0/20", true)
-	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "35.187.144.0/16", false)
-	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "35.187.144.0/8", false)
-	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/23", false)
-	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "::23:ffff:24bc:9000/126", false)
-	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "::23:ffff:24bc:9000/112", true)
+	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "35.187.144.0/20", true, false)
+	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "35.187.144.0/16", false, false)
+	e3 := testutils.GetExtSrcNetworkEntityInfo("3", "3", "35.187.144.0/8", false, false)
+	e4 := testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/23", false, false)
+	e5 := testutils.GetExtSrcNetworkEntityInfo("5", "5", "::23:ffff:24bc:9000/126", false, false)
+	e6 := testutils.GetExtSrcNetworkEntityInfo("6", "6", "::23:ffff:24bc:9000/112", true, false)
 
 	treeWrapper, err := NewNetworkTreeWrapper([]*storage.NetworkEntityInfo{e1, e2, e3, e4, e5, e6})
 	assert.NoError(t, err)
@@ -44,8 +44,8 @@ func TestNetworkTreeWrapper(t *testing.T) {
 	protoassert.Equal(t, e6, treeWrapper.GetSupernet("5"))
 	protoassert.Equal(t, networkgraph.InternetEntity().ToProto(), treeWrapper.GetSupernet(networkgraph.InternetExternalSourceID))
 
-	e7 := testutils.GetExtSrcNetworkEntityInfo("7", "7", "::23:ffff:24bc:9000/127", false)
-	e8 := testutils.GetExtSrcNetworkEntityInfo("8", "8", "35.188.144.0/5", false)
+	e7 := testutils.GetExtSrcNetworkEntityInfo("7", "7", "::23:ffff:24bc:9000/127", false, false)
+	e8 := testutils.GetExtSrcNetworkEntityInfo("8", "8", "35.188.144.0/5", false, false)
 
 	assert.NoError(t, treeWrapper.Insert(e7))
 	assert.NoError(t, treeWrapper.Insert(e8))
@@ -74,15 +74,15 @@ func TestNetworkTreeWrapper(t *testing.T) {
 	protoassert.ElementsMatch(t, []*storage.NetworkEntityInfo{e6, e8}, treeWrapper.GetSubnets(networkgraph.InternetExternalSourceID))
 
 	// Invalid CIDR
-	assert.Error(t, treeWrapper.Insert(testutils.GetExtSrcNetworkEntityInfo("9", "9", "0::0:0:0:0:0:ffff:0:0/0", false)))
+	assert.Error(t, treeWrapper.Insert(testutils.GetExtSrcNetworkEntityInfo("9", "9", "0::0:0:0:0:0:ffff:0:0/0", false, false)))
 
 	// Update CIDR
-	e4 = testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/26", false)
+	e4 = testutils.GetExtSrcNetworkEntityInfo("4", "4", "35.187.144.0/26", false, false)
 	assert.NoError(t, treeWrapper.Insert(e4))
 	protoassert.Equal(t, e4, treeWrapper.Get("4"))
 
 	// Existing CIDR
-	assert.Error(t, treeWrapper.Insert(testutils.GetExtSrcNetworkEntityInfo("88", "88", "35.188.144.0/5", false)))
+	assert.Error(t, treeWrapper.Insert(testutils.GetExtSrcNetworkEntityInfo("88", "88", "35.188.144.0/5", false, false)))
 
 	protoassert.Equal(t, e2, treeWrapper.GetMatchingSupernet("4", func(e *storage.NetworkEntityInfo) bool { return !e.GetExternalSource().GetDefault() }))
 	protoassert.Equal(t, e1, treeWrapper.GetMatchingSupernet("4", func(e *storage.NetworkEntityInfo) bool { return e.GetExternalSource().GetDefault() }))
@@ -110,7 +110,7 @@ func TestNetworkTreeWrapper(t *testing.T) {
 	protoassert.Equal(t, e2, treeWrapper.GetMatchingSupernet("4", func(e *storage.NetworkEntityInfo) bool { return !e.GetExternalSource().GetDefault() }))
 
 	// Existing entity different IP address family
-	e8 = testutils.GetExtSrcNetworkEntityInfo("8", "8", "::23:ffff:24bc:9000/100", false)
+	e8 = testutils.GetExtSrcNetworkEntityInfo("8", "8", "::23:ffff:24bc:9000/100", false, false)
 	assert.NoError(t, treeWrapper.Insert(e8))
 
 	/*


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The "Verify connections to external sources" test in https://github.com/stackrox/stackrox/pull/13098, was failing due to multiple duplicate connections to the internet, with different timestamps. This PR fixes that issue. 

There was existing code for removing duplicate connections to external entities with different timestamps. However, it was not working in this case.

The bug was in this part of the code

```
                flowProps.SrcEntity = anonymizeDiscoveredEntity(flowProps.SrcEntity)
                flowProps.DstEntity = anonymizeDiscoveredEntity(flowProps.DstEntity)

                srcEntity, dstEntity = flowProps.SrcEntity, flowProps.DstEntity

                // If both endpoints are not known external sources, skip processing.
                if !networkgraph.IsKnownExternalSrc(srcEntity) && !networkgraph.IsKnownExternalSrc(dstEntity) {
                        ret = append(ret, flow)
                        continue
                }
```

Here discovered entities are anonymized to `INTERNET` and then there is a check if either side of the connection is an external source. If neither of them is an external source the connection is added and the deduplication is skipped for the connection. After being anonymized to `INTERNET`, neither side of the connection will be an external source, so no connection involving a discovered entity will be deduplicated.

Please note that this branch was originally based on the one for the PR linked to above and some comments intended for that PR ended up here.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
~~- [ ] added e2e tests~~
~~- [ ] added regression tests~~
~~- [ ] added compatibility tests~~
~~- [ ] modified existing tests~~

E2e tests are added in the PR linked above. No other testing is required.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

In addition to the new unit tests, this fix was checked on the e2e tests that were failing due to the duplicate endpoints. The e2e tests passed with the fix and failed without it.
