### PR TITLE
ROX-28587: Retry kubectl on "unable to handle the request" error

### DIFF
--- a/scripts/retry-kubectl.sh
+++ b/scripts/retry-kubectl.sh
@@ -8,7 +8,13 @@
 
 set -euo pipefail
 
-error_regex=': i/o timeout$|net/http: request canceled \(Client\.Timeout exceeded while awaiting headers\)$'
+# RegExes for which we attempt a retry (one regex per line).
+error_regex=$(tr '\n' '|' <<EOT | sed -e 's/|$//;'
+: i/o timeout$
+net/http: request canceled \(Client\.Timeout exceeded while awaiting headers\)$
+: the server is currently unable to handle the request
+EOT
+)
 
 tmp_in="$(mktemp)"
 tmp_out="$(mktemp --suffix=-stdout.txt)"


### PR DESCRIPTION
### Description

Include 'unable to handle the request' in error regex list for retries.

This is an attempt to reduce CI flakiness.

See https://issues.redhat.com/browse/ROX-28587.

### Testing and quality

Verified locally by pointing `$KUBECTL` to a fake script:

```
#!/usr/bin/env bash

sleep 1

echo >&2 'Error from server (InternalError): an error on the server ("Internal Server Error: \"/api/v1/namespaces/stackrox/persistentvolumeclaims?fieldManager=kubectl-client-side-apply&fieldValidation=Strict\": the server is currently unable to handle the request") has prevented the request from succeeding (post persistentvolumeclaims)'

exit 1
```

