### PR TITLE
ROX-28699: fix verification of multiple cosign signatures

### DIFF
--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	imgUtils "github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/protoutils"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -160,14 +161,30 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 		allVerifyErrs = multierror.Append(allVerifyErrs, err)
 	}
 
+	// Find the union of all image references from verified signatures. The resulting status
+	// is verified if at least one verification was successful.
+	//
+	// verifier_1(sig_1) OR ... OR verifier_1(sig_N)
+	// OR
+	// ...
+	// OR
+	// verifier_N(sig_1) OR ... OR verifier_N(sig_N)
+	verifiedImageReferences := set.NewStringSet()
 	for _, opts := range c.verifierOpts {
-		verifiedImageReferences, err := verifyImageSignatures(ctx, sigs, hash, image, opts)
-		if err == nil && len(verifiedImageReferences) != 0 {
-			return storage.ImageSignatureVerificationResult_VERIFIED, verifiedImageReferences, nil
+		verifierReferenceSet, err := verifyImageSignatures(ctx, sigs, hash, image, opts)
+		if err != nil {
+			allVerifyErrs = multierror.Append(allVerifyErrs, err)
+			continue
 		}
-		allVerifyErrs = multierror.Append(allVerifyErrs, err)
+		verifiedImageReferences = verifiedImageReferences.Union(verifierReferenceSet)
 	}
 
+	if len(verifiedImageReferences) > 0 {
+		verifiedRefSlice := verifiedImageReferences.AsSortedSlice(
+			func(i, j string) bool { return i < j },
+		)
+		return storage.ImageSignatureVerificationResult_VERIFIED, verifiedRefSlice, nil
+	}
 	return storage.ImageSignatureVerificationResult_FAILED_VERIFICATION, nil, allVerifyErrs
 }
 
@@ -270,26 +287,35 @@ func cosignCheckOptsFromCert(cert certVerificationData) (cosign.CheckOpts, error
 	}
 }
 
