### PR TITLE
ROX-28733: Upgrade TypeScript 5.8.2

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -23,7 +23,7 @@
                 "@patternfly/react-user-feedback": "^5.0.0",
                 "axios": "^1.7.7",
                 "computed-style-to-inline-style": "^3.0.0",
-                "core-js": "^3.39.0",
+                "core-js": "^3.41.0",
                 "d3-axis": "^1.0.12",
                 "d3-brush": "^3.0.0",
                 "d3-polygon": "^3.0.1",
@@ -91,16 +91,16 @@
                 "yup": "^1.4.0"
             },
             "devDependencies": {
-                "@babel/core": "^7.26.0",
-                "@babel/eslint-parser": "^7.25.9",
+                "@babel/core": "^7.26.10",
+                "@babel/eslint-parser": "^7.27.0",
                 "@babel/plugin-proposal-decorators": "^7.25.9",
                 "@babel/plugin-proposal-private-property-in-object": "7.18.6",
-                "@babel/plugin-transform-flow-strip-types": "^7.25.9",
-                "@babel/plugin-transform-runtime": "^7.25.9",
-                "@babel/preset-env": "^7.26.0",
-                "@babel/preset-react": "^7.25.9",
-                "@babel/preset-typescript": "^7.26.0",
-                "@babel/runtime": "^7.26.0",
+                "@babel/plugin-transform-flow-strip-types": "^7.26.5",
+                "@babel/plugin-transform-runtime": "^7.26.10",
+                "@babel/preset-env": "^7.26.9",
+                "@babel/preset-react": "^7.26.3",
+                "@babel/preset-typescript": "^7.27.0",
+                "@babel/runtime": "^7.27.0",
                 "@eslint/json": "^0.8.0",
                 "@tailwindcss/forms": "^0.2.1",
                 "@testing-library/cypress": "^10.0.2",
@@ -116,8 +116,8 @@
                 "@types/react-dom": "^18.3.1",
                 "@types/react-redux": "^7.1.34",
                 "@types/segment-analytics": "^0.0.38",
-                "@typescript-eslint/eslint-plugin": "^8.17.0",
-                "@typescript-eslint/parser": "^8.17.0",
+                "@typescript-eslint/eslint-plugin": "^8.28.0",
+                "@typescript-eslint/parser": "^8.28.0",
                 "axe-core": "^4.10.0",
                 "cypress": "^13.16.1",
                 "cypress-axe": "^1.5.0",
@@ -151,7 +151,7 @@
                 "redux-saga-test-plan": "^3.7.0",
                 "tailwindcss": "^2.0.3",
                 "ts-jest": "^29.2.5",
-                "typescript": "^5.7.2"
+                "typescript": "^5.8.2"
             },
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -232,9 +232,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-            "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+            "version": "7.26.8",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+            "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -242,22 +242,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-            "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+            "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.0",
-                "@babel/generator": "^7.26.0",
-                "@babel/helper-compilation-targets": "^7.25.9",
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.10",
+                "@babel/helper-compilation-targets": "^7.26.5",
                 "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.0",
-                "@babel/parser": "^7.26.0",
-                "@babel/template": "^7.25.9",
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.26.0",
+                "@babel/helpers": "^7.26.10",
+                "@babel/parser": "^7.26.10",
+                "@babel/template": "^7.26.9",
+                "@babel/traverse": "^7.26.10",
+                "@babel/types": "^7.26.10",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -279,9 +279,9 @@
             "dev": true
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz",
-            "integrity": "sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.0.tgz",
+            "integrity": "sha512-dtnzmSjXfgL/HDgMcmsLSzyGbEosi4DrGWoCNfuI+W4IkVJw6izpTe7LtOdwAXnkDqw5yweboYCTkM2rQizCng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -307,13 +307,13 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+            "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.26.2",
-                "@babel/types": "^7.26.0",
+                "@babel/parser": "^7.27.0",
+                "@babel/types": "^7.27.0",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^3.0.2"
@@ -334,28 +334,14 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.25.9.tgz",
-            "integrity": "sha512-C47lC7LIDCnz0h4vai/tpNOI95tCd5ZT3iBt/DBH5lXKHZsyNQv18yf1wIIg2ntiQNgmAvA+DgZ82iW8Qdym8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-            "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+            "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.25.9",
+                "@babel/compat-data": "^7.26.8",
                 "@babel/helper-validator-option": "^7.25.9",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
