### PR TITLE
chore(pg): Teardown DB at test Cleanup

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ActiveComponentsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ActiveComponentsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ActiveComponentsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/administration/events/datastore/datastore_impl_postgres_test.go
+++ b/central/administration/events/datastore/datastore_impl_postgres_test.go
@@ -57,11 +57,6 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 	s.datastore = newDataStore(searcher, s.store, s.writer)
 }
 
-func (s *datastorePostgresTestSuite) TearDownTest() {
-	s.postgresTest.Teardown(s.T())
-	s.postgresTest.Close()
-}
-
 func (s *datastorePostgresTestSuite) assertEventsEqual(
 	event *events.AdministrationEvent,
 	storageEvent *storage.AdministrationEvent,

--- a/central/administration/events/datastore/internal/store/postgres/store_test.go
+++ b/central/administration/events/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *AdministrationEventsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *AdministrationEventsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *AdministrationEventsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/administration/events/service/service_impl_postgres_test.go
+++ b/central/administration/events/service/service_impl_postgres_test.go
@@ -45,11 +45,6 @@ func (s *servicePostgresTestSuite) SetupTest() {
 	s.service = newService(s.datastore)
 }
 
-func (s *servicePostgresTestSuite) TearDownTest() {
-	s.pool.Teardown(s.T())
-	s.pool.Close()
-}
-
 func (s *servicePostgresTestSuite) TestCount() {
 	fromBeforeNow, err := protocompat.ConvertTimeToTimestampOrError(time.Now().Add(-1 * time.Hour))
 	s.Require().NoError(err)

--- a/central/administration/usage/store/postgres/store_test.go
+++ b/central/administration/usage/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *SecuredUnitsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *SecuredUnitsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *SecuredUnitsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/alert/datastore/internal/search/searcher_postgres_test.go
+++ b/central/alert/datastore/internal/search/searcher_postgres_test.go
@@ -41,10 +41,6 @@ func (s *AlertsSearchSuite) SetupTest() {
 	s.searcher = New(s.store)
 }
 
-func (s *AlertsSearchSuite) TearDownTest() {
-	s.testPostgres.Teardown(s.T())
-}
-
 func (s *AlertsSearchSuite) TestSearch() {
 	alert := fixtures.GetAlert()
 	alert.EntityType = storage.Alert_DEPLOYMENT

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *AlertsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *AlertsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *AlertsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/apitoken/datastore/internal/schedulestore/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/schedulestore/postgres/store_test.go
@@ -31,7 +31,6 @@ func (s *NotificationSchedulesStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-
 func (s *NotificationSchedulesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/apitoken/datastore/internal/schedulestore/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/schedulestore/postgres/store_test.go
@@ -31,9 +31,6 @@ func (s *NotificationSchedulesStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *NotificationSchedulesStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
 
 func (s *NotificationSchedulesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *APITokensStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *APITokensStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *APITokensStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/apitoken/datastore/telemetry_postgres_test.go
+++ b/central/apitoken/datastore/telemetry_postgres_test.go
@@ -19,9 +19,6 @@ import (
 
 func TestGather(t *testing.T) {
 	pool := pgtest.ForT(t)
-	t.Cleanup(func() {
-		pool.Teardown(t)
-	})
 	store := pgStore.New(pool.DB)
 	ds := &datastoreImpl{storage: store}
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),

--- a/central/apitoken/expiration/expiration_test.go
+++ b/central/apitoken/expiration/expiration_test.go
@@ -41,10 +41,6 @@ func (s *apiTokenExpirationNotifierTestSuite) SetupTest() {
 	s.notifier = newExpirationNotifier(s.datastore)
 }
 
-func (s *apiTokenExpirationNotifierTestSuite) TearDownTest() {
-	s.testpostgres.Teardown(s.T())
-}
-
 func (s *apiTokenExpirationNotifierTestSuite) TestSelectTokenAboutToExpire() {
 	now := time.Now()
 	expiration := now.Add(2 * time.Hour)

--- a/central/auth/datastore/datastore_impl_test.go
+++ b/central/auth/datastore/datastore_impl_test.go
@@ -83,11 +83,6 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 	s.authDataStore = New(store, s.mockSet, issuerFetcher)
 }
 
-func (s *datastorePostgresTestSuite) TearDownTest() {
-	s.pool.Teardown(s.T())
-	s.pool.Close()
-}
-
 func (s *datastorePostgresTestSuite) TestKubeServiceAccountConfig() {
 	controller := gomock.NewController(s.T())
 	defer controller.Finish()

--- a/central/auth/service/service_impl_test.go
+++ b/central/auth/service/service_impl_test.go
@@ -126,11 +126,6 @@ func (s *authServiceAccessControlTestSuite) SetupTest() {
 	s.svc = &serviceImpl{authDataStore: authDataStore}
 }
 
-func (s *authServiceAccessControlTestSuite) TearDownTest() {
-	s.pool.Teardown(s.T())
-	s.pool.Close()
-}
-
 type testCase struct {
 	name string
 	ctx  context.Context

--- a/central/auth/store/postgres/store_test.go
+++ b/central/auth/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *AuthMachineToMachineConfigsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *AuthMachineToMachineConfigsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *AuthMachineToMachineConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/authprovider/datastore/internal/store/postgres/store_test.go
+++ b/central/authprovider/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *AuthProvidersStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *AuthProvidersStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *AuthProvidersStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/authprovider/service/service_impl_postgres_test.go
+++ b/central/authprovider/service/service_impl_postgres_test.go
@@ -69,7 +69,6 @@ func (s *authProviderServiceTestSuite) SetupSuite() {
 }
 
 func (s *authProviderServiceTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
 	s.mockCtrl.Finish()
 }
 

--- a/central/blob/datastore/datastore_test.go
+++ b/central/blob/datastore/datastore_test.go
@@ -51,10 +51,6 @@ func (s *blobTestSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *blobTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *blobTestSuite) createBlobs(prefix string, size int, n int, modTime time.Time) []*storage.Blob {
 	var blobs []*storage.Blob
 	for i := 0; i < n; i++ {

--- a/central/blob/datastore/store/postgres/store_test.go
+++ b/central/blob/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *BlobsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *BlobsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *BlobsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/blob/datastore/store/store_test.go
+++ b/central/blob/datastore/store/store_test.go
@@ -39,10 +39,6 @@ func (s *BlobsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *BlobsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *BlobsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 	size := 1024*1024 + 16

--- a/central/blob/snapshot/snapshot_test.go
+++ b/central/blob/snapshot/snapshot_test.go
@@ -44,10 +44,6 @@ func (s *snapshotTestSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *snapshotTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *snapshotTestSuite) TestSnapshot() {
 	ctx := sac.WithAllAccess(context.Background())
 	size := 1024*1024 + 16

--- a/central/cloudsources/datastore/datastore_impl_postgres_test.go
+++ b/central/cloudsources/datastore/datastore_impl_postgres_test.go
@@ -50,11 +50,6 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 	s.datastore = GetTestPostgresDataStore(s.T(), s.postgresTest.DB)
 }
 
-func (s *datastorePostgresTestSuite) TearDownTest() {
-	s.postgresTest.Teardown(s.T())
-	s.postgresTest.Close()
-}
-
 func (s *datastorePostgresTestSuite) TestCountCloudSources() {
 	count, err := s.datastore.CountCloudSources(s.readCtx, &v1.Query{})
 	s.Require().NoError(err)

--- a/central/cloudsources/datastore/internal/store/postgres/store_test.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *CloudSourcesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *CloudSourcesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *CloudSourcesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/cloudsources/manager/manager_postgres_test.go
+++ b/central/cloudsources/manager/manager_postgres_test.go
@@ -19,10 +19,6 @@ import (
 
 func TestChangeDiscoveredClustersStatus(t *testing.T) {
 	pool := pgtest.ForT(t)
-	defer func() {
-		pool.Teardown(t)
-		pool.Close()
-	}()
 	dcDS := discoveredClustersDS.GetTestPostgresDataStore(t, pool)
 
 	csDS := cloudSourcesDS.GetTestPostgresDataStore(t, pool)

--- a/central/cloudsources/service/service_impl_postgres_test.go
+++ b/central/cloudsources/service/service_impl_postgres_test.go
@@ -70,11 +70,6 @@ func (s *servicePostgresTestSuite) SetupTest() {
 	}
 }
 
-func (s *servicePostgresTestSuite) TearDownTest() {
-	s.pool.Teardown(s.T())
-	s.pool.Close()
-}
-
 func (s *servicePostgresTestSuite) TestCount() {
 	s.addCloudSources(50)
 

--- a/central/cluster/datastore/datastore_impl_postgres_test.go
+++ b/central/cluster/datastore/datastore_impl_postgres_test.go
@@ -113,10 +113,6 @@ func (s *ClusterPostgresDataStoreTestSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ClusterPostgresDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 // Test that when we try to remove a cluster that does not exist, we return an error.
 func (s *ClusterPostgresDataStoreTestSuite) TestHandlesClusterDoesNotExist() {
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *ClustersStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ClustersStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ClustersStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ClusterHealthStatusesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ClusterHealthStatusesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ClusterHealthStatusesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/clustercveedge/datastore/store/postgres/store_test.go
+++ b/central/clustercveedge/datastore/store/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *ClusterCveEdgesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ClusterCveEdgesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ClusterCveEdgesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/clustercveedge/datastoretest/datastore_sac_test.go
+++ b/central/clustercveedge/datastoretest/datastore_sac_test.go
@@ -43,10 +43,6 @@ func (s *clusterCVEEdgeDatastoreSACSuite) SetupSuite() {
 	s.Require().NoError(err)
 }
 
-func (s *clusterCVEEdgeDatastoreSACSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func (s *clusterCVEEdgeDatastoreSACSuite) cleanImageToVulnerabilitiesGraph() {
 	s.Require().NoError(s.testGraphDatastore.CleanClusterToVulnerabilitiesGraph())
 }

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ClusterInitBundlesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ClusterInitBundlesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ClusterInitBundlesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceConfigsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceConfigsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/compliance/datastore/internal/store/postgres/domain/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceDomainsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceDomainsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceDomainsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -44,10 +44,6 @@ func (s *ComplianceRunMetadataStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceRunMetadataStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceRunMetadataStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -44,10 +44,6 @@ func (s *ComplianceRunResultsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceRunResultsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceRunResultsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/compliance/datastore/internal/store/postgres/strings/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceStringsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceStringsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceStringsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/checkresults/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorCheckResultsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorCheckResultsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/profiles/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceOperatorProfilesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorProfilesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorProfilesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/rules/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceOperatorRulesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorRulesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorRulesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/scans/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceOperatorScansStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorScansStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorScansStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/benchmarks/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/benchmarks/datastore/datastore_impl_test.go
@@ -70,10 +70,6 @@ func (s *complianceBenchmarkDataStoreSuite) SetupTest() {
 	s.datastore = New(s.storage)
 }
 
-func (s *complianceBenchmarkDataStoreSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceBenchmarkDataStoreSuite) TestUpsertBenchmark() {
 	// make sure we have nothing
 	benchmarkIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store_test.go
@@ -48,10 +48,6 @@ func (s *ComplianceOperatorBenchmarkV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorBenchmarkV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorBenchmarkV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl_benchmark_test.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl_benchmark_test.go
@@ -94,9 +94,6 @@ func setupTest(b *testing.B, pool *pgtest.TestPostgres, datastore DataStore, num
 
 func BenchmarkComplianceCheckResultStats(b *testing.B) {
 	pool := pgtest.ForT(b)
-	b.Cleanup(func() {
-		pool.Teardown(b)
-	})
 	datastore := GetTestPostgresDataStore(b, pool)
 
 	setupTest(b, pool, datastore, 5, 10, 500)

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl_test.go
@@ -484,10 +484,6 @@ func (s *complianceCheckResultDataStoreTestSuite) SetupTest() {
 	s.dataStore = New(s.storage, s.db, s.searcher)
 }
 
-func (s *complianceCheckResultDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceCheckResultDataStoreTestSuite) TestUpsertResult() {
 	// make sure we have nothing
 	checkResultIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorCheckResultV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorCheckResultV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorCheckResultV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/integration/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/integration/datastore/datastore_impl_test.go
@@ -66,10 +66,6 @@ func (s *complianceIntegrationDataStoreTestSuite) SetupTest() {
 	s.dataStore = New(s.storage, s.db.DB)
 }
 
-func (s *complianceIntegrationDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceIntegrationDataStoreTestSuite) TestAddComplianceIntegration() {
 	testIntegrations := getDefaultTestIntegrations()
 	// This will add entries by calling AddComplianceIntegration

--- a/central/complianceoperator/v2/integration/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *ComplianceIntegrationsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceIntegrationsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceIntegrationsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/profiles/datastore/datastore_impl_test.go
@@ -81,10 +81,6 @@ func (s *complianceProfileDataStoreTestSuite) SetupTest() {
 	s.dataStore = GetTestPostgresDataStore(s.T(), s.db, searcher)
 }
 
-func (s *complianceProfileDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceProfileDataStoreTestSuite) TestUpsertProfile() {
 	// make sure we have nothing
 	profileIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorProfileV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorProfileV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorProfileV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/remediations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/remediations/datastore/datastore_impl_test.go
@@ -62,10 +62,6 @@ func (s *complianceRemediationDataStoreTestSuite) SetupTest() {
 	s.dataStore = GetTestPostgresDataStore(s.T(), s.db)
 }
 
-func (s *complianceRemediationDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceRemediationDataStoreTestSuite) TestSearchRemediation() {
 	remediationFixture := &storage.ComplianceOperatorRemediationV2{
 		Id:                        uuid.NewV4().String(),

--- a/central/complianceoperator/v2/remediations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorRemediationV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorRemediationV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorRemediationV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/report/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/report/datastore/datastore_impl_test.go
@@ -75,10 +75,6 @@ func (s *complianceReportSnapshotDataStoreSuite) SetupTest() {
 	require.NoError(s.T(), s.scanConfigDB.UpsertScanConfiguration(s.hasWriteCtx, &storage.ComplianceOperatorScanConfigurationV2{Id: uuidScanConfigStub2, ScanConfigName: uuidScanConfigStub2}))
 }
 
-func (s *complianceReportSnapshotDataStoreSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceReportSnapshotDataStoreSuite) TestUpsertReport() {
 	// make sure we have nothing
 	reportIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/report/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/report/store/postgres/store_test.go
@@ -46,10 +46,6 @@ func (s *ComplianceOperatorReportSnapshotV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorReportSnapshotV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorReportSnapshotV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/rules/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/rules/datastore/datastore_impl_test.go
@@ -68,10 +68,6 @@ func (s *complianceRuleDataStoreTestSuite) SetupTest() {
 	s.dataStore = GetTestPostgresDataStore(s.T(), s.db)
 }
 
-func (s *complianceRuleDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceRuleDataStoreTestSuite) TestGetControl() {
 	ctx := sac.WithAllAccess(context.Background())
 	exampleRule2 := &storage.ComplianceOperatorRuleV2{

--- a/central/complianceoperator/v2/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorRuleV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorRuleV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorRuleV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -142,10 +142,6 @@ func (s *complianceScanConfigDataStoreTestSuite) SetupTest() {
 	s.testContexts[noAccessCtx] = sac.WithGlobalAccessScopeChecker(context.Background(), sac.DenyAllAccessScopeChecker())
 }
 
-func (s *complianceScanConfigDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceScanConfigDataStoreTestSuite) TestGetScanConfiguration() {
 	configID := uuid.NewV4().String()
 

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store_test.go
@@ -48,10 +48,6 @@ func (s *ComplianceOperatorScanConfigurationV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorScanConfigurationV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorScanConfigurationV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scans/datastore/datastore_impl_test.go
@@ -71,10 +71,6 @@ func (s *complianceScanDataStoreTestSuite) SetupTest() {
 	s.dataStore = GetTestPostgresDataStore(s.T(), s.db)
 }
 
-func (s *complianceScanDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceScanDataStoreTestSuite) TestGetScan() {
 	// make sure we have nothing
 	ScanIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorScanV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorScanV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorScanV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
@@ -68,10 +68,6 @@ func (s *complianceSuiteDataStoreTestSuite) SetupTest() {
 	s.dataStore = GetTestPostgresDataStore(s.T(), s.db)
 }
 
-func (s *complianceSuiteDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *complianceSuiteDataStoreTestSuite) TestGetSuite() {
 	// make sure we have nothing
 	suiteIDs, err := s.storage.GetIDs(s.hasReadCtx)

--- a/central/complianceoperator/v2/suites/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store_test.go
@@ -51,10 +51,6 @@ func (s *ComplianceOperatorSuiteV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ComplianceOperatorSuiteV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ComplianceOperatorSuiteV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/componentcveedge/datastore/datastore_sac_test.go
+++ b/central/componentcveedge/datastore/datastore_sac_test.go
@@ -49,10 +49,6 @@ func (s *imageComponentCVEEdgeDatastoreSACTestSuite) SetupSuite() {
 	s.testContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Image)
 }
 
-func (s *imageComponentCVEEdgeDatastoreSACTestSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func (s *imageComponentCVEEdgeDatastoreSACTestSuite) cleanImageToVulnerabilitiesGraph() {
 	s.Require().NoError(s.testGraphDatastore.CleanImageToVulnerabilitiesGraph())
 }

--- a/central/componentcveedge/datastore/store/postgres/store_test.go
+++ b/central/componentcveedge/datastore/store/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *ImageComponentCveEdgesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageComponentCveEdgesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageComponentCveEdgesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/config/service/service_test.go
+++ b/central/config/service/service_test.go
@@ -80,10 +80,6 @@ func (s *configServiceTestSuite) SetupSuite() {
 	protoassert.Equal(s.T(), &v1.GetVulnerabilityExceptionConfigResponse{}, cfg)
 }
 
-func (s *configServiceTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *configServiceTestSuite) TestExceptionConfigOps() {
 	initialCfg := &storage.Config{
 		PrivateConfig: &storage.PrivateConfig{

--- a/central/config/store/postgres/store_test.go
+++ b/central/config/store/postgres/store_test.go
@@ -31,9 +31,6 @@ func (s *ConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *ConfigsStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
 
 func (s *ConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/config/store/postgres/store_test.go
+++ b/central/config/store/postgres/store_test.go
@@ -31,7 +31,6 @@ func (s *ConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-
 func (s *ConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/cve/cluster/datastore/store/postgres/store_test.go
+++ b/central/cve/cluster/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ClusterCvesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ClusterCvesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ClusterCvesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/cve/cluster/datastoretest/datastore_sac_test.go
+++ b/central/cve/cluster/datastoretest/datastore_sac_test.go
@@ -43,10 +43,6 @@ func (s *clusterCVEDatastoreSACSuite) SetupSuite() {
 	s.Require().NoError(err)
 }
 
-func (s *clusterCVEDatastoreSACSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func (s *clusterCVEDatastoreSACSuite) cleanImageToVulnerabilitiesGraph() {
 	s.Require().NoError(s.testGraphDatastore.CleanClusterToVulnerabilitiesGraph())
 }

--- a/central/cve/datastoretest/datastore_sac_test.go
+++ b/central/cve/datastoretest/datastore_sac_test.go
@@ -51,10 +51,6 @@ func (s *cveDataStoreSACTestSuite) SetupSuite() {
 	s.nodeTestContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Node)
 }
 
-func (s *cveDataStoreSACTestSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 // Vulnerability identifiers have been modified in the migration to Postgres to hold
 // operating system information as well. This information is propagated from the image
 // scan data.

--- a/central/cve/fetcher/manager_impl_postgres_test.go
+++ b/central/cve/fetcher/manager_impl_postgres_test.go
@@ -468,10 +468,6 @@ func (s *TestClusterCVEOpsInPostgresTestSuite) SetupSuite() {
 	}
 }
 
-func (s *TestClusterCVEOpsInPostgresTestSuite) TearDownSuite() {
-	s.testPostgres.Teardown(s.T())
-}
-
 func (s *TestClusterCVEOpsInPostgresTestSuite) TestBasicOps() {
 	// Upsert cluster.
 	c1ID, err := s.clusterDataStore.AddCluster(s.ctx, &storage.Cluster{

--- a/central/cve/image/datastore/store/postgres/store_test.go
+++ b/central/cve/image/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ImageCvesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageCvesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageCvesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/cve/image/v2/datastore/store/postgres/store_test.go
+++ b/central/cve/image/v2/datastore/store/postgres/store_test.go
@@ -46,10 +46,6 @@ func (s *ImageCvesV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageCvesV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageCvesV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/cve/node/datastore/store/postgres/store_test.go
+++ b/central/cve/node/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *NodeCvesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NodeCvesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NodeCvesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/declarativeconfig/health/datastore/store/postgres/store_test.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *DeclarativeConfigHealthsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *DeclarativeConfigHealthsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *DeclarativeConfigHealthsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/declarativeconfig/updater/access_scope_updater_test.go
+++ b/central/declarativeconfig/updater/access_scope_updater_test.go
@@ -49,11 +49,6 @@ func (s *updaterTestSuite) SetupTest() {
 		declarativeConfigHealth.GetTestPostgresDataStore(s.T(), s.pgTest.DB)).(*accessScopeUpdater)
 }
 
-func (s *updaterTestSuite) TearDownTest() {
-	s.pgTest.Teardown(s.T())
-	s.pgTest.Close()
-}
-
 func (s *updaterTestSuite) TestUpsert() {
 	cases := map[string]struct {
 		m   protocompat.Message

--- a/central/declarativeconfig/updater/permission_set_updater_test.go
+++ b/central/declarativeconfig/updater/permission_set_updater_test.go
@@ -46,11 +46,6 @@ func (s *permissionSetUpdaterTestSuite) SetupTest() {
 		s.pgTest.DB)).(*permissionSetUpdater)
 }
 
-func (s *permissionSetUpdaterTestSuite) TearDownTest() {
-	s.pgTest.Teardown(s.T())
-	s.pgTest.Close()
-}
-
 func (s *permissionSetUpdaterTestSuite) TestUpsert() {
 	cases := map[string]struct {
 		m   protocompat.Message

--- a/central/declarativeconfig/updater/role_updater_test.go
+++ b/central/declarativeconfig/updater/role_updater_test.go
@@ -54,11 +54,6 @@ func (s *roleUpdaterTestSuite) SetupTest() {
 		rds, declarativeConfigHealth.GetTestPostgresDataStore(s.T(), s.pgTest.DB)).(*roleUpdater)
 }
 
-func (s *roleUpdaterTestSuite) TearDownTest() {
-	s.pgTest.Teardown(s.T())
-	s.pgTest.Close()
-}
-
 func (s *roleUpdaterTestSuite) TestUpsert() {
 	cases := map[string]struct {
 		prepData func()

--- a/central/delegatedregistryconfig/store/postgres/store_test.go
+++ b/central/delegatedregistryconfig/store/postgres/store_test.go
@@ -31,7 +31,6 @@ func (s *DelegatedRegistryConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-
 func (s *DelegatedRegistryConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/delegatedregistryconfig/store/postgres/store_test.go
+++ b/central/delegatedregistryconfig/store/postgres/store_test.go
@@ -31,9 +31,6 @@ func (s *DelegatedRegistryConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *DelegatedRegistryConfigsStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
 
 func (s *DelegatedRegistryConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/deployment/datastore/datastore_impl_postgres_test.go
+++ b/central/deployment/datastore/datastore_impl_postgres_test.go
@@ -53,10 +53,6 @@ func (s *DeploymentPostgresDataStoreTestSuite) SetupSuite() {
 	s.deploymentDatastore = deploymentDS
 }
 
-func (s *DeploymentPostgresDataStoreTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 	ctx := sac.WithAllAccess(context.Background())
 	img1 := fixtures.GetImageWithUniqueComponents(5)

--- a/central/deployment/datastore/internal/store/postgres/store_test.go
+++ b/central/deployment/datastore/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *DeploymentsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *DeploymentsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *DeploymentsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/deployment/datastore/search_comparison_test.go
+++ b/central/deployment/datastore/search_comparison_test.go
@@ -50,10 +50,6 @@ func (s *SearchComparisonTestSuite) SetupSuite() {
 	s.optionsMap = pkgSchema.ImagesSchema.OptionsMap
 }
 
-func (s *SearchComparisonTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func compareResults(t *testing.T, matches bool, predResult *search.Result, searchResults []search.Result) {
 	assert.Equal(t, matches, len(searchResults) != 0)
 	imageKeyMap := map[string]string{"image.scan.components.vulns.cve": "imagecve.cve_base_info.cve", "image.scan.components.vulns.cvss": "imagecve.cvss"}

--- a/central/deployment/service/service_impl_benchmark_test.go
+++ b/central/deployment/service/service_impl_benchmark_test.go
@@ -21,7 +21,6 @@ func BenchmarkService_Export(b *testing.B) {
 	if err != nil {
 		b.Error(err)
 	}
-	defer testHelper.TearDownTest(b)
 	svc := New(testHelper.Deployments, nil, nil, nil, nil, nil)
 	benchmarkFunc := getExportServiceBenchmark(testHelper, svc)
 	testHelper.InjectDataAndRunBenchmark(b, false, benchmarkFunc)

--- a/central/discoveredclusters/datastore/datastore_impl_postgres_test.go
+++ b/central/discoveredclusters/datastore/datastore_impl_postgres_test.go
@@ -50,11 +50,6 @@ func (s *datastorePostgresTestSuite) SetupTest() {
 	s.datastore = GetTestPostgresDataStore(s.T(), s.postgresTest.DB)
 }
 
-func (s *datastorePostgresTestSuite) TearDownTest() {
-	s.postgresTest.Teardown(s.T())
-	s.postgresTest.Close()
-}
-
 func (s *datastorePostgresTestSuite) TestCountDiscoveredClusters() {
 	count, err := s.datastore.CountDiscoveredClusters(s.readCtx, &v1.Query{})
 	s.Require().NoError(err)

--- a/central/discoveredclusters/datastore/internal/store/postgres/store_test.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *DiscoveredClustersStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *DiscoveredClustersStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *DiscoveredClustersStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/discoveredclusters/service/service_impl_postgres_test.go
+++ b/central/discoveredclusters/service/service_impl_postgres_test.go
@@ -52,11 +52,6 @@ func (s *servicePostgresTestSuite) SetupTest() {
 	s.service = newService(s.datastore)
 }
 
-func (s *servicePostgresTestSuite) TearDownTest() {
-	s.pool.Teardown(s.T())
-	s.pool.Close()
-}
-
 func (s *servicePostgresTestSuite) TestCount() {
 	s.addDiscoveredClusters(50)
 

--- a/central/externalbackups/internal/store/postgres/store_test.go
+++ b/central/externalbackups/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ExternalBackupsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ExternalBackupsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ExternalBackupsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/graphdb/testutils/datastore.go
+++ b/central/graphdb/testutils/datastore.go
@@ -37,8 +37,6 @@ type TestGraphDataStore interface {
 	CleanClusterToVulnerabilitiesGraph() error
 	CleanImageToVulnerabilitiesGraph() error
 	CleanNodeToVulnerabilitiesGraph() error
-	// Post test cleanup (TearDown)
-	Cleanup(t *testing.T)
 }
 
 type testGraphDataStoreImpl struct {
@@ -296,10 +294,6 @@ func (s *testGraphDataStoreImpl) CleanNodeToVulnerabilitiesGraph() (err error) {
 	}
 	s.storedNodes = s.storedNodes[:0]
 	return nil
-}
-
-func (s *testGraphDataStoreImpl) Cleanup(t *testing.T) {
-	s.pgtestbase.Teardown(t)
 }
 
 // NewTestGraphDataStore provides a utility for storage testing, which contains a set of connected

--- a/central/graphql/handler/handler_benchmark_test.go
+++ b/central/graphql/handler/handler_benchmark_test.go
@@ -88,7 +88,6 @@ func BenchmarkDeploymentExport(b *testing.B) {
 	testHelper := &testutils.ExportServicePostgresTestHelper{}
 	err := testHelper.SetupTest(b)
 	require.NoError(b, err)
-	b.Cleanup(func() { testHelper.TearDownTest(b) })
 
 	testHelper.InjectDataAndRunBenchmark(b, false, getDeploymentBenchmark(testHelper))
 }
@@ -101,7 +100,6 @@ func BenchmarkImageExport(b *testing.B) {
 	testHelper := &testutils.ExportServicePostgresTestHelper{}
 	err := testHelper.SetupTest(b)
 	require.NoError(b, err)
-	b.Cleanup(func() { testHelper.TearDownTest(b) })
 
 	testHelper.InjectDataAndRunBenchmark(b, true, getImageBenchmark(testHelper))
 }
@@ -114,7 +112,6 @@ func BenchmarkDeploymentWithImageExport(b *testing.B) {
 	testHelper := &testutils.ExportServicePostgresTestHelper{}
 	err := testHelper.SetupTest(b)
 	require.NoError(b, err)
-	b.Cleanup(func() { testHelper.TearDownTest(b) })
 
 	testHelper.InjectDataAndRunBenchmark(b, true, getDeploymentWithImageBenchmark(testHelper))
 }

--- a/central/graphql/resolvers/cluster_vulnerabilities_postgres_test.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities_postgres_test.go
@@ -68,10 +68,6 @@ func (s *GraphQLClusterVulnerabilityTestSuite) SetupSuite() {
 	s.NoError(err)
 }
 
-func (s *GraphQLClusterVulnerabilityTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *GraphQLClusterVulnerabilityTestSuite) TestUnauthorizedClusterVulnerabilityEndpoint() {
 	_, err := s.resolver.ClusterVulnerability(s.ctx, IDQuery{})
 	s.Error(err, "Unauthorized request got through")

--- a/central/graphql/resolvers/clusters_postgres_test.go
+++ b/central/graphql/resolvers/clusters_postgres_test.go
@@ -61,10 +61,6 @@ func (s *graphQLClusterTestSuite) addClusterScopeObject(cluster *storage.Cluster
 	s.scopeObjects = append(s.scopeObjects, scopeObject)
 }
 
-func (s *graphQLClusterTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *graphQLClusterTestSuite) TestClustersForPermission() {
 	testCases := map[string]struct {
 		ctx            context.Context

--- a/central/graphql/resolvers/deployments_test.go
+++ b/central/graphql/resolvers/deployments_test.go
@@ -61,10 +61,6 @@ func (s *DeploymentResolversTestSuite) SetupSuite() {
 	}
 }
 
-func (s *DeploymentResolversTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *DeploymentResolversTestSuite) TestDeployments() {
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 

--- a/central/graphql/resolvers/image_components_postgres_test.go
+++ b/central/graphql/resolvers/image_components_postgres_test.go
@@ -78,10 +78,6 @@ func (s *GraphQLImageComponentTestSuite) SetupSuite() {
 	}
 }
 
-func (s *GraphQLImageComponentTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *GraphQLImageComponentTestSuite) TestUnauthorizedImageComponentEndpoint() {
 	_, err := s.resolver.ImageComponent(s.ctx, IDQuery{})
 	assert.Error(s.T(), err, "Unauthorized request got through")

--- a/central/graphql/resolvers/image_components_v2_postgres_test.go
+++ b/central/graphql/resolvers/image_components_v2_postgres_test.go
@@ -99,7 +99,7 @@ func (s *GraphQLImageComponentV2TestSuite) SetupSuite() {
 }
 
 func (s *GraphQLImageComponentV2TestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
+
 	s.T().Setenv("ROX_FLATTEN_CVE_DATA", "false")
 }
 

--- a/central/graphql/resolvers/image_scan_benchmark_test.go
+++ b/central/graphql/resolvers/image_scan_benchmark_test.go
@@ -74,7 +74,6 @@ func BenchmarkImageResolver(b *testing.B) {
 
 	mockCtrl := gomock.NewController(b)
 	testDB := SetupTestPostgresConn(b)
-	defer testDB.Teardown(b)
 
 	resolver, schema := SetupTestResolver(b,
 		imagesView.NewImageView(testDB.DB),

--- a/central/graphql/resolvers/image_vulnerabilities_test.go
+++ b/central/graphql/resolvers/image_vulnerabilities_test.go
@@ -97,10 +97,6 @@ func (s *GraphQLImageVulnerabilityTestSuite) SetupSuite() {
 	}
 }
 
-func (s *GraphQLImageVulnerabilityTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *GraphQLImageVulnerabilityTestSuite) TestUnauthorizedImageVulnerabilityEndpoint() {
 	_, err := s.resolver.ImageVulnerability(s.ctx, IDQuery{})
 	s.Error(err, "Unauthorized request got through")

--- a/central/graphql/resolvers/image_vulnerabilities_v2_test.go
+++ b/central/graphql/resolvers/image_vulnerabilities_v2_test.go
@@ -126,10 +126,6 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) SetupSuite() {
 	}
 }
 
-func (s *GraphQLImageVulnerabilityV2TestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *GraphQLImageVulnerabilityV2TestSuite) TestUnauthorizedImageVulnerabilityEndpoint() {
 	_, err := s.resolver.ImageVulnerability(s.ctx, IDQuery{})
 	s.Error(err, "Unauthorized request got through")

--- a/central/graphql/resolvers/images_test.go
+++ b/central/graphql/resolvers/images_test.go
@@ -65,10 +65,6 @@ func (s *ImageResolversTestSuite) SetupSuite() {
 	}
 }
 
-func (s *ImageResolversTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func sacAllowOnlyCluster2Namespace2(ctx context.Context) context.Context {
 	return sac.WithGlobalAccessScopeChecker(
 		ctx,

--- a/central/graphql/resolvers/node_components_postgres_test.go
+++ b/central/graphql/resolvers/node_components_postgres_test.go
@@ -60,10 +60,6 @@ func (s *GraphQLNodeComponentTestSuite) SetupSuite() {
 	}
 }
 
-func (s *GraphQLNodeComponentTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 // permission checks
 
 func (s *GraphQLNodeComponentTestSuite) TestUnauthorizedNodeComponentEndpoint() {

--- a/central/graphql/resolvers/node_scan_benchmark_test.go
+++ b/central/graphql/resolvers/node_scan_benchmark_test.go
@@ -57,7 +57,6 @@ func BenchmarkNodeResolver(b *testing.B) {
 
 	mockCtrl := gomock.NewController(b)
 	testDB := SetupTestPostgresConn(b)
-	defer testDB.Teardown(b)
 
 	nodeDS := CreateTestNodeDatastore(b, testDB, mockCtrl)
 	_, schema := SetupTestResolver(b,

--- a/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
+++ b/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
@@ -103,10 +103,6 @@ func (s *GraphQLNodeVulnerabilityTestSuite) SetupSuite() {
 	}
 }
 
-func (s *GraphQLNodeVulnerabilityTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 // permission checks
 
 func (s *GraphQLNodeVulnerabilityTestSuite) TestUnauthorizedNodeVulnerabilityEndpoint() {

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -358,7 +358,6 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 	testDB := pgtest.ForT(t)
 	testGormDB := testDB.GetGormDB(t)
 	defer pgtest.CloseGormDB(t, testGormDB)
-	defer testDB.Teardown(t)
 
 	roleBindingDatastore := k8sRoleBindingDataStore.GetTestPostgresDataStore(t, testDB.DB)
 
@@ -439,7 +438,6 @@ func TestImageLabelAutoCompleteSearch(t *testing.T) {
 	testDB := pgtest.ForT(t)
 	testGormDB := testDB.GetGormDB(t)
 	defer pgtest.CloseGormDB(t, testGormDB)
-	defer testDB.Teardown(t)
 
 	imageDatastore := imageDS.GetTestPostgresDataStore(t, testDB.DB)
 	ctx := loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))

--- a/central/graphql/resolvers/vulnerability_requests_test.go
+++ b/central/graphql/resolvers/vulnerability_requests_test.go
@@ -147,7 +147,7 @@ type VulnRequestResolverTestSuite struct {
 
 func (s *VulnRequestResolverTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
-	s.testDB.Teardown(s.T())
+
 }
 
 func (s *VulnRequestResolverTestSuite) SetupTest() {

--- a/central/group/datastore/datastore_impl_postgres_test.go
+++ b/central/group/datastore/datastore_impl_postgres_test.go
@@ -53,10 +53,6 @@ func (s *groupsWithPostgresTestSuite) SetupSuite() {
 	s.groupsDatastore = New(store, s.roleStore, s.authProviderStore)
 }
 
-func (s *groupsWithPostgresTestSuite) TearDownSuite() {
-	s.testPostgres.Teardown(s.T())
-}
-
 func (s *groupsWithPostgresTestSuite) TearDownTest() {
 	sql := fmt.Sprintf("TRUNCATE %s CASCADE", postgresSchema.GroupsTableName)
 	_, err := s.testPostgres.Exec(s.ctx, sql)

--- a/central/group/datastore/internal/store/postgres/store_test.go
+++ b/central/group/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *GroupsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *GroupsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *GroupsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/hash/datastore/store/postgres/store_test.go
+++ b/central/hash/datastore/store/postgres/store_test.go
@@ -48,10 +48,6 @@ func (s *HashesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *HashesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *HashesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/image/datastore/fixable_test.go
+++ b/central/image/datastore/fixable_test.go
@@ -47,10 +47,6 @@ func (s *FixableSearchTestSuite) SetupSuite() {
 	}
 }
 
-func (s *FixableSearchTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *FixableSearchTestSuite) TestImageSearch() {
 	for _, tc := range []struct {
 		desc                       string

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -64,7 +64,7 @@ func (s *ImagesStoreSuite) SetupTest() {
 }
 
 func (s *ImagesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
+
 	s.T().Setenv("ROX_FLATTEN_CVE_DATA", "false")
 }
 

--- a/central/image/service/service_impl_benchmark_test.go
+++ b/central/image/service/service_impl_benchmark_test.go
@@ -21,7 +21,7 @@ func BenchmarkService_Export(b *testing.B) {
 	if err != nil {
 		b.Error(err)
 	}
-	defer testHelper.TearDownTest(b)
+
 	svc := New(testHelper.Images, nil, nil, nil, nil, nil, nil, nil)
 	benchmarkFunc := getExportServiceBenchmark(testHelper, svc)
 	testHelper.InjectDataAndRunBenchmark(b, true, benchmarkFunc)

--- a/central/imagecomponent/datastore/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ImageComponentsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageComponentsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageComponentsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/imagecomponent/datastoretest/datastore_sac_test.go
+++ b/central/imagecomponent/datastoretest/datastore_sac_test.go
@@ -50,10 +50,6 @@ func (s *cveDataStoreSACTestSuite) SetupSuite() {
 	s.nodeTestContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Node)
 }
 
-func (s *cveDataStoreSACTestSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func getImageComponentID(component *storage.EmbeddedImageScanComponent, os string) string {
 	return scancomponent.ComponentID(component.GetName(), component.GetVersion(), os)
 }

--- a/central/imagecomponent/v2/datastore/store/postgres/store_test.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store_test.go
@@ -46,10 +46,6 @@ func (s *ImageComponentV2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageComponentV2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageComponentV2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/imagecomponentedge/datastore/datastore_sac_test.go
+++ b/central/imagecomponentedge/datastore/datastore_sac_test.go
@@ -47,10 +47,6 @@ func (s *imageComponentEdgeDatastoreSACTestSuite) SetupSuite() {
 	s.testContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Image)
 }
 
-func (s *imageComponentEdgeDatastoreSACTestSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func (s *imageComponentEdgeDatastoreSACTestSuite) cleanImageToVulnerabilityGraph() {
 	s.Require().NoError(s.testGraphDatastore.CleanImageToVulnerabilitiesGraph())
 }

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *ImageComponentEdgesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageComponentEdgesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageComponentEdgesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/imagecveedge/datastore/datastore_sac_test.go
+++ b/central/imagecveedge/datastore/datastore_sac_test.go
@@ -51,10 +51,6 @@ func (s *imageCVEEdgeDatastoreSACTestSuite) SetupSuite() {
 	s.testContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Image)
 }
 
-func (s *imageCVEEdgeDatastoreSACTestSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func (s *imageCVEEdgeDatastoreSACTestSuite) SetupTest() {
 	s.Require().NoError(s.testGraphDatastore.PushImageToVulnerabilitiesGraph())
 }

--- a/central/imagecveedge/datastore/postgres/store_test.go
+++ b/central/imagecveedge/datastore/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *ImageCveEdgesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageCveEdgesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageCveEdgesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/imageintegration/datastore/datastore_impl_test.go
+++ b/central/imageintegration/datastore/datastore_impl_test.go
@@ -70,10 +70,6 @@ func (suite *ImageIntegrationDataStoreTestSuite) SetupTest() {
 	suite.datastore = NewForTestOnly(suite.store, suite.mockSearcher)
 }
 
-func (suite *ImageIntegrationDataStoreTestSuite) TearDownTest() {
-	suite.testDB.Teardown(suite.T())
-}
-
 func (suite *ImageIntegrationDataStoreTestSuite) TestIntegrationsPersistence() {
 	testIntegrations(suite.T(), suite.store, suite.datastore)
 }

--- a/central/imageintegration/store/postgres/store_test.go
+++ b/central/imageintegration/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ImageIntegrationsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ImageIntegrationsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageIntegrationsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/installation/store/postgres/store_test.go
+++ b/central/installation/store/postgres/store_test.go
@@ -31,7 +31,6 @@ func (s *InstallationInfosStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-
 func (s *InstallationInfosStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/installation/store/postgres/store_test.go
+++ b/central/installation/store/postgres/store_test.go
@@ -31,9 +31,6 @@ func (s *InstallationInfosStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *InstallationInfosStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
 
 func (s *InstallationInfosStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *IntegrationHealthsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *IntegrationHealthsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *IntegrationHealthsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/logimbue/store/postgres/store_test.go
+++ b/central/logimbue/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *LogImbuesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *LogImbuesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *LogImbuesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -178,7 +178,6 @@ func (s *serviceImplTestSuite) TestDatabaseStatus() {
 
 func (s *serviceImplTestSuite) TestDatabaseBackupStatus() {
 	tp := pgtest.ForT(s.T())
-	defer tp.Teardown(s.T())
 
 	srv := &serviceImpl{
 		db:              tp.DB,

--- a/central/namespace/datastore/internal/store/postgres/store_test.go
+++ b/central/namespace/datastore/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *NamespacesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NamespacesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NamespacesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *NetworkBaselinesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NetworkBaselinesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NetworkBaselinesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *NetworkGraphConfigsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NetworkGraphConfigsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NetworkGraphConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/networkgraph/entity/datastore/datastore_bench_test.go
+++ b/central/networkgraph/entity/datastore/datastore_bench_test.go
@@ -34,7 +34,6 @@ func BenchmarkNetEntityCreates(b *testing.B) {
 	b.Run("createNetworkEntities", func(b *testing.B) {
 		// Need to recreate the DB to avoid failure due to key conflicts from the reruns.
 		db := pgtest.ForT(b)
-		defer db.Teardown(b)
 
 		store := postgres.New(db.DB)
 
@@ -65,7 +64,6 @@ func BenchmarkNetEntityCreateBatch(b *testing.B) {
 	b.Run("createNetworkEntitiesBatch", func(b *testing.B) {
 		// Need to recreate the DB to avoid failure due to key conflicts from the reruns.
 		db := pgtest.ForT(b)
-		defer db.Teardown(b)
 
 		store := postgres.New(db.DB)
 
@@ -88,7 +86,6 @@ func BenchmarkNetEntityUpdates(b *testing.B) {
 
 	// Need to recreate the DB to avoid failure due to key conflicts from the reruns.
 	db := pgtest.ForT(b)
-	defer db.Teardown(b)
 
 	store := postgres.New(db.DB)
 	ds := NewEntityDataStore(store, mocks.NewMockDataStore(mockCtrl), networktree.Singleton(), connection.ManagerSingleton())

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -92,7 +92,6 @@ func (suite *NetworkEntityDataStoreTestSuite) SetupSuite() {
 
 func (suite *NetworkEntityDataStoreTestSuite) TearDownSuite() {
 	suite.mockCtrl.Finish()
-	suite.db.Teardown(suite.T())
 }
 
 func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *NetworkEntitiesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NetworkEntitiesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NetworkEntitiesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -92,10 +92,6 @@ func (s *networkGraphServiceSuite) SetupTest() {
 	s.db = db
 }
 
-func (s *networkGraphServiceSuite) TeardownTest() {
-	s.db.Teardown(s.T())
-}
-
 func externalFlow(deployment *storage.Deployment, entity *storage.NetworkEntity, ingress bool) *storage.NetworkFlow {
 	deploymentEntityInfo := &storage.NetworkEntityInfo{
 		Type: storage.NetworkEntityInfo_DEPLOYMENT,

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *NetworkpoliciesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NetworkpoliciesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NetworkpoliciesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NetworkpoliciesundodeploymentsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NetworkpoliciesundodeploymentsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NetworkpolicyapplicationundorecordsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NetworkpolicyapplicationundorecordsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/node/datastore/datastore_bench_test.go
+++ b/central/node/datastore/datastore_bench_test.go
@@ -24,7 +24,6 @@ func BenchmarkNodes(b *testing.B) {
 
 	testDB := pgtest.ForT(b)
 	nodeDS := GetTestPostgresDataStore(b, testDB.DB)
-	defer testDB.Teardown(b)
 
 	fakeNode := fixtures.GetNodeWithUniqueComponents(100, 100)
 	nodes := make([]*storage.Node, 100)

--- a/central/nodecomponent/datastore/store/postgres/store_test.go
+++ b/central/nodecomponent/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *NodeComponentsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NodeComponentsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NodeComponentsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/nodecomponentcveedge/datastore/datastore_sac_test.go
+++ b/central/nodecomponentcveedge/datastore/datastore_sac_test.go
@@ -52,10 +52,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 }
 
-func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func getComponentID(component *storage.EmbeddedNodeScanComponent, os string) string {
 	return scancomponent.ComponentID(component.GetName(), component.GetVersion(), os)
 }

--- a/central/nodecomponentcveedge/datastore/store/postgres/store_test.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *NodeComponentsCvesEdgesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NodeComponentsCvesEdgesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NodeComponentsCvesEdgesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/nodecomponentedge/datastore/datastore_sac_test.go
+++ b/central/nodecomponentedge/datastore/datastore_sac_test.go
@@ -51,10 +51,6 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 }
 
-func (s *nodeComponentEdgeDatastoreSACTestSuite) TearDownSuite() {
-	s.testGraphDatastore.Cleanup(s.T())
-}
-
 func getComponentID(component *storage.EmbeddedNodeScanComponent, os string) string {
 	return scancomponent.ComponentID(component.GetName(), component.GetVersion(), os)
 }

--- a/central/nodecomponentedge/store/postgres/store_test.go
+++ b/central/nodecomponentedge/store/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *NodeComponentEdgesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NodeComponentEdgesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NodeComponentEdgesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/notifier/datastore/internal/store/postgres/store_test.go
+++ b/central/notifier/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *NotifiersStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *NotifiersStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NotifiersStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/notifier/encconfig/datastore/store/postgres/store_test.go
+++ b/central/notifier/encconfig/datastore/store/postgres/store_test.go
@@ -31,9 +31,6 @@ func (s *NotifierEncConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *NotifierEncConfigsStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
 
 func (s *NotifierEncConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/notifier/encconfig/datastore/store/postgres/store_test.go
+++ b/central/notifier/encconfig/datastore/store/postgres/store_test.go
@@ -31,7 +31,6 @@ func (s *NotifierEncConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-
 func (s *NotifierEncConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/pod/datastore/datastore_impl_real_test.go
+++ b/central/pod/datastore/datastore_impl_real_test.go
@@ -74,10 +74,6 @@ func (s *PodDatastoreSuite) SetupTest() {
 	s.datastore = newDatastoreImpl(podStorage, podSearcher, s.indicatorDataStore, s.plopDS, s.filter)
 }
 
-func (s *PodDatastoreSuite) TearDownTest() {
-	s.postgres.Teardown(s.T())
-}
-
 func (s *PodDatastoreSuite) getProcessIndicatorsFromDB() []*storage.ProcessIndicator {
 	indicatorsFromDB := []*storage.ProcessIndicator{}
 	err := s.indicatorDataStore.WalkAll(s.plopAndPiCtx,

--- a/central/pod/datastore/internal/store/postgres/store_test.go
+++ b/central/pod/datastore/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *PodsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *PodsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *PodsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/pod/service/service_impl_test.go
+++ b/central/pod/service/service_impl_test.go
@@ -79,7 +79,6 @@ func TestGetPods(t *testing.T) {
 			pgtestbase := pgtest.ForT(t)
 			require.NotNil(t, pgtestbase)
 			pool := pgtestbase.DB
-			defer pgtestbase.Teardown(t)
 
 			podsDS := datastore.NewPostgresDB(pool, mockIndicators, mockPlops, mockFilter)
 

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *PoliciesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *PoliciesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *PoliciesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/policycategory/store/postgres/store_test.go
+++ b/central/policycategory/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *PolicyCategoriesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *PolicyCategoriesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *PolicyCategoriesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/policycategoryedge/store/postgres/store_test.go
+++ b/central/policycategoryedge/store/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *PolicyCategoryEdgesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *PolicyCategoryEdgesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *PolicyCategoryEdgesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/postgres/compliance_report_pruning_test.go
+++ b/central/postgres/compliance_report_pruning_test.go
@@ -74,7 +74,6 @@ func TestComplianceReportPruning(t *testing.T) {
 
 var _ suite.SetupAllSuite = (*ComplianceReportPruningSuite)(nil)
 var _ suite.TearDownTestSuite = (*ComplianceReportPruningSuite)(nil)
-var _ suite.TearDownAllSuite = (*ComplianceReportPruningSuite)(nil)
 
 func (s *ComplianceReportPruningSuite) SetupSuite() {
 	s.db = pgtest.ForT(s.T())
@@ -97,10 +96,6 @@ func (s *ComplianceReportPruningSuite) TearDownTest() {
 	tag, err = s.db.Exec(s.ctx, fmt.Sprintf("TRUNCATE %s CASCADE", schema.BlobsTableName))
 	s.T().Logf("%s %v", schema.BlobsTableName, tag)
 	s.Require().NoError(err)
-}
-
-func (s *ComplianceReportPruningSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
 }
 
 func (s *ComplianceReportPruningSuite) Test_MustNotDeleteLastSuccessfulJobOneDownload() {

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -50,10 +50,6 @@ func (s *PostgresPruningSuite) SetupTest() {
 	s.ctx = sac.WithAllAccess(context.Background())
 }
 
-func (s *PostgresPruningSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *PostgresPruningSuite) TestPruneActiveComponents() {
 	depStore, _ := deploymentStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 	acDS := activeComponent.NewForTestOnly(s.T(), s.testDB.DB)
@@ -388,7 +384,7 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 	}
 	for _, c := range cases {
 		s.T().Run(c.name, func(t *testing.T) {
-			s.testDB.Teardown(s.T())
+
 			s.testDB = pgtest.ForT(s.T())
 			// Add deployments if necessary
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)

--- a/central/postgres/report_pruning_test.go
+++ b/central/postgres/report_pruning_test.go
@@ -71,10 +71,6 @@ func (s *ReportHistoryPruningSuite) TearDownTest() {
 	s.NoError(err)
 }
 
-func (s *ReportHistoryPruningSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ReportHistoryPruningSuite) TestMustNotDeleteLastSuccessfulJobOneDownload() {
 	// All downloads; all delivered; outside retention window
 	snapshots := []*storage.ReportSnapshot{

--- a/central/probeupload/manager/manager_impl_test.go
+++ b/central/probeupload/manager/manager_impl_test.go
@@ -44,10 +44,6 @@ func (s *managerTestSuite) SetupTest() {
 	s.mgr.freeStorageThreshold = 0 // not interested in testing this
 }
 
-func (s *managerTestSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *managerTestSuite) TestGetExistingProbeFilesWithNoProbes() {
 	s.Require().NoError(s.mgr.Initialize())
 

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *ProcessBaselinesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ProcessBaselinesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ProcessBaselinesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *ProcessBaselineResultsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ProcessBaselineResultsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ProcessBaselineResultsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/processindicator/datastore/datastore_impl_test.go
+++ b/central/processindicator/datastore/datastore_impl_test.go
@@ -78,7 +78,6 @@ func (suite *IndicatorDataStoreTestSuite) SetupTest() {
 }
 
 func (suite *IndicatorDataStoreTestSuite) TearDownTest() {
-	suite.postgres.Teardown(suite.T())
 	suite.mockCtrl.Finish()
 }
 

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *ProcessIndicatorsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ProcessIndicatorsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ProcessIndicatorsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -77,10 +77,6 @@ func (suite *PLOPDataStoreTestSuite) SetupTest() {
 	suite.datastore = New(suite.store, suite.indicatorDataStore, suite.postgres)
 }
 
-func (suite *PLOPDataStoreTestSuite) TearDownTest() {
-	suite.postgres.Teardown(suite.T())
-}
-
 func (suite *PLOPDataStoreTestSuite) getPlopsFromDB() []*storage.ProcessListeningOnPortStorage {
 	plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
 	err := suite.datastore.WalkAll(suite.hasReadCtx,
@@ -2462,7 +2458,6 @@ func (suite *PLOPDataStoreTestSuite) TestRemoveOrphanedPLOPs() {
 	}
 	for _, c := range cases {
 		suite.T().Run(c.name, func(t *testing.T) {
-			suite.TearDownTest()
 			suite.SetupTest()
 			// Add deployments if necessary
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)
@@ -2632,7 +2627,6 @@ func (suite *PLOPDataStoreTestSuite) TestRemoveOrphanedPLOPsByProcesses() {
 	}
 	for _, c := range cases {
 		suite.T().Run(c.name, func(t *testing.T) {
-			suite.TearDownTest()
 			suite.SetupTest()
 			// Add deployments if necessary
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)

--- a/central/processlisteningonport/store/postgres/store_test.go
+++ b/central/processlisteningonport/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *ListeningEndpointsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ListeningEndpointsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ListeningEndpointsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1309,8 +1309,6 @@ func (s *PruningTestSuite) TestRemoveOrphanedProcesses() {
 
 			processes.EXPECT().PruneProcessIndicators(gomock.Any(), c.expectedDeletions).AnyTimes()
 			gci.removeOrphanedProcesses()
-
-			db.Teardown(t)
 		})
 	}
 }

--- a/central/pruning/pruning_vuln_req_test.go
+++ b/central/pruning/pruning_vuln_req_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestExpiredVulnReqsPruning(t *testing.T) {
 	testingDB := pgtest.ForT(t)
-	defer testingDB.Teardown(t)
 	datastore := vulnReqDataStore.GetTestPostgresDataStore(t, testingDB.DB, cache.PendingReqsCacheSingleton(), cache.ActiveReqsCacheSingleton())
 
 	oneMonthDayPastRetention := (30 + configDS.DefaultExpiredVulnReqRetention) * 24 * time.Hour

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *K8sRolesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *K8sRolesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *K8sRolesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *RoleBindingsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *RoleBindingsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *RoleBindingsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/reports/config/datastore/datastore_impl_postgres_test.go
+++ b/central/reports/config/datastore/datastore_impl_postgres_test.go
@@ -39,10 +39,6 @@ func (s *ReportConfigurationPostgresDatastoreTests) SetupSuite() {
 			sac.ResourceScopeKeys(resources.WorkflowAdministration)))
 }
 
-func (s *ReportConfigurationPostgresDatastoreTests) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ReportConfigurationPostgresDatastoreTests) TearDownTest() {
 	s.truncateTable(postgresSchema.ReportConfigurationsTableName)
 }

--- a/central/reports/config/datastore/datastore_impl_v2_test.go
+++ b/central/reports/config/datastore/datastore_impl_v2_test.go
@@ -45,10 +45,6 @@ func (s *ReportConfigurationDatastoreV2Tests) SetupSuite() {
 			sac.ResourceScopeKeys(resources.WorkflowAdministration)))
 }
 
-func (s *ReportConfigurationDatastoreV2Tests) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ReportConfigurationDatastoreV2Tests) TestSortReportConfigByCompletionTime() {
 	reportConfig1 := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
 	reportConfig1.Id = ""

--- a/central/reports/config/service/config_separation_test.go
+++ b/central/reports/config/service/config_separation_test.go
@@ -80,7 +80,7 @@ func (s *ServiceLevelConfigSeparationSuite) SetupSuite() {
 
 func (s *ServiceLevelConfigSeparationSuite) TearDownSuite() {
 	s.mockCtrl.Finish()
-	s.testDB.Teardown(s.T())
+
 }
 
 func (s *ServiceLevelConfigSeparationSuite) TestGetReportConfigurations() {

--- a/central/reports/config/store/postgres/store_test.go
+++ b/central/reports/config/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ReportConfigurationsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ReportConfigurationsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ReportConfigurationsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_bench_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_bench_test.go
@@ -45,7 +45,6 @@ type ReportGeneratorBenchmarkTestSuite struct {
 func BenchmarkReportGenerator(b *testing.B) {
 	bts := &ReportGeneratorBenchmarkTestSuite{b: b}
 	bts.setupTestSuite()
-	defer bts.teardownTestSuite()
 
 	clusters := []*storage.Cluster{
 		{Id: uuid.NewV4().String(), Name: "c1"},
@@ -129,10 +128,6 @@ func (bts *ReportGeneratorBenchmarkTestSuite) setupTestSuite() {
 	bts.reportGenerator = newReportGeneratorImpl(bts.testDB, nil, bts.resolver.DeploymentDataStore,
 		bts.watchedImageDatastore, bts.collectionQueryResolver, nil, nil, bts.clusterDatastore,
 		bts.namespaceDatastore, imageCVEDatastore, bts.schema)
-}
-
-func (bts *ReportGeneratorBenchmarkTestSuite) teardownTestSuite() {
-	bts.testDB.Teardown(bts.b)
 }
 
 func (bts *ReportGeneratorBenchmarkTestSuite) upsertManyImages(images []*storage.Image) {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
@@ -93,10 +93,6 @@ func (s *EnhancedReportingTestSuite) SetupSuite() {
 		s.namespaceDatastore, imageCVEDatastore, s.schema)
 }
 
-func (s *EnhancedReportingTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *EnhancedReportingTestSuite) TearDownTest() {
 	s.truncateTable(postgresSchema.DeploymentsTableName)
 	s.truncateTable(postgresSchema.ImagesTableName)

--- a/central/reports/scheduler/vuln_report_collections_test.go
+++ b/central/reports/scheduler/vuln_report_collections_test.go
@@ -81,10 +81,6 @@ func (s *ReportingWithCollectionsTestSuite) SetupSuite() {
 		nil, nil, s.schema)
 }
 
-func (s *ReportingWithCollectionsTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ReportingWithCollectionsTestSuite) TearDownTest() {
 	s.truncateTable(postgresSchema.DeploymentsTableName)
 	s.truncateTable(postgresSchema.ImagesTableName)

--- a/central/reports/service/v2/config_separation_test.go
+++ b/central/reports/service/v2/config_separation_test.go
@@ -94,7 +94,7 @@ func (s *ServiceLevelConfigSeparationSuiteV2) SetupSuite() {
 
 func (s *ServiceLevelConfigSeparationSuiteV2) TearDownSuite() {
 	s.mockCtrl.Finish()
-	s.testDB.Teardown(s.T())
+
 }
 
 func (s *ServiceLevelConfigSeparationSuiteV2) TestListReportConfigurations() {

--- a/central/reports/snapshot/datastore/datastore_impl_test.go
+++ b/central/reports/snapshot/datastore/datastore_impl_test.go
@@ -43,10 +43,6 @@ func (s *ReportSnapshotDatastoreTestSuite) SetupSuite() {
 			sac.ResourceScopeKeys(resources.WorkflowAdministration)))
 }
 
-func (s *ReportSnapshotDatastoreTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ReportSnapshotDatastoreTestSuite) TestReportMetadataWorkflows() {
 	reportConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
 	reportConfig.Id = ""

--- a/central/reports/snapshot/datastore/store/postgres/store_test.go
+++ b/central/reports/snapshot/datastore/store/postgres/store_test.go
@@ -39,10 +39,6 @@ func (s *ReportSnapshotsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ReportSnapshotsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ReportSnapshotsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/resourcecollection/datastore/datastore_bench_postgres_test.go
+++ b/central/resourcecollection/datastore/datastore_bench_postgres_test.go
@@ -19,7 +19,6 @@ func BenchmarkCollections(b *testing.B) {
 	ctx := sac.WithAllAccess(context.Background())
 
 	db := pgtest.ForT(b)
-	defer db.Teardown(b)
 
 	datastore, _, err := GetTestPostgresDataStore(b, db)
 	require.NoError(b, err)

--- a/central/resourcecollection/datastore/datastore_impl_postgres_test.go
+++ b/central/resourcecollection/datastore/datastore_impl_postgres_test.go
@@ -52,10 +52,6 @@ func (s *CollectionPostgresDataStoreTestSuite) SetupTest() {
 	s.NoError(resetLocalGraph(s.datastore.(*datastoreImpl)))
 }
 
-func (s *CollectionPostgresDataStoreTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *CollectionPostgresDataStoreTestSuite) TestGraphInit() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/resourcecollection/datastore/store/postgres/store_test.go
+++ b/central/resourcecollection/datastore/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *CollectionsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *CollectionsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *CollectionsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/resourcecollection/service/service_impl_test.go
+++ b/central/resourcecollection/service/service_impl_test.go
@@ -53,7 +53,6 @@ func (suite *CollectionServiceTestSuite) SetupSuite() {
 }
 
 func (suite *CollectionServiceTestSuite) TearDownSuite() {
-	suite.testDB.Teardown(suite.T())
 	suite.mockCtrl.Finish()
 }
 

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *RisksStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *RisksStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *RisksStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/role/service/service_impl_test.go
+++ b/central/role/service/service_impl_test.go
@@ -534,10 +534,6 @@ func (s *serviceImplTestSuite) SetupSuite() {
 	}
 }
 
-func (s *serviceImplTestSuite) TearDownSuite() {
-	s.postgres.Teardown(s.T())
-}
-
 func (s *serviceImplTestSuite) SetupTest() {
 	s.storedAccessScopeIDs = make([]string, 0)
 	s.storedPermissionSetIDs = make([]string, 0)

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *PermissionSetsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *PermissionSetsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *PermissionSetsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *RolesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *RolesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *RolesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *SimpleAccessScopesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *SimpleAccessScopesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *SimpleAccessScopesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/scannerdefinitions/handler/handler_test.go
+++ b/central/scannerdefinitions/handler/handler_test.go
@@ -65,10 +65,6 @@ func (s *handlerTestSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *handlerTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *handlerTestSuite) postRequestV2() *http.Request {
 	var manifestBuf bytes.Buffer
 	zw := zip.NewWriter(&manifestBuf)

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *SecretsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *SecretsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *SecretsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/sensorupgradeconfig/datastore/internal/store/postgres/store_test.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/postgres/store_test.go
@@ -31,9 +31,6 @@ func (s *SensorUpgradeConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *SensorUpgradeConfigsStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
 
 func (s *SensorUpgradeConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/sensorupgradeconfig/datastore/internal/store/postgres/store_test.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/postgres/store_test.go
@@ -31,7 +31,6 @@ func (s *SensorUpgradeConfigsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-
 func (s *SensorUpgradeConfigsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -44,10 +44,6 @@ func (s *ServiceAccountsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ServiceAccountsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ServiceAccountsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *ServiceIdentitiesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *ServiceIdentitiesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ServiceIdentitiesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/signatureintegration/datastore/datastore_test.go
+++ b/central/signatureintegration/datastore/datastore_test.go
@@ -278,10 +278,6 @@ func newSignatureIntegration(name string) *storage.SignatureIntegration {
 	return signatureIntegration
 }
 
-func (s *signatureDataStoreTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func TestRemovePoliciesInvisibleToUser(t *testing.T) {
 	cases := map[string]struct {
 		policiesVisibleToUser []*storage.Policy

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *SignatureIntegrationsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *SignatureIntegrationsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *SignatureIntegrationsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/splunk/violations_query_test.go
+++ b/central/splunk/violations_query_test.go
@@ -53,11 +53,6 @@ func makeDS(t *testing.T, alerts []*storage.Alert) testDataStore {
 	return testDataStore{testDB: testDB, alertsDS: alertsDS}
 }
 
-// teardown cleans up test datastore.
-func (d *testDataStore) teardown(t *testing.T) {
-	d.testDB.Teardown(t)
-}
-
 // these simply converts varargs to slice for slightly less typing (pun intended).
 func these(alerts ...*storage.Alert) []*storage.Alert {
 	return alerts
@@ -66,7 +61,6 @@ func these(alerts ...*storage.Alert) []*storage.Alert {
 // withAlerts runs action in a scope of test datastore.DataStore that contains given alerts.
 func (s *violationsTestSuite) withAlerts(alerts []*storage.Alert, action func(alertsDS datastore.DataStore)) {
 	ds := makeDS(s.T(), alerts)
-	defer ds.teardown(s.T())
 	action(ds.alertsDS)
 }
 

--- a/central/splunk/violations_serialization_test.go
+++ b/central/splunk/violations_serialization_test.go
@@ -41,11 +41,6 @@ func (s *violationSerializationTestSuite) SetupTest() {
 	s.alertStore = alertStore
 }
 
-func (s *violationSerializationTestSuite) TearDownTest() {
-	s.pool.Teardown(s.T())
-	s.pool.Close()
-}
-
 func (s *violationSerializationTestSuite) TestViolationSerialization() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/splunk/violations_test.go
+++ b/central/splunk/violations_test.go
@@ -1289,7 +1289,6 @@ func (rb *requestBuilder) runRequest(responseWriter http.ResponseWriter) {
 	alertsDS := rb.alertsDS
 	if !rb.useAlertsDS {
 		ds := makeDS(rb.t, rb.alerts)
-		defer ds.teardown(rb.t)
 		alertsDS = ds.alertsDS
 	}
 

--- a/central/systeminfo/listener/listener_test.go
+++ b/central/systeminfo/listener/listener_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestListener(t *testing.T) {
 	testDB := pgtest.ForT(t)
-	defer testDB.Teardown(t)
+
 	sysInfoStore := systemInfoStorage.New(testDB.DB)
 	listener := newBackupListener(sysInfoStore)
 

--- a/central/systeminfo/store/postgres/store_test.go
+++ b/central/systeminfo/store/postgres/store_test.go
@@ -30,10 +30,6 @@ func (s *SystemInfosStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *SystemInfosStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *SystemInfosStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/telemetry/gatherers/gatherer_test.go
+++ b/central/telemetry/gatherers/gatherer_test.go
@@ -52,12 +52,6 @@ func (s *gathererTestSuite) SetupSuite() {
 	s.gatherer = newCentralGatherer(installationStore, newDatabaseGatherer(newPostgresGatherer(s.tp.DB, adminConfig)), newAPIGatherer(metrics.GRPCSingleton(), metrics.HTTPSingleton()), gatherers.NewComponentInfoGatherer(), s.sensorUpgradeConfigDatastore)
 }
 
-func (s *gathererTestSuite) TearDownSuite() {
-	if s.tp != nil {
-		s.tp.Teardown(s.T())
-	}
-}
-
 func (s *gathererTestSuite) TestJSONSerialization() {
 	metrics := s.gatherer.Gather(sac.WithAllAccess(context.Background()))
 

--- a/central/testutils/export.go
+++ b/central/testutils/export.go
@@ -63,12 +63,6 @@ func (h *ExportServicePostgresTestHelper) SetupTest(tb testing.TB) error {
 	return nil
 }
 
-// TearDownTest cleans up the ExportServicePostgresTestHelper resources after testing.
-func (h *ExportServicePostgresTestHelper) TearDownTest(tb testing.TB) {
-	h.pool.Teardown(tb)
-	h.pool.Close()
-}
-
 func getImageSetPath() (string, error) {
 	// Go up the directory tree from the current working directory
 	// to location where the subtree to the image data file matches.

--- a/central/version/postgres/store_test.go
+++ b/central/version/postgres/store_test.go
@@ -30,10 +30,6 @@ func (s *VersionsStoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *VersionsStoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *VersionsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -174,10 +174,6 @@ func (s *ImageCVEViewTestSuite) SetupSuite() {
 	s.testImagesToDeployments[images[2].Id] = []*storage.Deployment{deployments[2]}
 }
 
-func (s *ImageCVEViewTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageCVEViewTestSuite) TestGetImageCVECore() {
 	for _, tc := range s.testCases() {
 		s.T().Run(tc.desc, func(t *testing.T) {

--- a/central/views/images/view_test.go
+++ b/central/views/images/view_test.go
@@ -121,10 +121,6 @@ func (s *ImageViewTestSuite) SetupSuite() {
 	}
 }
 
-func (s *ImageViewTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *ImageViewTestSuite) TestGetImagesCore() {
 	contextMap := testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Image)
 	for _, tc := range []struct {

--- a/central/views/nodecve/view_test.go
+++ b/central/views/nodecve/view_test.go
@@ -164,10 +164,6 @@ func (s *NodeCVEViewTestSuite) SetupSuite() {
 	s.cveView = NewCVEView(s.testDB.DB)
 }
 
-func (s *NodeCVEViewTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *NodeCVEViewTestSuite) TestGetNodeCVECore() {
 	for _, tc := range s.testCases() {
 		s.T().Run(tc.desc, func(t *testing.T) {

--- a/central/views/platformcve/view_test.go
+++ b/central/views/platformcve/view_test.go
@@ -147,10 +147,6 @@ func (s *PlatformCVEViewTestSuite) SetupSuite() {
 	s.cveView = NewCVEView(s.testDB.DB)
 }
 
-func (s *PlatformCVEViewTestSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *PlatformCVEViewTestSuite) TestGetPlatformCVECore() {
 	for _, tc := range s.testCases() {
 		s.T().Run(tc.desc, func(t *testing.T) {

--- a/central/vulnmgmt/service/service_impl_benchmark_test.go
+++ b/central/vulnmgmt/service/service_impl_benchmark_test.go
@@ -18,7 +18,7 @@ func BenchmarkService_Export(b *testing.B) {
 	if err != nil {
 		b.Error(err)
 	}
-	defer testHelper.TearDownTest(b)
+
 	svc := New(testHelper.Deployments, testHelper.Images)
 	benchmarkFunc := getExportServiceBenchmark(testHelper, svc)
 	testHelper.InjectDataAndRunBenchmark(b, true, benchmarkFunc)

--- a/central/vulnmgmt/service/service_impl_postgres_test.go
+++ b/central/vulnmgmt/service/service_impl_postgres_test.go
@@ -37,10 +37,6 @@ func (s *servicePostgresTestSuite) SetupTest() {
 	s.service = New(s.helper.Deployments, s.helper.Images)
 }
 
-func (s *servicePostgresTestSuite) TearDownTest() {
-	s.helper.TearDownTest(s.T())
-}
-
 func (s *servicePostgresTestSuite) createDeployment(deployment *storage.Deployment, id string) *storage.Deployment {
 	deployment.Id = id
 	return deployment

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl_postgres_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl_postgres_test.go
@@ -113,10 +113,6 @@ func (s *VulnRequestPostgresDataStoreTestSuite) SetupSuite() {
 	}
 }
 
-func (s *VulnRequestPostgresDataStoreTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *VulnRequestPostgresDataStoreTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *VulnerabilityRequestsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *VulnerabilityRequestsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *VulnerabilityRequestsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/vulnmgmt/vulnerabilityrequest/manager/querymgr/query_manager_impl_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/manager/querymgr/query_manager_impl_test.go
@@ -44,7 +44,7 @@ type VulnReqQueryManagerTestSuite struct {
 
 func (s *VulnReqQueryManagerTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
-	s.testDB.Teardown(s.T())
+
 }
 
 func (s *VulnReqQueryManagerTestSuite) SetupTest() {

--- a/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_benchmark_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_benchmark_test.go
@@ -16,7 +16,6 @@ import (
 
 func BenchmarkCreate(b *testing.B) {
 	testDB := *pgtest.ForT(b)
-	defer testDB.Teardown(b)
 
 	pendingCache, activeCache := vulnReqCache.New(), vulnReqCache.New()
 	vulnReqDataStore := vulnReqDS.GetTestPostgresDataStore(b, testDB, pendingCache, activeCache)

--- a/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_create_req_test.go
@@ -187,7 +187,6 @@ func testApproval(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 
 	testDB := pgtest.ForT(t)
-	defer testDB.Teardown(t)
 
 	pendingReqCache, activeReqCache := vulnReqCache.New(), vulnReqCache.New()
 	datastore := vulReqDS.GetTestPostgresDataStore(t, testDB, pendingReqCache, activeReqCache)

--- a/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_reobserve_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_reobserve_test.go
@@ -91,10 +91,6 @@ func (s *VulnRequestManagerRevertExceptionTestSuite) SetupTest() {
 	}
 }
 
-func (s *VulnRequestManagerRevertExceptionTestSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *VulnRequestManagerRevertExceptionTestSuite) setupDataStores(pendingReqCache vulnReqCache.VulnReqCache, activeReqCache vulnReqCache.VulnReqCache) {
 	var err error
 	s.imageDataStore = imageDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)

--- a/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -96,10 +96,6 @@ func (s *VulnRequestManagerTestSuite) SetupTest() {
 	}
 }
 
-func (s *VulnRequestManagerTestSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *VulnRequestManagerTestSuite) setupDataStores(pendingReqCache vulnReqCache.VulnReqCache, activeReqCache vulnReqCache.VulnReqCache) {
 	var err error
 	s.imageDataStore = imageDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *WatchedImagesStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *WatchedImagesStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *WatchedImagesStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -90,7 +90,6 @@ func (m *mockCentral) destroyCentral() {
 		pgtest.DropDatabase(m.t, migrations.GetCurrentClone())
 		pgtest.DropDatabase(m.t, migrations.GetPreviousClone())
 		pgtest.DropDatabase(m.t, migrations.GetBackupClone())
-		m.tp.Teardown(m.t)
 	}
 	_ = os.RemoveAll(m.mountPath)
 }

--- a/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration_test.go
+++ b/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/migration_test.go
@@ -95,10 +95,6 @@ func (s *psMigrationTestSuite) SetupTest() {
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 
-func (s *psMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *psMigrationTestSuite) TestMigration() {
 	ctx := sac.WithAllAccess(context.Background())
 	var psToUpsert []*storage.PermissionSet

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
@@ -98,10 +98,6 @@ func (s *psMigrationTestSuite) SetupTest() {
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 
-func (s *psMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *psMigrationTestSuite) TestMigration() {
 	ctx := sac.WithAllAccess(context.Background())
 	var psToUpsert []*storage.PermissionSet

--- a/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/migration_test.go
+++ b/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/migration_test.go
@@ -44,10 +44,6 @@ func (s *categoriesMigrationTestSuite) SetupTest() {
 
 }
 
-func (s *categoriesMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *categoriesMigrationTestSuite) TestMigration() {
 	ctx := sac.WithAllAccess(context.Background())
 	testPolicy := fixtures.GetPolicy()

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
@@ -50,10 +50,6 @@ func (s *networkFlowsMigrationTestSuite) SetupTest() {
 	s.oldStore2 = previous.New(s.db.DB, cluster2)
 }
 
-func (s *networkFlowsMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *networkFlowsMigrationTestSuite) TestMigration() {
 	// Add some data to the original tables via the old stores.
 	s.addSomeOldData()

--- a/migrator/migrations/m_173_to_m_174_group_unique_constraint/migration_test.go
+++ b/migrator/migrations/m_173_to_m_174_group_unique_constraint/migration_test.go
@@ -124,10 +124,6 @@ func (s *groupUniqueConstraintMigrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchemav73.CreateTableGroupsStmt)
 }
 
-func (s *groupUniqueConstraintMigrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *groupUniqueConstraintMigrationTestSuite) TestMigration() {
 	previousStore := previous.New(s.db.DB)
 	updatedStore := updated.New(s.db.DB)

--- a/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/migration_test.go
+++ b/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/migration_test.go
@@ -118,10 +118,6 @@ func (s *apiTokenMigrationTestSuite) SetupTest() {
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), oldSchema.CreateTableAPITokensStmt)
 }
 
-func (s *apiTokenMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func getTimestampLookupQuery(label search.FieldLabel, date time.Time) *v1.Query {
 	oneSecondLater := date.Add(1 * time.Second)
 	fmt.Println(date.Format(timestampLayout))

--- a/migrator/migrations/m_177_to_m_178_group_permissions/migration_test.go
+++ b/migrator/migrations/m_177_to_m_178_group_permissions/migration_test.go
@@ -432,10 +432,6 @@ func (s *psMigrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 
-func (s *psMigrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *psMigrationTestSuite) TestMigration() {
 	store := permissionsetpostgresstore.New(s.db.DB)
 

--- a/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/migration_test.go
+++ b/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/migration_test.go
@@ -65,10 +65,6 @@ func (s *reportConfigMigrationTestSuite) SetupTest() {
 	s.newReportStore = newStore.New(s.db.DB)
 }
 
-func (s *reportConfigMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *reportConfigMigrationTestSuite) TestMigration() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/migration_test.go
+++ b/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/migration_test.go
@@ -38,10 +38,6 @@ func (s *categoriesMigrationTestSuite) SetupTest() {
 
 }
 
-func (s *categoriesMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *categoriesMigrationTestSuite) TestMigration() {
 	ctx := sac.WithAllAccess(context.Background())
 	testPolicy := fixtures.GetPolicy()

--- a/migrator/migrations/m_180_to_m_181_move_to_blobstore/migration_test.go
+++ b/migrator/migrations/m_180_to_m_181_move_to_blobstore/migration_test.go
@@ -39,10 +39,6 @@ func (s *blobMigrationTestSuite) SetupTest() {
 	s.db = pghelper.ForT(s.T(), false)
 }
 
-func (s *blobMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *blobMigrationTestSuite) TestScannerDefinitionMigration() {
 	// Nothing to migrate
 	s.Require().NoError(moveToBlobs(s.db.GetGormDB()))

--- a/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/migration_test.go
+++ b/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/migration_test.go
@@ -349,10 +349,6 @@ func (s *psMigrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 
-func (s *psMigrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *psMigrationTestSuite) TestMigration() {
 	store := permissionsetpostgresstore.New(s.db.DB)
 

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/migration_test.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/migration_test.go
@@ -44,10 +44,6 @@ func (s *migrationTestSuite) SetupTest() {
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTableRolesStmt)
 }
 
-func (s *migrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 const (
 	deployment = "Deployment"
 )

--- a/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/migration_test.go
+++ b/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/migration_test.go
@@ -180,10 +180,6 @@ func (s *psMigrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), frozenSchema.CreateTablePermissionSetsStmt)
 }
 
-func (s *psMigrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *psMigrationTestSuite) TestMigration() {
 	store := permissionSetStore.New(s.db.DB)
 

--- a/migrator/migrations/m_185_to_m_186_more_policy_migrations/migration_test.go
+++ b/migrator/migrations/m_185_to_m_186_more_policy_migrations/migration_test.go
@@ -62,10 +62,6 @@ func (s *policyMigrationTestSuite) SetupTest() {
 	s.NoError(s.policyStore.UpsertMany(s.ctx, policies))
 }
 
-func (s *policyMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 // TestPolicyDescriptionMigration tests that at least one of the policies that needs to have its description
 // updated does indeed get successfully get migrated
 func (s *policyMigrationTestSuite) TestPolicyDescriptionMigration() {

--- a/migrator/migrations/m_186_to_m_187_add_blob_search/migration_test.go
+++ b/migrator/migrations/m_186_to_m_187_add_blob_search/migration_test.go
@@ -37,10 +37,6 @@ func (s *blobMigrationTestSuite) SetupTest() {
 	s.gormDB = s.db.GetGormDB().WithContext(s.ctx)
 }
 
-func (s *blobMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *blobMigrationTestSuite) TestMigration() {
 	pgutils.CreateTableFromModel(s.ctx, s.gormDB, beforeSchema.CreateTableBlobsStmt)
 	batchSize = 9

--- a/migrator/migrations/m_187_to_m_188_remove_reports_without_migrated_collections/migration_test.go
+++ b/migrator/migrations/m_187_to_m_188_remove_reports_without_migrated_collections/migration_test.go
@@ -61,10 +61,6 @@ func (s *migrationTestSuite) createCollectionInDB(id string) {
 	s.Require().NoError(s.gormDB.Create(c).Error)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	var validV1Reports []string
 	var validV2Reports []string

--- a/migrator/migrations/m_188_to_m_189_logimbues_add_time_column/migration_test.go
+++ b/migrator/migrations/m_188_to_m_189_logimbues_add_time_column/migration_test.go
@@ -33,10 +33,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	s.db = pghelper.ForT(s.T(), false)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	dbs := &types.Databases{
 		GormDB:     s.db.GetGormDB(),

--- a/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/migration_test.go
+++ b/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/migration_test.go
@@ -41,10 +41,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), oldSchema.CreateTableVulnerabilityRequestsStmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	layout := "2006/01/02"
 	jun29, err := time.Parse(layout, "2023/06/29")

--- a/migrator/migrations/m_190_to_m_191_plop_add_closed_time_column/migration_test.go
+++ b/migrator/migrations/m_190_to_m_191_plop_add_closed_time_column/migration_test.go
@@ -35,10 +35,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	s.db = pghelper.ForT(s.T(), false)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	dbs := &types.Databases{
 		GormDB:     s.db.GetGormDB(),

--- a/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/migration_test.go
+++ b/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/migration_test.go
@@ -39,10 +39,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), oldSchema.CreateTableVulnerabilityRequestsStmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	imageScopedReqs := []*storage.VulnerabilityRequest{
 		fixtures.GetImageScopeDeferralRequest("reg-1", "remote-1", "tag-1", "cve-1"),

--- a/migrator/migrations/m_192_to_m_193_report_config_migrations/migration_test.go
+++ b/migrator/migrations/m_192_to_m_193_report_config_migrations/migration_test.go
@@ -81,10 +81,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	dbs := &types.Databases{
 		GormDB:     s.db.GetGormDB(),

--- a/migrator/migrations/m_193_to_m_194_policy_updates_for_4_3/migration_test.go
+++ b/migrator/migrations/m_193_to_m_194_policy_updates_for_4_3/migration_test.go
@@ -63,10 +63,6 @@ func (s *policyMigrationTestSuite) SetupTest() {
 	}
 }
 
-func (s *policyMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *policyMigrationTestSuite) TestMigration() {
 
 	// Insert the policies to be migrated

--- a/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/migration_test.go
+++ b/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/migration_test.go
@@ -42,10 +42,6 @@ func (s *apMigrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(ctx, s.db.GetGormDB(), schema.CreateTableGroupsStmt)
 }
 
-func (s *apMigrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 var unmigratedAuthProviders = []*storage.AuthProvider{
 	{
 		Id:   uuid.NewV5FromNonUUIDs(providerIDNamespace, "no-claims").String(),

--- a/migrator/migrations/m_198_to_m_199_policy_description_and_criteria_updates/migration_test.go
+++ b/migrator/migrations/m_198_to_m_199_policy_description_and_criteria_updates/migration_test.go
@@ -64,9 +64,6 @@ func (s *policyMigrationTestSuite) SetupTest() {
 	}
 }
 
-func (s *policyMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
 func (s *policyMigrationTestSuite) TestMigration() {
 
 	// Insert the policies to be migrated

--- a/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/migration_test.go
+++ b/migrator/migrations/m_199_to_m_200_policy_updates_for_4_5/migration_test.go
@@ -65,10 +65,6 @@ func (s *policyMigrationTestSuite) SetupTest() {
 	}
 }
 
-func (s *policyMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *policyMigrationTestSuite) TestMigration() {
 
 	// Insert the policies to be migrated

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/migration_test.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/migration_test.go
@@ -80,10 +80,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), oldSchemas.CreateTableComplianceOperatorProfileV2Stmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	s.addOldData()
 

--- a/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/migration_test.go
+++ b/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/migration_test.go
@@ -69,10 +69,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), schema.CreateTableVulnerabilityRequestsStmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	oldRequests := map[string]*storage.VulnerabilityRequest{
 		"1": fakeOldVulnReq(&requestParams{

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/migration_test.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/migration_test.go
@@ -48,10 +48,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), schema.CreateTableVulnerabilityRequestsStmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	images := []*storage.Image{
 		getTestImage("image1"),

--- a/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/migration_test.go
+++ b/migrator/migrations/m_203_to_m_204_openshift_policy_exclusions_for_4_5/migration_test.go
@@ -59,10 +59,6 @@ func (s *policyMigrationTestSuite) SetupTest() {
 	}
 }
 
-func (s *policyMigrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *policyMigrationTestSuite) TestMigration() {
 
 	// Insert the policies to be migrated

--- a/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/migration_test.go
+++ b/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/migration_test.go
@@ -39,10 +39,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), oldSchema.CreateTableClustersStmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	clusters := []*storage.Cluster{
 		s.getTestCluster("generic-1", storage.ClusterType_GENERIC_CLUSTER, "9.0"),

--- a/migrator/migrations/m_205_to_m_206_remove_bad_gorm_index/migration_test.go
+++ b/migrator/migrations/m_205_to_m_206_remove_bad_gorm_index/migration_test.go
@@ -36,10 +36,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), oldSchema.CreateTableComplianceIntegrationsStmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	dbs := &types.Databases{
 		GormDB:     s.db.GetGormDB(),

--- a/migrator/migrations/m_206_to_m_207_add_default_policy_edge/migration_test.go
+++ b/migrator/migrations/m_206_to_m_207_add_default_policy_edge/migration_test.go
@@ -68,10 +68,6 @@ func (s *migrationTestSuite) SetupTest() {
 	}
 }
 
-func (s *migrationTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	// Run the migration
 	s.Require().NoError(migration.Run(&types.Databases{

--- a/migrator/migrations/m_207_to_m_208_initialize_nvd_cvss/migration_test.go
+++ b/migrator/migrations/m_207_to_m_208_initialize_nvd_cvss/migration_test.go
@@ -36,10 +36,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), oldSchema.CreateTableImageCvesStmt)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	batchSize := 20
 	inputRows := make([][]interface{}, 0, batchSize)

--- a/migrator/migrations/m_208_to_m_209_policy_updates_for_4_6/migration_test.go
+++ b/migrator/migrations/m_208_to_m_209_policy_updates_for_4_6/migration_test.go
@@ -52,10 +52,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	}
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	// Insert the policies to be migrated
 	for _, diff := range policyDiffs {

--- a/migrator/migrations/m_209_to_m_210_add_updated_at_to_network_flows_v2/migration_test.go
+++ b/migrator/migrations/m_209_to_m_210_add_updated_at_to_network_flows_v2/migration_test.go
@@ -54,10 +54,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	s.oldStore2 = previous.New(s.db.DB, cluster2)
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
-
 func (s *migrationTestSuite) TestMigration() {
 	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Minute)
 	defer cancel()

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -55,10 +55,6 @@ func (s *postgresPolicyMigratorTestSuite) SetupTest() {
 
 }
 
-func (s *postgresPolicyMigratorTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *postgresPolicyMigratorTestSuite) comparePolicyWithDB(policyID string, policy *storage.Policy) {
 	newPolicy, exists, err := s.store.Get(s.ctx, policyID)
 	s.NoError(err)

--- a/pkg/postgres/gorm/largeobject/large_objects_test.go
+++ b/pkg/postgres/gorm/largeobject/large_objects_test.go
@@ -33,10 +33,6 @@ func (s *GormUtilsTestSuite) SetupTest() {
 	s.gormDB = s.db.GetGormDB(s.T()).WithContext(s.ctx)
 }
 
-func (s *GormUtilsTestSuite) TearDownTest() {
-	s.db.Teardown(s.T())
-}
-
 func (s *GormUtilsTestSuite) TestUpsertGet() {
 	// Write a long file
 	randomData := make([]byte, 90000)

--- a/pkg/postgres/pgtest/postgres.go
+++ b/pkg/postgres/pgtest/postgres.go
@@ -86,6 +86,7 @@ func DropDatabase(t testing.TB, database string) {
 }
 
 // ForT creates and returns a Postgres for the test
+// It will teardown DB at the end of the test.
 func ForT(t testing.TB) *TestPostgres {
 	// Bootstrap a test database
 	database := CreateADatabaseForT(t)
@@ -102,10 +103,16 @@ func ForT(t testing.TB) *TestPostgres {
 	// initialize pool to be used
 	pool := ForTCustomPool(t, database)
 
-	return &TestPostgres{
+	testPg := &TestPostgres{
 		DB:       pool,
 		database: database,
 	}
+
+	t.Cleanup(func() {
+		testPg.Teardown(t)
+	})
+
+	return testPg
 }
 
 // ForTCustomDB - creates and returns a Postgres for the test.  This is used primarily in testing migrations,

--- a/pkg/postgres/pgtest/postgres.go
+++ b/pkg/postgres/pgtest/postgres.go
@@ -109,7 +109,7 @@ func ForT(t testing.TB) *TestPostgres {
 	}
 
 	t.Cleanup(func() {
-		testPg.Teardown(t)
+		testPg.teardown(t)
 	})
 
 	return testPg
@@ -150,8 +150,7 @@ func (tp *TestPostgres) GetGormDB(t testing.TB) *gorm.DB {
 	return OpenGormDB(t, source)
 }
 
-// Teardown tears down a Postgres instance used in tests
-func (tp *TestPostgres) Teardown(t testing.TB) {
+func (tp *TestPostgres) teardown(t testing.TB) {
 	if tp == nil {
 		return
 	}

--- a/pkg/search/postgres/graph_queries_test.go
+++ b/pkg/search/postgres/graph_queries_test.go
@@ -655,7 +655,3 @@ func (s *GraphQueriesTestSuite) TestDerivedFieldHighlighted() {
 		},
 	})
 }
-
-func (s *GraphQueriesTestSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}

--- a/pkg/search/postgres/query/test/uuid_query_test.go
+++ b/pkg/search/postgres/query/test/uuid_query_test.go
@@ -35,10 +35,6 @@ func (s *UUIDTestSuite) SetupTest() {
 	s.ctx = sac.WithAllAccess(context.Background())
 }
 
-func (s *UUIDTestSuite) TearDownTest() {
-	s.postgres.Teardown(s.T())
-}
-
 func (s *UUIDTestSuite) TestRemovePLOPsWithoutPodUID() {
 	plops := []*storage.ProcessListeningOnPortStorage{
 		fixtures.GetPlopStorage1(),

--- a/pkg/search/postgres/select_query_test.go
+++ b/pkg/search/postgres/select_query_test.go
@@ -87,7 +87,6 @@ func TestSelectQuery(t *testing.T) {
 
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)
-	defer testDB.Teardown(t)
 
 	store := postgres.New(testDB.DB)
 
@@ -519,7 +518,6 @@ func TestSelectDerivedFieldQuery(t *testing.T) {
 
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)
-	defer testDB.Teardown(t)
 
 	store := postgres.New(testDB.DB)
 

--- a/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
+++ b/tools/generate-helpers/bootstrap-migration/migration_test.go.tpl
@@ -31,9 +31,6 @@ func (s *migrationTestSuite) SetupSuite() {
 	// {{template "TODO"}}: Create the schemas and tables required for the pre-migration dataset push to DB
 }
 
-func (s *migrationTestSuite) TearDownSuite() {
-	s.db.Teardown(s.T())
-}
 
 
 

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *TestStructsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestStructsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestStructsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/singleton_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/singleton_test.go.tpl
@@ -39,9 +39,6 @@ func (s *{{$namePrefix}}StoreSuite) SetupTest() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *{{$namePrefix}}StoreSuite) TearDownTest() {
-	s.testDB.Teardown(s.T())
-}
 
 func (s *{{$namePrefix}}StoreSuite) TestStore() {
     ctx := sac.WithAllAccess(context.Background())

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -60,10 +60,6 @@ func (s *{{$namePrefix}}StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *{{$namePrefix}}StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *TestSingleKeyStructsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestSingleKeyStructsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -41,10 +41,6 @@ func (s *TestChild1StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestChild1StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestChild1StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store_test.go
@@ -39,10 +39,6 @@ func (s *TestChild1P4StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestChild1P4StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestChild1P4StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store_test.go
@@ -39,10 +39,6 @@ func (s *TestChild2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestChild2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestChild2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store_test.go
@@ -39,10 +39,6 @@ func (s *TestG2GrandChild1StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestG2GrandChild1StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestG2GrandChild1StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -41,10 +41,6 @@ func (s *TestG3GrandChild1StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestG3GrandChild1StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestG3GrandChild1StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -41,10 +41,6 @@ func (s *TestGGrandChild1StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestGGrandChild1StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestGGrandChild1StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store_test.go
@@ -39,10 +39,6 @@ func (s *TestGrandChild1StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestGrandChild1StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestGrandChild1StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -41,10 +41,6 @@ func (s *TestGrandparentsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestGrandparentsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestGrandparentsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store_test.go
@@ -39,10 +39,6 @@ func (s *TestParent1StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestParent1StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestParent1StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store_test.go
@@ -39,10 +39,6 @@ func (s *TestParent2StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestParent2StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestParent2StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store_test.go
@@ -39,10 +39,6 @@ func (s *TestParent3StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestParent3StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestParent3StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store_test.go
@@ -39,10 +39,6 @@ func (s *TestParent4StoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestParent4StoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestParent4StoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
@@ -41,10 +41,6 @@ func (s *TestShortCircuitsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestShortCircuitsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestShortCircuitsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store_test.go
@@ -41,10 +41,6 @@ func (s *TestSingleUUIDKeyStructsStoreSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *TestSingleUUIDKeyStructsStoreSuite) TearDownSuite() {
-	s.testDB.Teardown(s.T())
-}
-
 func (s *TestSingleUUIDKeyStructsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 


### PR DESCRIPTION
### Description

Sometimes we forgot to teardown test database. This change make it automatically by adding teardown to test cleanup. It also removes all `Teardown` calls in tests as they are no longer needed.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
