### PR TITLE
ROX-28679: Roxctl central generate ignoring --output-dir in OutputZip

### DIFF
--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -252,9 +252,9 @@ func createBundle(config *renderer.Config) (*zip.Wrapper, error) {
 	return wrapper, nil
 }
 
-// OutputZip renders a deployment bundle. The deployment bundle can either be
+// outputZip renders a deployment bundle. The deployment bundle can either be
 // written directly into a directory, or as a zipfile to STDOUT.
-func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
+func outputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	logger.InfofLn("Generating deployment bundle...")
 
 	common.LogInfoPsp(logger, config.EnablePodSecurityPolicies)

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/buildinfo"
@@ -255,7 +256,7 @@ func createBundle(config *renderer.Config) (*zip.Wrapper, error) {
 
 // OutputZip renders a deployment bundle. The deployment bundle can either be
 // written directly into a directory, or as a zipfile to STDOUT.
-func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
+func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config, flags *pflag.FlagSet) error {
 	logger.InfofLn("Generating deployment bundle...")
 
 	common.LogInfoPsp(logger, config.EnablePodSecurityPolicies)
@@ -278,7 +279,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() || (!containers.IsRunningInContainer() && !flags.OutputDirManuallySet) {
+	if roxctl.InMainImage() || (!containers.IsRunningInContainer() && !flags.Changed("output-dir")) {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/certgen"
-	"github.com/stackrox/rox/pkg/containers"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
@@ -256,7 +254,7 @@ func createBundle(config *renderer.Config) (*zip.Wrapper, error) {
 
 // OutputZip renders a deployment bundle. The deployment bundle can either be
 // written directly into a directory, or as a zipfile to STDOUT.
-func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config, flags *pflag.FlagSet) error {
+func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	logger.InfofLn("Generating deployment bundle...")
 
 	common.LogInfoPsp(logger, config.EnablePodSecurityPolicies)
@@ -279,7 +277,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config, flags *p
 	}
 
 	var outputPath string
-	if roxctl.InMainImage() || (!containers.IsRunningInContainer() && !flags.Changed("output-dir")) {
+	if roxctl.InMainImage() || config.OutputDir == "" {
 		bytes, err := wrapper.Zip()
 		if err != nil {
 			return errors.Wrap(err, "error generating zip file")

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -252,9 +252,9 @@ func createBundle(config *renderer.Config) (*zip.Wrapper, error) {
 	return wrapper, nil
 }
 
-// outputZip renders a deployment bundle. The deployment bundle can either be
+// OutputZip renders a deployment bundle. The deployment bundle can either be
 // written directly into a directory, or as a zipfile to STDOUT.
-func outputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
+func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	logger.InfofLn("Generating deployment bundle...")
 
 	common.LogInfoPsp(logger, config.EnablePodSecurityPolicies)

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -95,7 +95,7 @@ func TestRestoreKeysAndCerts(t *testing.T) {
 			// Note: This test is not for parallel run.
 			config.OutputDir = filepath.Join(tmpDir, testCase.testDir)
 			config.BackupBundle = testCase.backupBundle
-			require.NoError(t, outputZip(logger, io, config))
+			require.NoError(t, OutputZip(logger, io, config))
 
 			// Load values-private.yaml file
 			values, err := chartutil.ReadValuesFile(filepath.Join(config.OutputDir, "values-private.yaml"))
@@ -182,7 +182,7 @@ func TestTelemetryConfiguration(t *testing.T) {
 			config.K8sConfig.Telemetry.Enabled = testCase.telemetry
 
 			bundleio, _, out, _ := io2.TestIO()
-			require.ErrorIs(t, outputZip(logger, bundleio, config), testCase.expected.err)
+			require.ErrorIs(t, OutputZip(logger, bundleio, config), testCase.expected.err)
 			if testCase.expected.err != nil {
 				return
 			}
@@ -282,7 +282,7 @@ func TestMonitoringConfiguration(t *testing.T) {
 			bundleio, _, out, _ := io2.TestIO()
 			config.ClusterType = testCase.clusterType
 			config.K8sConfig.Monitoring.OpenShiftMonitoring = testCase.flagEnabled
-			err := outputZip(logger, bundleio, config)
+			err := OutputZip(logger, bundleio, config)
 			require.ErrorIs(t, err, testCase.expectErr)
 			if err != nil {
 				return

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/pflag"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/buildinfo"
@@ -46,8 +45,6 @@ func TestRestoreKeysAndCerts(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	testutils.SetExampleVersion(t)
-
-	persistentFlags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 	flavorName := defaults.ImageFlavorNameDevelopmentBuild
 	if buildinfo.ReleaseBuild {
@@ -98,7 +95,7 @@ func TestRestoreKeysAndCerts(t *testing.T) {
 			// Note: This test is not for parallel run.
 			config.OutputDir = filepath.Join(tmpDir, testCase.testDir)
 			config.BackupBundle = testCase.backupBundle
-			require.NoError(t, OutputZip(logger, io, config, persistentFlags))
+			require.NoError(t, OutputZip(logger, io, config))
 
 			// Load values-private.yaml file
 			values, err := chartutil.ReadValuesFile(filepath.Join(config.OutputDir, "values-private.yaml"))
@@ -129,8 +126,6 @@ func TestTelemetryConfiguration(t *testing.T) {
 	t.Setenv("ROX_ROXCTL_IN_MAIN_IMAGE", "true")
 
 	testutils.SetExampleVersion(t)
-
-	persistentFlags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 	flavorName := defaults.ImageFlavorNameDevelopmentBuild
 	if buildinfo.ReleaseBuild {
@@ -187,7 +182,7 @@ func TestTelemetryConfiguration(t *testing.T) {
 			config.K8sConfig.Telemetry.Enabled = testCase.telemetry
 
 			bundleio, _, out, _ := io2.TestIO()
-			require.ErrorIs(t, OutputZip(logger, bundleio, config, persistentFlags), testCase.expected.err)
+			require.ErrorIs(t, OutputZip(logger, bundleio, config), testCase.expected.err)
 			if testCase.expected.err != nil {
 				return
 			}
@@ -217,8 +212,6 @@ func TestMonitoringConfiguration(t *testing.T) {
 	t.Setenv("ROX_ROXCTL_IN_MAIN_IMAGE", "true")
 
 	testutils.SetExampleVersion(t)
-
-	persistentFlags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 	flavorName := defaults.ImageFlavorNameDevelopmentBuild
 	if buildinfo.ReleaseBuild {
@@ -289,7 +282,7 @@ func TestMonitoringConfiguration(t *testing.T) {
 			bundleio, _, out, _ := io2.TestIO()
 			config.ClusterType = testCase.clusterType
 			config.K8sConfig.Monitoring.OpenShiftMonitoring = testCase.flagEnabled
-			err := OutputZip(logger, bundleio, config, persistentFlags)
+			err := OutputZip(logger, bundleio, config)
 			require.ErrorIs(t, err, testCase.expectErr)
 			if err != nil {
 				return

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/pflag"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/buildinfo"
@@ -45,6 +46,8 @@ func TestRestoreKeysAndCerts(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	testutils.SetExampleVersion(t)
+
+	persistentFlags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 	flavorName := defaults.ImageFlavorNameDevelopmentBuild
 	if buildinfo.ReleaseBuild {
@@ -95,7 +98,7 @@ func TestRestoreKeysAndCerts(t *testing.T) {
 			// Note: This test is not for parallel run.
 			config.OutputDir = filepath.Join(tmpDir, testCase.testDir)
 			config.BackupBundle = testCase.backupBundle
-			require.NoError(t, OutputZip(logger, io, config))
+			require.NoError(t, OutputZip(logger, io, config, persistentFlags))
 
 			// Load values-private.yaml file
 			values, err := chartutil.ReadValuesFile(filepath.Join(config.OutputDir, "values-private.yaml"))
@@ -126,6 +129,8 @@ func TestTelemetryConfiguration(t *testing.T) {
 	t.Setenv("ROX_ROXCTL_IN_MAIN_IMAGE", "true")
 
 	testutils.SetExampleVersion(t)
+
+	persistentFlags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 	flavorName := defaults.ImageFlavorNameDevelopmentBuild
 	if buildinfo.ReleaseBuild {
@@ -182,7 +187,7 @@ func TestTelemetryConfiguration(t *testing.T) {
 			config.K8sConfig.Telemetry.Enabled = testCase.telemetry
 
 			bundleio, _, out, _ := io2.TestIO()
-			require.ErrorIs(t, OutputZip(logger, bundleio, config), testCase.expected.err)
+			require.ErrorIs(t, OutputZip(logger, bundleio, config, persistentFlags), testCase.expected.err)
 			if testCase.expected.err != nil {
 				return
 			}
@@ -212,6 +217,8 @@ func TestMonitoringConfiguration(t *testing.T) {
 	t.Setenv("ROX_ROXCTL_IN_MAIN_IMAGE", "true")
 
 	testutils.SetExampleVersion(t)
+
+	persistentFlags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 	flavorName := defaults.ImageFlavorNameDevelopmentBuild
 	if buildinfo.ReleaseBuild {
@@ -282,7 +289,7 @@ func TestMonitoringConfiguration(t *testing.T) {
 			bundleio, _, out, _ := io2.TestIO()
 			config.ClusterType = testCase.clusterType
 			config.K8sConfig.Monitoring.OpenShiftMonitoring = testCase.flagEnabled
-			err := OutputZip(logger, bundleio, config)
+			err := OutputZip(logger, bundleio, config, persistentFlags)
 			require.ErrorIs(t, err, testCase.expectErr)
 			if err != nil {
 				return

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -95,7 +95,7 @@ func TestRestoreKeysAndCerts(t *testing.T) {
 			// Note: This test is not for parallel run.
 			config.OutputDir = filepath.Join(tmpDir, testCase.testDir)
 			config.BackupBundle = testCase.backupBundle
-			require.NoError(t, OutputZip(logger, io, config))
+			require.NoError(t, outputZip(logger, io, config))
 
 			// Load values-private.yaml file
 			values, err := chartutil.ReadValuesFile(filepath.Join(config.OutputDir, "values-private.yaml"))
@@ -182,7 +182,7 @@ func TestTelemetryConfiguration(t *testing.T) {
 			config.K8sConfig.Telemetry.Enabled = testCase.telemetry
 
 			bundleio, _, out, _ := io2.TestIO()
-			require.ErrorIs(t, OutputZip(logger, bundleio, config), testCase.expected.err)
+			require.ErrorIs(t, outputZip(logger, bundleio, config), testCase.expected.err)
 			if testCase.expected.err != nil {
 				return
 			}
@@ -282,7 +282,7 @@ func TestMonitoringConfiguration(t *testing.T) {
 			bundleio, _, out, _ := io2.TestIO()
 			config.ClusterType = testCase.clusterType
 			config.K8sConfig.Monitoring.OpenShiftMonitoring = testCase.flagEnabled
-			err := OutputZip(logger, bundleio, config)
+			err := outputZip(logger, bundleio, config)
 			require.ErrorIs(t, err, testCase.expectErr)
 			if err != nil {
 				return

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -81,9 +81,9 @@ func orchestratorCommand(shortName, _ string) *cobra.Command {
 	}
 	if !roxctl.InMainImage() {
 		if containers.IsRunningInContainer() {
-			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, defaultBundlePath), "output-dir", "The directory to output the deployment bundle to")
+			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, defaultBundlePath), "output-dir", "The directory to output the deployment bundle to.")
 		} else {
-			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, ""), "output-dir", "The directory to output the deployment bundle to")
+			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, ""), "output-dir", "The directory to output the deployment bundle to.")
 		}
 	}
 	return c

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/containers"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/istioutils"
@@ -79,8 +80,11 @@ func orchestratorCommand(shortName, _ string) *cobra.Command {
 		}),
 	}
 	if !roxctl.InMainImage() {
-		c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, defaultBundlePath), "output-dir", "The directory to output the deployment bundle to.")
-		flags.OutputDirManuallySet = c.PersistentFlags().Changed("output-dir")
+		if containers.IsRunningInContainer( {
+			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, defaultBundlePath), "output-dir", "The directory to output the deployment bundle to")
+		} else {
+			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, ""), "output-dir", "The directory to output the deployment bundle to")
+		}
 	}
 	return c
 }
@@ -97,9 +101,9 @@ func k8sBasedOrchestrator(cliEnvironment environment.Environment, k8sConfig *ren
 		return nil
 	}
 
-	c.AddCommand(externalVolume(cliEnvironment, c.PersistentFlags()))
-	c.AddCommand(hostPathVolume(cliEnvironment, c.PersistentFlags()))
-	c.AddCommand(noVolume(cliEnvironment, c.PersistentFlags()))
+	c.AddCommand(externalVolume(cliEnvironment))
+	c.AddCommand(hostPathVolume(cliEnvironment))
+	c.AddCommand(noVolume(cliEnvironment))
 
 	flagWrap := &flagsWrapper{FlagSet: c.PersistentFlags()}
 	// Adds k8s specific flags

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -97,9 +97,9 @@ func k8sBasedOrchestrator(cliEnvironment environment.Environment, k8sConfig *ren
 		return nil
 	}
 
-	c.AddCommand(externalVolume(cliEnvironment))
-	c.AddCommand(hostPathVolume(cliEnvironment))
-	c.AddCommand(noVolume(cliEnvironment))
+	c.AddCommand(externalVolume(cliEnvironment, c.PersistentFlags()))
+	c.AddCommand(hostPathVolume(cliEnvironment, c.PersistentFlags()))
+	c.AddCommand(noVolume(cliEnvironment, c.PersistentFlags()))
 
 	flagWrap := &flagsWrapper{FlagSet: c.PersistentFlags()}
 	// Adds k8s specific flags

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -80,7 +80,7 @@ func orchestratorCommand(shortName, _ string) *cobra.Command {
 		}),
 	}
 	if !roxctl.InMainImage() {
-		if containers.IsRunningInContainer( {
+		if containers.IsRunningInContainer() {
 			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, defaultBundlePath), "output-dir", "The directory to output the deployment bundle to")
 		} else {
 			c.PersistentFlags().Var(common.NewOutputDir(&cfg.OutputDir, ""), "output-dir", "The directory to output the deployment bundle to")

--- a/roxctl/central/generate/volumes.go
+++ b/roxctl/central/generate/volumes.go
@@ -30,7 +30,7 @@ func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return outputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	flagWrap := &flagsWrapper{FlagSet: c.Flags()}
 	flagWrap.StringVarP(&external.DB.Name, "db-name", "", "central-db", "External volume name for Central DB.", "central-db")
@@ -45,7 +45,7 @@ func noVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return outputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Hidden = true
 	return c
@@ -61,7 +61,7 @@ func hostPathVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return outputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Flags().StringVarP(&hostpath.DB.HostPath, "db-hostpath", "", "/var/lib/stackrox-central", "Path on the host.")
 	c.Flags().StringVarP(&hostpath.DB.NodeSelectorKey, "db-node-selector-key", "", "", "Node selector key (e.g. kubernetes.io/hostname).")

--- a/roxctl/central/generate/volumes.go
+++ b/roxctl/central/generate/volumes.go
@@ -30,7 +30,7 @@ func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return outputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	flagWrap := &flagsWrapper{FlagSet: c.Flags()}
 	flagWrap.StringVarP(&external.DB.Name, "db-name", "", "central-db", "External volume name for Central DB.", "central-db")
@@ -45,7 +45,7 @@ func noVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return outputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Hidden = true
 	return c
@@ -61,7 +61,7 @@ func hostPathVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return outputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Flags().StringVarP(&hostpath.DB.HostPath, "db-hostpath", "", "/var/lib/stackrox-central", "Path on the host.")
 	c.Flags().StringVarP(&hostpath.DB.NodeSelectorKey, "db-node-selector-key", "", "", "Node selector key (e.g. kubernetes.io/hostname).")

--- a/roxctl/central/generate/volumes.go
+++ b/roxctl/central/generate/volumes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/roxctl/common/environment"
 )
@@ -20,7 +21,7 @@ Output is a zip file printed to stdout.`, name),
 	}
 }
 
-func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
+func externalVolume(cliEnvironment environment.Environment, persistentFlags *pflag.FlagSet) *cobra.Command {
 	external := &renderer.ExternalPersistence{
 		DB: &renderer.ExternalPersistenceInstance{},
 	}
@@ -30,7 +31,7 @@ func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg, persistentFlags)
 	}
 	flagWrap := &flagsWrapper{FlagSet: c.Flags()}
 	flagWrap.StringVarP(&external.DB.Name, "db-name", "", "central-db", "External volume name for Central DB.", "central-db")
@@ -39,19 +40,19 @@ func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
 	return c
 }
 
-func noVolume(cliEnvironment environment.Environment) *cobra.Command {
+func noVolume(cliEnvironment environment.Environment, persistentFlags *pflag.FlagSet) *cobra.Command {
 	c := volumeCommand("none")
 	c.RunE = func(c *cobra.Command, args []string) error {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg, persistentFlags)
 	}
 	c.Hidden = true
 	return c
 }
 
-func hostPathVolume(cliEnvironment environment.Environment) *cobra.Command {
+func hostPathVolume(cliEnvironment environment.Environment, persistentFlags *pflag.FlagSet) *cobra.Command {
 	hostpath := &renderer.HostPathPersistence{
 		DB: &renderer.HostPathPersistenceInstance{},
 	}
@@ -61,7 +62,7 @@ func hostPathVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg, persistentFlags)
 	}
 	c.Flags().StringVarP(&hostpath.DB.HostPath, "db-hostpath", "", "/var/lib/stackrox-central", "Path on the host.")
 	c.Flags().StringVarP(&hostpath.DB.NodeSelectorKey, "db-node-selector-key", "", "", "Node selector key (e.g. kubernetes.io/hostname).")

--- a/roxctl/central/generate/volumes.go
+++ b/roxctl/central/generate/volumes.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/roxctl/common/environment"
 )
@@ -21,7 +20,7 @@ Output is a zip file printed to stdout.`, name),
 	}
 }
 
-func externalVolume(cliEnvironment environment.Environment, persistentFlags *pflag.FlagSet) *cobra.Command {
+func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
 	external := &renderer.ExternalPersistence{
 		DB: &renderer.ExternalPersistenceInstance{},
 	}
@@ -31,7 +30,7 @@ func externalVolume(cliEnvironment environment.Environment, persistentFlags *pfl
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg, persistentFlags)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	flagWrap := &flagsWrapper{FlagSet: c.Flags()}
 	flagWrap.StringVarP(&external.DB.Name, "db-name", "", "central-db", "External volume name for Central DB.", "central-db")
@@ -40,19 +39,19 @@ func externalVolume(cliEnvironment environment.Environment, persistentFlags *pfl
 	return c
 }
 
-func noVolume(cliEnvironment environment.Environment, persistentFlags *pflag.FlagSet) *cobra.Command {
+func noVolume(cliEnvironment environment.Environment) *cobra.Command {
 	c := volumeCommand("none")
 	c.RunE = func(c *cobra.Command, args []string) error {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg, persistentFlags)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Hidden = true
 	return c
 }
 
-func hostPathVolume(cliEnvironment environment.Environment, persistentFlags *pflag.FlagSet) *cobra.Command {
+func hostPathVolume(cliEnvironment environment.Environment) *cobra.Command {
 	hostpath := &renderer.HostPathPersistence{
 		DB: &renderer.HostPathPersistenceInstance{},
 	}
@@ -62,7 +61,7 @@ func hostPathVolume(cliEnvironment environment.Environment, persistentFlags *pfl
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg, persistentFlags)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Flags().StringVarP(&hostpath.DB.HostPath, "db-hostpath", "", "/var/lib/stackrox-central", "Path on the host.")
 	c.Flags().StringVarP(&hostpath.DB.NodeSelectorKey, "db-node-selector-key", "", "", "Node selector key (e.g. kubernetes.io/hostname).")

--- a/roxctl/common/flags/annotations.go
+++ b/roxctl/common/flags/annotations.go
@@ -17,8 +17,3 @@ const (
 	// PasswordKey allows an echoless prompt.
 	PasswordKey = "password"
 )
-
-var (
-	// OutputDirManuallySet returns true iff --output-dir was manually set in the roxctl command
-	OutputDirManuallySet = false
-)


### PR DESCRIPTION
### Description

When executing `roxctl central generate...` the expected behavior is that a zip file will be pushed into STDOUT so that it can be piped into a file. However this should explicitly NOT happen if `--output-dir` is set. I thought I had fixed this previously by querying for `flags.OutputDirManuallySet = c.PersistentFlags().Changed("output-dir")` during cobra command creation, but this `flags.OutputDirManuallySet` will always be false.

The reason for that as I understand it is that I was setting this during the creation of the cobra command before any parameters such as `--output-dir` were even parsed. The solution then is to check `PersistentFlags().Changed("output-dir")` during execution of the cobra command. This requires passing of the flags to `OutputZip` which I was previously trying to avoid to make the code nicer to read, but at least this actually works :)

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

Tested this locally with roxctl, and it works. Run:
```sh
roxctl central generate --output-dir="central-bundle" k8s pvc
```
With this PR it will _not_ dump the zip contents of the bundle into STDOUT, whereas with roxctl currently on master it does.

There are also automated tests for this OutputZip function which I have touched and will run on CI.
