### PR TITLE
ROX-28598: Hide Configuration Management if only Alert resource

### DIFF
--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -240,7 +240,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     configmanagement: {
         // Require at least one resource for a dashboard widget.
         resourceAccessRequirements: someResource([
-            'Alert',
+            everyResource(['Alert', 'WorkflowAdministration']), // PolicyViolationsBySeverity
             // 'Cluster',
             'Compliance',
             // 'Deployment',


### PR DESCRIPTION
### Description

### Problem

A user role that should see only **Dashboard** and **Violations**, also sees **Configuration Management**. Adding injury to insult, no data because RBAC errors.

### Analysis

I reduced RBAC resource requirements for routes in #7909

For **Configuration Management** widgets, I specified one resource per widget:
1. `PolicyViolationsBySeverity` widget: `'Alert'`
2. `ComplianceByControls` widget: `'Compliance'`
3. `UsersWithMostClusterAdminRoles` widget: `'K8sSubject'`
4. `SecretsMostUsedAcrossDeployments` widget: `'Secret'`

Here are complete resources for the queries:
1. `PolicyViolationsBySeverity` query `policyViolationsBySeverity` requires `['Alert', 'WorkflowAdministration']`
2. `ComplianceByControls` query `complianceByControls` requires `['Compliance']`
3. `UsersWithMostClusterAdminRoles` query `usersWithClusterAdminRoles` requires `['K8sRoleBinding', 'K8sSubject']`
4. `SecretsMostUsedAcrossDeployments` query `secrets` requires `['Deployment', 'Secret']`

### Solution

Replace `'Alert'` with `everyResource(['Alert', 'WorkflowAdministration'])` so the particular user role does not see **Configuration Management**.

This is minimal change that solves reported problem for this customer and is safe for backport.

It is possible to compose `someResource` and `everyResource` higher order functions.

### Residue

Make RBAC of **Configuration Management** consistent with other containers for 4.8 release.
* Conditionally render header and widgets on dashboard.
* Conditionally render menu items on dashboard.
    To be determined what **required** resources to render versus **optional** resources that might either cause errors (worst case) or be conditionally omitted from query and rendered as **Not available** (best case).
* Investigate links from other containers (especially Search).

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed because Jira bug will have Release Notes Text field

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform
3. `npm run start` in ui/apps/platform

### Manual testing

1. Visit /main/configmanagement with user role that has `READ_ACCESS` for only `'Alert'` resource.

    Before change, see presence of **Configuration Management** in left navigation and errors on the page.
    ![configmanagement_policyViolationsBySeverity_error](https://github.com/user-attachments/assets/d1ee199a-a0c6-4d2f-b4ab-4b8c13c24dd3)

    After change, see absence of **Configuration Management** in left navigation and `PageNotFound` element on the page.
    ![configmanagement_PageNotFound](https://github.com/user-attachments/assets/c8119d43-ac66-49f3-ac52-31f494bcaad1)
