### PR TITLE
ROX-28697: use Walk instead of GetAll in policy

### DIFF
--- a/central/policy/datastore/datastore.go
+++ b/central/policy/datastore/datastore.go
@@ -49,3 +49,16 @@ func New(storage store.Store, searcher search.Searcher,
 	}
 	return ds
 }
+
+// newWithoutDefaults should be used only for testing purposes.
+func newWithoutDefaults(storage store.Store,
+	searcher search.Searcher, clusterDatastore clusterDS.DataStore, notifierDatastore notifierDS.DataStore,
+	categoriesDatastore categoriesDataStore.DataStore) DataStore {
+	return &datastoreImpl{
+		storage:             storage,
+		searcher:            searcher,
+		clusterDatastore:    clusterDatastore,
+		notifierDatastore:   notifierDatastore,
+		categoriesDatastore: categoriesDatastore,
+	}
+}

--- a/central/policy/datastore/datastore.go
+++ b/central/policy/datastore/datastore.go
@@ -49,16 +49,3 @@ func New(storage store.Store, searcher search.Searcher,
 	}
 	return ds
 }
-
-// newWithoutDefaults should be used only for testing purposes.
-func newWithoutDefaults(storage store.Store,
-	searcher search.Searcher, clusterDatastore clusterDS.DataStore, notifierDatastore notifierDS.DataStore,
-	categoriesDatastore categoriesDataStore.DataStore) DataStore {
-	return &datastoreImpl{
-		storage:             storage,
-		searcher:            searcher,
-		clusterDatastore:    clusterDatastore,
-		notifierDatastore:   notifierDatastore,
-		categoriesDatastore: categoriesDatastore,
-	}
-}

--- a/central/policy/datastore/datastore_impl_test.go
+++ b/central/policy/datastore/datastore_impl_test.go
@@ -82,37 +82,6 @@ func (s *PolicyDatastoreTestSuite) testImportFailResponse(expectedPolicy *storag
 	}
 }
 
-// TODO: ROX-13888 Remove test.
-func (s *PolicyDatastoreTestSuite) TestReplacingResourceAccess() {
-	policy := &storage.Policy{
-		Name: "policy-to-import",
-		Id:   "import-1",
-	}
-
-	// Should work with READ access to WorkflowAdministration.
-	s.store.EXPECT().Get(s.hasReadWorkflowAdministrationAccess, policy.GetId()).Return(nil, false, nil).Times(1)
-	_, _, err := s.datastore.GetPolicy(s.hasReadWorkflowAdministrationAccess, policy.GetId())
-	s.NoError(err)
-
-	// Shouldn't work with READ access to WorkflowAdministration.
-	_, err = s.datastore.AddPolicy(s.hasReadWorkflowAdministrationAccess, policy)
-	s.Error(err)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
-	err = s.datastore.RemovePolicy(s.hasReadWorkflowAdministrationAccess, policy)
-	s.Error(err)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
-
-	// Should work with READ/WRITE access to WorkflowAdministration.
-	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policy).Return(nil).Times(1)
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil).Times(1)
-	s.store.EXPECT().Delete(s.hasReadWriteWorkflowAdministrationAccess, policy.GetId()).Return(nil).Times(1)
-
-	_, err = s.datastore.AddPolicy(s.hasReadWriteWorkflowAdministrationAccess, policy)
-	s.NoError(err)
-	err = s.datastore.RemovePolicy(s.hasReadWriteWorkflowAdministrationAccess, policy)
-	s.NoError(err)
-}
-
 func (s *PolicyDatastoreTestSuite) TestImportPolicySucceeds() {
 	policy := &storage.Policy{
 		Name:       "policy-to-import",
@@ -123,8 +92,10 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicySucceeds() {
 
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
 	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy.GetId()).Return(nil, false, nil)
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
-	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policy).Return(nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).Return(nil)
+	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, eq(policy)).Return(nil)
+	s.categoriesDatastore.EXPECT().SetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, policy.Id, policy.Categories)
+
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policy.CloneVT()}, false)
 	s.NoError(err)
 	s.True(allSucceeded)
@@ -140,21 +111,23 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateID() {
 		SORTName: "test policy",
 	}
 
