### PR TITLE
test: Add error message to list of errors for kubectl retries

### DIFF
--- a/scripts/retry-kubectl.sh
+++ b/scripts/retry-kubectl.sh
@@ -13,6 +13,7 @@ error_regex=$(tr '\n' '|' <<EOT | sed -e 's/|$//;'
 : i/o timeout$
 net/http: request canceled \(Client\.Timeout exceeded while awaiting headers\)$
 : the server is currently unable to handle the request
+: TLS handshake timeout
 EOT
 )
 


### PR DESCRIPTION
### Description

My kubectl today failed with an error message "TLS handshake timeout" -- let's add it to the list of regexes for `retry-kubctl.sh` so that it will automatically retry in case it hits such an error.

