### PR TITLE
fix(pg): ScanStrings should call row not rows

### DIFF
--- a/pkg/postgres/pgutils/scan.go
+++ b/pkg/postgres/pgutils/scan.go
@@ -11,13 +11,13 @@ type Unmarshaler[T any] interface {
 	*T
 }
 
-// ScanRows scans strings.
+// ScanStrings ScanRows scans strings.
 //
 // This function closes the rows automatically on return.
 func ScanStrings(rows pgx.Rows) ([]string, error) {
 	return pgx.CollectRows(rows, func(r pgx.CollectableRow) (string, error) {
 		var str string
-		if err := rows.Scan(&str); err != nil {
+		if err := r.Scan(&str); err != nil {
 			return "", errors.Wrap(err, "scanning string")
 		}
 		return str, nil

--- a/pkg/postgres/pgutils/scan.go
+++ b/pkg/postgres/pgutils/scan.go
@@ -11,7 +11,7 @@ type Unmarshaler[T any] interface {
 	*T
 }
 
-// ScanStrings ScanRows scans strings.
+// ScanStrings scans strings from rows.
 //
 // This function closes the rows automatically on return.
 func ScanStrings(rows pgx.Rows) ([]string, error) {


### PR DESCRIPTION
### Description

Fix r instead of rows and godoc.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
