### PR TITLE
fix(migrator): use RunCursorQueryForSchemaFn in Walk

### DIFF
--- a/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/permissionsetpostgresstore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -258,24 +257,5 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 // Walk iterates over all of the objects in the store and applies the closure
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PermissionSet](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -256,24 +255,5 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 // Walk iterates over all of the objects in the store and applies the closure
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PermissionSet](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }

--- a/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policycategoryedgepostgresstore/store.go
+++ b/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policycategoryedgepostgresstore/store.go
@@ -26,7 +26,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -259,26 +258,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
 // Walk iterates over all of the objects in the store and applies the closure
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategoryEdge) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PolicyCategoryEdge](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, _ ops.Op, _ string) (*postgres.Conn, func(), error) {

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/collectionPostgresStore/postgres_plugin.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/collectionPostgresStore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -385,24 +384,5 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.ResourceCollec
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ResourceCollection) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.ResourceCollection](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/reportConfigurationPostgresStore/postgres_plugin.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/reportConfigurationPostgresStore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -280,24 +279,5 @@ func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error 
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ReportConfiguration) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.ReportConfiguration](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }

--- a/migrator/migrations/m_173_to_m_174_group_unique_constraint/stores/updated/postgres_plugin.go
+++ b/migrator/migrations/m_173_to_m_174_group_unique_constraint/stores/updated/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -277,24 +276,5 @@ func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error 
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Group) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.Group](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }

--- a/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/newapitokenpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_174_to_m_175_enable_search_on_api_tokens/newapitokenpostgresstore/postgres_plugin.go
@@ -33,7 +33,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 

--- a/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkbaselinestore/postgres_plugin.go
+++ b/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkbaselinestore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -272,26 +271,7 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBasel
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkBaseline) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.NetworkBaseline](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Stubs for satisfying legacy interfaces

--- a/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkentitystore/postgres_plugin.go
+++ b/migrator/migrations/m_176_to_m_177_network_baselines_cidr/networkentitystore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 

--- a/migrator/migrations/m_177_to_m_178_group_permissions/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_177_to_m_178_group_permissions/permissionsetpostgresstore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -268,26 +267,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error 
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PermissionSet](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Interface functions - END

--- a/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/reportconfigstore/postgres_plugin.go
+++ b/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/reportconfigstore/postgres_plugin.go
@@ -32,7 +32,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -307,24 +306,5 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.ReportConfiguration) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.ReportConfiguration](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }

--- a/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/test/postgres_plugin.go
+++ b/migrator/migrations/m_178_to_m_179_embedded_collections_search_label/test/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 

