### PR TITLE
ROX-23975: Remove filtering of search options on risk page

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -49,7 +49,7 @@ import { Cluster } from 'types/cluster.proto';
 import { ClusterIdToRetentionInfo } from 'types/clusterService.proto';
 import { toggleRow, toggleSelectAll } from 'utils/checkboxUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { filterAllowedSearch, convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
+import { convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
 import {
     clustersBasePath,
     clustersDelegatedScanningPath,
@@ -214,8 +214,8 @@ function ClustersTablePanel({
             });
     }
 
-    const filteredSearch = filterAllowedSearch(searchOptions, searchFilter || {});
-    const restSearch = convertToRestSearch(filteredSearch || {});
+    const restSearch = convertToRestSearch(searchFilter || {});
+
     useDeepCompareEffect(() => {
         refreshClusterList(restSearch);
     }, [restSearch, pollingCount]);
@@ -250,7 +250,7 @@ function ClustersTablePanel({
         );
     }
 
-    const hasSearchApplied = getHasSearchApplied(filteredSearch);
+    const hasSearchApplied = getHasSearchApplied(searchFilter);
 
     // PatternFly clusters page: reconsider whether to factor out minimal common heading.
     //

--- a/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
@@ -57,7 +57,6 @@ const RiskPage = () => {
                         setSelectedDeploymentId={setSelectedDeploymentId}
                         isViewFiltered={isViewFiltered}
                         setIsViewFiltered={setIsViewFiltered}
-                        searchOptions={searchOptions}
                     />
                 </div>
                 {deploymentId && (

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
@@ -18,7 +18,6 @@ import {
 } from 'services/DeploymentsService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import {
-    filterAllowedSearch,
     convertToRestSearch,
     convertSortToGraphQLFormat,
     convertSortToRestFormat,
@@ -31,7 +30,6 @@ function RiskTablePanel({
     setSelectedDeploymentId,
     isViewFiltered,
     setIsViewFiltered,
-    searchOptions,
 }) {
     const navigate = useNavigate();
     const workflowState = useContext(workflowStateContext);
@@ -61,8 +59,7 @@ function RiskTablePanel({
      * Compute outside hook to avoid double requests if no page search options
      * before and after response to request for searchOptions.
      */
-    const filteredSearch = filterAllowedSearch(searchOptions, pageSearch || {});
-    const restSearch = convertToRestSearch(filteredSearch || {});
+    const restSearch = convertToRestSearch(pageSearch || {});
     const restSort = convertSortToRestFormat(sortOption);
 
     useDeepCompareEffect(() => {
@@ -137,12 +134,10 @@ RiskTablePanel.propTypes = {
     setSelectedDeploymentId: PropTypes.func.isRequired,
     isViewFiltered: PropTypes.bool.isRequired,
     setIsViewFiltered: PropTypes.func.isRequired,
-    searchOptions: PropTypes.arrayOf(PropTypes.string),
 };
 
 RiskTablePanel.defaultProps = {
     selectedDeploymentId: null,
-    searchOptions: [],
 };
 
 export default RiskTablePanel;

--- a/ui/apps/platform/src/services/searchOptionsToQuery.ts
+++ b/ui/apps/platform/src/services/searchOptionsToQuery.ts
@@ -1,6 +1,6 @@
 // Import from utils/searchUtils when it is written in TypeScript.
 export type RestSearchOption = {
-    label?: string;
+    label?: string | string[];
     type?: string; // for example, 'categoryOption'
     value: string | string[];
 };

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -1,10 +1,8 @@
 import {
     getViewStateFromSearch,
-    filterAllowedSearch,
     convertToRestSearch,
     convertSortToGraphQLFormat,
     convertSortToRestFormat,
-    searchOptionsToSearchFilter,
     getListQueryParams,
     getPaginationParams,
     searchValueAsArray,
@@ -56,78 +54,6 @@ describe('searchUtils', () => {
             const containsKey = getViewStateFromSearch(searchObj, key);
 
             expect(containsKey).toEqual(false);
-        });
-    });
-
-    describe('filterAllowedSearch', () => {
-        it('should return an empty object for an empty object', () => {
-            const allowedOptions = [
-                'Annotation',
-                'Deployment',
-                'Image',
-                'Image Created Time',
-                'Label',
-                'Namespace',
-                'Priority',
-                'Secret',
-                'Service Account',
-            ];
-            const pageSearch = {};
-
-            const allowedSearch = filterAllowedSearch(allowedOptions, pageSearch);
-
-            expect(allowedSearch).toEqual({});
-        });
-
-        it('should pass through all terms when allowed', () => {
-            const allowedOptions = [
-                'Annotation',
-                'Deployment',
-                'Image',
-                'Image Created Time',
-                'Label',
-                'Namespace',
-                'Priority',
-                'Secret',
-                'Service Account',
-            ];
-            const pageSearch = {
-                Deployment: 'nginx',
-                Label: 'web',
-                Namespace: 'production',
-            };
-
-            const allowedSearch = filterAllowedSearch(allowedOptions, pageSearch);
-
-            expect(allowedSearch).toEqual(pageSearch);
-        });
-
-        it('should filter out unallowed terms', () => {
-            const allowedOptions = [
-                'Annotation',
-                'Deployment',
-                'Image',
-                'Image Created Time',
-                'Label',
-                'Namespace',
-                'Priority',
-                'Secret',
-                'Service Account',
-            ];
-            const pageSearch = {
-                Deployment: 'nginx',
-                Label: 'web',
-                Marco: 'polo',
-                Namespace: 'production',
-            };
-
-            const allowedSearch = filterAllowedSearch(allowedOptions, pageSearch);
-
-            expect(allowedSearch).toEqual({
-                Deployment: 'nginx',
-                Label: 'web',
-                Namespace: 'production',
-            });
         });
     });
 
@@ -266,52 +192,6 @@ describe('searchUtils', () => {
                 field: 'Priority',
                 reversed: true,
             });
-        });
-    });
-
-    describe('searchOptionsToSearchFilter', () => {
-        it('should translate an array of SearchEntries to a SearchFilter object', () => {
-            expect(
-                searchOptionsToSearchFilter([
-                    { type: 'categoryOption', value: 'Image', label: 'Image' },
-                    { value: 'nginx:latest', label: 'nginx:latest' },
-                    { type: 'categoryOption', value: 'Status', label: 'Status' },
-                    { type: 'categoryOption', value: 'Severity', label: 'Severity' },
-                    { value: 'LOW_SEVERITY', label: 'LOW_SEVERITY' },
-                    { value: 'HIGH_SEVERITY', label: 'HIGH_SEVERITY' },
-                ])
-            ).toEqual({
-                Image: 'nginx:latest',
-                Status: '',
-                Severity: ['LOW_SEVERITY', 'HIGH_SEVERITY'],
-            });
-        });
-
-        it('should return an empty string value when no search options is provided for a category', () => {
-            expect(
-                searchOptionsToSearchFilter([
-                    { type: 'categoryOption', value: 'Status', label: 'Status' },
-                ])
-            ).toEqual({ Status: '' });
-        });
-
-        it('should return a string value when a single search options is provided for a category', () => {
-            expect(
-                searchOptionsToSearchFilter([
-                    { type: 'categoryOption', value: 'Image', label: 'Image' },
-                    { value: 'nginx:latest', label: 'nginx:latest' },
-                ])
-            ).toEqual({ Image: 'nginx:latest' });
-        });
-
-        it('should return an array value when multiple search options are provided for a category', () => {
-            expect(
-                searchOptionsToSearchFilter([
-                    { type: 'categoryOption', value: 'Severity', label: 'Severity' },
-                    { value: 'LOW_SEVERITY', label: 'LOW_SEVERITY' },
-                    { value: 'HIGH_SEVERITY', label: 'HIGH_SEVERITY' },
-                ])
-            ).toEqual({ Severity: ['LOW_SEVERITY', 'HIGH_SEVERITY'] });
         });
     });
 


### PR DESCRIPTION
### Description

Fixes a very rare test flake due to a double-request when visiting the risk page with pre-existing filters in the URL. The fix is more important to address the latter, and less important for fixing the rare flake.

The double request occurs when visiting Risk with search parameters in the URL. Prior to this change, search filters would be filtered to only include keys that were returned in part of the `searchOptions` array. This causes a request with no filters to be sent since the initial `searchOptions` array is empty, followed by a second request once the `searchOptions` are returned from the server. In the typical case of visiting the risk page directly with no filters, this is not a problem as the filtered search object is empty in both cases.

An alternative to this would be to block rendering of the page until the `searchOptions` response was received, but I did not feel like this degradation of UX was worthwhile to retain the filtering client side. Invalid parameters are already ignored by the search component, and are ignored by the backend queries, so there is little risk in removing this filter.

Update: Additionally fixes this for the clusters page, even though that is not related to a test flake

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit Risk with pre-applied filters and observed that only a single request to `deploymentswithprocessinfo` is made.
![image](https://github.com/user-attachments/assets/d5fff300-4932-4d22-bf9f-060f8fe99281)

Visit Clusters page with pre-applied filter and observe only a single request:
<img width="1668" alt="image" src="https://github.com/user-attachments/assets/a910dfa4-5631-447e-a637-e061b3e77545" />