-func verifyImageSignatures(ctx context.Context, signatures []oci.Signature, imageHash gcrv1.Hash, image *storage.Image,
-	cosignOpts cosign.CheckOpts) (verifiedImageReferences []string, verificationErrors error) {
+func verifyImageSignatures(ctx context.Context, signatures []oci.Signature,
+	imageHash gcrv1.Hash, image *storage.Image, cosignOpts cosign.CheckOpts,
+) (set.StringSet, error) {
+	verifiedImageReferences := set.NewStringSet()
+	var verificationErrors error
+
 	for _, signature := range signatures {
 		// The bundle references a rekor bundle within the transparency log. Since we do not support this, the
 		// bundle verified will _always_ be false.
 		// See: https://github.com/sigstore/cosign/blob/eaee4b7da0c1a42326bd82c6a4da7e16741db266/pkg/cosign/verify.go#L584-L586.
 		// If there is no error during the verification, the signature was successfully verified
 		// as well as the claims.
-		_, err := cosign.VerifyImageSignature(ctx, signature, imageHash, &cosignOpts)
-
-		if err != nil {
+		if _, err := cosign.VerifyImageSignature(ctx, signature, imageHash, &cosignOpts); err != nil {
 			verificationErrors = multierror.Append(verificationErrors, err)
 			continue
 		}
 
-		if verifiedImageReferences, err = getVerifiedImageReference(signature, image); err != nil {
+		refs, err := getVerifiedImageReference(signature, image)
+		if err != nil {
 			verificationErrors = multierror.Append(verificationErrors, err)
+			continue
 		}
+		verifiedImageReferences.AddAll(refs...)
 	}
-	return verifiedImageReferences, verificationErrors
+
+	if len(verifiedImageReferences) > 0 {
+		return verifiedImageReferences, nil
+	}
+	return nil, verificationErrors
 }
 
 // getVerificationResultStatusFromErr will map an error to a specific storage.ImageSignatureVerificationResult_Status.

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -14,6 +14,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	// imgName_1a and imgName_1b are both signed by pemPublicKey_1.
+	pemPublicKey_1 = "-----BEGIN PUBLIC KEY-----\n" +
+		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvVPaOS6sfpySbaceiwg0e6p6Bzo1\n" +
+		"A2qyHC5rfVNn2uBRz2Xy0nYBiJ1mFLXaiWGQ2AyCfVh5DzDqJx8eY7YwHQ==\n" +
+		"-----END PUBLIC KEY-----"
+	imgName_1a = "ttl.sh/2fd430e3-6589-4a5c-865b-4c0aa5b8b041@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
+		"26dbbdb3991714e501e1c9"
+	b64Signature_1a = "MEUCIDuWppiw7vQzqSRaNA7jx0DtLtWtQvDd/Sm6JfL3nb9uAiEA7bm6pY+GozjTE4hZLPf6ypJqusBNSc9OdC0X" +
+		"Mx7sXjk="
+	b64SignaturePayload_1a = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoLzJmZDQzMGUzL" +
+		"TY1ODktNGE1Yy04NjViLTRjMGFhNWI4YjA0MSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
+		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
+		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
+	b64Signature_1b = "MEQCIHJQ8ijck0xwcFpIru/VW8zhdOadKLuilZwyJGgbAEsaAiB4LdLNIvRJbNaRFhyYTXGFo8cK/VZ7P+Z4Ky+M" +
+		"Hk11IA=="
+	b64SignaturePayload_1b = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2FjNzExYTA1L" +
+		"WZhNjItNDBmYy04ZDNmLWVhM2JjMTk5N2E2NCJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" + "Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
+		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
+	imgName_1b = "ttl.sh/ac711a05-fa62-40fc-8d3f-ea3bc1997a64@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
+		"26dbbdb3991714e501e1c9"
+
+	// imgName_2 is signed by pemPublicKey_2.
+	pemPublicKey_2 = "-----BEGIN PUBLIC KEY-----\n" +
+		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKt34iWzgZUoGERCjOhjlxTviXQYk\n" +
+		"CxNmhRr5rMeatATTskxx0i6eB04jum2FFPmfIvThIuzyzQxlBDj1gNKXLw==\n" +
+		"-----END PUBLIC KEY-----"
+	b64Signature_2 = "MEUCIQCoqJSXaMtrHla2iARwMkSiQCadPUgL4y3QQYjW8MLgnAIgC+6233YksZtzLlyMfvHcGUzHg8QoEeKef027" +
+		"2n3JN2I="
+	b64SignaturePayload_2 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2MwMGRhZjA1L" +
+		"TljNWItNDA0MC05ZGJlLTQ0NDgzNjE3MGJlYSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
+		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
+		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
+	imgName_2 = "ttl.sh/c00daf05-9c5b-4040-9dbe-444836170bea@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
+		"26dbbdb3991714e501e1c9"
+
+	// imgName_3 is not signed by pemPublicKey_1 or pemPublicKey_2.
+	imgName_3 = "ttl.sh/c00daf05-9c5b-4040-9dbe-444836170bea@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
+		"26dbbdb3991714e501e1c9"
+	b64Signature_3 = "MEUCIQCoqJSXaMtrHla2iARwMkSiQCadPUgL4y3QQYjW8MLgnAIgC+6233YksZtzLlyMfvHcGUzHg8QoEeKef027" +
+		"2n3JN2I="
+	b64SignaturePayload_3 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2MwMGRhZjA1L" +
+		"TljNWItNDA0MC05ZGJlLTQ0NDgzNjE3MGJlYSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
+		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
+		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
+)
+
 func TestNewCosignSignatureVerifier(t *testing.T) {
 	cases := map[string]struct {
 		pemEncKey string
@@ -59,31 +106,18 @@ func TestNewCosignSignatureVerifier(t *testing.T) {
 }
 
 func TestCosignSignatureVerifier_VerifySignature_Success(t *testing.T) {
-	const pemPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
-		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE04soAoNygRhaytCtygPcwsP+6Ein\n" +
-		"YoDv/BJx1T9WmtsANh2HplRR66Fbm+3OjFuah2IhFufPhDl6a85I3ymVYw==\n" +
-		"-----END PUBLIC KEY-----"
-	const b64Signature = "MEUCIDGMmJyxVKGPxvPk/QlRzMSGzcI8pYCy+MB7RTTpegzTAiEArssqWntVN8oJOMV0Aey0zhsNqRmEVQAYZNkn8h" +
-		"kAnXI="
-	const b64SignaturePayload = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2Q4ZDM4OTJkLTQ" +
-		"4YmQtNDY3MS1hNTQ2LTJlNzBhOTAwYjcwMiJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OmVlODliMDA1Mj" +
-		"hmZjRmMDJmMjQwNWU0ZWUyMjE3NDNlYmMzZjhlOGRkMGJmZDVjNGMyMGEyZmEyYWFhN2VkZTMifSwidHlwZSI6ImNvc2lnbiBjb250YWluZ" +
-		"XIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgString = "ttl.sh/d8d3892d-48bd-4671-a546-2e70a900b702@sha256:ee89b00528ff4f02f2405e4ee221743ebc3f8e8dd0" +
-		"bfd5c4c20a2fa2aaa7ede3"
-
 	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
 				Name:            "cosignSignatureVerifier",
-				PublicKeyPemEnc: pemPublicKey,
+				PublicKeyPemEnc: pemPublicKey_1,
 			},
 		},
 	}})
 
 	require.NoError(t, err, "creating public key verifier")
 
