### PR TITLE
ROX-28495: Fix typo in Container CPU Limit policy field name

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -953,7 +953,7 @@ export const policyCriteriaDescriptors: Descriptor[] = [
     },
     {
         label: 'Container CPU limit',
-        name: 'Container CPU Limit"',
+        name: 'Container CPU Limit',
         shortName: 'Container CPU limit',
         category: policyCriteriaCategories.CONTAINER_CONFIGURATION,
         type: 'group',


### PR DESCRIPTION
### Description

My bad when I replaced `cpuLimit` function call with object literal on 2024-09-20 in #12631

Affects 4.6 and 4.7 release versions.

### Residue

1. Improve unit tests.

### User-facing documentation

- [x] CHANGELOG is not needed
- [x] documentation PR is not needed
- [x] Release Note Text field in Jira bug

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
3. `npm run build` in ui/apps/platform
4. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/policy-management/policies/?action=create and advance to **Rules** step.

2. Drag **Container CPU Limit** from **Container configuration** to rule.

3. Advance to **Review** step.

    Before changes, with stray double quote character.

    POST /v1/policies/dryrunjob has 400 Bad Request status.

    Payload has `fieldName: "Container CPU Limit\""`

    > Policy is invalid

    > policy invalid error: error validating lifecycle stage error: policy configuration is invalid for deploy time: policy validation error: validation of section "Rule 1" error: policy criteria name "Container CPU Limit\"" is invalid: invalid arguments

    After changes, without stray double quote character.

    POST /v1/policies?enableStrictValidation=true has 200 OK status

    Payload and response have `fieldName: "Container CPU Limit"`