@@ -366,18 +352,18 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
-            "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+            "integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.25.9",
                 "@babel/helper-member-expression-to-functions": "^7.25.9",
                 "@babel/helper-optimise-call-expression": "^7.25.9",
-                "@babel/helper-replace-supers": "^7.25.9",
+                "@babel/helper-replace-supers": "^7.26.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-                "@babel/traverse": "^7.25.9",
+                "@babel/traverse": "^7.27.0",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -406,10 +392,11 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
-            "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
+            "integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -480,9 +467,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-            "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -508,35 +495,21 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-            "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+            "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.25.9",
                 "@babel/helper-optimise-call-expression": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/traverse": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-simple-access": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
-            "integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
@@ -597,26 +570,26 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+            "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.27.0",
+                "@babel/types": "^7.27.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-            "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+            "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.0"
+                "@babel/types": "^7.27.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1123,15 +1096,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
-            "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
+            "version": "7.26.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+            "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.26.5",
                 "@babel/helper-remap-async-to-generator": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/traverse": "^7.26.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1159,13 +1132,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
-            "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+            "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1355,13 +1328,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.25.9.tgz",
-            "integrity": "sha512-KRhdhlVk2nObA5AYa7QMgTMTVJdfHprfpAk4DjZVtllqRg9qarilstTKEhpVjyt+Npi8ThRyiV8176Am3CodPA==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
+            "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.25.9",
                 "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
@@ -1388,14 +1360,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-flow-strip-types": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.9.tgz",
-            "integrity": "sha512-/VVukELzPDdci7UUsWQaSkhgnjIWXnIyRpM02ldxaVoFK96c41So8JcKT3m0gYjyv7j5FNPGS5vfELrWalkbDA==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.26.5.tgz",
+            "integrity": "sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9",
-                "@babel/plugin-syntax-flow": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.26.5",
+                "@babel/plugin-syntax-flow": "^7.26.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1405,13 +1377,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
-            "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
+            "integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.26.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
             },
             "engines": {
@@ -1521,15 +1493,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz",
-            "integrity": "sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+            "integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.25.9",
-                "@babel/helper-simple-access": "^7.25.9"
+                "@babel/helper-module-transforms": "^7.26.0",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1608,13 +1579,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
-            "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
+            "version": "7.26.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+            "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1909,16 +1880,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz",
-            "integrity": "sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.10.tgz",
+            "integrity": "sha512-NWaL2qG6HRpONTnj4JvDU6th4jYeZOJgu3QhmFTCihib0ermtOJqktA5BduGm3suhhVe9EMP9c9+mfJ/I9slqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.26.5",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.6",
+                "babel-plugin-polyfill-corejs3": "^0.11.0",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
                 "semver": "^6.3.1"
             },
@@ -1979,13 +1950,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
-            "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
+            "version": "7.26.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+            "integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1995,13 +1966,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
-            "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.0.tgz",
+            "integrity": "sha512-+LLkxA9rKJpNoGsbLnAgOCdESl73vwYn+V6b+5wHbrE7OGKVDPHIQvbFSzqE6rwqaCw2RE+zdJrlLkcf8YOA0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2011,15 +1982,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.9.tgz",
-            "integrity": "sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
+            "integrity": "sha512-fRGGjO2UEGPjvEcyAZXRXAS8AfdaQoq7HnxAbJoAoW10B9xOKesmmndJv+Sym2a+9FHWZ9KbyyLCe9s0Sn5jtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.25.9",
-                "@babel/helper-create-class-features-plugin": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-create-class-features-plugin": "^7.27.0",
+                "@babel/helper-plugin-utils": "^7.26.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
                 "@babel/plugin-syntax-typescript": "^7.25.9"
             },
@@ -2098,15 +2069,15 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
-            "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
+            "integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.26.0",
-                "@babel/helper-compilation-targets": "^7.25.9",
-                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/compat-data": "^7.26.8",
+                "@babel/helper-compilation-targets": "^7.26.5",
+                "@babel/helper-plugin-utils": "^7.26.5",
                 "@babel/helper-validator-option": "^7.25.9",
                 "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
                 "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
