### PR TITLE
ROX-28501: Debug image for 4.5

### DIFF
--- a/pkg/env/max_deduper_entries_per_message.go
+++ b/pkg/env/max_deduper_entries_per_message.go
@@ -7,6 +7,7 @@ const (
 var (
 	// MaxDeduperEntriesPerMessage sets the max number of deduper entries per message to be sent during the sync
 	MaxDeduperEntriesPerMessage = RegisterIntegerSetting("ROX_MAX_DEDUPER_ENTRIES_PER_MESSAGE", defaultMaxDeduperEntriesPerMessage)
+	TmpCrashGrpcAfterMessages   = RegisterIntegerSetting("ROX_TMP_NUM_MSG_CRASH_GRPC", 0)
 )
 
 // GetMaxDeduperEntriesPerMessage returns a sanitized MaxDeduperEntriesPerMessage

--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -64,6 +64,7 @@ func (s *centralSenderImpl) send(stream central.SensorService_CommunicateClient,
 	wrappedStream = deduper.NewDedupingMessageStream(wrappedStream, s.initialDeduperState, sendUnchangedIDs)
 	wrappedStream = metrics.NewCountingEventStream(wrappedStream, "total")
 	wrappedStream = metrics.NewTimingEventStream(wrappedStream, "total")
+	wrappedStream = NewDebuggingMessageStream(wrappedStream)
 
 	// NB: The centralSenderImpl reserves the right to perform arbitrary reads and writes on the returned objects.
 	// The providers that send the messages below are responsible for making sure that once they send events here,

--- a/sensor/common/sensor/debuggingStream.go
+++ b/sensor/common/sensor/debuggingStream.go
@@ -1,0 +1,30 @@
+package sensor
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/reflectutils"
+	"github.com/stackrox/rox/pkg/stringutils"
+	"github.com/stackrox/rox/sensor/common/messagestream"
+)
+
+// deduper takes care of deduping sensor events.
+type streamDebugger struct {
+	stream messagestream.SensorMessageStream
+}
+
+// NewDebuggingMessageStream wraps a SensorMessageStream and prints all messages to log
+func NewDebuggingMessageStream(stream messagestream.SensorMessageStream) messagestream.SensorMessageStream {
+	return &streamDebugger{
+		stream: stream,
+	}
+}
+
+func (d *streamDebugger) Send(msg *central.MsgFromSensor) error {
+	ty := stringutils.GetAfter(reflectutils.Type(msg.Msg), "_")
+	log.Infof("TYPE=%s, MSG=%s\n", ty, msg.String())
+	if err := d.stream.Send(msg); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Description

Do not merge - this image is used to debug an issue specific for version 4.5.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Run that in local-sensor connected to Central and looked at the logs
- Run that in the cluster and simulated arbitrary connection crash