### PR TITLE
ROX-28665: Save metrics from long running clusters to Elasticsearch

### DIFF
--- a/deploy/charts/monitoring/templates/deployment.yaml
+++ b/deploy/charts/monitoring/templates/deployment.yaml
@@ -114,12 +114,12 @@ spec:
               secretKeyRef:
                 name: monitoring
                 key: elasticsearch_url
-            name: ELASTICSEARCH_USER
+          - name: ELASTICSEARCH_USER
             valueFrom:
               secretKeyRef:
                 name: monitoring
                 key: elasticsearch_user
-            name: ELASTICSEARCH_PASSWORD
+          - name: ELASTICSEARCH_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: monitoring

--- a/deploy/charts/monitoring/templates/deployment.yaml
+++ b/deploy/charts/monitoring/templates/deployment.yaml
@@ -108,6 +108,22 @@ spec:
             readOnly: true
           - name: prometheus-data-volume
             mountPath: /var/prometheus
+        env:
+          - name: ELASTICSEARCH_URL
+            valueFrom:
+              secretKeyRef:
+                name: monitoring
+                key: elasticsearch_url
+            name: ELASTICSEARCH_USER
+            valueFrom:
+              secretKeyRef:
+                name: monitoring
+                key: elasticsearch_user
+            name: ELASTICSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: monitoring
+                key: elasticsearch_password
       volumes:
       - name: monitoring-ui-volume
         secret:

--- a/deploy/charts/monitoring/templates/prometheus.yaml
+++ b/deploy/charts/monitoring/templates/prometheus.yaml
@@ -16,6 +16,12 @@ data:
             - targets:
                 - {{ .Release.Name }}-alertmanager:9093
 
+    remote_write:
+      - url: "${ELASTICSEARCH_URL}"
+        basic_auth:
+          username: "${ELASTICSEARCH_USER}"
+          password: "${ELASTICSEARCH_PASSWORD}"
+
     rule_files:
       - /etc/prometheus/rules_*.yml
 

--- a/deploy/charts/monitoring/templates/secret.yaml
+++ b/deploy/charts/monitoring/templates/secret.yaml
@@ -18,3 +18,10 @@ stringData:
     {{- $uiCert.Cert | nindent 4 }}
   monitoring-ui-key.pem: |
     {{- $uiCert.Key | nindent 4 }}
+data:
+  elasticsearch_url: |
+    {{- .Values.elasticsearch.url | b64enc | nindent 4 }}
+  elasticsearch_user: |
+    {{- .Values.elasticsearch.user | b64enc | nindent 4 }}
+  elasticsearch_password: |
+    {{- .Values.elasticsearch.password | b64enc | nindent 4 }}

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 function realpath {
 	[[ -n "$1" ]] || return 0
@@ -328,9 +329,9 @@ function launch_central {
         )
 
         elastic_count=0 # A counter for Elasticsearch related environment variables
-	[[ -n "${ELASTICSEARCH_URL:-}" ]] && ((elastic_count++))
-	[[ -n "${ELASTICSEARCH_USER:-}" ]] && ((elastic_count++))
-	[[ -n "${ELASTICSEARCH_PASSWORD:-}" ]] && ((elastic_count++))
+	[[ -n "${ELASTICSEARCH_URL:-}" ]] && elastic_count=$((elastic_count + 1))
+	[[ -n "${ELASTICSEARCH_USER:-}" ]] && elastic_count=$((elastic_count + 1))
+	[[ -n "${ELASTICSEARCH_PASSWORD:-}" ]] && elastic_count=$((elastic_count + 1))
 
 	# Either all or none of the Elastic search environment variables should be set
 	if [[ "$elastic_count" -ne 0 && "$elastic_count" -ne 3 ]]; then

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -326,6 +326,25 @@ function launch_central {
           --set persistence.type="${STORAGE}"
           --set exposure.type="${MONITORING_LOAD_BALANCER}"
         )
+
+        elastic_count=0 # A counter for Elasticsearch related environment variables
+	[[ -n "${ELASTICSEARCH_URL:-}" ]] && ((elastic_count++))
+	[[ -n "${ELASTICSEARCH_USER:-}" ]] && ((elastic_count++))
+	[[ -n "${ELASTICSEARCH_PASSWORD:-}" ]] && ((elastic_count++))
+
+	# Either all or none of the Elastic search environment variables should be set
+	if [[ "$elastic_count" -ne 0 && "$elastic_count" -ne 3 ]]; then
+	  echo "Either all or none of ELASTICSEARCH_URL, ELASTICSEARCH_USER, and ELASTICSEARCH_PASSWORD should be set"
+	  exit 1
+	fi
+
+	if [[ "$elastic_count" -eq 3 ]]; then
+          helm_args+=(--set elasticsearch.url="${ELASTICSEARCH_URL}")
+          helm_args+=(--set elasticsearch.user="${ELASTICSEARCH_USER}")
+          helm_args+=(--set elasticsearch.password="${ELASTICSEARCH_PASSWORD}")
+        fi
+
+
         if [[ "${is_local_dev}" == "true" ]]; then
           helm_args+=(-f "${COMMON_DIR}/monitoring-values-local.yaml")
         fi


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This will not work. OpenSearch does not support Prometheus' remote_write.

Makes it so that if environment variables for Elastic search are set than Prometheus metrics will be sent to Elasticsearch. The motivation for this is to save data from the long running clusters, so long running clusters from different releases can be saved.

The changes to github actions are here https://github.com/stackrox/actions/pull/56

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The changes here were tested by deploying a long running cluster using the PR linked to in this one.

Went to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml

Clicked on "Run workflow".

Set the branch to jv-ROX-28665-save-metrics-from-long-running-clusters-to-elasticsearch

Set the version to 0.0.4.

Checked "Create a long-running cluster on RC1"

Click "Run workflow"

Checked the deployment.

```
infractl artifacts long-fake-es-0-0-4 --download-dir /tmp/artifacts-long-fake-es-0-0-4
export KUBECONFIG=/tmp/artifacts-long-fake-es-0-0-4/kubeconfig
```

```
ks get deployment monitoring -o yaml
```

```
      - args:
        - --config.file=/etc/prometheus/prometheus.yml
        - --storage.tsdb.path=/var/prometheus
        - --web.console.libraries=/usr/share/prometheus/console_libraries
        - --web.console.templates=/usr/share/prometheus/consoles
        command:
        - /bin/prometheus
        env:
        - name: ELASTICSEARCH_URL
          valueFrom:
            secretKeyRef:
              key: elasticsearch_url
              name: monitoring
        - name: ELASTICSEARCH_USER
          valueFrom:
            secretKeyRef:
              key: elasticsearch_user
              name: monitoring
        - name: ELASTICSEARCH_PASSWORD
          valueFrom:
            secretKeyRef:
              key: elasticsearch_password
              name: monitoring
```

```
ks get configmap prometheus -o yaml
```

```
    remote_write:
      - url: "${ELASTICSEARCH_URL}"
        basic_auth:
          username: "${ELASTICSEARCH_USER}"
          password: "${ELASTICSEARCH_PASSWORD}"
```

```
ks get secret monitoring -o yaml
```

```
apiVersion: v1
data:
  elasticsearch_password: ***
  elasticsearch_url: ***
  elasticsearch_user: ***
```

Have not yet confirmed that the data is in Elasticsearch.