@@ -2118,9 +2089,9 @@
                 "@babel/plugin-syntax-import-attributes": "^7.26.0",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.25.9",
-                "@babel/plugin-transform-async-generator-functions": "^7.25.9",
+                "@babel/plugin-transform-async-generator-functions": "^7.26.8",
                 "@babel/plugin-transform-async-to-generator": "^7.25.9",
-                "@babel/plugin-transform-block-scoped-functions": "^7.25.9",
+                "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
                 "@babel/plugin-transform-block-scoping": "^7.25.9",
                 "@babel/plugin-transform-class-properties": "^7.25.9",
                 "@babel/plugin-transform-class-static-block": "^7.26.0",
@@ -2131,21 +2102,21 @@
                 "@babel/plugin-transform-duplicate-keys": "^7.25.9",
                 "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
                 "@babel/plugin-transform-dynamic-import": "^7.25.9",
-                "@babel/plugin-transform-exponentiation-operator": "^7.25.9",
+                "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
                 "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-                "@babel/plugin-transform-for-of": "^7.25.9",
+                "@babel/plugin-transform-for-of": "^7.26.9",
                 "@babel/plugin-transform-function-name": "^7.25.9",
                 "@babel/plugin-transform-json-strings": "^7.25.9",
                 "@babel/plugin-transform-literals": "^7.25.9",
                 "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
                 "@babel/plugin-transform-member-expression-literals": "^7.25.9",
                 "@babel/plugin-transform-modules-amd": "^7.25.9",
-                "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+                "@babel/plugin-transform-modules-commonjs": "^7.26.3",
                 "@babel/plugin-transform-modules-systemjs": "^7.25.9",
                 "@babel/plugin-transform-modules-umd": "^7.25.9",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
                 "@babel/plugin-transform-new-target": "^7.25.9",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
                 "@babel/plugin-transform-numeric-separator": "^7.25.9",
                 "@babel/plugin-transform-object-rest-spread": "^7.25.9",
                 "@babel/plugin-transform-object-super": "^7.25.9",
@@ -2161,17 +2132,17 @@
                 "@babel/plugin-transform-shorthand-properties": "^7.25.9",
                 "@babel/plugin-transform-spread": "^7.25.9",
                 "@babel/plugin-transform-sticky-regex": "^7.25.9",
-                "@babel/plugin-transform-template-literals": "^7.25.9",
-                "@babel/plugin-transform-typeof-symbol": "^7.25.9",
+                "@babel/plugin-transform-template-literals": "^7.26.8",
+                "@babel/plugin-transform-typeof-symbol": "^7.26.7",
                 "@babel/plugin-transform-unicode-escapes": "^7.25.9",
                 "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
                 "@babel/plugin-transform-unicode-regex": "^7.25.9",
                 "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.6",
+                "babel-plugin-polyfill-corejs3": "^0.11.0",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.38.1",
+                "core-js-compat": "^3.40.0",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -2208,9 +2179,9 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.25.9.tgz",
-            "integrity": "sha512-D3to0uSPiWE7rBrdIICCd0tJSIGpLaaGptna2+w7Pft5xMqLpA1sz99DK5TZ1TjGbdQ/VI1eCSZ06dv3lT4JOw==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+            "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2229,17 +2200,17 @@
             }
         },
         "node_modules/@babel/preset-typescript": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz",
-            "integrity": "sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.0.tgz",
+            "integrity": "sha512-vxaPFfJtHhgeOVXRKuHpHPAOgymmy8V8I65T1q53R7GCZlefKeCaTyDs3zOPHTTbmquvNlQYC5klEvWsBAtrBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9",
+                "@babel/helper-plugin-utils": "^7.26.5",
                 "@babel/helper-validator-option": "^7.25.9",
                 "@babel/plugin-syntax-jsx": "^7.25.9",
