### PR TITLE
feat(pg): increase cursor batch size

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -50,6 +50,8 @@ var (
 	}
 )
 
+const cursorBatchSize = 1000
+
 // QueryType describe what type of query to execute
 //
 //go:generate stringer -type=QueryType
@@ -1077,7 +1079,6 @@ func RunCursorQueryForSchemaFn[T any, PT pgutils.Unmarshaler[T]](ctx context.Con
 		return errors.Wrap(err, "creating cursor")
 	}
 
-	const cursorBatchSize = 1000
 	for {
 		rows, err := tx.Query(ctx, fmt.Sprintf("FETCH %d FROM %s", cursorBatchSize, cursor))
 		if err != nil {

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1077,6 +1077,7 @@ func RunCursorQueryForSchemaFn[T any, PT pgutils.Unmarshaler[T]](ctx context.Con
 		return errors.Wrap(err, "creating cursor")
 	}
 
+	const cursorBatchSize = 1000
 	for {
 		rows, err := tx.Query(ctx, fmt.Sprintf("FETCH %d FROM %s", cursorBatchSize, cursor))
 		if err != nil {

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	batchAfter      = 100
-	cursorBatchSize = 50
 	deleteBatchSize = 65000
 	pruneBatchSize  = 5000
 


### PR DESCRIPTION
### Description

With following code I've tested how cursor size affects the `Walk`ing time. We can significantly increase the throughput by increasing from 25 to 1000 without putting too much pressure on the database. Of course the bigger the window is the less time we spend in db queries round trips. 

![chart-studio plotly com_create_ (2)](https://github.com/user-attachments/assets/0f6e70b4-cfbc-46b5-9a82-c4064bbaf431)


```go
package postgres

import (
	"context"
	"fmt"
	"testing"

	"github.com/stackrox/rox/generated/storage"
	"github.com/stackrox/rox/pkg/postgres/pgtest"
	"github.com/stackrox/rox/pkg/sac"
	"github.com/stackrox/rox/pkg/search/postgres"
	"github.com/stackrox/rox/pkg/testutils"
	"github.com/stretchr/testify/assert"
)

func BenchmarkMany(b *testing.B) {
	var alerts []*storage.Alert
	const alertsNum = 10000
	for i := 0; i < alertsNum; i++ {
		alert := &storage.Alert{}
		err := testutils.FullInit(alert, testutils.UniqueInitializer(), testutils.JSONFieldsFilter)
		if err != nil {
			b.Fatal(err)
		}
		alerts = append(alerts, alert)
	}

	var idx []string
	for _, a := range alerts {
		idx = append(idx, a.Id)
	}

	testDB := pgtest.ForT(b)
	store := New(testDB.DB)

	ctx := sac.WithAllAccess(context.Background())
	err := store.UpsertMany(ctx, alerts)
	if err != nil {
		b.Fatal(err)
	}

	for n := int64(100); n <= alertsNum; n = n + 100 {
		postgres.CursorBatchSize = n
		b.Run(fmt.Sprintf("CursorBatchSize=%d", n), func(b *testing.B) {
			for i := 0; i < b.N; i++ {
				count := 0
				err := store.Walk(ctx, func(obj *storeType) error {
					count++
					return nil
				})
				assert.NoError(b, err)
				assert.Equal(b, alertsNum, count)
			}
		})
	}
}
```

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
