### PR TITLE
ROX-28698: Fix wrong default value of node index mapping URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Removed Features
 
+- ROX-28698: Environment variable `ROX_NODE_INDEX_MAPPING_URL` has been removed. The mapping URL is now computed by concatenating `ROX_ADVERTISED_ENDPOINT` and `ROX_NODE_INDEX_MAPPING_URL_PATH`.
+
 ### Deprecated Features
 
 ### Technical Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Removed Features
 
-- ROX-28698: Environment variable `ROX_NODE_INDEX_MAPPING_URL` has been removed. The mapping URL is now computed by concatenating `ROX_ADVERTISED_ENDPOINT` and `ROX_NODE_INDEX_MAPPING_URL_PATH`.
-
 ### Deprecated Features
 
 ### Technical Changes

--- a/compliance/cmd/compliance/main.go
+++ b/compliance/cmd/compliance/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	np := &node.EnvNodeNameProvider{}
-	cfg := index.DefaultNodeIndexerConfig
+	cfg := index.DefaultNodeIndexerConfig()
 
 	scanner := inventory.NewNodeInventoryComponentScanner(np)
 	scanner.Connect(env.NodeScanningEndpoint.Setting())

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -126,6 +126,9 @@ func DefaultNodeIndexerConfig() NodeIndexerConfig {
 }
 
 func buildMappingURL() string {
+	if len(env.NodeIndexMappingURL.Setting()) > 0 {
+		return urlfmt.FormatURL(env.NodeIndexMappingURL.Setting(), urlfmt.HTTPS, urlfmt.NoTrailingSlash)
+	}
 	URL := env.AdvertisedEndpoint.Setting() + scannerDefinitionsRouteInSensor + "?file=" + sensorMappingsFile
 	return urlfmt.FormatURL(URL, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
 }

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -109,12 +109,14 @@ type NodeIndexerConfig struct {
 }
 
 // DefaultNodeIndexerConfig is the default configuration for a node indexer.
-var DefaultNodeIndexerConfig = NodeIndexerConfig{
-	HostPath: env.NodeIndexHostPath.Setting(),
-	// The default, mTLS-capable client will be used.
-	Client:             nil,
-	Repo2CPEMappingURL: "https://" + env.AdvertisedEndpoint.Setting() + env.NodeIndexMappingURLPath.Setting(),
-	Timeout:            10 * time.Second,
+func DefaultNodeIndexerConfig() NodeIndexerConfig {
+	return NodeIndexerConfig{
+		HostPath: env.NodeIndexHostPath.Setting(),
+		// The default, mTLS-capable client will be used.
+		Client:             nil,
+		Repo2CPEMappingURL: "https://" + env.AdvertisedEndpoint.Setting() + env.NodeIndexMappingURLPath.Setting(),
+		Timeout:            10 * time.Second,
+	}
 }
 
 type localNodeIndexer struct {

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -129,8 +129,8 @@ func buildMappingURL() string {
 	if len(env.NodeIndexMappingURL.Setting()) > 0 {
 		return urlfmt.FormatURL(env.NodeIndexMappingURL.Setting(), urlfmt.HTTPS, urlfmt.NoTrailingSlash)
 	}
-	URL := env.AdvertisedEndpoint.Setting() + scannerDefinitionsRouteInSensor + "?file=" + sensorMappingsFile
-	return urlfmt.FormatURL(URL, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
+	u := env.AdvertisedEndpoint.Setting() + scannerDefinitionsRouteInSensor + "?file=" + sensorMappingsFile
+	return urlfmt.FormatURL(u, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
 }
 
 type localNodeIndexer struct {

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -29,7 +29,9 @@ import (
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/scannerv4/mappers"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/urlfmt"
 	pkgutils "github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/common/sensor"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -37,6 +39,8 @@ const (
 	layerMediaType = "application/vnd.claircore.filesystem"
 
 	rhcosPackageDB = "sqlite:usr/share/rpm"
+
+	sensorMappingsFile = "repo2cpe"
 )
 
 var (
@@ -114,9 +118,14 @@ func DefaultNodeIndexerConfig() NodeIndexerConfig {
 		HostPath: env.NodeIndexHostPath.Setting(),
 		// The default, mTLS-capable client will be used.
 		Client:             nil,
-		Repo2CPEMappingURL: "https://" + env.AdvertisedEndpoint.Setting() + env.NodeIndexMappingURLPath.Setting(),
+		Repo2CPEMappingURL: buildMappingURL(),
 		Timeout:            10 * time.Second,
 	}
+}
+
+func buildMappingURL() string {
+	URL := env.AdvertisedEndpoint.Setting() + sensor.ScannerDefinitionsRoute + "?file=" + sensorMappingsFile
+	return urlfmt.FormatURL(URL, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
 }
 
 type localNodeIndexer struct {

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	pkgutils "github.com/stackrox/rox/pkg/utils"
-	"github.com/stackrox/rox/sensor/common/sensor"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -40,7 +39,10 @@ const (
 
 	rhcosPackageDB = "sqlite:usr/share/rpm"
 
-	sensorMappingsFile = "repo2cpe"
+	// scannerDefinitionsRouteInSensor should be in sync with `scannerDefinitionsRoute` in sensor/sensor.go
+	// Direct import is prohibited by import rules
+	scannerDefinitionsRouteInSensor = "/scanner/definitions"
+	sensorMappingsFile              = "repo2cpe"
 )
 
 var (
@@ -124,7 +126,7 @@ func DefaultNodeIndexerConfig() NodeIndexerConfig {
 }
 
 func buildMappingURL() string {
-	URL := env.AdvertisedEndpoint.Setting() + sensor.ScannerDefinitionsRoute + "?file=" + sensorMappingsFile
+	URL := env.AdvertisedEndpoint.Setting() + scannerDefinitionsRouteInSensor + "?file=" + sensorMappingsFile
 	return urlfmt.FormatURL(URL, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
 }
 

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -114,7 +114,7 @@ type NodeIndexerConfig struct {
 	Timeout time.Duration
 }
 
-// DefaultNodeIndexerConfig is the default configuration for a node indexer.
+// DefaultNodeIndexerConfig provides the default configuration for a node indexer.
 func DefaultNodeIndexerConfig() NodeIndexerConfig {
 	return NodeIndexerConfig{
 		HostPath: env.NodeIndexHostPath.Setting(),

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -113,7 +113,7 @@ var DefaultNodeIndexerConfig = NodeIndexerConfig{
 	HostPath: env.NodeIndexHostPath.Setting(),
 	// The default, mTLS-capable client will be used.
 	Client:             nil,
-	Repo2CPEMappingURL: env.NodeIndexMappingURL.Setting(),
+	Repo2CPEMappingURL: "https://" + env.AdvertisedEndpoint.Setting() + env.NodeIndexMappingURLPath.Setting(),
 	Timeout:            10 * time.Second,
 }
 

--- a/compliance/node/index/indexer_test.go
+++ b/compliance/node/index/indexer_test.go
@@ -154,9 +154,11 @@ func (s *nodeIndexerSuite) TestRunPackageScannerAnyPath() {
 
 func (s *nodeIndexerSuite) TestMappingURL() {
 	s.T().Setenv("ROX_ADVERTISED_ENDPOINT", "example.com:8080")
-	s.Equal("https://example.com:8080/scanner/definitions?file=repo2cpe", DefaultNodeIndexerConfig().Repo2CPEMappingURL)
+	s.Equal("https://example.com:8080/scanner/definitions?file=repo2cpe", buildMappingURL())
 	s.T().Setenv("ROX_ADVERTISED_ENDPOINT", "sensor.rhacs.svc")
-	s.Equal("https://sensor.rhacs.svc/scanner/definitions?file=repo2cpe", DefaultNodeIndexerConfig().Repo2CPEMappingURL)
+	s.Equal("https://sensor.rhacs.svc/scanner/definitions?file=repo2cpe", buildMappingURL())
+	s.T().Setenv("ROX_ADVERTISED_ENDPOINT", "http://example.com")
+	s.Equal("https://example.com/scanner/definitions?file=repo2cpe", buildMappingURL())
 }
 
 func (s *nodeIndexerSuite) TestIndexerE2E() {

--- a/compliance/node/index/indexer_test.go
+++ b/compliance/node/index/indexer_test.go
@@ -152,11 +152,18 @@ func (s *nodeIndexerSuite) TestRunPackageScannerAnyPath() {
 	s.Len(packages, 0)
 }
 
+func (s *nodeIndexerSuite) TestMappingURL() {
+	s.T().Setenv("ROX_ADVERTISED_ENDPOINT", "example.com:8080")
+	s.Equal("https://example.com:8080/scanner/definitions?file=repo2cpe", DefaultNodeIndexerConfig().Repo2CPEMappingURL)
+	s.T().Setenv("ROX_ADVERTISED_ENDPOINT", "sensor.rhacs.svc")
+	s.Equal("https://sensor.rhacs.svc/scanner/definitions?file=repo2cpe", DefaultNodeIndexerConfig().Repo2CPEMappingURL)
+}
+
 func (s *nodeIndexerSuite) TestIndexerE2E() {
 	s.T().Setenv(mtls.CertFilePathEnvName, filepath.Join("testdata", "certs", "client-cert.pem"))
 	s.T().Setenv(mtls.KeyFileEnvName, filepath.Join("testdata", "certs", "client-key.pem"))
 	server := s.createTestServer(true)
-	cfg := DefaultNodeIndexerConfig
+	cfg := DefaultNodeIndexerConfig()
 	cfg.HostPath = "testdata"
 	cfg.Repo2CPEMappingURL = server.URL
 	indexer := NewNodeIndexer(cfg)
@@ -172,7 +179,7 @@ func (s *nodeIndexerSuite) TestIndexerE2E() {
 
 func (s *nodeIndexerSuite) TestIndexerE2ENoPath() {
 	server := s.createTestServer(false)
-	cfg := DefaultNodeIndexerConfig
+	cfg := DefaultNodeIndexerConfig()
 	cfg.Client = server.Client()
 	cfg.HostPath = "doesnotexist"
 	cfg.Repo2CPEMappingURL = server.URL

--- a/compliance/node/index/indexer_test.go
+++ b/compliance/node/index/indexer_test.go
@@ -152,7 +152,7 @@ func (s *nodeIndexerSuite) TestRunPackageScannerAnyPath() {
 	s.Len(packages, 0)
 }
 
-func (s *nodeIndexerSuite) TestMappingURL() {
+func (s *nodeIndexerSuite) TestBuildMappingURL() {
 	tcs := map[string]struct {
 		advertisedEndpointSetting string
 		mappingURLSetting         string

--- a/pkg/env/node_index.go
+++ b/pkg/env/node_index.go
@@ -7,8 +7,8 @@ var (
 	// that should be scanned by Scanners NodeIndexer
 	NodeIndexHostPath = RegisterSetting("ROX_NODE_INDEX_HOST_PATH", WithDefault("/host"))
 
-	// NodeIndexMappingURL defines the endpoint for the RepositoryScanner to download mapping information from.
-	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", WithDefault("https://sensor.stackrox.svc/scanner/definitions?file=repo2cpe"))
+	// NodeIndexMappingURLPath defines the Sensor URL path for the RepositoryScanner to download mapping information from.
+	NodeIndexMappingURLPath = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL_PATH", WithDefault("/scanner/definitions?file=repo2cpe"))
 
 	// NodeIndexCacheDuration defines the time a cached node index will be considered fresh and served from file.
 	// Defaults to 75% of the default rescan interval.

--- a/pkg/env/node_index.go
+++ b/pkg/env/node_index.go
@@ -7,8 +7,10 @@ var (
 	// that should be scanned by Scanners NodeIndexer
 	NodeIndexHostPath = RegisterSetting("ROX_NODE_INDEX_HOST_PATH", WithDefault("/host"))
 
-	// NodeIndexMappingURLPath defines the Sensor URL path for the RepositoryScanner to download mapping information from.
-	NodeIndexMappingURLPath = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL_PATH", WithDefault("/scanner/definitions?file=repo2cpe"))
+	// NodeIndexMappingURL defines the endpoint for the RepositoryScanner to download mapping information from.
+	// If left empty, the URL will be computed based on Sensor's ROX_ADVERTISED_ENDPOINT.
+	// The default "https://sensor.stackrox.svc/scanner/definitions?file=repo2cpe" is not set here to not hardcode the namespace of Sensor.
+	NodeIndexMappingURL = RegisterSetting("ROX_NODE_INDEX_MAPPING_URL", AllowEmpty())
 
 	// NodeIndexCacheDuration defines the time a cached node index will be considered fresh and served from file.
 	// Defaults to 75% of the default rescan interval.

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -11,7 +11,8 @@ var (
 
 	// AdvertisedEndpoint is used to provide the Sensor with the endpoint it
 	// should advertise to services that need to contact it, within its own cluster.
-	AdvertisedEndpoint = RegisterSetting("ROX_ADVERTISED_ENDPOINT", WithDefault("sensor.stackrox.svc:443"))
+	AdvertisedEndpoint = RegisterSetting("ROX_ADVERTISED_ENDPOINT", WithDefault("sensor.stackrox.svc:443"),
+		StripAnyPrefix("https://", "http://"))
 
 	// SensorEndpoint is used to communicate the sensor endpoint to other services in the same cluster.
 	SensorEndpoint = RegisterSetting("ROX_SENSOR_ENDPOINT", WithDefault("sensor.stackrox.svc:443"))

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -45,8 +45,9 @@ const (
 
 	publicAPIEndpoint = ":8443"
 
-	publicWebhookEndpoint   = ":9443"
-	ScannerDefinitionsRoute = "/scanner/definitions"
+	publicWebhookEndpoint = ":9443"
+
+	scannerDefinitionsRoute = "/scanner/definitions"
 )
 
 var (
@@ -328,7 +329,7 @@ func (s *Sensor) newScannerDefinitionsRoute(centralEndpoint string, centralCerti
 	s.AddNotifiable(handler)
 	// We rely on central to handle content encoding negotiation.
 	return &routes.CustomRoute{
-		Route:         ScannerDefinitionsRoute,
+		Route:         scannerDefinitionsRoute,
 		Authorizer:    or.Or(idcheck.ScannerOnly(), idcheck.ScannerV4IndexerOnly(), idcheck.CollectorOnly()),
 		ServerHandler: handler,
 	}, nil

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -45,7 +45,8 @@ const (
 
 	publicAPIEndpoint = ":8443"
 
-	publicWebhookEndpoint = ":9443"
+	publicWebhookEndpoint   = ":9443"
+	ScannerDefinitionsRoute = "/scanner/definitions"
 )
 
 var (
@@ -327,7 +328,7 @@ func (s *Sensor) newScannerDefinitionsRoute(centralEndpoint string, centralCerti
 	s.AddNotifiable(handler)
 	// We rely on central to handle content encoding negotiation.
 	return &routes.CustomRoute{
-		Route:         "/scanner/definitions",
+		Route:         ScannerDefinitionsRoute,
 		Authorizer:    or.Or(idcheck.ScannerOnly(), idcheck.ScannerV4IndexerOnly(), idcheck.CollectorOnly()),
 		ServerHandler: handler,
 	}, nil


### PR DESCRIPTION
### Description

The value of `ROX_NODE_INDEX_MAPPING_URL` must point to Sensor's https endpoint for obtaining repo to CPE mapping for node indexing. This env var was defaulting to `sensor.stackrox.svc` which worked only when Sensor was installed in the stackrox namespace. For other namespaces, we should have change the Sensor host part in Helm charts, but apparently that has never been done.

In this PR I leave out the Sensor host address from this var and keep only the URL-path. The entire address is now concatenated from  `ROX_ADVERTISED_ENDPOINT` (which contains a correct address) and the new var `ROX_NODE_INDEX_MAPPING_URL_PATH` that defaults to `/scanner/definitions?file=repo2cpe`.


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- [x] Unit test
- [x] Manually on a cluster by deploying to non-stackrox namespace and looking into the logs of compliance pod to check that node indexes are successfully being sent to Sensor; i.e., not seeing the log message:
```
{"level":"error","version":"1.2","component":"rhel/internal/common/Updater.Get","error":"Get \"https://sensor.stackrox.svc/scanner/definitions?file=repo2cpe\": dial tcp: lookup sensor.stackrox.svc on 172.30.0.10:53: no such host","message":"error updating mapping
```

![Screenshot 2025-04-02 at 13 28 58](https://github.com/user-attachments/assets/7b5db94a-5e9b-437e-83c0-aa536dd5808d)
Those Compliance logs confirm that the mapping was downloaded successfully and v4 indexing is working properly (installation in `rhacs-operator` namespace).