-	img, err := generateImageWithCosignSignature(imgString, b64Signature, b64SignaturePayload, nil, nil)
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 
 	status, verifiedImageReferences, err := pubKeyVerifier.VerifySignature(context.Background(), img)
@@ -95,31 +129,18 @@ func TestCosignSignatureVerifier_VerifySignature_Success(t *testing.T) {
 }
 
 func TestCosignSignatureVerifier_VerifySignature_Multiple_Names_One_Sig(t *testing.T) {
-	const pemPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
-		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE04soAoNygRhaytCtygPcwsP+6Ein\n" +
-		"YoDv/BJx1T9WmtsANh2HplRR66Fbm+3OjFuah2IhFufPhDl6a85I3ymVYw==\n" +
-		"-----END PUBLIC KEY-----"
-	const b64Signature = "MEUCIDGMmJyxVKGPxvPk/QlRzMSGzcI8pYCy+MB7RTTpegzTAiEArssqWntVN8oJOMV0Aey0zhsNqRmEVQAYZNkn8h" +
-		"kAnXI="
-	const b64SignaturePayload = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2Q4ZDM4OTJkLTQ" +
-		"4YmQtNDY3MS1hNTQ2LTJlNzBhOTAwYjcwMiJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OmVlODliMDA1Mj" +
-		"hmZjRmMDJmMjQwNWU0ZWUyMjE3NDNlYmMzZjhlOGRkMGJmZDVjNGMyMGEyZmEyYWFhN2VkZTMifSwidHlwZSI6ImNvc2lnbiBjb250YWluZ" +
-		"XIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgString = "ttl.sh/d8d3892d-48bd-4671-a546-2e70a900b702@sha256:ee89b00528ff4f02f2405e4ee221743ebc3f8e8dd0" +
-		"bfd5c4c20a2fa2aaa7ede3"
-
 	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
 				Name:            "cosignSignatureVerifier",
-				PublicKeyPemEnc: pemPublicKey,
+				PublicKeyPemEnc: pemPublicKey_1,
 			},
 		},
 	}})
 
 	require.NoError(t, err, "creating public key verifier")
 
-	img, err := generateImageWithCosignSignature(imgString, b64Signature, b64SignaturePayload, nil, nil)
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 
 	secondImageName := &storage.ImageName{
@@ -142,40 +163,20 @@ func TestCosignSignatureVerifier_VerifySignature_Multiple_Names_One_Sig(t *testi
 }
 
 func TestCosignSignatureVerifier_VerifySignature_Multiple_Names_Multiple_Sigs(t *testing.T) {
-	const pemPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
-		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvVPaOS6sfpySbaceiwg0e6p6Bzo1\n" +
-		"A2qyHC5rfVNn2uBRz2Xy0nYBiJ1mFLXaiWGQ2AyCfVh5DzDqJx8eY7YwHQ==\n" +
-		"-----END PUBLIC KEY-----"
-	const b64Signature_1 = "MEUCIDuWppiw7vQzqSRaNA7jx0DtLtWtQvDd/Sm6JfL3nb9uAiEA7bm6pY+GozjTE4hZLPf6ypJqusBNSc9OdC0X" +
-		"Mx7sXjk="
-	const b64SignaturePayload_1 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoLzJmZDQzMGUzL" +
-		"TY1ODktNGE1Yy04NjViLTRjMGFhNWI4YjA0MSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
-		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
-		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgName_1 = "ttl.sh/2fd430e3-6589-4a5c-865b-4c0aa5b8b041@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
-		"26dbbdb3991714e501e1c9"
-	const b64Signature_2 = "MEQCIHJQ8ijck0xwcFpIru/VW8zhdOadKLuilZwyJGgbAEsaAiB4LdLNIvRJbNaRFhyYTXGFo8cK/VZ7P+Z4Ky+M" +
-		"Hk11IA=="
-	const b64SignaturePayload_2 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2FjNzExYTA1L" +
-		"WZhNjItNDBmYy04ZDNmLWVhM2JjMTk5N2E2NCJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" + "Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
-		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgName_2 = "ttl.sh/ac711a05-fa62-40fc-8d3f-ea3bc1997a64@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
-		"26dbbdb3991714e501e1c9"
-
 	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
 				Name:            "cosignSignatureVerifier",
-				PublicKeyPemEnc: pemPublicKey,
+				PublicKeyPemEnc: pemPublicKey_1,
 			},
 		},
 	}})
 	require.NoError(t, err, "creating public key verifier")
 
