### PR TITLE
ROX-28599: Conditionally render on Configuration Management dashboard

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.js
@@ -2,17 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ExportButton from 'Components/ExportButton';
 import useCaseTypes from 'constants/useCaseTypes';
+import usePermissions from 'hooks/usePermissions';
 import PoliciesTile from './PoliciesTile';
 import CISControlsTile from './CISControlsTile';
 import AppMenu from './AppMenu';
 import RBACMenu from './RBACMenu';
 
 const Header = ({ isExporting, setIsExporting }) => {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForPoliciesTile = hasReadAccess('WorkflowAdministration');
+    const hasReadAccessForCISControlsTile = hasReadAccess('Compliance');
     return (
         <div className="flex flex-1 justify-end">
             <div className="border-base-400 border-r-2 mr-1 flex ">
-                <PoliciesTile />
-                <CISControlsTile />
+                {hasReadAccessForPoliciesTile && <PoliciesTile />}
+                {hasReadAccessForCISControlsTile && <CISControlsTile />}
                 <div className="flex w-32 mr-2">
                     <AppMenu />
                 </div>

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Page.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import useCaseLabels from 'messages/useCase';
 import useCaseTypes from 'constants/useCaseTypes';
 import { standardTypes } from 'constants/entityTypes';
+import usePermissions from 'hooks/usePermissions';
 
 import DashboardLayout from 'Components/DashboardLayout';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
@@ -14,6 +15,14 @@ import SecretsMostUsedAcrossDeployments from './widgets/SecretsMostUsedAcrossDep
 
 const ConfigManagementDashboardPage = () => {
     const [isExporting, setIsExporting] = useState(false);
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForPolicyViolationsBySeverity =
+        hasReadAccess('Alert') && hasReadAccess('WorkflowAdministration');
+    const hasReadAccessForComplianceByControls = hasReadAccess('Compliance');
+    const hasReadAccessForUsersWithMostClusterAdminRoles =
+        hasReadAccess('Cluster') && hasReadAccess('K8sRoleBinding') && hasReadAccess('K8sSubject');
+    const hasReadAccessForSecretsMostUsedAcrossDeployments =
+        hasReadAccess('Deployment') && hasReadAccess('Secret');
     return (
         <>
             <DashboardLayout
@@ -22,13 +31,19 @@ const ConfigManagementDashboardPage = () => {
                     <Header isExporting={isExporting} setIsExporting={setIsExporting} />
                 }
             >
-                <PolicyViolationsBySeverity />
-                <ComplianceByControls
-                    className="pdf-page"
-                    standardOptions={[standardTypes.CIS_Kubernetes_v1_5]}
-                />
-                <UsersWithMostClusterAdminRoles />
-                <SecretsMostUsedAcrossDeployments />
+                {hasReadAccessForPolicyViolationsBySeverity && <PolicyViolationsBySeverity />}
+                {hasReadAccessForComplianceByControls && (
+                    <ComplianceByControls
+                        className="pdf-page"
+                        standardOptions={[standardTypes.CIS_Kubernetes_v1_5]}
+                    />
+                )}
+                {hasReadAccessForUsersWithMostClusterAdminRoles && (
+                    <UsersWithMostClusterAdminRoles />
+                )}
+                {hasReadAccessForSecretsMostUsedAcrossDeployments && (
+                    <SecretsMostUsedAcrossDeployments />
+                )}
             </DashboardLayout>
             {isExporting && <BackdropExporting />}
         </>


### PR DESCRIPTION
### Description

### Problem

Dashboard counts and widgets make requests that are doomed to fail if user roles have limited resources.

### Analysis

I reduced RBAC resource requirements for routes in #7909

For **Configuration Management** widgets, I specified one resource per widget:
1. `PolicyViolationsBySeverity` widget: `'Alert'`
2. `ComplianceByControls` widget: `'Compliance'`
3. `UsersWithMostClusterAdminRoles` widget: `'K8sSubject'`
4. `SecretsMostUsedAcrossDeployments` widget: `'Secret'`

Here are complete resources for counts queries in header:
1. `PoliciesTile` query `numPolicies` requires `['WorkflowAdministration']`
2. `CISControlsTile` query `numCISControls` requires `['Compliance']`

Here are complete resources for data queries of widgets:
1. `PolicyViolationsBySeverity` query `policyViolationsBySeverity` requires `['Alert', 'WorkflowAdministration']`
2. `ComplianceByControls` query `complianceByControls` requires `['Compliance']`
3. `UsersWithMostClusterAdminRoles` query `usersWithClusterAdminRoles` requires `['K8sRoleBinding', 'K8sSubject']`
4. `SecretsMostUsedAcrossDeployments` query `secrets` requires `['Deployment', 'Secret']`

### Solution

Conditionally render elements only if user role has required resources.

### Residue

* Investigate which resources with `READ_ACCESS` are required for compliance scan in addition to `Compliance` with `READ_WRITE_ACCESS` level.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed (yet)

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4661202 - 4661202
        total 279 = 11567500 - 11567221
    * `ls -al build/static/js/*.js | wc`
        files 0 = 177 - 177
3. `npm run start` in ui/apps/platform

### Manual testing

With user role that has `READ_ACCESS` for only the following resources:

1. `['Alert']`

    POST /api/graphql?opname=policyViolationsBySeverity response does not have data

    This scenario will not be possible after we merge #14714

    However, conditional rendering is consistent, and will become necessary if in the future we remove `Alert` from resource requirements for `configmanagement` route.
    ![configmanagement_policyViolationsBySeverity_error](https://github.com/user-attachments/assets/244b3b84-eaea-42e9-80fc-0dea287af4cd)

2. `['Alert', 'WorkflowAdministration']`

    POST /api/graphql?opname=policyViolationsBySeverity response has data

    Page renders `PolicyViolationsBySeverity` element with data.
    ![configmanagement_policyViolationsBySeverity_data](https://github.com/user-attachments/assets/0fbf05ea-0532-43e5-8516-bc5de8359eed)

3. `['Compliance']`

    POST /api/graphql?opname=complianceByControls
    * has `results: []` before scan
    * has `results: […]` after scan

    ![configmanagement_complianceByControls_data](https://github.com/user-attachments/assets/cb499045-85a8-49fa-8b9a-156397704a02)

    After changes, see absence of elements.

4. `['Secret']`

    POST /api/graphql?opname=secrets does not have data
    ![configmanagement_secrets_error](https://github.com/user-attachments/assets/c426113a-df35-4ed2-b16f-7d6a620f8435)

5. `['Deployment', 'Secret']`

    POST /api/graphql?opname=secrets does have data

    ![configmanagement_secrets_data](https://github.com/user-attachments/assets/642eff58-5d52-4911-b70b-cde79db7b524)

    Before changes, also see errors for queries
    POST /api/graphql?opname=numPolicies
    POST /api/graphql?opname=numCISControls

6. `['K8sSubject']`

    POST /api/graphql?opname=usersWithClusterAdminRoles does not have data
    ![configmanagement_usersWithClusterAdminRoles_error](https://github.com/user-attachments/assets/5f03853f-9888-425a-a9d7-3b862ad02759)
