### PR TITLE
ROX-28680: Test the exclusion in compatibility tests

### DIFF
--- a/.openshift-ci/get_compatibility_test_tuples.py
+++ b/.openshift-ci/get_compatibility_test_tuples.py
@@ -44,6 +44,29 @@ def main():
         )
 
 
+# Returns True if the helm_version is newer than the current_version
+def is_newer_version(current_version: str, helm_version: str):
+    helm_version_split = helm_version.split(sep='.')
+    current_version_split = current_version.split(sep='.')
+    # Remove the trailing 0s
+    # Helm chart versions have two trailing 0s in the major version number
+    helm_version_split[0] = helm_version_split[0][:-2]
+    # Remove commit hash from the current version
+    current_version_split = current_version_split[:-1]
+    # If we are in a release branch, we will have patch version with '-rc'
+    if len(current_version_split) > 2:
+        # Remove '-rc' if present
+        current_version_split[2] = str(current_version_split[2]).rstrip("-rc")
+
+    for (current, helm) in zip(current_version_split, helm_version_split):
+        if current > helm:
+            break
+        if current < helm:
+            return True
+
+    return False
+
+
 def get_compatibility_test_tuples():
     Release = namedtuple("Release", ["major", "minor"])
 
@@ -58,6 +81,22 @@ def get_compatibility_test_tuples():
         shell=False,
         encoding="utf-8",
     ).strip()
+
+    # Remove the versions that are newer than the version of the current branch.
+    # This will make sure we do not test with an old test suite newer versions.
+    # It is important to not test newer versions with old tests suites because
+    # old test suites might depend on endpoints that no longer exist in newer
+    # versions.
+    # There is no risk in excluding newer versions as the compatibility tests in
+    # their respective branches will test against older versions.
+    central_chart_versions = [i for i in central_chart_versions
+                              if not
+                              is_newer_version(current_version=latest_tag,
+                                               helm_version=i)]
+    sensor_chart_versions = [i for i in sensor_chart_versions
+                             if not
+                             is_newer_version(current_version=latest_tag,
+                                              helm_version=i)]
 
     if len(central_chart_versions) == 0:
         logging.info("Found no older central chart versions to test against according to the product lifecycles API.")


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Do not merge, this changes will be cherry picked from master once #14770 is merged.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

```
# Groovy
INFO:root:Running compatibility tests for central-v4.6.4-rc.2-1-gaa78ac0d4b, sensor-v400.6.3 with function QaE2eTestCompatibility
INFO:root:Running compatibility tests for central-v4.6.4-rc.2-1-gaa78ac0d4b, sensor-v400.5.7 with function QaE2eTestCompatibility
INFO:root:Running compatibility tests for central-v400.6.3, sensor-v4.6.4-rc.2-1-gaa78ac0d4b with function QaE2eTestCompatibility
INFO:root:Running compatibility tests for central-v400.5.7, sensor-v4.6.4-rc.2-1-gaa78ac0d4b with function QaE2eTestCompatibility
INFO:root:Running compatibility tests for central-v4.6.4-rc.2-1-gaa78ac0d4b, sensor-v74.9.0 with function QaE2eTestCompatibility
```

```
# Go
INFO:root:Running compatibility tests for central-v4.6.4-rc.2-1-gaa78ac0d4b, sensor-v400.6.3 with function QaE2eGoCompatibilityTest
INFO:root:Running compatibility tests for central-v4.6.4-rc.2-1-gaa78ac0d4b, sensor-v400.5.7 with function QaE2eGoCompatibilityTest
INFO:root:Running compatibility tests for central-v400.6.3, sensor-v4.6.4-rc.2-1-gaa78ac0d4b with function QaE2eGoCompatibilityTest
INFO:root:Running compatibility tests for central-v400.5.7, sensor-v4.6.4-rc.2-1-gaa78ac0d4b with function QaE2eGoCompatibilityTest
INFO:root:Running compatibility tests for central-v4.6.4-rc.2-1-gaa78ac0d4b, sensor-v74.9.0 with function QaE2eGoCompatibilityTest
```
