### PR TITLE
chore(deps): remove unix utils from release image

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -55,7 +55,7 @@ RUN rpm --import RPM-GPG-KEY-CentOS-Official && \
     microdnf -y upgrade --nobest && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
-    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 util-linux && \
+    microdnf install --setopt=install_weak_deps=0 --nodocs -y lz4 bzip2 && \
     microdnf clean all -y && \
     rm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities


### PR DESCRIPTION
### Description

`linux-utils` was added when we moved to ubi-minimal as it was required by e2e tests that uses `kill` in main container.
This need was removed when test was rewritten in go. So we can remove linux-utils.

- https://github.com/stackrox/stackrox/pull/12292
- https://github.com/stackrox/stackrox/pull/1054
---


- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
