### PR TITLE
fix(qa): add keepalive and idle connection timeout

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -1,5 +1,7 @@
 package services
 
+import java.util.concurrent.TimeUnit
+
 import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import groovy.util.logging.Slf4j
@@ -137,6 +139,8 @@ class BaseService {
                     // .enableRetry()
                     .negotiationType(NegotiationType.TLS)
                     .sslContext(sslContext)
+                    .keepAliveTime(1, TimeUnit.SECONDS)
+                    .idleTimeout(1, TimeUnit.MINUTES)
                     .build()
             effectiveChannel = null
 


### PR DESCRIPTION
### Description

This PR sets two grpc connection setting keep alive and idle connection. The values are used arbitrary with not in depth testing as we do not use Groovy tests for benchmarking so there should not be any problem with making a connection per request. Since our most popular method of retrying accepts seconds as interval time it's ok to set keep alive every second. As some tests adds longer sleep time (e.g. to wait for sensor/collector or image scan) we can shutdown this connection after 1 minute. 

See:
- https://github.com/grpc/grpc-java/issues/7851#issuecomment-780025689
- https://stackoverflow.com/a/57930958

---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
