### PR TITLE
chore(CI): do not fail connected Go tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   go:
     strategy:
+      fail-fast: false
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
@@ -80,6 +81,7 @@ jobs:
 
   go-postgres:
     strategy:
+      fail-fast: false
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
         pg: [ '13', '15' ]


### PR DESCRIPTION
### Description

To prevent cancellation of running jobs if other job in same matrix fails let's disable fail fast.

> [`jobs.<job_id>.strategy.fail-fast` applies to the entire matrix. If `jobs.<job_id>.strategy.fail-fast` is set to true or its expression evaluates to true, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails. This property defaults to true.](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions)


- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
