### PR TITLE
ROX-28707: Add Button-LinkShim-href lint rule

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -4,6 +4,44 @@ const rules = {
     // ESLint naming convention for positive rules:
     // If your rule is enforcing the inclusion of something, use a short name without a special prefix.
 
+    'Button-LinkShim-href': {
+        // Enforce assumption about Button and LinkShim elements.
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Require tbat Button element with component={LinkShim} also has href prop',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'Button') {
+                        if (
+                            node.attributes.some(
+                                (attribute) =>
+                                    attribute.name?.name === 'component' &&
+                                    attribute.value?.expression?.name === 'LinkShim'
+                            )
+                        ) {
+                            if (
+                                !node.attributes.some(
+                                    (attribute) => attribute.name?.name === 'href'
+                                )
+                            ) {
+                                context.report({
+                                    node,
+                                    message:
+                                        'Require tbat Button element with component={LinkShim} also has href prop',
+                                });
+                            }
+                        }
+                    }
+                },
+            };
+        },
+    },
     'ExternalLink-anchor': {
         // Require ExternalLink with anchor element as child for consistent presentation of external links.
         meta: {

--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -10,7 +10,7 @@ const rules = {
             type: 'problem',
             docs: {
                 description:
-                    'Require tbat Button element with component={LinkShim} also has href prop',
+                    'Require that Button element with component={LinkShim} also has href prop',
             },
             schema: [],
         },
@@ -33,7 +33,7 @@ const rules = {
                                 context.report({
                                     node,
                                     message:
-                                        'Require tbat Button element with component={LinkShim} also has href prop',
+                                        'Require that Button element with component={LinkShim} also has href prop',
                                 });
                             }
                         }
@@ -79,7 +79,7 @@ const rules = {
             type: 'problem',
             docs: {
                 description:
-                    'Require tbat Link element with target="_blank" also has rel="noopener noreferrer" prop',
+                    'Require that Link element with target="_blank" also has rel="noopener noreferrer" prop',
             },
             schema: [],
         },
@@ -104,7 +104,7 @@ const rules = {
                                 context.report({
                                     node,
                                     message:
-                                        'Require tbat Link element with target="_blank" also has rel="noopener noreferrer" prop',
+                                        'Require that Link element with target="_blank" also has rel="noopener noreferrer" prop',
                                 });
                             }
                         }


### PR DESCRIPTION
### Description

### Problem

React Router 6 upgrade required code change (because of stricter type checking) in case `Button` element does not have `href` prop when it does have `component={LinkShim}` prop.

### Analysis

**Brad** and I agreed:
* Keep code change based on what TypeScript static inference understands.
* Add lint rule to enforce assumption that `Button` element with `component={LinkShim}` prop has `href` prop.

### Solution

Use typescript-eslint playground to understand `attribute.value?.expression?.name === 'LinkShim'` condition corresponds to `component={LinkShim}` prop.

https://typescript-eslint.io/play/#ts=5.8.2&showAST=es&fileType=.tsx

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Temporarily edit a `Button` element with `component={LinkShim}` to omit `href` prop.

By the way, you need to restart Visual Studio code after you edit lint rules.

1. `npm run lint` in ui/apps/platform