### PR TITLE
ROX-27255: increase junit2jira threshold

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1604,7 +1604,7 @@ post_process_test_results() {
             -job-name "${JOB_NAME}" \
             -junit-reports-dir "${ARTIFACT_DIR}" \
             -orchestrator "${ORCHESTRATOR_FLAVOR:-PROW}" \
-            -threshold 5 \
+            -threshold 10 \
             -html-output "$ARTIFACT_DIR/junit2jira-summary.html" \
             -slack-output "${slack_attachments_file}" \
             -summary-output "${summary_file}" \


### PR DESCRIPTION
### Description

We do not create a separated issues if there are more than 5 failed tests. This lead to creation of umbrella issues that collect different failures. Let's increase limit to 10 to get more granular results in jira.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
