### PR TITLE
ROX-26854: external entities garbage collection

### DIFF
--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -21,6 +22,7 @@ import (
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/uuid"
 	"gorm.io/gorm"
 )
@@ -104,6 +106,36 @@ const (
 		(SELECT 1 from deployments parent WHERE child.Props_DstEntity_Id = parent.id::text AND parent.clusterid = $1)
 		AND Props_DstEntity_Type = 1
 		AND UpdatedAt < $2`
+
+	pruneNetworkFlowsReturnStmt = ` RETURNING child.Props_SrcEntity_Type, child.Props_SrcEntity_Id, child.Props_DstEntity_Type,
+		child.Props_DstEntity_Id, child.Props_DstPort, child.Props_L4Protocol,
+		child.LastSeenTimestamp, child.UpdatedAt, child.ClusterId::text;`
+
+	// The idea behind this statement is to prune orphan external (discovered)
+	// entities from the entities table. When flows are pruned using the above
+	// statements, the returned deleted flows are used to construct a list of
+	// deletion candidates for the external entities table, and then if any of
+	// those are no longer referenced by a network flow, they are deleted.
+	//
+	// As with flow pruning, this is performed in two queries (for src and dst entities)
+	// to improve query performance
+	pruneOrphanExternalNetworkEntitiesSrcStmt = `DELETE FROM network_entities entity
+	WHERE (entity.Info_Id = ANY($1)) AND
+	NOT EXISTS
+		(SELECT 1 FROM %s flow
+			WHERE flow.Props_SrcEntity_Type = 4
+			AND flow.Props_SrcEntity_Id = entity.Info_Id
+			AND entity.Info_ExternalSource_Discovered = true
+		);`
+
+	pruneOrphanExternalNetworkEntitiesDstStmt = `DELETE FROM network_entities entity
+	WHERE (entity.Info_Id = ANY($1)) AND
+	NOT EXISTS
+		(SELECT 1 FROM %s flow
+			WHERE flow.Props_DstEntity_Type = 4
+			AND flow.Props_DstEntity_Id = entity.Info_Id
+			AND entity.Info_ExternalSource_Discovered = true
+		);`
 )
 
 var (
@@ -115,6 +147,8 @@ var (
 	deleteTimeout = env.PostgresDefaultNetworkFlowDeleteTimeout.DurationSetting()
 
 	queryTimeout = env.PostgresDefaultNetworkFlowQueryTimeout.DurationSetting()
+
+	orphanedEntitiesPruningBatchSize = 4096
 )
 
 // FlowStore stores all of the flows for a single cluster.
@@ -602,6 +636,24 @@ func (s *flowStoreImpl) RemoveOrphanedFlows(ctx context.Context, orphanWindow *t
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	if features.ExternalIPs.Enabled() || env.ExternalIPsPruning.BooleanSetting() {
+		// We are adding a return statement to retrieve the pruned flows. They are useful
+		// to limit the pruning of 'discovered' entities to only potential new orphans.
+		pruneStmt := fmt.Sprintf(pruneNetworkFlowsSrcStmt+pruneNetworkFlowsReturnStmt, s.partitionName)
+		srcFlows, err := s.pruneAndReturnFlows(ctx, pruneStmt, orphanWindow)
+		if err != nil {
+			return err
+		}
+
+		pruneStmt = fmt.Sprintf(pruneNetworkFlowsDestStmt+pruneNetworkFlowsReturnStmt, s.partitionName)
+		dstFlows, err := s.pruneAndReturnFlows(ctx, pruneStmt, orphanWindow)
+		if err != nil {
+			return err
+		}
+
+		return s.pruneOrphanExternalEntities(ctx, srcFlows, dstFlows)
+	}
+
 	// To avoid a full scan with an OR delete source and destination flows separately
 	pruneStmt := fmt.Sprintf(pruneNetworkFlowsSrcStmt, s.partitionName)
 	err := s.pruneFlows(ctx, pruneStmt, orphanWindow)
@@ -611,6 +663,44 @@ func (s *flowStoreImpl) RemoveOrphanedFlows(ctx context.Context, orphanWindow *t
 
 	pruneStmt = fmt.Sprintf(pruneNetworkFlowsDestStmt, s.partitionName)
 	return s.pruneFlows(ctx, pruneStmt, orphanWindow)
+}
+
+func (s *flowStoreImpl) pruneOrphanExternalEntities(ctx context.Context, srcFlows []*storage.NetworkFlow, dstFlows []*storage.NetworkFlow) error {
+	// srcFlows contains flows where src is the deployment,
+	// so prune external flows based on the dst entity
+	if len(srcFlows) != 0 {
+		err := utils.BatchProcess(srcFlows, orphanedEntitiesPruningBatchSize, func(flows []*storage.NetworkFlow) error {
+			entities := make([]string, 0, len(flows))
+			for _, flow := range flows {
+				entities = append(entities, flow.GetProps().GetDstEntity().GetId())
+			}
+
+			pruneStmt := fmt.Sprintf(pruneOrphanExternalNetworkEntitiesSrcStmt, s.partitionName)
+			return s.pruneEntities(ctx, pruneStmt, entities)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// dstFlows contains flows where dst is the deployment,
+	// so prune external flows based on the src entity
+	if len(dstFlows) != 0 {
+		err := utils.BatchProcess(dstFlows, orphanedEntitiesPruningBatchSize, func(flows []*storage.NetworkFlow) error {
+			entities := make([]string, 0, len(flows))
+			for _, flow := range flows {
+				entities = append(entities, flow.GetProps().GetSrcEntity().GetId())
+			}
+
+			pruneStmt := fmt.Sprintf(pruneOrphanExternalNetworkEntitiesDstStmt, s.partitionName)
+			return s.pruneEntities(ctx, pruneStmt, entities)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *flowStoreImpl) pruneFlows(ctx context.Context, deleteStmt string, orphanWindow *time.Time) error {
@@ -624,6 +714,41 @@ func (s *flowStoreImpl) pruneFlows(ctx context.Context, deleteStmt string, orpha
 	defer cancel()
 
 	if _, err := conn.Exec(ctx, deleteStmt, s.clusterID, orphanWindow); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *flowStoreImpl) pruneAndReturnFlows(ctx context.Context, deleteStmt string, orphanWindow *time.Time) ([]*storage.NetworkFlow, error) {
+	conn, release, err := s.acquireConn(ctx, ops.Remove, "NetworkFlow")
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	rows, err := conn.Query(ctx, deleteStmt, s.clusterID, orphanWindow)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.readRows(rows, nil)
+}
+
+func (s *flowStoreImpl) pruneEntities(ctx context.Context, deleteStmt string, entityIds []string) error {
+	conn, release, err := s.acquireConn(ctx, ops.Remove, "NetworkFlow")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
+
+	if _, err := conn.Exec(ctx, deleteStmt, entityIds); err != nil {
 		return err
 	}
 

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -138,7 +138,7 @@ var (
 
 	queryTimeout = env.PostgresDefaultNetworkFlowQueryTimeout.DurationSetting()
 
-	orphanedEntitiesPruningBatchSize = 1000
+	orphanedEntitiesPruningBatchSize = 100
 )
 
 // FlowStore stores all of the flows for a single cluster.

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -148,7 +148,7 @@ var (
 
 	queryTimeout = env.PostgresDefaultNetworkFlowQueryTimeout.DurationSetting()
 
-	orphanedEntitiesPruningBatchSize = 4096
+	orphanedEntitiesPruningBatchSize = 1000
 )
 
 // FlowStore stores all of the flows for a single cluster.

--- a/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/networkgraph/externalsrcs"
 	ngTestutils "github.com/stackrox/rox/pkg/networkgraph/testutils"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -272,6 +273,15 @@ func (s *NetworkflowStoreSuite) TestPruneStaleNetworkFlows() {
 	s.Equal(count, 2)
 }
 
+// Create a discovered External-Source entity that is ClusterScoped
+func GetClusterScopedDiscoveredEntity(ip string, clusterID string) *storage.NetworkEntity {
+	id, err := externalsrcs.NewClusterScopedID(clusterID, ip)
+	if err != nil {
+		return nil
+	}
+	return ngTestutils.GetExtSrcNetworkEntity(id.String(), ip, ip, false, clusterID, true)
+}
+
 // Two flows using two distinct external-entities. Both are pruned
 // and we expect that all entities are pruned as well.
 func (s *NetworkflowStoreSuite) TestPruneExternalEntitiesAllOrphaned() {
@@ -279,11 +289,11 @@ func (s *NetworkflowStoreSuite) TestPruneExternalEntitiesAllOrphaned() {
 
 	now := time.Now()
 
-	extEntity1 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.1/32", clusterID)
+	extEntity1 := GetClusterScopedDiscoveredEntity("223.42.0.1/32", clusterID)
 	err := s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity1, false)
 	s.Nil(err)
 
-	extEntity2 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.2/32", clusterID)
+	extEntity2 := GetClusterScopedDiscoveredEntity("223.42.0.2/32", clusterID)
 	err = s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity2, false)
 	s.Nil(err)
 
@@ -360,7 +370,7 @@ func (s *NetworkflowStoreSuite) TestPruneExternalEntitiesPartial() {
 
 	now := time.Now()
 
-	extEntity1 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.1/32", clusterID)
+	extEntity1 := GetClusterScopedDiscoveredEntity("223.42.0.1/32", clusterID)
 	err := s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity1, false)
 	s.Nil(err)
 
@@ -442,11 +452,11 @@ func (s *NetworkflowStoreSuite) TestPruneExternalEntitiesNoneOrphaned() {
 
 	now := time.Now()
 
-	extEntity1 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.1/32", clusterID)
+	extEntity1 := GetClusterScopedDiscoveredEntity("223.42.0.1/32", clusterID)
 	err := s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity1, false)
 	s.Nil(err)
 
-	extEntity2 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.2/32", clusterID)
+	extEntity2 := GetClusterScopedDiscoveredEntity("223.42.0.2/32", clusterID)
 	err = s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity2, false)
 	s.Nil(err)
 
@@ -523,11 +533,11 @@ func (s *NetworkflowStoreSuite) TestRemoveDeplExternalEntitiesOrphaned() {
 
 	now := time.Now()
 
-	extEntity1 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.1/32", clusterID)
+	extEntity1 := GetClusterScopedDiscoveredEntity("223.42.0.1/32", clusterID)
 	err := s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity1, false)
 	s.Nil(err)
 
-	extEntity2 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.2/32", clusterID)
+	extEntity2 := GetClusterScopedDiscoveredEntity("223.42.0.2/32", clusterID)
 	err = s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity2, false)
 	s.Nil(err)
 

--- a/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
@@ -300,7 +300,7 @@ func (s *NetworkflowStoreSuite) TestPruneOrphanedExternalEntities() {
 				},
 			},
 			ClusterId:         clusterID,
-			LastSeenTimestamp: timestamppb.New(now.Add(-1000)),
+			LastSeenTimestamp: timestamppb.New(now.Add(-100 * time.Second)),
 		},
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -315,11 +315,11 @@ func (s *NetworkflowStoreSuite) TestPruneOrphanedExternalEntities() {
 				},
 			},
 			ClusterId:         clusterID,
-			LastSeenTimestamp: timestamppb.New(now.Add(-1000)),
+			LastSeenTimestamp: timestamppb.New(now.Add(-100 * time.Second)),
 		},
 	}
 
-	err = s.flowStore.UpsertFlows(s.ctx, flows, timestamp.FromGoTime(now))
+	err = s.flowStore.UpsertFlows(s.ctx, flows, timestamp.FromGoTime(now.Add(-100*time.Second)))
 	s.Nil(err)
 
 	// flows initially in the DB
@@ -335,8 +335,9 @@ func (s *NetworkflowStoreSuite) TestPruneOrphanedExternalEntities() {
 	s.Nil(err)
 	s.Equal(2, count)
 
-	// pruning
-	window := now.Add(-100)
+	// pruning (anything older than 10s).
+	// Flows should get pruned because Deployment1 is not in the DB.
+	window := now.Add(-10 * time.Second)
 	err = s.flowStore.RemoveOrphanedFlows(s.ctx, &window)
 	s.Nil(err)
 

--- a/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
@@ -43,7 +43,6 @@ type NetworkflowStoreSuite struct {
 }
 
 func TestNetworkflowStore(t *testing.T) {
-	t.Setenv(features.ExternalIPs.EnvVar(), "true")
 	suite.Run(t, new(NetworkflowStoreSuite))
 }
 
@@ -275,6 +274,8 @@ func (s *NetworkflowStoreSuite) TestPruneStaleNetworkFlows() {
 }
 
 func (s *NetworkflowStoreSuite) TestPruneOrphanedExternalEntities() {
+	s.T().Setenv(features.ExternalIPs.EnvVar(), "true")
+
 	now := time.Now()
 
 	extEntity1 := ngTestutils.GetDiscoveredExtSrcNetworkEntity("223.42.0.1/32", clusterID)

--- a/pkg/env/external_ips.go
+++ b/pkg/env/external_ips.go
@@ -1,0 +1,7 @@
+package env
+
+var (
+	// ExternalIPsPruning enables the pruning of 'discovered' external entities.
+	// The pruning is always enabled when ROX_EXTERNAL_IPS is enabled.
+	ExternalIPsPruning = RegisterBooleanSetting("ROX_EXTERNAL_IPS_PRUNING", false)
+)

--- a/pkg/networkgraph/testutils/utils.go
+++ b/pkg/networkgraph/testutils/utils.go
@@ -105,6 +105,29 @@ func GetExtSrcNetworkEntityInfo(id, name, cidr string, isDefault bool, isDiscove
 	}
 }
 
+// GetDiscoveredExtSrcNetworkEntity returns a discovered external source named after its CIDR.
+func GetDiscoveredExtSrcNetworkEntity(cidr string, clusterID string) *storage.NetworkEntity {
+	id, _ := externalsrcs.NewClusterScopedID(clusterID, cidr)
+	return &storage.NetworkEntity{
+		Info: &storage.NetworkEntityInfo{
+			Id:   id.String(),
+			Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+			Desc: &storage.NetworkEntityInfo_ExternalSource_{
+				ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+					Name: cidr,
+					Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
+						Cidr: cidr,
+					},
+					Discovered: true,
+				},
+			},
+		},
+		Scope: &storage.NetworkEntity_Scope{
+			ClusterId: clusterID,
+		},
+	}
+}
+
 // GetNetworkFlow returns a network flow constructed from supplied data.
 func GetNetworkFlow(src, dst *storage.NetworkEntityInfo, port int, protocol storage.L4Protocol, ts *time.Time) *storage.NetworkFlow {
 	return &storage.NetworkFlow{

--- a/pkg/networkgraph/testutils/utils.go
+++ b/pkg/networkgraph/testutils/utils.go
@@ -105,29 +105,6 @@ func GetExtSrcNetworkEntityInfo(id, name, cidr string, isDefault bool, isDiscove
 	}
 }
 
-// GetDiscoveredExtSrcNetworkEntity returns a discovered external source named after its CIDR.
-func GetDiscoveredExtSrcNetworkEntity(cidr string, clusterID string) *storage.NetworkEntity {
-	id, _ := externalsrcs.NewClusterScopedID(clusterID, cidr)
-	return &storage.NetworkEntity{
-		Info: &storage.NetworkEntityInfo{
-			Id:   id.String(),
-			Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
-			Desc: &storage.NetworkEntityInfo_ExternalSource_{
-				ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
-					Name: cidr,
-					Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{
-						Cidr: cidr,
-					},
-					Discovered: true,
-				},
-			},
-		},
-		Scope: &storage.NetworkEntity_Scope{
-			ClusterId: clusterID,
-		},
-	}
-}
-
 // GetNetworkFlow returns a network flow constructed from supplied data.
 func GetNetworkFlow(src, dst *storage.NetworkEntityInfo, port int, protocol storage.L4Protocol, ts *time.Time) *storage.NetworkFlow {
 	return &storage.NetworkFlow{

--- a/pkg/utils/batch_process.go
+++ b/pkg/utils/batch_process.go
@@ -1,5 +1,6 @@
 package utils
 
+// BatchProcess calls f with slices of the provided set. Slices are batchSize size max.
 func BatchProcess[T interface{}](set []T, batchSize int, f func([]T) error) error {
 	localBatchSize := batchSize
 	for {

--- a/pkg/utils/batch_process.go
+++ b/pkg/utils/batch_process.go
@@ -1,0 +1,22 @@
+package utils
+
+func BatchProcess[T interface{}](set []T, batchSize int, f func([]T) error) error {
+	localBatchSize := batchSize
+	for {
+		if len(set) == 0 {
+			break
+		}
+
+		if len(set) < localBatchSize {
+			localBatchSize = len(set)
+		}
+
+		batch := set[:localBatchSize]
+		if err := f(batch); err != nil {
+			return err
+		}
+
+		set = set[localBatchSize:]
+	}
+	return nil
+}

--- a/pkg/utils/batch_process_test.go
+++ b/pkg/utils/batch_process_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchProcess(t *testing.T) {
+	type Run struct {
+		name     string
+		input    []int
+		expected [][]int
+	}
+	runs := []Run{
+		{
+			name:     "partial",
+			input:    []int{1, 2, 3, 4, 5, 6, 7, 8},
+			expected: [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8}},
+		},
+		{
+			name:     "boundary",
+			input:    []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			expected: [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+		},
+		{
+			name:     "empty",
+			input:    []int{},
+			expected: [][]int{},
+		},
+	}
+
+	for _, run := range runs {
+		t.Run(run.name, func(t *testing.T) {
+			actual := make([][]int, 0)
+			err := BatchProcess(run.input, 3, func(set []int) error {
+				actual = append(actual, set)
+				return nil
+			})
+			assert.Equal(t, nil, err)
+			assert.EqualValues(t, run.expected, actual)
+		})
+	}
+
+	err := BatchProcess([]int{1}, 3, func(set []int) error {
+		return errors.New("fail")
+	})
+
+	assert.NotEqual(t, nil, err)
+}


### PR DESCRIPTION
### Description

Note that this PR is built upon here https://github.com/stackrox/stackrox/pull/15008

With the addition of the External-IPs feature, we now receive and store 'discovered' external entities into the network_entities table. As all the preexisting entities, 'discovered' entities are references as src or dst from network flows.

Up to now, all network entities stored in the database were static (or almost, since custom CIDR-blocks can be added/removed via API, and default entities are either enabled or disabled. But they were not discovered from the network). So we need a way to prune the database to ensure that the number of 'discovered' entities does not grow infinitely.

This PR adds a second stage of pruning after the flow pruning.

We are deleting all 'discovered' external entities for which there is no flow remaining that is pointing a them.

We make use of an optimization: when flows are pruned, we now retrieve the src/dst entities of those flows. Then, when searching for orphaned entities, we limit the search to this set.

The pruning occurs only when `ROX_EXTERNAL_IPS` is enabled or when `ROX_EXTERNAL_IPS_PRUNING` is _true_. When the pruning is disabled, there should be no extra cost involved.

This is a rework of #12858, as the technique used here was rendered possible after #13862 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

The pruning query was run on a database filled with 1 million flows and 10000 entities. It resulted in the following execution plan:

```
# explain(analyze,verbose,buffers,settings) DELETE FROM network_entities entity
WHERE entity.Info_Id = 'caaaaaaa-bbbb-4011-0000-111111111111__MC4wLjAuNi8zMg' AND entity.Info_ExternalSource_Discovered = true AND
NOT EXISTS
(SELECT 1 FROM network_flows_v2_caaaaaaa_bbbb_4011_0000_111111111111 flow WHERE
    (flow.Props_SrcEntity_Type = 4 AND flow.Props_SrcEntity_Id = entity.Info_Id))
AND
NOT EXISTS
(SELECT 1 FROM network_flows_v2_caaaaaaa_bbbb_4011_0000_111111111111 flow WHERE
  (flow.Props_DstEntity_Type = 4 AND flow.Props_DstEntity_Id = entity.Info_Id)
);
                                                                                                       QUERY PLAN                                                               
                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-----------------------------------------
 Delete on public.network_entities entity  (cost=5.18..415.18 rows=0 width=0) (actual time=0.044..0.046 rows=0 loops=1)
   Buffers: shared hit=3
   ->  Nested Loop Anti Join  (cost=5.18..415.18 rows=1 width=18) (actual time=0.043..0.044 rows=0 loops=1)
         Output: entity.ctid, flow.ctid, flow_1.ctid
         Buffers: shared hit=3
         ->  Nested Loop Anti Join  (cost=5.18..407.15 rows=1 width=67) (actual time=0.043..0.043 rows=0 loops=1)
               Output: entity.ctid, entity.info_id, flow.ctid
               Buffers: shared hit=3
               ->  Index Scan using network_entities_pkey on public.network_entities entity  (cost=0.41..8.43 rows=1 width=61) (actual time=0.042..0.042 rows=0 loops=1)
                     Output: entity.ctid, entity.info_id
                     Index Cond: ((entity.info_id)::text = 'caaaaaaa-bbbb-4011-0000-111111111111__MC4wLjAuNi8zMg'::text)
                     Filter: entity.info_externalsource_discovered
                     Buffers: shared hit=3
               ->  Bitmap Heap Scan on public.network_flows_v2_caaaaaaa_bbbb_4011_0000_111111111111 flow  (cost=4.77..398.72 rows=1 width=61) (never executed)
                     Output: flow.ctid, flow.props_srcentity_id
                     Recheck Cond: ((flow.props_srcentity_id)::text = 'caaaaaaa-bbbb-4011-0000-111111111111__MC4wLjAuNi8zMg'::text)
                     Filter: (flow.props_srcentity_type = 4)
                     ->  Bitmap Index Scan on network_flows_v2_caaaaaaa_bbbb_4011_0000_props_srcentity_id_idx  (cost=0.00..4.77 rows=103 width=0) (never executed)
                           Index Cond: ((flow.props_srcentity_id)::text = 'caaaaaaa-bbbb-4011-0000-111111111111__MC4wLjAuNi8zMg'::text)
         ->  Index Scan using network_flows_v2_caaaaaaa_bbbb_4011_0000_props_dstentity_id_idx on public.network_flows_v2_caaaaaaa_bbbb_4011_0000_111111111111 flow_1  (cost=0.00
..8.02 rows=1 width=43) (never executed)
               Output: flow_1.ctid, flow_1.props_dstentity_id
               Index Cond: ((flow_1.props_dstentity_id)::text = 'caaaaaaa-bbbb-4011-0000-111111111111__MC4wLjAuNi8zMg'::text)
               Filter: (flow_1.props_dstentity_type = 4)
 Query Identifier: 2539863372710694734
 Planning:
   Buffers: shared hit=77
 Planning Time: 0.609 ms
 Execution Time: 0.114 ms
(28 rows)
```

#### Automated testing

- [x] added unit tests

