### PR TITLE
ROX-28294: Collect telemetry for number of admin events

### DIFF
--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -17,7 +17,7 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 		ctx = sac.WithGlobalAccessScopeChecker(ctx,
 			sac.AllowFixedScopes(
 				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.Integration),
+				sac.ResourceScopeKeys(resources.Administration),
 			),
 		)
 		props := map[string]any{}

--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -26,7 +26,7 @@ var (
 	}
 )
 
-// Gather the number of administration events
+// Gather the number of administration events.
 func Gather(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
 		ctx = sac.WithGlobalAccessScopeChecker(ctx,

--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -58,6 +58,7 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 					ProtoQuery(),
 			)
 		})
+		errorList.AddError(err)
 		err = phonehome.AddTotal(ctx, props, "Default domain Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
@@ -65,6 +66,7 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 					ProtoQuery(),
 			)
 		})
+		errorList.AddError(err)
 		err = phonehome.AddTotal(ctx, props, "Image Scanning domain Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
@@ -72,6 +74,7 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 					ProtoQuery(),
 			)
 		})
+		errorList.AddError(err)
 		err = phonehome.AddTotal(ctx, props, "Integration domain Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().

--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -22,21 +22,21 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 		_ = phonehome.AddTotal(ctx, props, "Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx, search.EmptyQuery())
 		})
-		_ = phonehome.AddTotal(ctx, props, "Info type administrative events", func(ctx context.Context) (int, error) {
+		_ = phonehome.AddTotal(ctx, props, "Info type Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
 					AddStrings(search.EventLevel, storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_INFO.String()).
 					ProtoQuery(),
 			)
 		})
-		_ = phonehome.AddTotal(ctx, props, "Warning type administrative events", func(ctx context.Context) (int, error) {
+		_ = phonehome.AddTotal(ctx, props, "Warning type Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
 					AddStrings(search.EventLevel, storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING.String()).
 					ProtoQuery(),
 			)
 		})
-		_ = phonehome.AddTotal(ctx, props, "Error type administrative events", func(ctx context.Context) (int, error) {
+		_ = phonehome.AddTotal(ctx, props, "Error type Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
 					AddStrings(search.EventLevel, storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR.String()).

--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -38,16 +38,16 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 		props := map[string]any{}
 		errorList := errorhelpers.NewErrorList("Administration Events Telemetry")
 		for key, query := range telemetryMap {
-			errorList.AddError(addTelemetry(ctx, ds, props, key, query))
+			errorList.AddError(phonehome.AddTotal(ctx, props, key, countEvents(ds, query)))
 		}
 		return props, errorList.ToError()
 	}
 }
 
-func addTelemetry(ctx context.Context, ds DataStore, props map[string]any, key string, query *v1.Query) error {
-	return phonehome.AddTotal(ctx, props, key, func(ctx context.Context) (int, error) {
+func countEvents(ds DataStore, query *v1.Query) func(context.Context) (int, error) {
+	return func(ctx context.Context) (int, error) {
 		return ds.CountEvents(ctx, query)
-	})
+	}
 }
 
 func stringQuery(label search.FieldLabel, value string) *v1.Query {

--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -21,7 +22,7 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 			),
 		)
 		props := map[string]any{}
-		var errorList errorhelpers.ErrorList
+		errorList := errorhelpers.NewErrorList("Administrative Events Telemetry")
 		err := phonehome.AddTotal(ctx, props, "Administrative Events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx, search.EmptyQuery())
 		})
@@ -46,6 +47,35 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
 					AddStrings(search.EventLevel, storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR.String()).
+					ProtoQuery(),
+			)
+		})
+		errorList.AddError(err)
+		err = phonehome.AddTotal(ctx, props, "Authentication domain Administrative Events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx,
+				search.NewQueryBuilder().
+					AddStrings(search.EventDomain, events.AuthenticationDomain).
+					ProtoQuery(),
+			)
+		})
+		err = phonehome.AddTotal(ctx, props, "Default domain Administrative Events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx,
+				search.NewQueryBuilder().
+					AddStrings(search.EventDomain, events.DefaultDomain).
+					ProtoQuery(),
+			)
+		})
+		err = phonehome.AddTotal(ctx, props, "Image Scanning domain Administrative Events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx,
+				search.NewQueryBuilder().
+					AddStrings(search.EventDomain, events.ImageScanningDomain).
+					ProtoQuery(),
+			)
+		})
+		err = phonehome.AddTotal(ctx, props, "Integration domain Administrative Events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx,
+				search.NewQueryBuilder().
+					AddStrings(search.EventDomain, events.IntegrationDomain).
 					ProtoQuery(),
 			)
 		})

