### PR TITLE
ROX-28715: Improve consistency of delegated image scanning

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -18,7 +18,7 @@ describe('Delegated Image Scanning', () => {
     it(`should have a link on the clusters main page`, () => {
         visitClusters();
 
-        cy.get('a:contains("Delegated scanning")').click();
+        cy.get('a:contains("Delegated image scanning")').click();
 
         cy.location('pathname').should('eq', '/main/clusters/delegated-image-scanning');
     });
@@ -27,7 +27,7 @@ describe('Delegated Image Scanning', () => {
         visitDelegateScanning();
 
         // make sure the static page loads
-        cy.get('h1:contains("Delegated Image Scanning")');
+        cy.get('h1:contains("Delegated image scanning")');
 
         cy.get('.pf-v5-c-breadcrumb__item a:contains("Clusters")').should(
             'have.attr',
@@ -35,7 +35,7 @@ describe('Delegated Image Scanning', () => {
             '/main/clusters'
         );
 
-        cy.get('.pf-v5-c-breadcrumb__item:contains("Delegated Image Scanning")');
+        cy.get('.pf-v5-c-breadcrumb__item:contains("Delegated image scanning")');
 
         // check the initial state of the delegate config
         getInputByLabel('None').should('be.checked');
@@ -80,7 +80,7 @@ describe('Delegated Image Scanning', () => {
                 saveDelegatedRegistryConfig();
 
                 cy.get(
-                    '.pf-v5-c-alert.pf-m-success .pf-v5-c-alert__title:contains("Delegated scanning configuration saved successfully")'
+                    '.pf-v5-c-alert.pf-m-success .pf-v5-c-alert__title:contains("Delegated image scanning configuration saved successfully")'
                 );
             });
     });
@@ -100,7 +100,7 @@ describe('Delegated Image Scanning', () => {
                 );
 
                 // make sure page does not load
-                cy.get('h1:contains("Delegated Image Scanning")').should('not.exist');
+                cy.get('h1:contains("Delegated image scanning")').should('not.exist');
             });
         });
 
@@ -115,7 +115,7 @@ describe('Delegated Image Scanning', () => {
                 visitWithStaticResponseForPermissions(clustersPath, staticResponseForPermissions);
 
                 // make sure link is not present
-                cy.get('a:contains("Delegated scanning")').should('not.exist');
+                cy.get('a:contains("Delegated image scanning")').should('not.exist');
             });
         });
     });

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -361,7 +361,7 @@ function ClustersTablePanel({
                                         component={LinkShim}
                                         href={clustersDelegatedScanningPath}
                                     >
-                                        Delegated scanning
+                                        Delegated image scanning
                                     </Button>
                                 </ToolbarItem>
                             )}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesList.tsx
@@ -1,16 +1,5 @@
-// TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
-/* eslint-disable react/prop-types */
 import React from 'react';
