### PR TITLE
chore(tests): remove SkipIfPostgresEnabled

### DIFF
--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -454,10 +454,10 @@ func (ds *datastoreImpl) validateUniqueNameAndID(ctx context.Context, policy *st
 		// Similarly, new policy cannot have the same name as default policies
 		if existingPolicy.GetIsDefault() {
 			importErrors = append(importErrors,
-				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateSystemPolicyName, policy.GetName(), "system policy with name %q already exists, unable to import policy", policy.GetName()))
+				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateSystemPolicyName, policy.GetName(), "system policy with id %q already exists, unable to import policy", policy.GetId()))
 		} else if !overwrite { // And if not system policy, then it's only an error if it is not an overwrite operation
 			importErrors = append(importErrors,
-				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateName, policy.GetName(), "policy with name %q already exists, unable to import policy", policy.GetName()))
+				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateName, policy.GetName(), "policy with id %q already exists, unable to import policy", policy.GetId()))
 		}
 	}
 	return importErrors, nil

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -454,10 +454,10 @@ func (ds *datastoreImpl) validateUniqueNameAndID(ctx context.Context, policy *st
 		// Similarly, new policy cannot have the same name as default policies
 		if existingPolicy.GetIsDefault() {
 			importErrors = append(importErrors,
-				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateSystemPolicyName, policy.GetName(), "system policy with name %q already exists, unable to import policy", policy.GetId()))
+				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateSystemPolicyName, policy.GetName(), "system policy with name %q already exists, unable to import policy", policy.GetName()))
 		} else if !overwrite { // And if not system policy, then it's only an error if it is not an overwrite operation
 			importErrors = append(importErrors,
-				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateName, policy.GetName(), "policy with name %q already exists, unable to import policy", policy.GetId()))
+				duplicateNameImportErrf(policiesPkg.ErrImportDuplicateName, policy.GetName(), "policy with name %q already exists, unable to import policy", policy.GetName()))
 		}
 	}
 	return importErrors, nil

--- a/central/policy/datastore/datastore_impl_test.go
+++ b/central/policy/datastore/datastore_impl_test.go
@@ -14,7 +14,6 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/policies"
-	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -42,7 +41,6 @@ type PolicyDatastoreTestSuite struct {
 }
 
 func (s *PolicyDatastoreTestSuite) SetupTest() {
-	pgtest.SkipIfPostgresEnabled(s.T())
 	s.mockCtrl = gomock.NewController(s.T())
 	s.store = storeMocks.NewMockStore(s.mockCtrl)
 	s.clusterDatastore = clusterMocks.NewMockDataStore(s.mockCtrl)

--- a/pkg/postgres/pgtest/postgres.go
+++ b/pkg/postgres/pgtest/postgres.go
@@ -178,9 +178,3 @@ func OpenGormDB(t testing.TB, source string) *gorm.DB {
 func CloseGormDB(t testing.TB, db *gorm.DB) {
 	conn.CloseGormDB(t, db)
 }
-
-// SkipIfPostgresEnabled skips the tests if the Postgres flag is on
-func SkipIfPostgresEnabled(t testing.TB) {
-	t.Skip("Skipping test because Postgres is enabled")
-	t.SkipNow()
-}

--- a/pkg/scanners/clairify/convert_test.go
+++ b/pkg/scanners/clairify/convert_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
-	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/scanners/clairify/mock"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
@@ -350,7 +349,6 @@ func TestConvertNodeVulnerabilities(t *testing.T) {
 }
 
 func TestConvertFeatures(t *testing.T) {
-	pgtest.SkipIfPostgresEnabled(t)
 	// metadata is based on the fixture used below.
 	metadata := &storage.ImageMetadata{
 		V1: &storage.V1Metadata{
@@ -452,12 +450,7 @@ func TestConvertFeatures(t *testing.T) {
 			HasLayerIndex: &storage.EmbeddedImageScanComponent_LayerIndex{
 				LayerIndex: 0,
 			},
-			Executables: []*storage.EmbeddedImageScanComponent_Executable{
-				{
-					Path:         "/bin/rpm",
-					Dependencies: []string{"Z2xpYmM:MQ", "bGliLnNv:Mg"},
-				},
-			},
+			Executables: []*storage.EmbeddedImageScanComponent_Executable{},
 		},
 		{
 			Name:    "curl",


### PR DESCRIPTION
### Description

It's long time since we switch to postgres and it's time to cleanup. 
`SkipIfPostgresEnabled` was introduced to skip tests that will not work on postgres and run them when the feature flag is disable. Over the time it evolved to skip test always (as feature flag was always on, and eventually removed). This PR removes this functions and fixes tests or remove them when the new postgres test was added. 

- #4719
- https://github.com/stackrox/stackrox/pull/6526#discussion_r1230780085
- #11953 
---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