--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -25,36 +25,24 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 		_ = phonehome.AddTotal(ctx, props, "Info type administrative events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
-					AddStrings(search.EventLevel, "info").
+					AddStrings(search.EventLevel, storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_INFO.String()).
 					ProtoQuery(),
 			)
 		})
 		_ = phonehome.AddTotal(ctx, props, "Warning type administrative events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
-					AddStrings(search.EventLevel, "warn").
+					AddStrings(search.EventLevel, storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING.String()).
 					ProtoQuery(),
 			)
 		})
 		_ = phonehome.AddTotal(ctx, props, "Error type administrative events", func(ctx context.Context) (int, error) {
 			return ds.CountEvents(ctx,
 				search.NewQueryBuilder().
-					AddStrings(search.EventLevel, "error").
+					AddStrings(search.EventLevel, storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR.String()).
 					ProtoQuery(),
 			)
 		})
 		return props, nil
 	}
 }
-
-/*
-
-		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_INFO
-	case "warn":
-		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING
-	case "error":
-		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR
-	default:
-		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_UNKNOWN
-
-*/

--- a/central/administration/events/datastore/telemetry.go
+++ b/central/administration/events/datastore/telemetry.go
@@ -1,0 +1,60 @@
+package datastore
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+)
+
+func Gather(ds DataStore) phonehome.GatherFunc {
+	return func(ctx context.Context) (map[string]any, error) {
+		ctx = sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Integration),
+			),
+		)
+		props := map[string]any{}
+		_ = phonehome.AddTotal(ctx, props, "Administrative Events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx, search.EmptyQuery())
+		})
+		_ = phonehome.AddTotal(ctx, props, "Info type administrative events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx,
+				search.NewQueryBuilder().
+					AddStrings(search.EventLevel, "info").
+					ProtoQuery(),
+			)
+		})
+		_ = phonehome.AddTotal(ctx, props, "Warning type administrative events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx,
+				search.NewQueryBuilder().
+					AddStrings(search.EventLevel, "warn").
+					ProtoQuery(),
+			)
+		})
+		_ = phonehome.AddTotal(ctx, props, "Error type administrative events", func(ctx context.Context) (int, error) {
+			return ds.CountEvents(ctx,
+				search.NewQueryBuilder().
+					AddStrings(search.EventLevel, "error").
+					ProtoQuery(),
+			)
+		})
+		return props, nil
+	}
+}
+
+/*
+
+		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_INFO
+	case "warn":
+		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING
+	case "error":
+		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR
+	default:
+		return storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_UNKNOWN
+
+*/

