### PR TITLE
ROX-28697: use Walk instead of GetAll in service identites

### DIFF
--- a/central/serviceidentities/datastore/datastore.go
+++ b/central/serviceidentities/datastore/datastore.go
@@ -11,7 +11,7 @@ import (
 //
 //go:generate mockgen-wrapper
 type DataStore interface {
-	GetServiceIdentities(context.Context) ([]*storage.ServiceIdentity, error)
+	ProcessServiceIdentities(context.Context, func(obj *storage.ServiceIdentity) error) error
 	AddServiceIdentity(ctx context.Context, identity *storage.ServiceIdentity) error
 }
 

--- a/central/serviceidentities/datastore/datastore_impl.go
+++ b/central/serviceidentities/datastore/datastore_impl.go
@@ -17,14 +17,14 @@ type dataStoreImpl struct {
 	storage store.Store
 }
 
-func (ds *dataStoreImpl) GetServiceIdentities(ctx context.Context) ([]*storage.ServiceIdentity, error) {
+func (ds *dataStoreImpl) ProcessServiceIdentities(ctx context.Context, fn func(obj *storage.ServiceIdentity) error) error {
 	if ok, err := administrationSAC.ReadAllowed(ctx); err != nil {
-		return nil, err
+		return err
 	} else if !ok {
-		return nil, nil
+		return nil
 	}
 
-	return ds.storage.GetAll(ctx)
+	return ds.storage.Walk(ctx, fn)
 }
 
 func (ds *dataStoreImpl) AddServiceIdentity(ctx context.Context, identity *storage.ServiceIdentity) error {

--- a/central/serviceidentities/datastore/mocks/datastore.go
+++ b/central/serviceidentities/datastore/mocks/datastore.go
@@ -55,17 +55,16 @@ func (mr *MockDataStoreMockRecorder) AddServiceIdentity(ctx, identity any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddServiceIdentity", reflect.TypeOf((*MockDataStore)(nil).AddServiceIdentity), ctx, identity)
 }
 
-// GetServiceIdentities mocks base method.
-func (m *MockDataStore) GetServiceIdentities(arg0 context.Context) ([]*storage.ServiceIdentity, error) {
+// ProcessServiceIdentities mocks base method.
+func (m *MockDataStore) ProcessServiceIdentities(arg0 context.Context, arg1 func(*storage.ServiceIdentity) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceIdentities", arg0)
-	ret0, _ := ret[0].([]*storage.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "ProcessServiceIdentities", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetServiceIdentities indicates an expected call of GetServiceIdentities.
-func (mr *MockDataStoreMockRecorder) GetServiceIdentities(arg0 any) *gomock.Call {
+// ProcessServiceIdentities indicates an expected call of ProcessServiceIdentities.
+func (mr *MockDataStoreMockRecorder) ProcessServiceIdentities(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceIdentities", reflect.TypeOf((*MockDataStore)(nil).GetServiceIdentities), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessServiceIdentities", reflect.TypeOf((*MockDataStore)(nil).ProcessServiceIdentities), arg0, arg1)
 }

--- a/central/serviceidentities/internal/store/mocks/store.go
+++ b/central/serviceidentities/internal/store/mocks/store.go
@@ -41,21 +41,6 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// GetAll mocks base method.
-func (m *MockStore) GetAll(ctx context.Context) ([]*storage.ServiceIdentity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAll", ctx)
-	ret0, _ := ret[0].([]*storage.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAll indicates an expected call of GetAll.
-func (mr *MockStoreMockRecorder) GetAll(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll), ctx)
-}
-
 // Upsert mocks base method.
 func (m *MockStore) Upsert(ctx context.Context, obj *storage.ServiceIdentity) error {
 	m.ctrl.T.Helper()
@@ -68,4 +53,18 @@ func (m *MockStore) Upsert(ctx context.Context, obj *storage.ServiceIdentity) er
 func (mr *MockStoreMockRecorder) Upsert(ctx, obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockStore)(nil).Upsert), ctx, obj)
+}
+
+// Walk mocks base method.
+func (m *MockStore) Walk(ctx context.Context, fn func(*storage.ServiceIdentity) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Walk", ctx, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Walk indicates an expected call of Walk.
+func (mr *MockStoreMockRecorder) Walk(ctx, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockStore)(nil).Walk), ctx, fn)
 }

--- a/central/serviceidentities/internal/store/postgres/gen.go
+++ b/central/serviceidentities/internal/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.ServiceIdentity --get-all-func
+//go:generate pg-table-bindings-wrapper --type=storage.ServiceIdentity

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -49,7 +49,6 @@ type Store interface {
 	Get(ctx context.Context, serialStr string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
-	GetAll(ctx context.Context) ([]*storeType, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -92,9 +92,6 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, serviceIdentitys))
-	allServiceIdentity, err := store.GetAll(ctx)
-	s.NoError(err)
-	protoassert.ElementsMatch(s.T(), serviceIdentitys, allServiceIdentity)
 
 	serviceIdentityCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/serviceidentities/internal/store/store.go
+++ b/central/serviceidentities/internal/store/store.go
@@ -10,6 +10,6 @@ import (
 //
 //go:generate mockgen-wrapper
 type Store interface {
-	GetAll(ctx context.Context) ([]*storage.ServiceIdentity, error)
+	Walk(ctx context.Context, fn func(obj *storage.ServiceIdentity) error) error
 	Upsert(ctx context.Context, obj *storage.ServiceIdentity) error
 }

--- a/central/serviceidentities/service/service_impl.go
+++ b/central/serviceidentities/service/service_impl.go
@@ -54,7 +54,11 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 
 // GetServiceIdentities returns the currently defined service identities.
 func (s *serviceImpl) GetServiceIdentities(ctx context.Context, _ *v1.Empty) (*v1.ServiceIdentityResponse, error) {
-	serviceIdentities, err := s.dataStore.GetServiceIdentities(ctx)
+	var serviceIdentities []*storage.ServiceIdentity
+	err := s.dataStore.ProcessServiceIdentities(ctx, func(si *storage.ServiceIdentity) error {
+		serviceIdentities = append(serviceIdentities, si)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