-	errString1 := "policy with id '\"test-policy-1\"' already exists, unable to import policy"
-	errString2 := "policy with name 'test policy' already exists, unable to import policy"
+	errString := "policy with id \"test-policy-1\" already exists, unable to import policy"
 
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
 	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy.GetId()).Return(policy, true, nil)
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return([]*storage.Policy{
-		policy,
-	}, nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).DoAndReturn(
+		func(_ context.Context, fn func(obj *storage.Policy) error) error {
+			return fn(policy)
+		})
+	s.categoriesDatastore.EXPECT().GetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, policy.Id).Return(nil, nil).Times(1)
+
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policy.CloneVT()}, false)
 	s.NoError(err)
 	s.False(allSucceeded)
 	s.Require().Len(responses, 1)
 
 	s.testImportFailResponse(policy, []string{policies.ErrImportDuplicateID, policies.ErrImportDuplicateName},
-		[]string{errString1, errString2}, []string{policy.GetName(), policy.GetName()}, responses[0])
+		[]string{errString, errString}, []string{policy.GetName(), policy.GetName()}, responses[0])
 }
 
 func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateName() {
@@ -165,19 +138,20 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyDuplicateName() {
 		SORTName: name,
 	}
 
-	errString := fmt.Sprintf("policy with name '%s' already exists, unable to import policy", name)
+	errString := fmt.Sprintf("policy with id %q already exists, unable to import policy", policy.GetId())
 
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
 	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy.GetId()).Return(nil, false, nil)
 	s.categoriesDatastore.EXPECT().GetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).AnyTimes().Return(nil, nil)
 
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return([]*storage.Policy{
-		{
-			Name:     name,
-			Id:       "some-other-id",
-			SORTName: name,
-		},
-	}, nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).DoAndReturn(
+		func(_ context.Context, fn func(obj *storage.Policy) error) error {
+			return fn(&storage.Policy{
+				Name:     name,
+				Id:       "some-other-id",
+				SORTName: name,
+			})
+		})
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policy.CloneVT()}, false)
 	s.NoError(err)
 	s.False(allSucceeded)
@@ -229,13 +203,15 @@ func (s *PolicyDatastoreTestSuite) TestImportPolicyMixedSuccessAndFailure() {
 
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
 
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).Return(nil)
 
 	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policySucceed).Return(nil)
 	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).Return(nil, false, nil).AnyTimes()
 
 	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policyFail1).Return(errorFail1)
 	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policyFail2).Return(errorFail2)
+
+	s.categoriesDatastore.EXPECT().SetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, policySucceed.Id, policySucceed.Categories)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policySucceed.CloneVT(), policyFail1.CloneVT(), policyFail2.CloneVT()}, false)
 	s.NoError(err)
@@ -263,7 +239,7 @@ func (s *PolicyDatastoreTestSuite) TestUnknownError() {
 
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
 	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy.GetId()).Return(nil, false, nil)
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).Return(nil)
 	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policy).Return(storeError)
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policy.CloneVT()}, false)
 	s.NoError(err)
@@ -299,15 +275,27 @@ func (s *PolicyDatastoreTestSuite) TestImportOverwrite() {
 
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
 
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return([]*storage.Policy{existingPolicy1, existingPolicy2}, nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).DoAndReturn(
+		func(_ context.Context, fn func(obj *storage.Policy) error) error {
+			for _, p := range []*storage.Policy{existingPolicy1, existingPolicy2} {
+				if err := fn(p); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, id1).Return(existingPolicy1, true, nil).Times(2)
+	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy2.Id).Return(existingPolicy1, true, nil).Times(2)
+	s.store.EXPECT().Delete(s.hasReadWriteWorkflowAdministrationAccess, id1).Return(nil)
+	s.store.EXPECT().Delete(s.hasReadWriteWorkflowAdministrationAccess, policy2.Id).Return(nil)
+	s.store.EXPECT().Delete(s.hasReadWriteWorkflowAdministrationAccess, existingPolicy2.Id).Return(nil)
+	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, eq(policy1)).Return(nil)
+	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, eq(policy2)).Return(nil)
 
-	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, existingPolicy1.GetId()).Return(nil, true, nil)
-	s.store.EXPECT().Delete(s.hasReadWriteWorkflowAdministrationAccess, existingPolicy1.GetId()).Return(nil)
-	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policy1).Return(nil)
-
-	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy2.GetId()).Return(nil, false, nil)
-	s.store.EXPECT().Delete(s.hasReadWriteWorkflowAdministrationAccess, existingPolicy2.GetId()).Return(nil)
-	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policy2).Return(nil)
+	s.categoriesDatastore.EXPECT().GetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, existingPolicy1.Id).Return(nil, nil).Times(1)
+	s.categoriesDatastore.EXPECT().GetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, existingPolicy2.Id).Return(nil, nil).Times(1)
+	s.categoriesDatastore.EXPECT().SetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, policy2.Id, nil).Return(nil).Times(1)
+	s.categoriesDatastore.EXPECT().SetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, existingPolicy1.Id, nil).Return(nil).Times(1)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policy1.CloneVT(), policy2.CloneVT()}, true)
 
@@ -352,8 +340,9 @@ func (s *PolicyDatastoreTestSuite) TestRemoveScopesAndNotifiers() {
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
 	s.notifierDatastore.EXPECT().GetNotifier(s.hasReadWriteWorkflowAdministrationAccess, notifierName).Return(nil, false, nil)
 	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy.GetId()).Return(nil, false, nil)
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).Return(nil)
 	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policy).Return(nil)
+	s.categoriesDatastore.EXPECT().SetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, policy.Id, policy.Categories)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policy}, false)
 	s.NoError(err)
