### PR TITLE
ROX-27567: terminate sensor connection after Run returns

### DIFF
--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -295,6 +295,7 @@ func (m *manager) HandleConnection(ctx context.Context, sensorHello *central.Sen
 
 	err = conn.Run(ctx, server, conn.capabilities)
 	m.handleConnectionError(clusterID, err)
+	conn.Terminate(err)
 
 	// Address the scenario in which the sensor loses its connection during
 	// the initial synchronization process.


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

After the `sensorConnection.Run` method the connection gets never terminated. This leads to the issue that if the connection was not terminated by a error triggered in one of the sensorConnections methods it is never Terminated.

Some goroutines rely on the connection being in a running state or being properly terminated otherwise they'd block the registration of new clusters by holding onto the lock on the connection map forever.

This is suspected to be root cause of [ROX-27567](https://issues.redhat.com/browse/ROX-27656)
Context: https://redhat-internal.slack.com/archives/C08HDHC0QP8/p1741950653179639

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

This simple change seems to be hard to test (at least for me), because we'd have to supply a load of mocked objects to construct a case where the HandleConnection method would run into this. Additionally the connection is currently not mockable because it is constructed within the HandleConnection method. I also think this sort of change will be well tested by existing e2e tests..
