### PR TITLE
ROX-28028: anonymise external IPs in network baselines

### DIFF
--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -236,17 +236,7 @@ func (m *manager) lookUpPeerInfo(entity networkgraph.Entity) peerInfo {
 			log.Warnf("network entity peer %q not found", entity.ID)
 			return peerInfo{}
 		}
-
 		externalSource := networkEntity.GetInfo().GetExternalSource()
-
-		if externalSource.GetDiscovered() {
-			// If it's a discovered external IP, we anonymise to the
-			// internet to better reflect the baseline behavior
-			return peerInfo{
-				name: networkgraph.InternetExternalSourceName,
-			}
-		}
-
 		return peerInfo{
 			name:      externalSource.GetName(),
 			cidrBlock: externalSource.GetCidr(),

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -229,7 +229,17 @@ func (m *manager) lookUpPeerInfo(entity networkgraph.Entity) peerInfo {
 			log.Warnf("network entity peer %q not found", entity.ID)
 			return peerInfo{}
 		}
+
 		externalSource := networkEntity.GetInfo().GetExternalSource()
+
+		if externalSource.GetDiscovered() {
+			// If it's a discovered external IP, we anonymise to the
+			// internet to better reflect the baseline behavior
+			return peerInfo{
+				name: networkgraph.InternetExternalSourceName,
+			}
+		}
+
 		return peerInfo{
 			name:      externalSource.GetName(),
 			cidrBlock: externalSource.GetCidr(),


### PR DESCRIPTION
### Description

When constructing a network baseline, we want to ignore IP information and instead focus on the port/protocol that is exposed to better reflect the behaviour of alerts and network policy generation.

Without these changes, IP information appears in the network baseline, which implies that the deployment is only allowed to talk to that IP. In practice, it can talk to any external IP on the same port/protocol.

### User-facing documentation

~- [ ] CHANGELOG is updated **OR** update is not needed~
~- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

~- [ ] added unit tests~
~- [ ] added e2e tests~
~- [ ] added regression tests~
~- [ ] added compatibility tests~
- [x] modified existing tests

#### How I validated my change

The added test case covers the anonymization, and I've also spun this up on an OCP cluster with a short baseline period and have observed external IPs appearing in the external flows list, but being represented as "External Entities" in the network baseline