--- a/central/administration/events/datastore/telemetry_administration_events_test.go
+++ b/central/administration/events/datastore/telemetry_administration_events_test.go
@@ -36,57 +36,74 @@ func TestGather(t *testing.T) {
 	infoEvent := storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_INFO
 	warningEvent := storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING
 	errorEvent := storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR
+	authDomain := events.AuthenticationDomain
+	defaultDomain := events.DefaultDomain
+	imageScanningDomain := events.ImageScanningDomain
+	integrationDomain := events.IntegrationDomain
 
 	testCases := map[string]struct {
-		administrativeEvents  []*events.AdministrationEvent
-		expectedTotalEvents   int
-		expectedInfoEvents    int
-		expectedWarningEvents int
-		expectedErrorEvents   int
+		administrativeEvents              []*events.AdministrationEvent
+		expectedTotalEvents               int
+		expectedInfoEvents                int
+		expectedWarningEvents             int
+		expectedErrorEvents               int
+		expectedAuthDomainEvents          int
+		expectedDefaultDomainEvents       int
+		expectedImageScanningDomainEvents int
+		expectedIntegrationDomainEvents   int
 	}{
-		"one info event": {
+		"one info event in default domain": {
 			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(infoEvent),
+				testutils.GenerateAdministrativeEvent(infoEvent, defaultDomain),
 			},
-			expectedTotalEvents: 1,
-			expectedInfoEvents:  1,
+			expectedTotalEvents:         1,
+			expectedInfoEvents:          1,
+			expectedDefaultDomainEvents: 1,
 		},
-		"one warning event": {
+		"one warning event in image scanning": {
 			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(warningEvent),
+				testutils.GenerateAdministrativeEvent(warningEvent, imageScanningDomain),
 			},
-			expectedTotalEvents:   1,
-			expectedWarningEvents: 1,
+			expectedTotalEvents:               1,
+			expectedWarningEvents:             1,
+			expectedImageScanningDomainEvents: 1,
 		},
-		"one error event": {
+		"one error event in integrations": {
 			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(errorEvent),
+				testutils.GenerateAdministrativeEvent(errorEvent, integrationDomain),
 			},
-			expectedTotalEvents: 1,
-			expectedErrorEvents: 1,
+			expectedTotalEvents:             1,
+			expectedErrorEvents:             1,
+			expectedIntegrationDomainEvents: 1,
 		},
-		"one of each event": {
+		"one of each": {
 			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(infoEvent),
-				testutils.GenerateAdministrativeEvent(warningEvent),
-				testutils.GenerateAdministrativeEvent(errorEvent),
+				testutils.GenerateAdministrativeEvent(infoEvent, authDomain),
+				testutils.GenerateAdministrativeEvent(warningEvent, imageScanningDomain),
+				testutils.GenerateAdministrativeEvent(errorEvent, integrationDomain),
+				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
 			},
-			expectedTotalEvents:   3,
-			expectedInfoEvents:    1,
-			expectedWarningEvents: 1,
-			expectedErrorEvents:   1,
+			expectedTotalEvents:               4,
+			expectedInfoEvents:                1,
+			expectedWarningEvents:             1,
+			expectedErrorEvents:               2,
+			expectedAuthDomainEvents:          1,
+			expectedImageScanningDomainEvents: 1,
+			expectedIntegrationDomainEvents:   1,
+			expectedDefaultDomainEvents:       1,
 		},
-		"3 errors 2 warning events": {
+		"3 errors 2 warning events, all in default domain": {
 			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(warningEvent),
-				testutils.GenerateAdministrativeEvent(warningEvent),
-				testutils.GenerateAdministrativeEvent(errorEvent),
-				testutils.GenerateAdministrativeEvent(errorEvent),
-				testutils.GenerateAdministrativeEvent(errorEvent),
+				testutils.GenerateAdministrativeEvent(warningEvent, defaultDomain),
+				testutils.GenerateAdministrativeEvent(warningEvent, defaultDomain),
+				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
+				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
+				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
 			},
-			expectedTotalEvents:   5,
-			expectedWarningEvents: 2,
-			expectedErrorEvents:   3,
+			expectedTotalEvents:         5,
+			expectedWarningEvents:       2,
+			expectedErrorEvents:         3,
+			expectedDefaultDomainEvents: 5,
 		},
 		"no event": {},
 	}
@@ -104,10 +121,14 @@ func TestGather(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedProps := map[string]any{
-				"Total Error type Administrative Events":   tc.expectedErrorEvents,
-				"Total Info type Administrative Events":    tc.expectedInfoEvents,
-				"Total Administrative Events":              tc.expectedTotalEvents,
-				"Total Warning type Administrative Events": tc.expectedWarningEvents,
+				"Total Error type Administrative Events":            tc.expectedErrorEvents,
+				"Total Info type Administrative Events":             tc.expectedInfoEvents,
+				"Total Administrative Events":                       tc.expectedTotalEvents,
+				"Total Warning type Administrative Events":          tc.expectedWarningEvents,
+				"Total Authentication domain Administrative Events": tc.expectedAuthDomainEvents,
+				"Total Default domain Administrative Events":        tc.expectedDefaultDomainEvents,
+				"Total Image Scanning domain Administrative Events": tc.expectedImageScanningDomainEvents,
+				"Total Integration domain Administrative Events":    tc.expectedIntegrationDomainEvents,
 			}
 			assert.Equal(t, expectedProps, props)
 

--- a/central/administration/events/datastore/telemetry_administration_events_test.go
+++ b/central/administration/events/datastore/telemetry_administration_events_test.go
@@ -1,0 +1,115 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	pgStore "github.com/stackrox/rox/central/administration/events/datastore/internal/store/postgres"
+	"github.com/stackrox/rox/central/administration/events/testutils"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGather(t *testing.T) {
+	pool := pgtest.ForT(t)
+	t.Cleanup(func() {
+		pool.Teardown(t)
+	})
+	store := pgStore.New(pool.DB)
+	ds := &datastoreImpl{store: store}
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Integration),
+		),
+	)
+	infoEvent := storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_INFO
+	warningEvent := storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING
+	errorEvent := storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR
+
+	testCases := map[string]struct {
+		administrativeEvents  []*events.AdministrationEvent
+		expectedTotalEvents   int
+		expectedInfoEvents    int
+		expectedWarningEvents int
+		expectedErrorEvents   int
+	}{
+		"one info event": {
+			administrativeEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrativeEvent(infoEvent),
+			},
+			expectedTotalEvents: 1,
+			expectedInfoEvents:  1,
+		},
+		"one warning event": {
+			administrativeEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrativeEvent(warningEvent),
+			},
+			expectedTotalEvents:   1,
+			expectedWarningEvents: 1,
+		},
+		"one error event": {
+			administrativeEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrativeEvent(errorEvent),
+			},
+			expectedTotalEvents: 1,
+			expectedErrorEvents: 1,
+		},
+		"one of each event": {
+			administrativeEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrativeEvent(infoEvent),
+				testutils.GenerateAdministrativeEvent(warningEvent),
+				testutils.GenerateAdministrativeEvent(errorEvent),
+			},
+			expectedTotalEvents:   3,
+			expectedInfoEvents:    1,
+			expectedWarningEvents: 1,
+			expectedErrorEvents:   1,
+		},
+		"3 errors 2 warning events": {
+			administrativeEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrativeEvent(warningEvent),
+				testutils.GenerateAdministrativeEvent(warningEvent),
+				testutils.GenerateAdministrativeEvent(errorEvent),
+				testutils.GenerateAdministrativeEvent(errorEvent),
+				testutils.GenerateAdministrativeEvent(errorEvent),
+			},
+			expectedTotalEvents:   5,
+			expectedWarningEvents: 2,
+			expectedErrorEvents:   3,
+		},
+		"no event": {},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			for _, event := range tc.administrativeEvents {
+				err := ds.AddEvent(ctx, event)
+				require.NoError(t, err)
+			}
+
+			props, err := Gather(ds)(ctx)
+			require.NoError(t, err)
+
+			expectedProps := map[string]any{
+				"Total administrative events":        tc.expectedTotalEvents,
+				"Info type administrative events":    tc.expectedInfoEvents,
+				"Warning type administrative events": tc.expectedWarningEvents,
+				"Error type administrative events":   tc.expectedErrorEvents,
+			}
+			assert.Equal(t, expectedProps, props)
+
+			for _, event := range tc.administrativeEvents {
+				err := store.Delete(ctx, event.GetResourceID())
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/central/administration/events/datastore/telemetry_administration_events_test.go
+++ b/central/administration/events/datastore/telemetry_administration_events_test.go
@@ -42,7 +42,7 @@ func TestGather(t *testing.T) {
 	integrationDomain := events.IntegrationDomain
 
 	testCases := map[string]struct {
-		administrativeEvents              []*events.AdministrationEvent
+		administrationEvents              []*events.AdministrationEvent
 		expectedTotalEvents               int
 		expectedInfoEvents                int
 		expectedWarningEvents             int
@@ -53,35 +53,35 @@ func TestGather(t *testing.T) {
 		expectedIntegrationDomainEvents   int
 	}{
 		"one info event in default domain": {
-			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(infoEvent, defaultDomain),
+			administrationEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrationEvent(infoEvent, defaultDomain),
 			},
 			expectedTotalEvents:         1,
 			expectedInfoEvents:          1,
 			expectedDefaultDomainEvents: 1,
 		},
 		"one warning event in image scanning": {
-			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(warningEvent, imageScanningDomain),
+			administrationEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrationEvent(warningEvent, imageScanningDomain),
 			},
 			expectedTotalEvents:               1,
 			expectedWarningEvents:             1,
 			expectedImageScanningDomainEvents: 1,
 		},
 		"one error event in integrations": {
-			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(errorEvent, integrationDomain),
+			administrationEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrationEvent(errorEvent, integrationDomain),
 			},
 			expectedTotalEvents:             1,
 			expectedErrorEvents:             1,
 			expectedIntegrationDomainEvents: 1,
 		},
 		"one of each": {
-			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(infoEvent, authDomain),
-				testutils.GenerateAdministrativeEvent(warningEvent, imageScanningDomain),
-				testutils.GenerateAdministrativeEvent(errorEvent, integrationDomain),
-				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
+			administrationEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrationEvent(infoEvent, authDomain),
+				testutils.GenerateAdministrationEvent(warningEvent, imageScanningDomain),
+				testutils.GenerateAdministrationEvent(errorEvent, integrationDomain),
+				testutils.GenerateAdministrationEvent(errorEvent, defaultDomain),
 			},
 			expectedTotalEvents:               4,
 			expectedInfoEvents:                1,
@@ -93,12 +93,12 @@ func TestGather(t *testing.T) {
 			expectedDefaultDomainEvents:       1,
 		},
 		"3 errors 2 warning events, all in default domain": {
-			administrativeEvents: []*events.AdministrationEvent{
-				testutils.GenerateAdministrativeEvent(warningEvent, defaultDomain),
-				testutils.GenerateAdministrativeEvent(warningEvent, defaultDomain),
-				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
-				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
-				testutils.GenerateAdministrativeEvent(errorEvent, defaultDomain),
+			administrationEvents: []*events.AdministrationEvent{
+				testutils.GenerateAdministrationEvent(warningEvent, defaultDomain),
+				testutils.GenerateAdministrationEvent(warningEvent, defaultDomain),
+				testutils.GenerateAdministrationEvent(errorEvent, defaultDomain),
+				testutils.GenerateAdministrationEvent(errorEvent, defaultDomain),
+				testutils.GenerateAdministrationEvent(errorEvent, defaultDomain),
 			},
 			expectedTotalEvents:         5,
 			expectedWarningEvents:       2,
@@ -110,7 +110,7 @@ func TestGather(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			for _, event := range tc.administrativeEvents {
+			for _, event := range tc.administrationEvents {
 				err := datastore.AddEvent(ctx, event)
 				require.NoError(t, err)
 			}
@@ -121,18 +121,18 @@ func TestGather(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedProps := map[string]any{
-				"Total Error type Administrative Events":            tc.expectedErrorEvents,
-				"Total Info type Administrative Events":             tc.expectedInfoEvents,
-				"Total Administrative Events":                       tc.expectedTotalEvents,
-				"Total Warning type Administrative Events":          tc.expectedWarningEvents,
-				"Total Authentication domain Administrative Events": tc.expectedAuthDomainEvents,
-				"Total Default domain Administrative Events":        tc.expectedDefaultDomainEvents,
-				"Total Image Scanning domain Administrative Events": tc.expectedImageScanningDomainEvents,
-				"Total Integration domain Administrative Events":    tc.expectedIntegrationDomainEvents,
+				"Total Error type Administration Events":            tc.expectedErrorEvents,
+				"Total Info type Administration Events":             tc.expectedInfoEvents,
+				"Total Administration Events":                       tc.expectedTotalEvents,
+				"Total Warning type Administration Events":          tc.expectedWarningEvents,
+				"Total Authentication domain Administration Events": tc.expectedAuthDomainEvents,
+				"Total Default domain Administration Events":        tc.expectedDefaultDomainEvents,
+				"Total Image Scanning domain Administration Events": tc.expectedImageScanningDomainEvents,
+				"Total Integration domain Administration Events":    tc.expectedIntegrationDomainEvents,
 			}
 			assert.Equal(t, expectedProps, props)
 
-			for _, event := range tc.administrativeEvents {
+			for _, event := range tc.administrationEvents {
 				err = store.Delete(ctx, events.GenerateEventID(event))
 				require.NoError(t, err)
 			}

--- a/central/administration/events/datastore/types.go
+++ b/central/administration/events/datastore/types.go
@@ -1,0 +1,4 @@
+package datastore
+
+// The timestamp format / layout is borrowed from `pkg/search/postgres/query/time_query.go`.
+const TimestampLayout = "01/02/2006 3:04:05 PM MST"

--- a/central/administration/events/datastore/types.go
+++ b/central/administration/events/datastore/types.go
@@ -1,4 +1,0 @@
-package datastore
-
-// The timestamp format / layout is borrowed from `pkg/search/postgres/query/time_query.go`.
-const TimestampLayout = "01/02/2006 3:04:05 PM MST"

--- a/central/administration/events/testutils/testutils.go
+++ b/central/administration/events/testutils/testutils.go
@@ -3,13 +3,12 @@ package testutils
 import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events"
-	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/pkg/fixtures"
 )
 
 // GenerateAdministrativeEvent creates an administrative event for testing.
 func GenerateAdministrativeEvent(eventLevel storage.AdministrationEventLevel) *events.AdministrationEvent {
-	return &events.AdministrationEvent{
-		ResourceID: uuid.NewV4().String(),
-		Level:      eventLevel,
-	}
+	event := fixtures.GetAdministrationEvent()
+	event.Level = eventLevel
+	return event
 }

--- a/central/administration/events/testutils/testutils.go
+++ b/central/administration/events/testutils/testutils.go
@@ -12,9 +12,9 @@ var (
 )
 
 // GenerateAdministrativeEvent creates an administrative event for testing.
-func GenerateAdministrativeEvent(eventLevel storage.AdministrationEventLevel) *events.AdministrationEvent {
+func GenerateAdministrativeEvent(eventLevel storage.AdministrationEventLevel, domain string) *events.AdministrationEvent {
 	event := &events.AdministrationEvent{
-		Domain:       fmt.Sprintf("sample domain %d", eventCounter),
+		Domain:       domain,
 		Hint:         fmt.Sprintf("sample hint %d", eventCounter),
 		Level:        eventLevel,
 		Message:      fmt.Sprintf("sample message %d", eventCounter),

--- a/central/administration/events/testutils/testutils.go
+++ b/central/administration/events/testutils/testutils.go
@@ -1,14 +1,27 @@
 package testutils
 
 import (
+	"fmt"
+
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/administration/events"
-	"github.com/stackrox/rox/pkg/fixtures"
+)
+
+var (
+	eventCounter = 0
 )
 
 // GenerateAdministrativeEvent creates an administrative event for testing.
 func GenerateAdministrativeEvent(eventLevel storage.AdministrationEventLevel) *events.AdministrationEvent {
-	event := fixtures.GetAdministrationEvent()
-	event.Level = eventLevel
+	event := &events.AdministrationEvent{
+		Domain:       fmt.Sprintf("sample domain %d", eventCounter),
+		Hint:         fmt.Sprintf("sample hint %d", eventCounter),
+		Level:        eventLevel,
+		Message:      fmt.Sprintf("sample message %d", eventCounter),
+		ResourceID:   fmt.Sprintf("some resource ID %d", eventCounter),
+		ResourceType: "Image",
+		Type:         storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_GENERIC,
+	}
+	eventCounter++
 	return event
 }

--- a/central/administration/events/testutils/testutils.go
+++ b/central/administration/events/testutils/testutils.go
@@ -11,8 +11,8 @@ var (
 	eventCounter = 0
 )
 
-// GenerateAdministrativeEvent creates an administrative event for testing.
-func GenerateAdministrativeEvent(eventLevel storage.AdministrationEventLevel, domain string) *events.AdministrationEvent {
+// GenerateAdministrationEvent creates an administration event for testing.
+func GenerateAdministrationEvent(eventLevel storage.AdministrationEventLevel, domain string) *events.AdministrationEvent {
 	event := &events.AdministrationEvent{
 		Domain:       domain,
 		Hint:         fmt.Sprintf("sample hint %d", eventCounter),

--- a/central/administration/events/testutils/testutils.go
+++ b/central/administration/events/testutils/testutils.go
@@ -1,0 +1,15 @@
+package testutils
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events"
+	"github.com/stackrox/rox/pkg/uuid"
+)
+
+// GenerateAdministrativeEvent creates an administrative event for testing.
+func GenerateAdministrativeEvent(eventLevel storage.AdministrationEventLevel) *events.AdministrationEvent {
+	return &events.AdministrationEvent{
+		ResourceID: uuid.NewV4().String(),
+		Level:      eventLevel,
+	}
+}

--- a/central/main.go
+++ b/central/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
+	administrationEventDS "github.com/stackrox/rox/central/administration/events/datastore"
 	administrationEventHandler "github.com/stackrox/rox/central/administration/events/handler"
 	administrationEventService "github.com/stackrox/rox/central/administration/events/service"
 	administrationUsageCSV "github.com/stackrox/rox/central/administration/usage/csv"
@@ -621,6 +622,7 @@ func startGRPCServer() {
 				centralclient.RegisterCentralClient(&config, basicAuthProvider.ID())
 				centralclient.StartPeriodicReload(1 * time.Hour)
 				gs := cfg.Gatherer()
+				gs.AddGatherer(administrationEventDS.Gather(administrationEventDS.Singleton()))
 				gs.AddGatherer(apitokenDS.Gather(apitokenDS.Singleton()))
 				gs.AddGatherer(authDS.Gather)
 				gs.AddGatherer(authProviderTelemetry.Gather)

--- a/pkg/administration/events/domain.go
+++ b/pkg/administration/events/domain.go
@@ -3,18 +3,18 @@ package events
 import "regexp"
 
 const (
-	authenticationDomain = "Authentication"
-	defaultDomain        = "General"
-	imageScanningDomain  = "Image Scanning"
-	integrationDomain    = "Integrations"
+	AuthenticationDomain = "Authentication"
+	DefaultDomain        = "General"
+	ImageScanningDomain  = "Image Scanning"
+	IntegrationDomain    = "Integrations"
 )
 
 var moduleToDomain = map[*regexp.Regexp]string{
-	regexp.MustCompile(`^apitoken/expiration`):       authenticationDomain,
-	regexp.MustCompile(`(^|/)externalbackups(/|$)`):  integrationDomain,
-	regexp.MustCompile(`(^|/)cloudsources(/|$)`):     integrationDomain,
-	regexp.MustCompile(`(^|/)notifiers(/|$)`):        integrationDomain,
-	regexp.MustCompile(`^reprocessor|image/service`): imageScanningDomain,
+	regexp.MustCompile(`^apitoken/expiration`):       AuthenticationDomain,
+	regexp.MustCompile(`(^|/)externalbackups(/|$)`):  IntegrationDomain,
+	regexp.MustCompile(`(^|/)cloudsources(/|$)`):     IntegrationDomain,
+	regexp.MustCompile(`(^|/)notifiers(/|$)`):        IntegrationDomain,
+	regexp.MustCompile(`^reprocessor|image/service`): ImageScanningDomain,
 }
 
 // GetDomainFromModule retrieves a domain based on a specific module which will be
@@ -25,5 +25,5 @@ func GetDomainFromModule(module string) string {
 			return domain
 		}
 	}
-	return defaultDomain
+	return DefaultDomain
 }

--- a/pkg/administration/events/hints.go
+++ b/pkg/administration/events/hints.go
@@ -15,7 +15,7 @@ var (
 	// In the future, we may extend this, and possibly also ensure hints are loaded externally (similar to
 	// vulnerability definitions).
 	hints = map[string]map[string]map[string]string{
-		authenticationDomain: {
+		AuthenticationDomain: {
 			adminResources.APIToken: {
 				"": `An API token is about to expire. See the details on the expiration time within the event message.
 You cannot re-create the token. Instead, perform these steps:
@@ -26,8 +26,8 @@ You can then use the newly-created API token.
 `,
 			},
 		},
-		defaultDomain: {},
-		imageScanningDomain: {
+		DefaultDomain: {},
+		ImageScanningDomain: {
 			// For now, this is an example string. We may want to revisit those together with UX / the docs team to get
 			// errors that are in-line with documentation guidelines.
 			adminResources.Image: {
@@ -37,7 +37,7 @@ You can then use the newly-created API token.
 - The scanned manifest exists within the registry or repository.`,
 			},
 		},
-		integrationDomain: {
+		IntegrationDomain: {
 			adminResources.Notifier: {
 				codes.AWSSHGeneric: `An issue occurred when using the AWS Security Hub notifier.
 Ensure that:


### PR DESCRIPTION
### Description

Telemetry collection for administrative events, collecting total number of events and number of events by level.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Added tests, will run on CI.