-	img, err := generateImageWithCosignSignature(imgName_1, b64Signature_1, b64SignaturePayload_1, nil, nil)
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 	// Use the helper function to create a new image, but we only want the signature here.
-	img_2, err := generateImageWithCosignSignature(imgName_2, b64Signature_2, b64SignaturePayload_2, nil, nil)
+	img_2, err := generateImageWithCosignSignature(imgName_1b, b64Signature_1b, b64SignaturePayload_1b, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 	// `img` must have both names and signatures for the test.
 	img.Names = append(img.GetNames(), img_2.GetNames()...)
@@ -190,30 +191,17 @@ func TestCosignSignatureVerifier_VerifySignature_Multiple_Names_Multiple_Sigs(t 
 }
 
 func TestCosignSignatureVerifier_VerifySignature_Duplicate_Names_Multiple_Sigs(t *testing.T) {
-	const pemPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
-		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvVPaOS6sfpySbaceiwg0e6p6Bzo1\n" +
-		"A2qyHC5rfVNn2uBRz2Xy0nYBiJ1mFLXaiWGQ2AyCfVh5DzDqJx8eY7YwHQ==\n" +
-		"-----END PUBLIC KEY-----"
-	const b64Signature_1 = "MEUCIDuWppiw7vQzqSRaNA7jx0DtLtWtQvDd/Sm6JfL3nb9uAiEA7bm6pY+GozjTE4hZLPf6ypJqusBNSc9OdC0X" +
-		"Mx7sXjk="
-	const b64SignaturePayload_1 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoLzJmZDQzMGUzL" +
-		"TY1ODktNGE1Yy04NjViLTRjMGFhNWI4YjA0MSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
-		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
-		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgName_1 = "ttl.sh/2fd430e3-6589-4a5c-865b-4c0aa5b8b041@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
-		"26dbbdb3991714e501e1c9"
-
 	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
 				Name:            "cosignSignatureVerifier",
-				PublicKeyPemEnc: pemPublicKey,
+				PublicKeyPemEnc: pemPublicKey_1,
 			},
 		},
 	}})
 	require.NoError(t, err, "creating public key verifier")
 
-	img, err := generateImageWithCosignSignature(imgName_1, b64Signature_1, b64SignaturePayload_1, nil, nil)
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 	// Duplicate the names and signature for testing purposes.
 	img.Names = append(img.GetNames(), img.GetNames()...)
@@ -228,45 +216,24 @@ func TestCosignSignatureVerifier_VerifySignature_Duplicate_Names_Multiple_Sigs(t
 }
 
 func TestCosignSignatureVerifier_VerifySignature_One_Key_Partial_Match(t *testing.T) {
-	const pemPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
-		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvVPaOS6sfpySbaceiwg0e6p6Bzo1\n" +
-		"A2qyHC5rfVNn2uBRz2Xy0nYBiJ1mFLXaiWGQ2AyCfVh5DzDqJx8eY7YwHQ==\n" +
-		"-----END PUBLIC KEY-----"
-	const b64Signature_1 = "MEUCIDuWppiw7vQzqSRaNA7jx0DtLtWtQvDd/Sm6JfL3nb9uAiEA7bm6pY+GozjTE4hZLPf6ypJqusBNSc9OdC0X" +
-		"Mx7sXjk="
-	const b64SignaturePayload_1 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoLzJmZDQzMGUzL" +
-		"TY1ODktNGE1Yy04NjViLTRjMGFhNWI4YjA0MSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
-		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
-		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgName_1 = "ttl.sh/2fd430e3-6589-4a5c-865b-4c0aa5b8b041@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
-		"26dbbdb3991714e501e1c9"
-	const b64Signature_2 = "MEUCIQCoqJSXaMtrHla2iARwMkSiQCadPUgL4y3QQYjW8MLgnAIgC+6233YksZtzLlyMfvHcGUzHg8QoEeKef027" +
-		"2n3JN2I="
-	const b64SignaturePayload_2 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2MwMGRhZjA1L" +
-		"TljNWItNDA0MC05ZGJlLTQ0NDgzNjE3MGJlYSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
-		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
-		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgName_2 = "ttl.sh/c00daf05-9c5b-4040-9dbe-444836170bea@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
-		"26dbbdb3991714e501e1c9"
-
 	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
 				Name:            "cosignSignatureVerifier",
-				PublicKeyPemEnc: pemPublicKey,
+				PublicKeyPemEnc: pemPublicKey_1,
 			},
 		},
 	}})
 	require.NoError(t, err, "creating public key verifier")
 