-                "@babel/plugin-transform-modules-commonjs": "^7.25.9",
-                "@babel/plugin-transform-typescript": "^7.25.9"
+                "@babel/plugin-transform-modules-commonjs": "^7.26.3",
+                "@babel/plugin-transform-typescript": "^7.27.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2249,9 +2220,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+            "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -2261,30 +2232,30 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+            "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.26.2",
+                "@babel/parser": "^7.27.0",
+                "@babel/types": "^7.27.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-            "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+            "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/generator": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.25.9",
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.27.0",
+                "@babel/parser": "^7.27.0",
+                "@babel/template": "^7.27.0",
+                "@babel/types": "^7.27.0",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -2301,9 +2272,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+            "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -5268,21 +5239,21 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.17.0.tgz",
-            "integrity": "sha512-HU1KAdW3Tt8zQkdvNoIijfWDMvdSweFYm4hWh+KwhPstv+sCmWb89hCIP8msFm9N1R/ooh9honpSuvqKWlYy3w==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
+            "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.17.0",
-                "@typescript-eslint/type-utils": "8.17.0",
-                "@typescript-eslint/utils": "8.17.0",
-                "@typescript-eslint/visitor-keys": "8.17.0",
+                "@typescript-eslint/scope-manager": "8.28.0",
+                "@typescript-eslint/type-utils": "8.28.0",
+                "@typescript-eslint/utils": "8.28.0",
+                "@typescript-eslint/visitor-keys": "8.28.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^1.3.0"
+                "ts-api-utils": "^2.0.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5293,25 +5264,34 @@
             },
             "peerDependencies": {
                 "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-                "eslint": "^8.57.0 || ^9.0.0"
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.17.0.tgz",
-            "integrity": "sha512-Drp39TXuUlD49F7ilHHCG7TTg8IkA+hxCuULdmzWYICxGXvDXmDmWEjJYZQYgf6l/TFfYNE167m7isnc3xlIEg==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
+            "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.17.0",
-                "@typescript-eslint/types": "8.17.0",
-                "@typescript-eslint/typescript-estree": "8.17.0",
-                "@typescript-eslint/visitor-keys": "8.17.0",
+                "@typescript-eslint/scope-manager": "8.28.0",
+                "@typescript-eslint/types": "8.28.0",
+                "@typescript-eslint/typescript-estree": "8.28.0",
+                "@typescript-eslint/visitor-keys": "8.28.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -5322,23 +5302,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz",
-            "integrity": "sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
+            "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.17.0",
-                "@typescript-eslint/visitor-keys": "8.17.0"
+                "@typescript-eslint/types": "8.28.0",
+                "@typescript-eslint/visitor-keys": "8.28.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5349,16 +5325,16 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.17.0.tgz",
-            "integrity": "sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz",
+            "integrity": "sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.17.0",
-                "@typescript-eslint/utils": "8.17.0",
+                "@typescript-eslint/typescript-estree": "8.28.0",
+                "@typescript-eslint/utils": "8.28.0",
                 "debug": "^4.3.4",
-                "ts-api-utils": "^1.3.0"
+                "ts-api-utils": "^2.0.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5368,18 +5344,27 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0"
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.17.0.tgz",
-            "integrity": "sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
+            "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5391,20 +5376,20 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz",
-            "integrity": "sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
+            "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.17.0",
-                "@typescript-eslint/visitor-keys": "8.17.0",
+                "@typescript-eslint/types": "8.28.0",
+                "@typescript-eslint/visitor-keys": "8.28.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
                 "minimatch": "^9.0.4",
                 "semver": "^7.6.0",
-                "ts-api-utils": "^1.3.0"
+                "ts-api-utils": "^2.0.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5413,10 +5398,8 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -5446,9 +5429,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5458,17 +5441,30 @@
                 "node": ">=10"
             }
         },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
