### PR TITLE
ROX-27838: Override npm peer depenency conflicts / 4.6

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -29,7 +29,7 @@
                 "d3-brush": "^3.0.0",
                 "d3-polygon": "^3.0.1",
                 "d3-scale": "^4.0.2",
-                "d3-selection": "^2.0.0",
+                "d3-selection": "^3.0.0",
                 "d3-zoom": "^3.0.0",
                 "date-fns": "1.30.1",
                 "deepmerge": "^4.2.2",
@@ -8507,14 +8507,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/d3-brush/node_modules/d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha1-wlM4IH76csxbm9FFihpBkB8eGzE= sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/d3-chord": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
@@ -8585,14 +8577,6 @@
                 "d3-dispatch": "1 - 3",
                 "d3-selection": "3"
             },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-drag/node_modules/d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha1-wlM4IH76csxbm9FFihpBkB8eGzE= sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "engines": {
                 "node": ">=12"
             }
@@ -8812,9 +8796,12 @@
             "integrity": "sha1-oQvMD5hsNytym6RHOCQTqr9bB2c= sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
         },
         "node_modules/d3-selection": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-            "integrity": "sha1-lKEWOOohQbdWX4g3gNq8fvamEGY= sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/d3-shape": {
             "version": "3.2.0",
@@ -8887,15 +8874,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
             "integrity": "sha1-AzFuWVlV0fzTnZ82EK1Bu5AZTQo= sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3-transition/node_modules/d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha1-wlM4IH76csxbm9FFihpBkB8eGzE= sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -8978,14 +8956,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
             "integrity": "sha1-It+TkDL7WnGuixgA1h3beFHEJSY= sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/d3/node_modules/d3-selection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-            "integrity": "sha1-wlM4IH76csxbm9FFihpBkB8eGzE= sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "engines": {
                 "node": ">=12"
             }

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -196,6 +196,7 @@
         "connected-react-router": {
             "react": "^18.0.0"
         },
+        "eslint": "^8.56.0",
         "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-jest-dom": {
             "@testing-library/dom": "^10.1.0"

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -33,7 +33,7 @@
         "d3-brush": "^3.0.0",
         "d3-polygon": "^3.0.1",
         "d3-scale": "^4.0.2",
-        "d3-selection": "^2.0.0",
+        "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
         "date-fns": "1.30.1",
         "deepmerge": "^4.2.2",
@@ -207,58 +207,10 @@
         "monaco-yaml": {
             "monaco-editor": "0.34.1"
         },
-        "react-collapsible": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "react-copy-to-clipboard": {
-            "react": "^18.0.0"
-        },
-        "react-feather": {
-            "react": "^18.0.0"
-        },
-        "react-modal": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "react-popper": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "react-scripts": {
             "typescript": "5.6.2"
-        },
-        "react-select": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "react-spinners": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "react-table-6": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "react-test-renderer": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "react-truncate": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "react-vis": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "redoc": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
-        },
-        "redux-form": {
-            "react": "^18.0.0",
-            "react-dom": "^18.0.0"
         }
     },
     "jest": {


### PR DESCRIPTION
### Description

This applies https://github.com/stackrox/stackrox/pull/14244 to `release-4.6` branch to allow downstream builds pass with Hermeto instead of Cachito.
This change is to be followed up by a Hermeto switch for 4.6 in <https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/4082>.

Related Slack discussions:
1. https://redhat-internal.slack.com/archives/C7ERNFL0M/p1737985051478809
2. https://redhat-internal.slack.com/archives/C01R0E7CVMX/p1741716667956819
3. https://redhat-internal.slack.com/archives/C02AD1GUA0Y/p1741736650355549

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No change.

#### How I validated my change

- CI with its tests.
- Downstream build in <https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/4082>.