-	img, err := generateImageWithCosignSignature(imgName_1, b64Signature_1, b64SignaturePayload_1, nil, nil)
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 	// Use the helper function to create a new image, but we only want the signature here.
-	img_2, err := generateImageWithCosignSignature(imgName_2, b64Signature_2, b64SignaturePayload_2, nil, nil)
+	img_3, err := generateImageWithCosignSignature(imgName_3, b64Signature_3, b64SignaturePayload_3, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 	// `img` must have both names and signatures for the test.
-	img.Names = append(img.GetNames(), img_2.GetNames()...)
-	img.Signature.Signatures = append(img.GetSignature().GetSignatures(), img_2.GetSignature().GetSignatures()...)
+	img.Names = append(img.GetNames(), img_3.GetNames()...)
+	img.Signature.Signatures = append(img.GetSignature().GetSignatures(), img_3.GetSignature().GetSignatures()...)
 
 	status, verifiedImageReferences, err := pubKeyVerifier.VerifySignature(context.Background(), img)
 	assert.NoError(t, err, "verification should be successful")
@@ -274,36 +241,11 @@ func TestCosignSignatureVerifier_VerifySignature_One_Key_Partial_Match(t *testin
 	require.Len(t, verifiedImageReferences, 1)
 	assert.Contains(t, verifiedImageReferences, img.GetName().GetFullName(),
 		"image full name should match verified image reference")
-	assert.NotContains(t, verifiedImageReferences, img_2.GetName().GetFullName(),
+	assert.NotContains(t, verifiedImageReferences, img_3.GetName().GetFullName(),
 		"image full name must not match verified image reference")
 }
 
 func TestCosignSignatureVerifier_VerifySignature_Multiple_Keys_Full_Match(t *testing.T) {
-	const pemPublicKey_1 = "-----BEGIN PUBLIC KEY-----\n" +
-		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvVPaOS6sfpySbaceiwg0e6p6Bzo1\n" +
-		"A2qyHC5rfVNn2uBRz2Xy0nYBiJ1mFLXaiWGQ2AyCfVh5DzDqJx8eY7YwHQ==\n" +
-		"-----END PUBLIC KEY-----"
-	const b64Signature_1 = "MEUCIDuWppiw7vQzqSRaNA7jx0DtLtWtQvDd/Sm6JfL3nb9uAiEA7bm6pY+GozjTE4hZLPf6ypJqusBNSc9OdC0X" +
-		"Mx7sXjk="
-	const b64SignaturePayload_1 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoLzJmZDQzMGUzL" +
-		"TY1ODktNGE1Yy04NjViLTRjMGFhNWI4YjA0MSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
-		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
-		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgName_1 = "ttl.sh/2fd430e3-6589-4a5c-865b-4c0aa5b8b041@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
-		"26dbbdb3991714e501e1c9"
-	const pemPublicKey_2 = "-----BEGIN PUBLIC KEY-----\n" +
-		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKt34iWzgZUoGERCjOhjlxTviXQYk\n" +
-		"CxNmhRr5rMeatATTskxx0i6eB04jum2FFPmfIvThIuzyzQxlBDj1gNKXLw==\n" +
-		"-----END PUBLIC KEY-----"
-	const b64Signature_2 = "MEUCIQCoqJSXaMtrHla2iARwMkSiQCadPUgL4y3QQYjW8MLgnAIgC+6233YksZtzLlyMfvHcGUzHg8QoEeKef027" +
-		"2n3JN2I="
-	const b64SignaturePayload_2 = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2MwMGRhZjA1L" +
-		"TljNWItNDA0MC05ZGJlLTQ0NDgzNjE3MGJlYSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
-		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
-		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgName_2 = "ttl.sh/c00daf05-9c5b-4040-9dbe-444836170bea@sha256:298d1eed2893f61ed254c68aff2417deaf342632ab" +
-		"26dbbdb3991714e501e1c9"
-
 	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
 			{
@@ -318,7 +260,7 @@ func TestCosignSignatureVerifier_VerifySignature_Multiple_Keys_Full_Match(t *tes
 	}})
 	require.NoError(t, err, "creating public key verifier")
 
-	img, err := generateImageWithCosignSignature(imgName_1, b64Signature_1, b64SignaturePayload_1, nil, nil)
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 	// Use the helper function to create a new image, but we only want the signature here.
 	img_2, err := generateImageWithCosignSignature(imgName_2, b64Signature_2, b64SignaturePayload_2, nil, nil)
@@ -342,14 +284,6 @@ func TestCosignSignatureVerifier_VerifySignature_Failure(t *testing.T) {
 		"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWi3tSxvBH7S/WUmv408nKPxNSJx6\n" +
 		"+w7c9FtFSk6coxx2VUbPy/X3US3cXfk/zVA+G7NbXGBYhAGaOsps5ZKjkQ==\n" +
 		"-----END PUBLIC KEY-----"
-	const b64Signature = "MEUCIDGMmJyxVKGPxvPk/QlRzMSGzcI8pYCy+MB7RTTpegzTAiEArssqWntVN8oJOMV0Aey0zhsNqRmEVQAYZNkn8h" +
-		"kAnXI="
-	const b64SignaturePayload = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2Q4ZDM4OTJkLTQ" +
-		"4YmQtNDY3MS1hNTQ2LTJlNzBhOTAwYjcwMiJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OmVlODliMDA1Mj" +
-		"hmZjRmMDJmMjQwNWU0ZWUyMjE3NDNlYmMzZjhlOGRkMGJmZDVjNGMyMGEyZmEyYWFhN2VkZTMifSwidHlwZSI6ImNvc2lnbiBjb250YWluZ" +
-		"XIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
-	const imgString = "ttl.sh/d8d3892d-48bd-4671-a546-2e70a900b702@sha256:ee89b00528ff4f02f2405e4ee221743ebc3f8e8dd0" +
-		"bfd5c4c20a2fa2aaa7ede3"
 
 	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{
 		PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
@@ -365,7 +299,7 @@ func TestCosignSignatureVerifier_VerifySignature_Failure(t *testing.T) {
 	emptyPubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{Cosign: &storage.CosignPublicKeyVerification{}})
 	require.NoError(t, err, "creating empty public key verifier")
 
-	img, err := generateImageWithCosignSignature(imgString, b64Signature, b64SignaturePayload, nil, nil)
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil)
 	require.NoError(t, err, "creating image with signature")
 
 	cases := map[string]struct {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Consider a setup where images are signed by two different keys
```
$ cosign sign --key key-1.key quay.io/stehessel/nginx:t1
$ cosign sign --key key-2.key quay.io/stehessel/nginx:t1
```

As a result, the image `quay.io/rhn_support_rissingh/tastest:t1` now contains two signatures `sig-1` and `sig-2`. Create an ACS signature integration with both `key-1` and `key-2`.
There is now a mismatch between the cosign cli behavior and ACS behavior:

* ACS verifies keys with OR and signatures with AND. In other words, it verifies successfully if (`key-1` has signed `sig-1` AND `sig-2`) OR (`key-2` has signed `sig-1` AND `sig-2`).
* cosign verifies keys with OR and signatures with OR. In other words, it verifies successfully if (`key-1` has signed `sig-1` OR `sig-2`) OR (`key-2` has signed `sig-1` OR `sig-2`).

I have convinced myselve that the cosign behavior is desirable:
* consistency with cosign is expected by users.
* the ACS behavior doesn’t make much sense:
  * adding a new signature with a different key to an existing image should not in-validate the otherwise valid signature.
  * signing images with a primary and backup key seems to be a plausible use case. ACS currently always rejects such images regardless of which keys are added in integrations.

This PR addresses the problem by changing to the cosign `OR` logic. We now return verified status + all matched image references. This happens regardless of other unverified signatures that may be present.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

see added tests