@@ -401,9 +390,11 @@ func (s *PolicyDatastoreTestSuite) TestDoesNotRemoveScopesAndNotifiers() {
 	}
 	s.clusterDatastore.EXPECT().GetClusters(s.hasReadWriteWorkflowAdministrationAccess).Return(mockClusters, nil)
 	s.notifierDatastore.EXPECT().GetNotifier(s.hasReadWriteWorkflowAdministrationAccess, notifierName).Return(nil, true, nil)
-	s.store.EXPECT().GetAll(s.hasReadWriteWorkflowAdministrationAccess).Return(nil, nil)
+	s.store.EXPECT().Walk(s.hasReadWriteWorkflowAdministrationAccess, gomock.Any()).Return(nil)
 	s.store.EXPECT().Get(s.hasReadWriteWorkflowAdministrationAccess, policy.Id).Return(nil, false, nil)
-	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, policy).Return(nil)
+	s.store.EXPECT().Upsert(s.hasReadWriteWorkflowAdministrationAccess, eq(policy)).Return(nil)
+
+	s.categoriesDatastore.EXPECT().SetPolicyCategoriesForPolicy(s.hasReadWriteWorkflowAdministrationAccess, policy.Id, policy.Categories)
 
 	responses, allSucceeded, err := s.datastore.ImportPolicies(s.hasReadWriteWorkflowAdministrationAccess, []*storage.Policy{policy.CloneVT()}, false)
 	s.NoError(err)
@@ -414,4 +405,12 @@ func (s *PolicyDatastoreTestSuite) TestDoesNotRemoveScopesAndNotifiers() {
 	s.True(resp.GetSucceeded())
 	protoassert.Equal(s.T(), resp.GetPolicy(), policy)
 	s.Empty(resp.GetErrors())
+}
+
+func eq(expected *storage.Policy) gomock.Matcher {
+	return gomock.Cond(func(actual *storage.Policy) bool {
+		e := expected.CloneVT()
+		e.Categories = nil
+		return e.EqualVT(actual)
+	})
 }

--- a/central/policy/store/mocks/store.go
+++ b/central/policy/store/mocks/store.go
@@ -119,21 +119,6 @@ func (mr *MockStoreMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
-// GetAll mocks base method.
-func (m *MockStore) GetAll(ctx context.Context) ([]*storage.Policy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAll", ctx)
-	ret0, _ := ret[0].([]*storage.Policy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAll indicates an expected call of GetAll.
-func (mr *MockStoreMockRecorder) GetAll(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll), ctx)
-}
-
 // GetIDs mocks base method.
 func (m *MockStore) GetIDs(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -206,4 +191,18 @@ func (m *MockStore) UpsertMany(ctx context.Context, objs []*storage.Policy) erro
 func (mr *MockStoreMockRecorder) UpsertMany(ctx, objs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMany", reflect.TypeOf((*MockStore)(nil).UpsertMany), ctx, objs)
+}
+
+// Walk mocks base method.
+func (m *MockStore) Walk(ctx context.Context, fn func(*storage.Policy) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Walk", ctx, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Walk indicates an expected call of Walk.
+func (mr *MockStoreMockRecorder) Walk(ctx, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockStore)(nil).Walk), ctx, fn)
 }

--- a/central/policy/store/postgres/gen.go
+++ b/central/policy/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.Policy --search-category POLICIES --get-all-func
+//go:generate pg-table-bindings-wrapper --type=storage.Policy --search-category POLICIES

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -51,7 +51,6 @@ type Store interface {
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
-	GetAll(ctx context.Context) ([]*storeType, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -92,9 +92,6 @@ func (s *PoliciesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, policys))
-	allPolicy, err := store.GetAll(ctx)
-	s.NoError(err)
-	protoassert.ElementsMatch(s.T(), policys, allPolicy)
 
 	policyCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/policy/store/store.go
+++ b/central/policy/store/store.go
@@ -18,7 +18,7 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Get(ctx context.Context, id string) (*storage.Policy, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Policy, []int, error)
-	GetAll(ctx context.Context) ([]*storage.Policy, error)
+	Walk(ctx context.Context, fn func(obj *storage.Policy) error) error
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Upsert(ctx context.Context, obj *storage.Policy) error


### PR DESCRIPTION
### Description

Use Walk instead of GetAll in policies
---
- #14784
- #14781
- #14779
- #14778
- #14763
- #14759
- #14758
- #14757
- #14747  :point_left: 
- #14742
---
- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI

## Summary by Sourcery

Replace GetAll method with Walk method in policy-related code to improve iteration and memory efficiency

Enhancements:
- Refactored policy store and datastore to use Walk method instead of GetAll, reducing memory overhead by iterating over policies without loading all of them into memory at once

Tests:
- Updated test cases to use Walk method instead of GetAll
- Modified mock generation and test expectations to support the new Walk method

Chores:
- Removed GetAll method from policy store interfaces
- Updated go:generate directive to remove GetAll-related generation