### PR TITLE
ROX-28390: Fix race condition in TLS issuer

### DIFF
--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -87,7 +87,6 @@ func newSecuredClusterTLSIssuerFixture(k8sClientConfig fakeK8sClientConfig) *sec
 		getServiceCertificatesRepoFn: fixture.componentGetter.getServiceCertificatesRepo,
 		msgToCentralC:                make(chan *message.ExpiringMessage),
 		newMsgFromSensorFn:           newSecuredClusterMsgFromSensor,
-		responseFromCentral:          make(chan *Response),
 		stopSig:                      concurrency.NewSignal(),
 		requiredCentralCapability: func() *centralsensor.CentralCapability {
 			centralCap := centralsensor.CentralCapability(centralsensor.SecuredClusterCertificatesReissue)
@@ -268,6 +267,10 @@ func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessage
 		},
 	}
 
+	fixture.mockForStart(mockForStartConfig{})
+	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
+	s.Require().NoError(fixture.tlsIssuer.Start())
+
 	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(msg))
 	assert.Eventually(s.T(), func() bool {
 		select {
@@ -284,6 +287,10 @@ func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessage
 	msg := &central.MsgToSensor{
 		Msg: &central.MsgToSensor_ReprocessDeployments{},
 	}
+
+	fixture.mockForStart(mockForStartConfig{})
+	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
+	s.Require().NoError(fixture.tlsIssuer.Start())
 
 	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(msg))
 	assert.Never(s.T(), func() bool {
@@ -311,6 +318,10 @@ func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerRequestSuccess
 	f := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+
+	f.mockForStart(mockForStartConfig{})
+	f.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
+	s.Require().NoError(f.tlsIssuer.Start())
 
 	go f.respondRequest(ctx, s.T(), nil)
 

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -88,6 +88,7 @@ func newSecuredClusterTLSIssuerFixture(k8sClientConfig fakeK8sClientConfig) *sec
 		msgToCentralC:                make(chan *message.ExpiringMessage),
 		newMsgFromSensorFn:           newSecuredClusterMsgFromSensor,
 		responseFromCentral:          make(chan *Response),
+		stopSig:                      concurrency.NewSignal(),
 		requiredCentralCapability: func() *centralsensor.CentralCapability {
 			centralCap := centralsensor.CentralCapability(centralsensor.SecuredClusterCertificatesReissue)
 			return &centralCap


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The Secured Cluster TLS issuer allows only one request to Central at a time. In order to do this, it was using an atomic bool `requestOngoing`  to stop other simultaneous requests, and `ongoingRequestID` (guarded by `ongoingRequestIDMutex`) to make sure that received responses belong to the current request.

However, this approach allowed a race condition to take place when there are requests happening in quick succession, and the online / offline mode of Sensor changes. The situation was the following, as reproduced occasionally by the `TestSensorOnlineOfflineModes` test:
* request (1) is triggered
* sensor goes into offline mode, and cancels request (1)
* before request (1) manages to reset `requestOngoing`, a response arrives and it is stored in `responseFromCentral`
* request (2) is triggered, receives the response of request (1) and finishes; the response to request (2) is discarded because there is no `requestOngoing`
* as the response to request (1) was a preprogrammed error, request (2) doesn't create TLS secrets and the test fails

To eliminate this scenario, I made the following changes:
* replace the `requestOngoing` atomic bool with a `requestMutex` that surrounds the entire request. This simplifies things a bit, and if a second request is coming while the previous didn't finish, it won't return an error but instead will wait until the first request completes
* use a queue  to pass received messages to the `requestCertificates` goroutine
* moved the request ID check to the `receive` function, which runs in the same goroutine as `requestCertificates`, therefore eliminating the need for a mutex for `ongoingRequestID`

In the current approach it's still possible that a response from a previous request arrives when a new request is already taking place (this is something that can't be prevented), but it will simply be discarded in `receive`, which then reads the channel until the correct response arrives, or the context expires.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Ran the `TestSensorOnlineOfflineModes` test in a loop overnight.
