### PR TITLE
chore(ui): Enable one retry for Cypress tests

### DIFF
--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -14,6 +14,14 @@ module.exports = {
     video: true, // Videos options
     videoCompression: 32, // Videos options
 
+    retries: {
+        // Configure retry attempts for `cypress run`
+        // Attempt a single retry for failed tests when run headless
+        runMode: 1,
+        // Configure retry attempts for `cypress open`
+        openMode: 0,
+    },
+
     e2e: {
         baseUrl: 'https://localhost:3000',
         specPattern: 'cypress/integration/**/*.test.{js,ts}',


### PR DESCRIPTION
### Description

Allows Cypress to retry a failed test during run mode one (1) time, in an attempt to avoid recurring, but rare, flakes that UI e2e tests cannot easily recover from. Analysis of CI problems for these tests can be found [here](https://docs.google.com/document/d/1RzEi_FzPKYask0FfeFSg3g1h6UetztNQtXMmAKrL_AI/edit?tab=t.0#heading=h.66y4kqbj468a). 

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

With a locally modified test suite to ensure the first instance of the test fails:
```
npm run cypress-spec violations/filteredWorkflowViews.test.ts && echo "Pass"
```
```
2025-03-21T17:57:21.318Z running test suite: filteredWorkflowViews.test.ts

  Violations - Filtered Workflow Views
    (Attempt 1 of 2) should filter the violations table when the "Applications view" is selected
    ✓ should filter the violations table when the "Applications view" is selected (10648ms)
    ✓ should filter the violations table when the "Platform view" is selected (6977ms)
    ✓ should filter the violations table when the "Full view" is selected (8430ms)


  3 passing (49s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        3                                                                                │
  │ Passing:      3                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  1                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     48 seconds                                                                       │
  │ Spec Ran:     filteredWorkflowViews.test.ts                                                    │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Screenshots)

  -  /Users/dvail/go/src/github.com/stackrox/stackrox/ui/apps/platform/cypress/test-r     (1280x720)
     esults/artifacts/screenshots/filteredWorkflowViews.test.ts/Violations - Filtered
      Workflow Views -- should filter the violations table when the Applications view
      is selected (failed).png


  (Video)

  -  Started compressing: Compressing to 32 CRF
  -  Finished compressing: 2 seconds

  -  Video output: /Users/dvail/go/src/github.com/stackrox/stackrox/ui/apps/platform/cypress/test-results/artifacts/videos/filteredWorkflowViews.test.ts.mp4


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  filteredWorkflowViews.test.ts            00:48        3        3        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:48        3        3        -        -        -

Pass
```

Running the same, via the Cypress UI:
![image](https://github.com/user-attachments/assets/659de5dd-99cc-4ff8-8e3e-2d0357842c1d)
 