### PR TITLE
ROX-26692: Updates http-proxy-middleware to latest

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -12481,10 +12481,11 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-            "integrity": "sha1-4aTdaXlXLHq1pOS1UJXR8yp0lj8= sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
                 "http-proxy": "^1.18.1",


### PR DESCRIPTION
### Description

Needs to go into next 4.6 and 4.7 patch releases.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

This is a patch version for a dev dependency used by `webpack-dev-server`. To test, install the latest version and run a local development server, smoke testing pages in the app.