+            }
+        },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.17.0.tgz",
-            "integrity": "sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
+            "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.17.0",
-                "@typescript-eslint/types": "8.17.0",
-                "@typescript-eslint/typescript-estree": "8.17.0"
+                "@typescript-eslint/scope-manager": "8.28.0",
+                "@typescript-eslint/types": "8.28.0",
+                "@typescript-eslint/typescript-estree": "8.28.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5478,22 +5474,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.17.0.tgz",
-            "integrity": "sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
+            "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.17.0",
+                "@typescript-eslint/types": "8.28.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -6554,13 +6546,14 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.10.6",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-            "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+            "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.2",
-                "core-js-compat": "^3.38.0"
+                "@babel/helper-define-polyfill-provider": "^0.6.3",
+                "core-js-compat": "^3.40.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -6864,9 +6857,9 @@
             "peer": true
         },
         "node_modules/browserslist": {
-            "version": "4.24.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-            "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6883,9 +6876,9 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001669",
-                "electron-to-chromium": "^1.5.41",
-                "node-releases": "^2.0.18",
+                "caniuse-lite": "^1.0.30001688",
+                "electron-to-chromium": "^1.5.73",
+                "node-releases": "^2.0.19",
                 "update-browserslist-db": "^1.1.1"
             },
             "bin": {
@@ -7075,9 +7068,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001684",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001684.tgz",
-            "integrity": "sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==",
+            "version": "1.0.30001707",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
+            "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7644,9 +7637,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.39.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
-            "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+            "version": "3.41.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
+            "integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -7655,12 +7648,13 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.38.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
-            "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
+            "version": "3.41.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
+            "integrity": "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3"
+                "browserslist": "^4.24.4"
             },
             "funding": {
                 "type": "opencollective",
@@ -9602,9 +9596,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.64",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
-            "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
+            "version": "1.5.127",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.127.tgz",
+            "integrity": "sha512-Ke5OggqOtEqzCzcUyV+9jgO6L6sv1gQVKGtSExXHjD/FK0p4qzPZbrDsrCdy0DptcQprD0V80RCBYSWLMhTTgQ==",
             "license": "ISC"
         },
         "node_modules/emittery": {
@@ -15914,9 +15908,10 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "license": "MIT"
         },
         "node_modules/nopt": {
             "version": "1.0.10",
@@ -22241,9 +22236,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -27,7 +27,7 @@
         "@patternfly/react-user-feedback": "^5.0.0",
         "axios": "^1.7.7",
         "computed-style-to-inline-style": "^3.0.0",
-        "core-js": "^3.39.0",
+        "core-js": "^3.41.0",
         "d3-axis": "^1.0.12",
         "d3-brush": "^3.0.0",
         "d3-polygon": "^3.0.1",
@@ -114,16 +114,16 @@
         "eject": "react-app-rewired eject"
     },
     "devDependencies": {
-        "@babel/core": "^7.26.0",
-        "@babel/eslint-parser": "^7.25.9",
+        "@babel/core": "^7.26.10",
+        "@babel/eslint-parser": "^7.27.0",
         "@babel/plugin-proposal-decorators": "^7.25.9",
         "@babel/plugin-proposal-private-property-in-object": "7.18.6",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.9",
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "@babel/preset-env": "^7.26.0",
-        "@babel/preset-react": "^7.25.9",
-        "@babel/preset-typescript": "^7.26.0",
-        "@babel/runtime": "^7.26.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.26.5",
+        "@babel/plugin-transform-runtime": "^7.26.10",
+        "@babel/preset-env": "^7.26.9",
+        "@babel/preset-react": "^7.26.3",
+        "@babel/preset-typescript": "^7.27.0",
+        "@babel/runtime": "^7.27.0",
         "@eslint/json": "^0.8.0",
         "@tailwindcss/forms": "^0.2.1",
         "@testing-library/cypress": "^10.0.2",
@@ -139,8 +139,8 @@
         "@types/react-dom": "^18.3.1",
         "@types/react-redux": "^7.1.34",
         "@types/segment-analytics": "^0.0.38",
-        "@typescript-eslint/eslint-plugin": "^8.17.0",
-        "@typescript-eslint/parser": "^8.17.0",
+        "@typescript-eslint/eslint-plugin": "^8.28.0",
+        "@typescript-eslint/parser": "^8.28.0",
         "axe-core": "^4.10.0",
         "cypress": "^13.16.1",
         "cypress-axe": "^1.5.0",
@@ -174,12 +174,12 @@
         "redux-saga-test-plan": "^3.7.0",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^29.2.5",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
     },
     "overrides": {
         "@jest/types": "^29.6.3",
-        "@typescript-eslint/eslint-plugin": "^8.17.0",
-        "@typescript-eslint/parser": "^8.17.0",
+        "@typescript-eslint/eslint-plugin": "^8.28.0",
+        "@typescript-eslint/parser": "^8.28.0",
         "autoprefixer": "10.4.5",
         "babel-jest": "^29.7.0",
         "eslint": "^9.16.0",
@@ -198,7 +198,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": {
-            "typescript": "5.7.2"
+            "typescript": "5.8.2"
         }
     },
     "jest": {

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmValueWarning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmValueWarning.tsx
@@ -26,7 +26,11 @@ function HelmValueWarning({ currentValue, helmValue }: HelmValueWarningProps): R
             break;
         }
         default: {
-            normalizedValue = String(helmValue);
+            try {
+                normalizedValue = JSON.stringify(helmValue, null, 0);
+            } catch {
+                // default value is better than exception
+            }
         }
     }
     return (

--- a/ui/apps/platform/src/react-app-env.d.ts
+++ b/ui/apps/platform/src/react-app-env.d.ts
@@ -1,9 +1,5 @@
 /// <reference types="react-scripts" />
 
-// this overrides the analytics definition thats found in the @types/segment-analytics package to include undefined
-// var appears to be required to augment the type because of how its defined in the package
-declare var analytics: SegmentAnalytics.AnalyticsJS | undefined; // eslint-disable-line no-var
-
 declare global {
     // Allows importing of .ico files as a string representing the URL path to the file
     module '*.ico' {


### PR DESCRIPTION
### Description

TypeScript updates a minor version every quarter.

### Description

https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/

https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#granular-checks-for-branches-in-return-expressions

In TypeScript 5.8, the type system special-cases conditional expressions directly inside return statements. Each branch of the conditional is checked against the declared return type of the containing functions (if one exists)

https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#the---erasablesyntaxonly-option

Recently, Node.js 23.6 unflagged experimental support for running TypeScript files directly; however, only certain constructs are supported under this mode. Node.js has unflagged a mode called `--experimental-strip-types` which requires that any TypeScript-specific syntax cannot have runtime semantics. Phrased differently, it must be possible to easily *erase* or “strip out” any TypeScript-specific syntax from a file, leaving behind a valid JavaScript file.

That means constructs like the following are not supported:

* `enum` declarations
* `namespace`s and `module`s with runtime code
* parameter properties in classes
* `import =` aliases

TypeScript 5.8 introduces the `--erasableSyntaxOnly` flag. When this flag is enabled, TypeScript will error on most TypeScript-specific constructs that have runtime behavior.

Typically, you will want to combine this flag with the `--verbatimModuleSyntax`, which ensures that a module contains the appropriate import syntax, and that import elision does not take place.

https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#optimizations-on-program-loads-and-updates

TypeScript now avoids array allocations that would be involved while normalizing paths.

When edits are made that don’t change the fundamental structure of a project, TypeScript now avoids re-validating the options provided to it (e.g. the contents of a `tsconfig.json`).

### Procedure

1. Update babel packages, especially `preset-typescript` package.
    If TypeScript adds new syntax, wait until babel packages update to support it.
    By the way, babel eslint-parser might be because of react-scripts, but unused.
    Also I skipped update to plugin-proposal-private-property-in-object because of react-scripts if I remember correctly.
2. Update types packages.
    These are also relevant to update for both compile and lint updates.
3. Update core-js package in `dependencies` object.
4. Update globals package? Skip this time, because so many different versions.
5. Update typescript-eslint packages. It supports TypeScript 5.8 in 8.26.0 on 2025-03-03 just a few days after 2025-02-28.
    Before, update `npm run lint` displays the following:

    * @typescript-eslint/typescript-estree version: 8.17.0
    * Supported TypeScript versions: >=4.8.4 <5.8.0
    * Your TypeScript version: 5.8.2

6. Update some packages in `overrides` if needed.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

For contribution `npm install` to update package-lock.json file according to changes in package.json file, but for team `npm ci` to delete and recreate node_modules folder.

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.css: 4 = 4700070 - 4700066
        total: 27 = 11606819 - 11606788
    * `ls -al build/static/js/*.js | wc -l`
        0 = 180 - 160 files
3. `npm run start` in ui

### lint errors

ui/apps/platform/src/Containers/Clusters/Components/HelmValueWarning.tsx
  29:38  error  'helmValue' may use Object's default stringification format ('[object Object]') when stringified  @typescript-eslint/no-base-to-string

Replaced `String(helmValue)` with `JSON.stringify(helmValue, null, 0)`

ui/apps/platform/src/react-app-env.d.ts
  5:13  error  'analytics' is defined but never used  @typescript-eslint/no-unused-vars

Deleted `analytics` declaration, because `npm run lint` and `npm run build` pass without it.