### PR TITLE
fix(pg): use pgx.ForEachRows in walker

### DIFF
--- a/central/alert/datastore/internal/store/postgres/bench_test.go
+++ b/central/alert/datastore/internal/store/postgres/bench_test.go
@@ -30,6 +30,9 @@ func BenchmarkMany(b *testing.B) {
 	}
 
 	testDB := pgtest.ForT(b)
+	b.Cleanup(func() {
+		testDB.Teardown(b)
+	})
 	store := New(testDB.DB)
 
 	ctx := sac.WithAllAccess(context.Background())


### PR DESCRIPTION
### Description

It looks like using pgx.ForEachRow has some benefits over our current implementation. It handles memory better although it has almost the same runtime.

```
pkg: github.com/stackrox/rox/central/alert/datastore/internal/store/postgres
                        │   old.txt   │              new.txt               │
                        │   sec/op    │   sec/op     vs base               │
Many/walk_1_alerts-8      109.3m ± 2%   107.3m ± 2%  -1.83% (p=0.035 n=10)
Many/walk_2_alerts-8      109.2m ± 2%   107.6m ± 2%  -1.51% (p=0.011 n=10)
Many/walk_4_alerts-8      108.3m ± 2%   107.2m ± 1%       ~ (p=0.143 n=10)
Many/walk_8_alerts-8      109.2m ± 2%   108.0m ± 0%  -1.06% (p=0.023 n=10)
Many/walk_16_alerts-8     108.9m ± 2%   107.9m ± 5%       ~ (p=0.631 n=10)
Many/walk_32_alerts-8     109.6m ± 2%   108.3m ± 1%       ~ (p=0.280 n=10)
Many/walk_64_alerts-8     108.2m ± 1%   107.6m ± 2%       ~ (p=0.280 n=10)
Many/walk_128_alerts-8    109.4m ± 2%   107.9m ± 1%  -1.36% (p=0.023 n=10)
Many/walk_256_alerts-8    108.4m ± 2%   107.6m ± 2%       ~ (p=0.190 n=10)
Many/walk_512_alerts-8    108.5m ± 2%   107.8m ± 2%       ~ (p=0.190 n=10)
Many/walk_1024_alerts-8   109.9m ± 3%   109.0m ± 3%       ~ (p=0.218 n=10)
Many/walk_2048_alerts-8   108.9m ± 2%   107.6m ± 2%       ~ (p=0.089 n=10)
Many/walk_4096_alerts-8   109.2m ± 1%   107.9m ± 2%       ~ (p=0.123 n=10)
Many/walk_8192_alerts-8   108.2m ± 3%   107.4m ± 2%       ~ (p=0.971 n=10)
geomean                   108.9m        107.8m       -1.06%

                        │   old.txt    │               new.txt               │
                        │     B/op     │     B/op      vs base               │
Many/walk_1_alerts-8      49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_2_alerts-8      49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_4_alerts-8      49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_8_alerts-8      49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_16_alerts-8     49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_32_alerts-8     49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_64_alerts-8     49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_128_alerts-8    49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_256_alerts-8    49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_512_alerts-8    49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_1024_alerts-8   49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_2048_alerts-8   49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_4096_alerts-8   49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
Many/walk_8192_alerts-8   49.84Mi ± 0%   49.47Mi ± 0%  -0.75% (p=0.000 n=10)
geomean                   49.84Mi        49.47Mi       -0.75%

                        │   old.txt   │              new.txt               │
                        │  allocs/op  │  allocs/op   vs base               │
Many/walk_1_alerts-8      451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_2_alerts-8      451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_4_alerts-8      451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_8_alerts-8      451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_16_alerts-8     451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_32_alerts-8     451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_64_alerts-8     451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_128_alerts-8    451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_256_alerts-8    451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_512_alerts-8    451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_1024_alerts-8   451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_2048_alerts-8   451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_4096_alerts-8   451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
Many/walk_8192_alerts-8   451.9k ± 0%   432.3k ± 0%  -4.34% (p=0.000 n=10)
geomean                   451.9k        432.3k       -4.34%
```

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
