### PR TITLE
fix(pg): cleanup store generators

### DIFF
--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -426,6 +426,11 @@ func (s *Schema) NoPrimaryKey() bool {
 	return len(s.PrimaryKeys()) == 0
 }
 
+// MultiplePrimaryKeys returns true if the current schema have more than 1 primary key defined
+func (s *Schema) MultiplePrimaryKeys() bool {
+	return len(s.PrimaryKeys()) > 1
+}
+
 // SearchField is the parsed representation of the search tag on the struct field
 type SearchField struct {
 	FieldName string

--- a/tools/generate-helpers/pg-table-bindings/main.go
+++ b/tools/generate-helpers/pg-table-bindings/main.go
@@ -159,7 +159,7 @@ func main() {
 		if schema.NoPrimaryKey() && !props.SingletonStore {
 			log.Fatal("No primary key defined, please check relevant proto file and ensure a primary key is specified using the \"sql:\"pk\"\" tag")
 		}
-		if schema.MultiplePrimaryKeys() && !props.SingletonStore {
+		if schema.MultiplePrimaryKeys() {
 			log.Fatal("Multiple primary keys defined, please check relevant proto file and ensure a primary key is specified once using the \"sql:\"pk\"\" tag")
 		}
 

--- a/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
@@ -1,10 +1,5 @@
 {{define "schemaVar"}}pkgSchema.{{.Table|upperCamelCase}}Schema{{end}}
-{{define "paramList"}}{{range $index, $pk := .}}{{if $index}}, {{end}}{{$pk.ColumnName|lowerCamelCase}} {{$pk.Type}}{{end}}{{end}}
-{{define "argList"}}{{range $index, $pk := .}}{{if $index}}, {{end}}{{$pk.ColumnName|lowerCamelCase}}{{end}}{{end}}
-{{define "whereMatch"}}{{range $index, $pk := .}}{{if $index}} AND {{end}}{{$pk.ColumnName}} = ${{add $index 1}}{{end}}{{end}}
 {{define "commaSeparatedColumns"}}{{range $index, $field := .}}{{if $index}}, {{end}}{{$field.ColumnName}}{{end}}{{end}}
-{{define "commandSeparatedRefs"}}{{range $index, $field := .}}{{if $index}}, {{end}}{{$field.Reference}}{{end}}{{end}}
-{{define "updateExclusions"}}{{range $index, $field := .}}{{if $index}}, {{end}}{{$field.ColumnName}} = EXCLUDED.{{$field.ColumnName}}{{end}}{{end}}
 
 {{- $ := . }}
 

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -1,8 +1,6 @@
-{{define "paramList"}}{{ $singlePK := index .Schema.PrimaryKeys 0 }}{{$name := .TrimmedType|lowerCamelCase}}{{$singlePK.Getter $name}}{{end}}
-
 {{- $ := . }}
 {{- $name := .TrimmedType|lowerCamelCase }}
-
+{{- $paramList := (index .Schema.PrimaryKeys 0).Getter $name }}
 {{- $namePrefix := .Table|upperCamelCase}}
 
 //go:build sql_integration
@@ -70,7 +68,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	{{$name}}.{{.EmbeddedFK}} = nil
 	{{- end}}
 
-	found{{.TrimmedType|upperCamelCase}}, exists, err := store.Get(ctx, {{template "paramList" $}})
+	found{{.TrimmedType|upperCamelCase}}, exists, err := store.Get(ctx, {{$paramList}})
 	s.NoError(err)
 	s.False(exists)
 	s.Nil(found{{.TrimmedType|upperCamelCase}})
@@ -81,7 +79,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	{{- end }}
 
 	s.NoError(store.Upsert(ctx, {{$name}}))
-	found{{.TrimmedType|upperCamelCase}}, exists, err = store.Get(ctx, {{template "paramList" $}})
+	found{{.TrimmedType|upperCamelCase}}, exists, err = store.Get(ctx, {{$paramList}})
 	s.NoError(err)
 	s.True(exists)
 	protoassert.Equal(s.T(), {{$name}}, found{{.TrimmedType|upperCamelCase}})
@@ -96,7 +94,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.Zero({{$name}}Count)
 	{{- end }}
 
-	{{$name}}Exists, err := store.Exists(ctx, {{template "paramList" $}})
+	{{$name}}Exists, err := store.Exists(ctx, {{$paramList}})
 	s.NoError(err)
 	s.True({{$name}}Exists)
 	s.NoError(store.Upsert(ctx, {{$name}}))
@@ -104,16 +102,16 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.ErrorIs(store.Upsert(withNoAccessCtx, {{$name}}), sac.ErrResourceAccessDenied)
 	{{- end }}
 
-	s.NoError(store.Delete(ctx, {{template "paramList" $}}))
-	found{{.TrimmedType|upperCamelCase}}, exists, err = store.Get(ctx, {{template "paramList" $}})
+	s.NoError(store.Delete(ctx, {{$paramList}}))
+	found{{.TrimmedType|upperCamelCase}}, exists, err = store.Get(ctx, {{$paramList}})
 	s.NoError(err)
 	s.False(exists)
 	s.Nil(found{{.TrimmedType|upperCamelCase}})
 
 	{{- if or (.Obj.IsGloballyScoped) (.Obj.HasPermissionChecker) }}
-	s.ErrorIs(store.Delete(withNoAccessCtx, {{template "paramList" $}}), sac.ErrResourceAccessDenied)
+	s.ErrorIs(store.Delete(withNoAccessCtx, {{$paramList}}), sac.ErrResourceAccessDenied)
 	{{- else }}
-	s.NoError(store.Delete(withNoAccessCtx, {{template "paramList" $}}))
+	s.NoError(store.Delete(withNoAccessCtx, {{$paramList}}))
 	{{- end }}
 
 	var {{$name}}s []*{{.Type}}
@@ -125,7 +123,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 		{{$name}}.{{.EmbeddedFK}} = nil
 		{{- end}}
 		{{$name}}s = append({{.TrimmedType|lowerCamelCase}}s, {{.TrimmedType|lowerCamelCase}})
-		{{$name}}IDs = append({{$name}}IDs, {{template "paramList" $}})
+		{{$name}}IDs = append({{$name}}IDs, {{$paramList}})
 	}
 
 	s.NoError(store.UpsertMany(ctx, {{.TrimmedType|lowerCamelCase}}s))

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -1,5 +1,4 @@
-
-{{define "paramList"}}{{$name := .TrimmedType|lowerCamelCase}}{{range $index, $pk := .Schema.PrimaryKeys}}{{if $index}}, {{end}}{{$pk.Getter $name}}{{end}}{{end}}
+{{define "paramList"}}{{ $singlePK := index .Schema.PrimaryKeys 0 }}{{$name := .TrimmedType|lowerCamelCase}}{{$singlePK.Getter $name}}{{end}}
 
 {{- $ := . }}
 {{- $name := .TrimmedType|lowerCamelCase }}


### PR DESCRIPTION
### Description

This PR removes support for multiple primary keys in generated stores as we don't have such stores. It removes unused template functions and adds a check to prevent multiple primary keys to be used in the future.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
