### PR TITLE
ROX-28148: Collect metrics for scan semaphore queue sizes

### DIFF
--- a/central/image/metrics/metrics.go
+++ b/central/image/metrics/metrics.go
@@ -1,0 +1,19 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+var (
+	ImageScanSemaphoreQueueSize = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "image_scan_semaphore_queue_size",
+		Help:      "A counter that tracks the queue size of the scan semaphre used in image scan.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(ImageScanSemaphoreQueueSize)
+}

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	clusterUtil "github.com/stackrox/rox/central/cluster/util"
 	"github.com/stackrox/rox/central/image/datastore"
+	"github.com/stackrox/rox/central/image/metrics"
 	iiStore "github.com/stackrox/rox/central/imageintegration/store"
 	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/role/sachelper"
@@ -242,7 +243,7 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 		)
 		return nil, err
 	}
-	defer s.internalScanSemaphore.Release(1)
+	defer s.releaseFromScanSemaphore(1)
 
 	var (
 		img       *storage.Image
@@ -435,7 +436,7 @@ func (s *serviceImpl) GetImageVulnerabilitiesInternal(ctx context.Context, reque
 		)
 		return nil, err
 	}
-	defer s.internalScanSemaphore.Release(1)
+	defer s.releaseFromScanSemaphore(1)
 
 	imgID := request.GetImageId()
 
@@ -476,9 +477,15 @@ func (s *serviceImpl) GetImageVulnerabilitiesInternal(ctx context.Context, reque
 	return internalScanRespFromImage(img), nil
 }
 
+func (s *serviceImpl) releaseFromScanSemaphore(n int64) {
+	metrics.ImageScanSemaphoreQueueSize.Add(float64(-n))
+	s.internalScanSemaphore.Release(n)
+}
+
 func (s *serviceImpl) acquireScanSemaphore(ctx context.Context) error {
 	semaphoreCtx, cancel := context.WithTimeout(ctx, maxSemaphoreWaitTime)
 	defer cancel()
+	metrics.ImageScanSemaphoreQueueSize.Add(1)
 	if err := s.internalScanSemaphore.Acquire(semaphoreCtx, 1); err != nil {
 		wrappedErr := errors.Wrap(err, "acquiring scan semaphore")
 
@@ -516,7 +523,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 		return nil, err
 	}
 
-	defer s.internalScanSemaphore.Release(1)
+	defer s.releaseFromScanSemaphore(1)
 
 	imgID := request.GetImageId()
 	var hasErrors bool

--- a/tests/performance/scale/config/metrics-acs-central.yml
+++ b/tests/performance/scale/config/metrics-acs-central.yml
@@ -265,6 +265,9 @@
 - query: rox_central_image_upsert_deduper{namespace="stackrox",container="central"}
   metricName: central_rox_central_image_upsert_deduper
 
+- query: rox_central_image_scan_semaphore_queue_size{namespace="stackrox",container="central"}
+  metricName: central_rox_central_image_scan_semaphore_queue_size
+  
 - query: rox_central_info{namespace="stackrox",container="central"}
   metricName: central_rox_central_info
 

--- a/tests/performance/scale/config/metrics-acs.yml
+++ b/tests/performance/scale/config/metrics-acs.yml
@@ -281,6 +281,9 @@
 - query: rox_central_image_upsert_deduper{namespace="stackrox",container="central"}
   metricName: central_rox_central_image_upsert_deduper
 
+- query: rox_central_image_scan_semaphore_queue_size{namespace="stackrox",container="central"}
+  metricName: central_rox_central_image_scan_semaphore_queue_size
+
 - query: rox_central_info{namespace="stackrox",container="central"}
   metricName: central_rox_central_info
 

--- a/tests/performance/scale/config/metrics-full.yml
+++ b/tests/performance/scale/config/metrics-full.yml
@@ -456,6 +456,9 @@
 - query: rox_central_image_upsert_deduper{namespace="stackrox",container="central"}
   metricName: central_rox_central_image_upsert_deduper
 
+- query: rox_central_image_scan_semaphore_queue_size{namespace="stackrox",container="central"}
+  metricName: central_rox_central_image_scan_semaphore_queue_size
+
 - query: rox_central_info{namespace="stackrox",container="central"}
   metricName: central_rox_central_info
 


### PR DESCRIPTION
### Description

Adds a prometheus metric that tracks the scan semaphore queue size in image scan.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Not sure if it makes sense to add automated tests here(?) For other simple metrics we don't have tests at least. If automated tests are not required I suppose the best way to test this is to put the image on a cluster and trigger image scans to see if the metric reports expected results, but I have not yet done that.