-import {
-    Bullseye,
-    Button,
-    Card,
-    CardFooter,
-    EmptyState,
-    EmptyStateBody,
-    EmptyStateHeader,
-    EmptyStateFooter,
-} from '@patternfly/react-core';
+import { Button, FormGroup } from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
 import {
@@ -28,8 +17,6 @@ type DelegatedRegistriesListProps = {
     deleteRow: (number) => void;
     handlePathChange: (number, string) => void;
     handleClusterChange: (number, string) => void;
-    // TODO: re-enable next type after @typescript-eslint deps can be resolved to ^5.2.x
-    // updateRegistriesOrder: (DelegatedRegistry[]) => void;
 };
 
 function DelegatedRegistriesList({
@@ -41,13 +28,9 @@ function DelegatedRegistriesList({
     handleClusterChange,
     addRegistryRow,
     deleteRow,
-    // TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    updateRegistriesOrder,
 }: DelegatedRegistriesListProps) {
     return (
-        <Card className="pf-v5-u-mb-lg">
+        <FormGroup label="Registries">
             {registries.length > 0 ? (
                 <>
                     <DelegatedRegistriesTable
@@ -58,43 +41,24 @@ function DelegatedRegistriesList({
                         handlePathChange={handlePathChange}
                         handleClusterChange={handleClusterChange}
                         deleteRow={deleteRow}
-                        // TODO: remove lint override after @typescript-eslint deps can be resolved to ^5.2.x
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-ignore
-                        updateRegistriesOrder={updateRegistriesOrder}
                         key="delegated-registries-table"
                     />
-                    {isEditing && (
-                        <CardFooter>
-                            <Button
-                                variant="link"
-                                icon={<PlusCircleIcon />}
-                                onClick={addRegistryRow}
-                            >
-                                Add registry
-                            </Button>
-                        </CardFooter>
-                    )}
                 </>
             ) : (
-                <Bullseye className="pf-v5-u-flex-grow-1">
-                    <EmptyState>
-                        <EmptyStateHeader titleText="No registries specified." headingLevel="h2" />
-                        <EmptyStateBody>
-                            <p>All scans will be delegated to the default cluster.</p>
-                            <p>You can override this for specific registries.</p>
-                        </EmptyStateBody>
-                        {isEditing && (
-                            <EmptyStateFooter>
-                                <Button variant="primary" onClick={addRegistryRow}>
-                                    Add registry
-                                </Button>
-                            </EmptyStateFooter>
-                        )}
-                    </EmptyState>
-                </Bullseye>
+                <p>No registries specified.</p>
             )}
-        </Card>
+            {isEditing && (
+                <Button
+                    variant="link"
+                    isInline
+                    icon={<PlusCircleIcon />}
+                    onClick={addRegistryRow}
+                    className="pf-v5-u-mt-md"
+                >
+                    Add registry
+                </Button>
+            )}
+        </FormGroup>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { Card, CardBody, Flex, FlexItem } from '@patternfly/react-core';
+import {
+    Flex,
+    FlexItem,
+    FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+} from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
-import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import { DelegatedRegistryCluster } from 'services/DelegatedRegistryConfigService';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
@@ -40,43 +46,38 @@ function DelegatedScanningSettings({
         clusters.find((cluster) => selectedClusterId === cluster.id)?.name ?? 'None';
 
     return (
-        <Card className="pf-v5-u-mb-lg">
-            <CardBody>
-                <FormLabelGroup
-                    label="Select default cluster to delegate to"
-                    helperText="Select a cluster to process CLI and API-originated scanning requests"
-                    fieldId="selectedClusterId"
-                    touched={{}}
-                    errors={{}}
-                >
-                    <Flex>
-                        <FlexItem>
-                            <Select
-                                className="cluster-select"
-                                placeholderText={
-                                    <span>
-                                        <span style={{ position: 'relative', top: '1px' }}>
-                                            None
-                                        </span>
-                                    </span>
-                                }
-                                toggleAriaLabel="Select a cluster"
-                                onToggle={(_e, v) => toggleIsClusterOpen(v)}
-                                onSelect={onClusterSelect}
-                                isDisabled={!isEditing}
-                                isOpen={isClusterOpen}
-                                selections={selectedClusterName}
-                            >
-                                <SelectOption key="no-cluster-selected" value="" isPlaceholder>
-                                    <span>None</span>
-                                </SelectOption>
-                                <>{clusterSelectOptions}</>
-                            </Select>
-                        </FlexItem>
-                    </Flex>
-                </FormLabelGroup>
-            </CardBody>
-        </Card>
+        <FormGroup label="Default cluster to delegate to">
+            <Flex>
+                <FlexItem>
+                    <Select
+                        className="cluster-select"
+                        placeholderText={
+                            <span>
+                                <span style={{ position: 'relative', top: '1px' }}>None</span>
+                            </span>
+                        }
+                        toggleAriaLabel="Select a cluster"
+                        onToggle={(_e, v) => toggleIsClusterOpen(v)}
+                        onSelect={onClusterSelect}
+                        isDisabled={!isEditing}
+                        isOpen={isClusterOpen}
+                        selections={selectedClusterName}
+                    >
+                        <SelectOption key="no-cluster-selected" value="" isPlaceholder>
+                            <span>None</span>
+                        </SelectOption>
+                        <>{clusterSelectOptions}</>
+                    </Select>
+                </FlexItem>
+            </Flex>
+            <FormHelperText>
+                <HelperText>
+                    <HelperTextItem>
+                        Select a cluster to process CLI and API-originated scanning requests
+                    </HelperTextItem>
+                </HelperText>
+            </FormHelperText>
+        </FormGroup>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Card, CardBody, Flex, FlexItem, Radio } from '@patternfly/react-core';
+import { FormGroup, Radio } from '@patternfly/react-core';
 
-import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import { DelegatedRegistryConfigEnabledFor } from 'services/DelegatedRegistryConfigService';
 
 type ToggleDelegatedScanningProps = {
@@ -16,55 +15,38 @@ function ToggleDelegatedScanning({
     onChangeEnabledFor,
 }: ToggleDelegatedScanningProps) {
     return (
-        <Card className="pf-v5-u-mb-lg">
-            <CardBody>
-                <FormLabelGroup
-                    label="Delegate scanning for"
-                    fieldId="enabledFor"
-                    touched={{}}
-                    errors={{}}
-                >
-                    <Flex className="pf-v5-u-mt-md pf-v5-u-mb-lg">
-                        <FlexItem>
-                            <Radio
-                                label="None"
-                                isChecked={enabledFor === 'NONE'}
-                                isDisabled={!isEditing}
-                                id="choose-none"
-                                name="enabledFor"
-                                onChange={() => {
-                                    onChangeEnabledFor('NONE');
-                                }}
-                            />
-                        </FlexItem>
-                        <FlexItem>
-                            <Radio
-                                label="All registries"
-                                isChecked={enabledFor === 'ALL'}
-                                isDisabled={!isEditing}
-                                id="choose-all-registries"
-                                name="enabledFor"
-                                onChange={() => {
-                                    onChangeEnabledFor('ALL');
-                                }}
-                            />
-                        </FlexItem>
-                        <FlexItem>
-                            <Radio
-                                label="Specified registries"
-                                isChecked={enabledFor === 'SPECIFIC'}
-                                isDisabled={!isEditing}
-                                id="chose-specified-registries"
-                                name="enabledFor"
-                                onChange={() => {
-                                    onChangeEnabledFor('SPECIFIC');
-                                }}
-                            />
-                        </FlexItem>
-                    </Flex>
-                </FormLabelGroup>
-            </CardBody>
-        </Card>
+        <FormGroup role="radiogroup" isInline label="Delegate scanning for" fieldId="enabledFor">
+            <Radio
+                label="None"
+                isChecked={enabledFor === 'NONE'}
+                isDisabled={!isEditing}
+                id="choose-none"
+                name="enabledFor"
+                onChange={() => {
+                    onChangeEnabledFor('NONE');
+                }}
+            />
+            <Radio
+                label="All registries"
+                isChecked={enabledFor === 'ALL'}
+                isDisabled={!isEditing}
+                id="choose-all-registries"
+                name="enabledFor"
+                onChange={() => {
+                    onChangeEnabledFor('ALL');
+                }}
+            />
+            <Radio
+                label="Specified registries"
+                isChecked={enabledFor === 'SPECIFIC'}
+                isDisabled={!isEditing}
+                id="chose-specified-registries"
+                name="enabledFor"
+                onChange={() => {
+                    onChangeEnabledFor('SPECIFIC');
+                }}
+            />
+        </FormGroup>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect, ReactNode } from 'react';
 import {
+    ActionGroup,
     Alert,
     Breadcrumb,
     BreadcrumbItem,
     Button,
+    Divider,
     Flex,
     FlexItem,
     Form,
@@ -39,7 +41,7 @@ const initialDelegatedState: DelegatedRegistryConfig = {
 };
 
 function DelegateScanningPage() {
-    const displayedPageTitle = 'Delegated Image Scanning';
+    const displayedPageTitle = 'Delegated image scanning';
     const [delegatedRegistryConfig, setDedicatedRegistryConfig] =
         useState<DelegatedRegistryConfig>(initialDelegatedState);
     const [delegatedRegistryClusters, setDelegatedRegistryClusters] = useState<
@@ -190,7 +192,7 @@ function DelegateScanningPage() {
             .then(() => {
                 const newSuccessObj: AlertObj = {
                     type: 'success',
-                    title: 'Delegated scanning configuration saved successfully',
+                    title: 'Delegated image scanning configuration saved successfully',
                     body: <></>,
                 };
                 setAlertObj(newSuccessObj);
@@ -255,7 +257,8 @@ function DelegateScanningPage() {
                     </FlexItem>
                 </Flex>
             </PageSection>
-            <PageSection>
+            <Divider component="div" />
+            <PageSection variant="light">
                 {!!alertObj && (
                     <Alert
                         title={alertObj.title}
@@ -273,7 +276,6 @@ function DelegateScanningPage() {
                         isEditing={isEditing}
                         onChangeEnabledFor={onChangeEnabledFor}
                     />
-                    {/* TODO: decide who to structure this form, where the `enabledFor` value spans multiple inputs */}
                     {delegatedRegistryConfig.enabledFor !== 'NONE' && (
                         <>
                             <DelegatedScanningSettings
@@ -291,25 +293,20 @@ function DelegateScanningPage() {
                                 handleClusterChange={handleClusterChange}
                                 addRegistryRow={addRegistryRow}
                                 deleteRow={deleteRow}
-                                key="delegated-registries-list"
                             />
                         </>
                     )}
+                    {isEditing && (
+                        <ActionGroup>
+                            <Button variant="primary" onClick={onSave}>
+                                Save
+                            </Button>
+                            <Button variant="secondary" onClick={onCancel}>
+                                Cancel
+                            </Button>
+                        </ActionGroup>
+                    )}
                 </Form>
-                {isEditing && (
-                    <Flex>
-                        <FlexItem>
-                            <Flex>
-                                <Button variant="primary" onClick={onSave}>
-                                    Save
-                                </Button>
-                                <Button variant="secondary" onClick={onCancel}>
-                                    Cancel
-                                </Button>
-                            </Flex>
-                        </FlexItem>
-                    </Flex>
-                )}
             </PageSection>
         </>
     );


### PR DESCRIPTION
### Description

While content changes for clarity and correctness simmer in mental slow cooker:
* Replace inconsistent text and capitalization.
* Replace unusual markup with usual PatternFly form markup.

### Changes

Because of indentation changes, it might help if you ignore white space.

1. Edit delegatedScanning.test.js file.
    * Change text as in components below.
2. Edit ClustersTablePanel.tsx file.
    * Replace **Delegated scanning** with **Delegated image scanning** in button link for consistency with page heading.
3. Edit DelegatedRegistriesList.tsx file.
    * Delete obsolete `updateRegistriesOrder` prop that I might have missed in earlier prerequisite contribution.
    * Replace `Card` with `FormGroup` element.
    * Delete `EmptyState` markup and move **No registries specified.** above **Add registry** button link.
    * Delete incorrect text. Replace with text that is always visible and specific to selected scanning option (therefore, probably in `ToggleDelegatedScanning` element).
    * Add `isInline` to `Button` with `variant="link"` prop for left alignment  instead of misalignment (because of invisible padding).
4. Edit DelegatedScanningSettings.tsx file.
    * Replace `Card` with `FormGroup` element.
    * Delete **Select** verb because it assumes edit mode.
    * Move text into explicit `FormHelperText` element. A goal is to no need for this helper text because better explained by text that is specific to selected scanning option.
5. Edit ToggleDelegatedScanning.tsx file.
    * Replace `Card` and `FormLabelGroup` with `FormGroup` element as in example code:
        https://www.patternfly.org/components/forms/form/#basic
6. Edit DelegateScanningPage.tsx file.
    * Replace title case with sentence case in **Delegated Image Scanning** breadcrumb, heading, and title.
    * Add `Divider` element following page heading.
    * Replace generic flex layout with PatternFly `ActionGroup` element and move it into the `Form` element.

### Residue

1. Disable **Edit** button before any changes to form data and also while request is in progress.
    Apparently, the abandoned attempt at drag-and-drop interaction blocked basic form behavior.
2. Investigate why absence of `Flex` causes `Select` element to have entire page width, unlike in PatternFly examples.
    Hypothesis: because form in in `PageSection` element?

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed yet

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4700066 - 4700066
        total -1078 = 11605710 - 11606788 less is more!
    * `ls -al build/static/js/*.js | wc`
        files 0 = 180 - 180
3. `npm run start` in ui/apps/platform

### Manual testing

1. Visit /main/clusters

    Before changes, see inconsistent **Delegated scanning** text.
    ![ClustersTablePanel_inconsistent](https://github.com/user-attachments/assets/23dd8eca-3abe-45a1-b122-1b3131d3c92a)

    After changes, see consistent **Delegated image scanning** text.
    ![ClustersTablePanel_consistent](https://github.com/user-attachments/assets/7fb4689c-ed49-4592-9320-a04d11ea5283)

2. Click the button link.

    Before changes, see inconsistent title case.
    ![DelegateScanningPage_title_inconsistent](https://github.com/user-attachments/assets/a3924c5f-def7-4acc-a083-ceda575be501)

    After changes, see consistent sentence case.
    ![DelegateScanningPage_title_consistent](https://github.com/user-attachments/assets/cc86d4ca-97ac-4ace-90ea-14cca65c81a9)

3. Click **All registries** option.

    Before changes, see presence of verb and also unusual layout for default .cluster
    ![DelegatedScanningSettings_inconsistent](https://github.com/user-attachments/assets/dc779078-4839-4663-8518-477d6d930a5b)

    After changes, see absence of verb and also usual layout for default cluster.
    ![DelegatedScanningSettings_consistent](https://github.com/user-attachments/assets/7ce2c8b9-733c-49bb-80e3-e105e7a6affd)

    Before changes, see presence of incorrect text and also unusual layout for registries.
    ![DelegatedRegistriesList0_inconsistent](https://github.com/user-attachments/assets/c0e534ed-bd4f-47af-b5c8-cf7efab8c3d3)

    After changes, see absence of incorrect text and also usual layout for registries.
    ![DelegatedRegistriesList0_consistent](https://github.com/user-attachments/assets/6e34c623-e701-475f-9d3c-e6551997dba2)

4. Click **Add registry** button.

    Before changes, see misalignment of **Add registries** link.
    ![DelegatedRegistriesList1_inconsistent](https://github.com/user-attachments/assets/aed41c98-1cff-40ce-b88c-459d06ba8b96)

    After changes, see alignment of **Add registries** link.
    ![DelegatedRegistriesList1_consistent](https://github.com/user-attachments/assets/4daebec9-0cdb-4a27-8521-c8c0fd19948a)

5. Click **Save** button.

    After changes, see layout of `Alert` element.
    ![Alert](https://github.com/user-attachments/assets/17c36653-6710-4e93-97f4-af51229ee2f4)

6. Click **Edit** button and then click **Specified registries** option.

    After changes, see layout of form on page.
    ![Form](https://github.com/user-attachments/assets/335784bf-1e2b-475e-a322-60e834cd82be)

#### Integration testing

* clusters/delegatedScanning.test.js
