### PR TITLE
ROX-28697: use Walk instead of GetAll in cloud sources

### DIFF
--- a/central/cloudsources/datastore/datastore.go
+++ b/central/cloudsources/datastore/datastore.go
@@ -17,7 +17,7 @@ import (
 type DataStore interface {
 	CountCloudSources(ctx context.Context, query *v1.Query) (int, error)
 	GetCloudSource(ctx context.Context, id string) (*storage.CloudSource, error)
-	GetAllCloudSources(ctx context.Context) ([]*storage.CloudSource, error)
+	ProcessCloudSources(ctx context.Context, fn func(obj *storage.CloudSource) error) error
 	ListCloudSources(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error)
 	UpsertCloudSource(ctx context.Context, cloudSource *storage.CloudSource) error
 	DeleteCloudSource(ctx context.Context, id string) error

--- a/central/cloudsources/datastore/datastore.go
+++ b/central/cloudsources/datastore/datastore.go
@@ -17,7 +17,7 @@ import (
 type DataStore interface {
 	CountCloudSources(ctx context.Context, query *v1.Query) (int, error)
 	GetCloudSource(ctx context.Context, id string) (*storage.CloudSource, error)
-	ProcessCloudSources(ctx context.Context, fn func(obj *storage.CloudSource) error) error
+	ForEachCloudSource(ctx context.Context, fn func(obj *storage.CloudSource) error) error
 	ListCloudSources(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error)
 	UpsertCloudSource(ctx context.Context, cloudSource *storage.CloudSource) error
 	DeleteCloudSource(ctx context.Context, id string) error

--- a/central/cloudsources/datastore/datastore_impl.go
+++ b/central/cloudsources/datastore/datastore_impl.go
@@ -56,8 +56,8 @@ func (ds *datastoreImpl) GetCloudSource(ctx context.Context, id string) (*storag
 	return cloudSource, nil
 }
 
-func (ds *datastoreImpl) GetAllCloudSources(ctx context.Context) ([]*storage.CloudSource, error) {
-	return ds.store.GetAll(ctx)
+func (ds *datastoreImpl) ProcessCloudSources(ctx context.Context, fn func(obj *storage.CloudSource) error) error {
+	return ds.store.Walk(ctx, fn)
 }
 
 func (ds *datastoreImpl) ListCloudSources(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error) {

--- a/central/cloudsources/datastore/datastore_impl.go
+++ b/central/cloudsources/datastore/datastore_impl.go
@@ -56,7 +56,7 @@ func (ds *datastoreImpl) GetCloudSource(ctx context.Context, id string) (*storag
 	return cloudSource, nil
 }
 
-func (ds *datastoreImpl) ProcessCloudSources(ctx context.Context, fn func(obj *storage.CloudSource) error) error {
+func (ds *datastoreImpl) ForEachCloudSource(ctx context.Context, fn func(obj *storage.CloudSource) error) error {
 	return ds.store.Walk(ctx, fn)
 }
 

--- a/central/cloudsources/datastore/datastore_impl_postgres_test.go
+++ b/central/cloudsources/datastore/datastore_impl_postgres_test.go
@@ -77,16 +77,22 @@ func (s *datastorePostgresTestSuite) TestGetCloudSource() {
 	protoassert.Equal(s.T(), cloudSource, roundtripCloudSource)
 }
 
-func (s *datastorePostgresTestSuite) TestGetAllCloudSources() {
-	cloudSources, err := s.datastore.GetAllCloudSources(s.readCtx)
+func (s *datastorePostgresTestSuite) TestProcessCloudSources() {
+	count := 0
+	counter := func(_ *storage.CloudSource) error {
+		count++
+		return nil
+	}
+
+	err := s.datastore.ProcessCloudSources(s.readCtx, counter)
 	s.Require().NoError(err)
-	s.Assert().Empty(cloudSources)
+	s.Assert().Equal(count, 0)
 
 	s.addCloudSources(100)
 
-	cloudSources, err = s.datastore.GetAllCloudSources(s.readCtx)
+	err = s.datastore.ProcessCloudSources(s.readCtx, counter)
 	s.Require().NoError(err)
-	s.Assert().Len(cloudSources, 100)
+	s.Assert().Equal(count, 100)
 }
 
 func (s *datastorePostgresTestSuite) TestListCloudSources() {

--- a/central/cloudsources/datastore/datastore_impl_postgres_test.go
+++ b/central/cloudsources/datastore/datastore_impl_postgres_test.go
@@ -84,13 +84,13 @@ func (s *datastorePostgresTestSuite) TestProcessCloudSources() {
 		return nil
 	}
 
-	err := s.datastore.ProcessCloudSources(s.readCtx, counter)
+	err := s.datastore.ForEachCloudSource(s.readCtx, counter)
 	s.Require().NoError(err)
 	s.Assert().Equal(count, 0)
 
 	s.addCloudSources(100)
 
-	err = s.datastore.ProcessCloudSources(s.readCtx, counter)
+	err = s.datastore.ForEachCloudSource(s.readCtx, counter)
 	s.Require().NoError(err)
 	s.Assert().Equal(count, 100)
 }

--- a/central/cloudsources/datastore/internal/store/mocks/store.go
+++ b/central/cloudsources/datastore/internal/store/mocks/store.go
@@ -88,21 +88,6 @@ func (mr *MockStoreMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
-// GetAll mocks base method.
-func (m *MockStore) GetAll(ctx context.Context) ([]*storage.CloudSource, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAll", ctx)
-	ret0, _ := ret[0].([]*storage.CloudSource)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAll indicates an expected call of GetAll.
-func (mr *MockStoreMockRecorder) GetAll(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockStore)(nil).GetAll), ctx)
-}
-
 // GetByQuery mocks base method.
 func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error) {
 	m.ctrl.T.Helper()
@@ -145,4 +130,18 @@ func (m *MockStore) Upsert(ctx context.Context, obj *storage.CloudSource) error 
 func (mr *MockStoreMockRecorder) Upsert(ctx, obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockStore)(nil).Upsert), ctx, obj)
+}
+
+// Walk mocks base method.
+func (m *MockStore) Walk(ctx context.Context, fn func(*storage.CloudSource) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Walk", ctx, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Walk indicates an expected call of Walk.
+func (mr *MockStoreMockRecorder) Walk(ctx, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockStore)(nil).Walk), ctx, fn)
 }

--- a/central/cloudsources/datastore/internal/store/postgres/gen.go
+++ b/central/cloudsources/datastore/internal/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.CloudSource --search-category CLOUD_SOURCES --cached-store --get-all-func
+//go:generate pg-table-bindings-wrapper --type=storage.CloudSource --search-category CLOUD_SOURCES --cached-store

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -51,7 +51,6 @@ type Store interface {
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
-	GetAll(ctx context.Context) ([]*storeType, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error

--- a/central/cloudsources/datastore/internal/store/postgres/store_test.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store_test.go
@@ -92,9 +92,6 @@ func (s *CloudSourcesStoreSuite) TestStore() {
 	}
 
 	s.NoError(store.UpsertMany(ctx, cloudSources))
-	allCloudSource, err := store.GetAll(ctx)
-	s.NoError(err)
-	protoassert.ElementsMatch(s.T(), cloudSources, allCloudSource)
 
 	cloudSourceCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/cloudsources/datastore/internal/store/store.go
+++ b/central/cloudsources/datastore/internal/store/store.go
@@ -12,7 +12,7 @@ import (
 //
 //go:generate mockgen-wrapper
 type Store interface {
-	GetAll(ctx context.Context) ([]*storage.CloudSource, error)
+	Walk(ctx context.Context, fn func(obj *storage.CloudSource) error) error
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Get(ctx context.Context, id string) (*storage.CloudSource, bool, error)

--- a/central/cloudsources/manager/manager.go
+++ b/central/cloudsources/manager/manager.go
@@ -144,7 +144,7 @@ func (m *managerImpl) getDiscoveredClustersFromCloudSources() []*discoveredclust
 
 	var clients []cloudsources.Client
 	var clientCreationErrs error
-	err := m.cloudSourcesDataStore.ProcessCloudSources(cloudSourceCtx, func(cloudSource *storage.CloudSource) error {
+	err := m.cloudSourcesDataStore.ForEachCloudSource(cloudSourceCtx, func(cloudSource *storage.CloudSource) error {
 		client, err := cloudsources.NewClientForCloudSource(createCtx, cloudSource)
 		if err != nil {
 			clientCreationErrs = errors.Join(clientCreationErrs,
@@ -259,7 +259,7 @@ func (m *managerImpl) changeStatusForDiscoveredClusters(clusterID string, status
 	}
 
 	var discoveredClusterIds []string
-	err = m.cloudSourcesDataStore.ProcessCloudSources(cloudSourceCtx, func(c *storage.CloudSource) error {
+	err = m.cloudSourcesDataStore.ForEachCloudSource(cloudSourceCtx, func(c *storage.CloudSource) error {
 		discoveredClusterIds = append(discoveredClusterIds, createDiscoveredClusterId(cluster, c))
 		return nil
 	})


### PR DESCRIPTION
### Description

---
- #14784
- #14781 :point_left: 
- #14779
- #14778
- #14763
- #14759
- #14758
- #14757
- #14747
- #14742
---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