--- a/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/postgres/store.go
+++ b/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/postgres/store.go
@@ -20,8 +20,6 @@ import (
 )
 
 const (
-	baseTable       = "policies"
-	cursorBatchSize = 50
 	batchAfter      = 100
 	batchSize       = 10000
 	deleteBatchSize = 5000

--- a/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/permissionsetstore/store.go
+++ b/migrator/migrations/m_181_to_m_182_group_role_permission_with_access_one/permissionsetstore/store.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -268,26 +267,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error 
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PermissionSet](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Interface functions - END

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/apitokenstore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/apitokenstore/postgres_plugin.go
@@ -34,7 +34,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -320,26 +319,7 @@ func (s *storeImpl) GetMany(ctx context.Context, identifiers []string) ([]*stora
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.TokenMetadata) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.TokenMetadata](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Interface functions - END

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/groupstore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/groupstore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -283,26 +282,7 @@ func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error 
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Group) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.Group](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Interface functions - END

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/permissionsetstore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/permissionsetstore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -287,26 +286,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PermissionSet,
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PermissionSet](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Interface functions - END

--- a/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/rolestore/postgres_plugin.go
+++ b/migrator/migrations/m_182_to_m_183_remove_default_scope_manager_role/rolestore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -282,26 +281,7 @@ func (s *storeImpl) Get(ctx context.Context, name string) (*storage.Role, bool, 
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.Role) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.Role](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Interface functions - END

--- a/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/permissionsetstore/postgres_plugin.go
+++ b/migrator/migrations/m_184_to_m_185_remove_policy_vulnerability_report_resources/permissionsetstore/postgres_plugin.go
@@ -30,7 +30,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 
@@ -286,26 +285,7 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PermissionSet,
 // Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PermissionSet](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 //// Interface functions - END

--- a/migrator/migrations/m_185_to_m_186_more_policy_migrations/policypostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_185_to_m_186_more_policy_migrations/policypostgresstore/postgres_plugin.go
@@ -31,7 +31,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 

--- a/migrator/migrations/policymigrationhelper/categorypostgresstorefortest/postgres_policy_category_plugin.go
+++ b/migrator/migrations/policymigrationhelper/categorypostgresstorefortest/postgres_policy_category_plugin.go
@@ -15,10 +15,6 @@ import (
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 )
 
-const (
-	cursorBatchSize = 50
-)
-
 var (
 	schema = frozenSchema.PolicyCategoriesSchema
 )
@@ -53,26 +49,7 @@ func (s *storeImpl) GetAll(ctx context.Context) ([]*storeType, error) {
 // Walk iterates through each policy category
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategory) error) error {
 	var sacQueryFilter *v1.Query
-	fetcher, closer, err := pgSearch.RunCursorQueryForSchema[storage.PolicyCategory](ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return err
-	}
-	defer closer()
-	for {
-		rows, err := fetcher(cursorBatchSize)
-		if err != nil {
-			return pgutils.ErrNilIfNoRows(err)
-		}
-		for _, data := range rows {
-			if err := fn(data); err != nil {
-				return err
-			}
-		}
-		if len(rows) != cursorBatchSize {
-			break
-		}
-	}
-	return nil
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_policy_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_policy_plugin.go
@@ -33,7 +33,6 @@ const (
 	// proceed and move into more e2e and larger performance testing
 	batchSize = 10000
 
-	cursorBatchSize = 50
 	deleteBatchSize = 5000
 )
 

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -992,55 +992,6 @@ func RunGetManyQueryForSchema[T any, PT pgutils.Unmarshaler[T]](ctx context.Cont
 	})
 }
 
-// RunCursorQueryForSchema creates a cursor against the database
-//
-// Deprecated: use RunCursorQueryForSchemaFn instead
-func RunCursorQueryForSchema[T any, PT pgutils.Unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB) (fetcher func(n int) ([]*T, error), closer func(), err error) {
-	if q == nil {
-		q = searchPkg.EmptyQuery()
-	}
-
-	query, err := standardizeQueryAndPopulatePath(ctx, q, schema, GET)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error creating query")
-	}
-	if query == nil {
-		return nil, nil, emptyQueryErr
-	}
-
-	queryStr := query.AsSQL()
-
-	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, cursorDefaultTimeout)
-
-	tx, err := db.Begin(ctx)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating transaction")
-	}
-	closer = func() {
-		defer cancel()
-		if err := tx.Commit(ctx); err != nil {
-			log.Errorf("error committing cursor transaction: %v", err)
-		}
-	}
-
-	cursorSuffix := random.GenerateString(16, random.CaseInsensitiveAlpha)
-	cursor := stringutils.JoinNonEmpty("_", query.From, cursorSuffix)
-	_, err = tx.Exec(ctx, fmt.Sprintf("DECLARE %s CURSOR FOR %s", cursor, queryStr), query.Data...)
-	if err != nil {
-		closer()
-		return nil, nil, errors.Wrap(err, "creating cursor")
-	}
-
-	return func(n int) ([]*T, error) {
-		rows, err := tx.Query(ctx, fmt.Sprintf("FETCH %d FROM %s", n, cursor))
-		if err != nil {
-			return nil, errors.Wrap(err, "advancing in cursor")
-		}
-
-		return pgutils.ScanRows[T, PT](rows)
-	}, closer, nil
-}
-
 // RunCursorQueryForSchemaFn creates a cursor against the database
 func RunCursorQueryForSchemaFn[T any, PT pgutils.Unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB, callback func(obj PT) error) error {
 	if q == nil {


### PR DESCRIPTION
### Description

In this PR we replace `RunCursorQueryForSchema` with `RunCursorQueryForSchemaFn` in walk. This results in much simpler code in `store.go` and allow removal of `RunCursorQueryForSchema` as it's not longer used.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
