### PR TITLE
ROX-28352: Fix scanner-tls secret keys in deployment template

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -153,7 +153,16 @@ spec:
         configMap:
           name: scanner-config
       {{- if ._rox._securedClusterCertRefresh }}
-      {{- include "srox.tlsCertsInitContainerVolumes" (list "scanner") | indent 6 }}
+      - name: certs
+        emptyDir: {}
+      - name: certs-legacy
+        secret:
+          secretName: scanner-tls
+          optional: true
+      - name: certs-new
+        secret:
+          secretName: tls-cert-scanner
+          optional: true
       {{- else }}
       - name: certs
         secret:

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -157,7 +157,16 @@ spec:
       - name: etc-pki-volume
         emptyDir: {}
       {{- if ._rox._securedClusterCertRefresh }}
-      {{- include "srox.tlsCertsInitContainerVolumes" (list "scanner-v4-indexer") | indent 6 }}
+      - name: certs
+        emptyDir: { }
+      - name: certs-legacy
+        secret:
+          secretName: scanner-v4-indexer-tls
+          optional: true
+      - name: certs-new
+        secret:
+          secretName: tls-cert-scanner-v4-indexer
+          optional: true
       {{- else }}
       - name: certs
         secret:

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -158,7 +158,7 @@ spec:
         emptyDir: {}
       {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
-        emptyDir: { }
+        emptyDir: {}
       - name: certs-legacy
         secret:
           secretName: scanner-v4-indexer-tls


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR fixes an issue that arose in https://github.com/stackrox/stackrox/pull/13568, which inadvertently changed the way legacy certs are mounted in the `scanner` and `scanner-v4-indexer` deployments of Secured Clusters, from:
```
        - name: certs-legacy
          secret:
            secretName: scanner-tls
            optional: true
```
to:
```
        - name: certs-legacy
          secret:
            secretName: scanner-tls
            items:
              - key: scanner-cert.pem
                path: cert.pem
              - key: scanner-key.pem
                path: key.pem
              - key: ca.pem
                path: ca.pem
            defaultMode: 420
            optional: true
```

However the original version was correct, because the keys of the `scanner-tls` secret are `cert.pem`, `key.pem`, and `ca.pem`. 

This causes local scanner in 4.7.0 to not start when only the legacy certificates are present (which is the case if Central is older than 4.6.0).

`scanner-v4-indexer-tls` is also affected by the same problem.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual testing on an OpenShift infra cluster:
1. Deployed using `make deploy-via-olm`, installed Central and Secured Cluster services.
2. Manually deleted `tls-cert-scanner` and `tls-cert-scanner-v4-indexer`, to make sure that the legacy certificates are used (`scanner-tls` and `scanner-v4-indexer-tls`)
3. Manually deleted a `scanner` pod and a `scanner-v4-indexer` pod, and verified that they start up normally and can load the legacy certs:
```
2025/03/19 19:04:41 Using 3 legacy certificates from "/run/secrets/stackrox.io/certs-legacy/".
2025/03/19 19:04:41 Copied "/run/secrets/stackrox.io/certs-legacy/..2025_03_19_19_04_41.854906748/ca.pem" to "/run/secrets/stackrox.io/certs/ca.pem"
2025/03/19 19:04:41 Copied "/run/secrets/stackrox.io/certs-legacy/..2025_03_19_19_04_41.854906748/cert.pem" to "/run/secrets/stackrox.io/certs/cert.pem"
2025/03/19 19:04:41 Copied "/run/secrets/stackrox.io/certs-legacy/..2025_03_19_19_04_41.854906748/key.pem" to "/run/secrets/stackrox.io/certs/key.pem"
```

Performed the exact steps also with the 4.7.0 build, where step 3 was failing (as expected).