### PR TITLE
ROX-28716: Added "Days Since CVE Was Published" policy criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - ROX-13493: Support for scale subresource in the admission controller to enable policy detection and enforcement on admission review requests on the scale subresource.
 - RHPF-98: Log creation of API token. The token creation log message will trigger an administration event.
+- ROX-28716: New policy criterion "Days Since CVE Was Published" to allow creation of a policy that offers a grace period to teams to fix vulnerabilities within the number of days from when the CVE was published in the vulnerability feeds.
 
 ### Removed Features
 

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -209,6 +209,55 @@ func (suite *DefaultPoliciesTestSuite) TestFixableAndImageFirstOccurenceCriteria
 
 }
 
+func (suite *DefaultPoliciesTestSuite) TestDaysSinceCVEPublishedCriteria() {
+	heartbleedDep := &storage.Deployment{
+		Id: "HEARTBLEEDDEPID",
+		Containers: []*storage.Container{
+			{
+				Name:            "nginx",
+				SecurityContext: &storage.SecurityContext{Privileged: true},
+				Image:           &storage.ContainerImage{Id: "HEARTBLEEDDEPSHA"},
+			},
+		},
+	}
+
+	ts := time.Now().AddDate(0, 0, -5)
+	protoTs, err := protocompat.ConvertTimeToTimestampOrError(ts)
+	require.NoError(suite.T(), err)
+
+	suite.addDepAndImages(heartbleedDep, &storage.Image{
+		Id:   "HEARTBLEEDDEPSHA",
+		Name: &storage.ImageName{FullName: "heartbleed"},
+		Scan: &storage.ImageScan{
+			Components: []*storage.EmbeddedImageScanComponent{
+				{Name: "heartbleed", Version: "1.2", Vulns: []*storage.EmbeddedVulnerability{
+					{Cve: "CVE-2014-0160", Link: "https://heartbleed", Cvss: 6, SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{FixedBy: "v1.2"},
+						PublishedOn: protoTs},
+				}},
+			},
+		},
+	})
+
+	fixablePolicyGroup := &storage.PolicyGroup{
+		FieldName: fieldnames.Fixable,
+		Values:    []*storage.PolicyValue{{Value: "true"}},
+	}
+	cvePublishedGroup := &storage.PolicyGroup{
+		FieldName: fieldnames.DaysSincePublished,
+		Values:    []*storage.PolicyValue{{Value: "2"}},
+	}
+
+	policy := policyWithGroups(storage.EventSource_NOT_APPLICABLE, fixablePolicyGroup, cvePublishedGroup)
+
+	deployment := suite.deployments["HEARTBLEEDDEPID"]
+	depMatcher, err := BuildDeploymentMatcher(policy)
+	require.NoError(suite.T(), err)
+	violations, err := depMatcher.MatchDeployment(nil, enhancedDeployment(deployment, suite.getImagesForDeployment(deployment)))
+	require.Len(suite.T(), violations.AlertViolations, 1)
+	require.NoError(suite.T(), err)
+
+}
+
 func (suite *DefaultPoliciesTestSuite) TestNoDuplicatePolicyIDs() {
 	ids := set.NewStringSet()
 	for _, p := range suite.defaultPolicies {

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -282,6 +282,15 @@ func initializeFieldMetadata() FieldMetadata {
 		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
 		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
 
+	f.registerFieldMetadata(fieldnames.DaysSincePublished,
+		querybuilders.ForDays(search.CVEPublishedOn),
+		violationmessages.VulnContextFields,
+		func(*validateConfiguration) *regexp.Regexp {
+			return integerValueRegex
+		},
+		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
+		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
+
 	f.registerFieldMetadata(fieldnames.DisallowedAnnotation,
 		querybuilders.ForFieldLabelMap(search.DeploymentAnnotation, query.MapShouldContain),
 		nil,

--- a/pkg/booleanpolicy/fieldnames/list.go
+++ b/pkg/booleanpolicy/fieldnames/list.go
@@ -17,6 +17,7 @@ var (
 	ContainerMemLimit              = newFieldName("Container Memory Limit")
 	ContainerMemRequest            = newFieldName("Container Memory Request")
 	ContainerName                  = newFieldName("Container Name")
+	DaysSincePublished             = newFieldName("Days Since CVE Was Published")
 	DaysSinceImageFirstDiscovered  = newFieldName("Days Since CVE Was First Discovered In Image")
 	DaysSinceSystemFirstDiscovered = newFieldName("Days Since CVE Was First Discovered In System")
 	DisallowedAnnotation           = newFieldName("Disallowed Annotation")

--- a/pkg/booleanpolicy/violationmessages/printer.go
+++ b/pkg/booleanpolicy/violationmessages/printer.go
@@ -30,6 +30,7 @@ var (
 		fieldnames.ContainerMemLimit:              {{required: set.NewStringSet(search.MemoryLimit.String()), printerFuncKey: printer.ResourceKey}},
 		fieldnames.ContainerMemRequest:            {{required: set.NewStringSet(search.MemoryRequest.String()), printerFuncKey: printer.ResourceKey}},
 		fieldnames.ContainerName:                  {{required: set.NewStringSet(search.ContainerName.String()), printerFuncKey: printer.ContainerNameKey}},
+		fieldnames.DaysSincePublished:             {{required: set.NewStringSet(search.CVE.String(), search.CVEPublishedOn.String()), printerFuncKey: printer.CveKey}},
 		fieldnames.DaysSinceImageFirstDiscovered:  {{required: set.NewStringSet(search.CVE.String(), search.FirstImageOccurrenceTimestamp.String()), printerFuncKey: printer.CveKey}},
 		fieldnames.DaysSinceSystemFirstDiscovered: {{required: set.NewStringSet(search.CVE.String(), search.FirstSystemOccurrenceTimestamp.String()), printerFuncKey: printer.CveKey}},
 		fieldnames.DisallowedAnnotation:           {{required: set.NewStringSet(search.DeploymentAnnotation.String()), printerFuncKey: printer.DisallowedAnnotationKey}},

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -582,6 +582,16 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
+        label: 'Days Since CVE Was Published',
+        name: 'Days Since CVE Was Published',
+        shortName: 'Days since CVE was published',
+        category: policyCriteriaCategories.IMAGE_CONTENTS,
+        type: 'number',
+        placeholder: '0',
+        canBooleanLogic: false,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
+    },
+    {
         label: 'Days Since CVE Was First Discovered In Image',
         name: 'Days Since CVE Was First Discovered In Image',
         shortName: 'Days since CVE was first discovered in image',


### PR DESCRIPTION
### Description

Adding a new policy criteria "Days since CVE was published".  This allows customers to build a policy to allow teams a grace period from the CVE published date to fix vulnerabilities in images, or get violations if the grace period has elapsed.

@kcarmichael08  This criteria will need to be documented.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Manually created a policy on the cluster. 