### PR TITLE
fix(ui): Fix vulnerability reporting edit page route

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/vulnerabilityReporting/vulnerabilityReports.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/vulnerabilityReporting/vulnerabilityReports.json
@@ -1,0 +1,32 @@
+{
+    "reportConfigs": [
+        {
+            "id": "6537010c-f3a8-40a2-b75c-3070d51ba578",
+            "name": "fake-report",
+            "description": "",
+            "type": "VULNERABILITY",
+            "vulnReportFilters": {
+                "fixability": "FIXABLE",
+                "severities": [
+                    "CRITICAL_VULNERABILITY_SEVERITY",
+                    "IMPORTANT_VULNERABILITY_SEVERITY"
+                ],
+                "imageTypes": [
+                    "DEPLOYED",
+                    "WATCHED"
+                ],
+                "allVuln": true,
+                "includeNvdCvss": false,
+                "includeEpssProbability": false
+            },
+            "schedule": null,
+            "resourceScope": {
+                "collectionScope": {
+                    "collectionId": "0acb2818-5482-4c90-9e46-bd139ed54406",
+                    "collectionName": "test"
+                }
+            },
+            "notifiers": []
+        }
+    ]
+}

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -66,7 +66,7 @@ const routeMatcherMapForAuthenticatedRoutes = {
  * @param {Record<string, RouteMatcherOptions>} [routeMatcherMap]
  * @param {Record<string, RouteHandler>} [staticResponseMap]
  * @param {WaitOptions} [waitOptions]
- * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
+ * @returns {Cypress.Chainable<Interception[] | Interception}
  */
 export function visit(pageUrl, routeMatcherMap, staticResponseMap, waitOptions) {
     interceptRequests(routeMatcherMapForAuthenticatedRoutes);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
@@ -45,7 +45,7 @@ const routeMatcherMapForWizardStep2 = {
     },
 };
 
-const basePath = '/main/vulnerabilities/reports';
+export const vulnerabilityReportsBasePath = '/main/vulnerabilities/reports';
 
 // visit
 
@@ -53,9 +53,14 @@ const basePath = '/main/vulnerabilities/reports';
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitVulnerabilityReports(staticResponseMap) {
-    visit(basePath, routeMatcherMapForVulnerabilityReports, staticResponseMap);
+    const interceptions = visit(
+        vulnerabilityReportsBasePath,
+        routeMatcherMapForVulnerabilityReports,
+        staticResponseMap
+    );
 
     assertReportsTable();
+    return interceptions;
 }
 
 export function assertReportsTable() {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
@@ -22,14 +22,17 @@ describe('Vulnerability Reporting Navigation', () => {
 
     it('navigates to the index page', () => {
         visitVulnerabilityReports(staticResponseMap);
-        cy.url().should('include', vulnerabilityReportsBasePath);
+        cy.location('pathname').should('eq', vulnerabilityReportsBasePath);
         cy.get('h1').should('contain', 'Vulnerability reporting');
     });
 
     it('navigates to the create page', () => {
         visitVulnerabilityReports(staticResponseMap);
         cy.contains('button', 'Create report').click();
-        cy.url().should('include', `${vulnerabilityReportsBasePath}?action=create`);
+        cy.location().should((location) => {
+            expect(location.pathname).to.eq(vulnerabilityReportsBasePath);
+            expect(location.search).to.include('action=create');
+        });
         cy.get('h1').should('contain', 'Create report');
     });
 
@@ -38,10 +41,13 @@ describe('Vulnerability Reporting Navigation', () => {
             const firstReport = response.body.reportConfigs[0];
 
             interceptVulnerabilityReport(firstReport.id, firstReport, () => {
-                cy.contains('a', firstReport.name).click();
+                cy.get('td').contains('a', firstReport.name).click();
             });
 
-            cy.url().should('include', `${vulnerabilityReportsBasePath}/${firstReport.id}`);
+            cy.location('pathname').should(
+                'eq',
+                `${vulnerabilityReportsBasePath}/${firstReport.id}`
+            );
             cy.get('h1').should('contain', firstReport.name);
         });
     });
@@ -54,22 +60,26 @@ describe('Vulnerability Reporting Navigation', () => {
                 cy.contains('button', 'Edit report').click();
             });
 
-            cy.url().should(
-                'include',
-                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=edit`
-            );
+            cy.location().should((location) => {
+                expect(location.pathname).to.eq(
+                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                );
+                expect(location.search).to.include('action=edit');
+            });
             cy.get('h1').should('contain', 'Edit report');
 
             cy.get('nav[aria-label="Breadcrumb"] a').click();
-            cy.contains('a', firstReport.name).click();
+            cy.get('td').contains('a', firstReport.name).click();
 
             cy.contains('button', 'Actions').click();
             cy.contains('button', 'Edit report').click();
 
-            cy.url().should(
-                'include',
-                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=edit`
-            );
+            cy.location().should((location) => {
+                expect(location.pathname).to.eq(
+                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                );
+                expect(location.search).to.include('action=edit');
+            });
             cy.get('h1').should('contain', 'Edit report');
         });
     });
@@ -82,22 +92,26 @@ describe('Vulnerability Reporting Navigation', () => {
                 cy.contains('button', 'Clone report').click();
             });
 
-            cy.url().should(
-                'include',
-                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=clone`
-            );
+            cy.location().should((location) => {
+                expect(location.pathname).to.eq(
+                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                );
+                expect(location.search).to.include('action=clone');
+            });
             cy.get('h1').should('contain', 'Clone report');
 
             cy.get('nav[aria-label="Breadcrumb"] a').click();
-            cy.contains('a', firstReport.name).click();
+            cy.get('td').contains('a', firstReport.name).click();
 
             cy.contains('button', 'Actions').click();
             cy.contains('button', 'Clone report').click();
 
-            cy.url().should(
-                'include',
-                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=clone`
-            );
+            cy.location().should((location) => {
+                expect(location.pathname).to.eq(
+                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                );
+                expect(location.search).to.include('action=clone');
+            });
             cy.get('h1').should('contain', 'Clone report');
         });
     });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
@@ -1,104 +1,104 @@
 import withAuth from '../../../helpers/basicAuth';
+import {
+    visitVulnerabilityReports,
+    vulnerabilityReportsBasePath,
+} from './VulnerabilityReporting.helpers';
 
-const reportingBasePath = '/main/vulnerabilities/reports';
+const staticResponseMap = {
+    'reports/configurations': {
+        fixture: 'vulnerabilities/vulnerabilityReporting/vulnerabilityReports.json',
+    },
+};
 
-const reportsFixture = 'vulnerabilities/vulnerabilityReporting/vulnerabilityReports.json';
+function interceptVulnerabilityReport(reportId, response, interaction) {
+    cy.intercept('GET', `/v2/reports/configurations/${reportId}`, response).as('reportDetails');
+
+    interaction();
+    cy.wait('@reportDetails');
+}
 
 describe('Vulnerability Reporting Navigation', () => {
     withAuth();
 
-    beforeEach(() => {
-        cy.intercept(
-            {
-                method: 'GET',
-                pathname: '/v2/reports/configurations',
-            },
-            { fixture: reportsFixture }
-        ).as('reports');
-
-        cy.visit(reportingBasePath);
-        cy.wait('@reports');
-    });
-
     it('navigates to the index page', () => {
-        cy.url().should('include', reportingBasePath);
+        visitVulnerabilityReports(staticResponseMap);
+        cy.url().should('include', vulnerabilityReportsBasePath);
         cy.get('h1').should('contain', 'Vulnerability reporting');
     });
 
     it('navigates to the create page', () => {
+        visitVulnerabilityReports(staticResponseMap);
         cy.contains('button', 'Create report').click();
-        cy.url().should('include', `${reportingBasePath}?action=create`);
+        cy.url().should('include', `${vulnerabilityReportsBasePath}?action=create`);
         cy.get('h1').should('contain', 'Create report');
     });
 
     it('navigates to the details page', () => {
-        cy.get('@reports')
-            .its('response')
-            .then((response) => {
-                const firstReport = response.body.reportConfigs[0];
-                cy.intercept('GET', `/v2/reports/configurations/${firstReport.id}`, firstReport).as(
-                    'reportDetails'
-                );
+        visitVulnerabilityReports(staticResponseMap).then(([{ response }]) => {
+            const firstReport = response.body.reportConfigs[0];
 
+            interceptVulnerabilityReport(firstReport.id, firstReport, () => {
                 cy.contains('a', firstReport.name).click();
-                cy.wait('@reportDetails');
-
-                cy.url().should('include', `${reportingBasePath}/${firstReport.id}`);
-                cy.get('h1').should('contain', firstReport.name);
             });
+
+            cy.url().should('include', `${vulnerabilityReportsBasePath}/${firstReport.id}`);
+            cy.get('h1').should('contain', firstReport.name);
+        });
     });
 
     it('navigates to the edit page', () => {
-        cy.get('@reports')
-            .its('response')
-            .then((response) => {
-                const firstReport = response.body.reportConfigs[0];
-                cy.intercept('GET', `/v2/reports/configurations/${firstReport.id}`, firstReport).as(
-                    'reportDetails'
-                );
-
-                cy.get('table .pf-v5-c-menu-toggle').first().click();
+        visitVulnerabilityReports(staticResponseMap).then(([{ response }]) => {
+            const firstReport = response.body.reportConfigs[0];
+            interceptVulnerabilityReport(firstReport.id, firstReport, () => {
+                cy.get('table button[aria-label="Kebab toggle"]').first().click();
                 cy.contains('button', 'Edit report').click();
-
-                cy.wait('@reportDetails');
-                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=edit`);
-                cy.get('h1').should('contain', 'Edit report');
-
-                cy.get('.pf-v5-c-breadcrumb__link').click();
-                cy.contains('a', firstReport.name).click();
-
-                cy.contains('button', 'Actions').click();
-                cy.contains('button', 'Edit report').click();
-
-                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=edit`);
-                cy.get('h1').should('contain', 'Edit report');
             });
+
+            cy.url().should(
+                'include',
+                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=edit`
+            );
+            cy.get('h1').should('contain', 'Edit report');
+
+            cy.get('nav[aria-label="Breadcrumb"] a').click();
+            cy.contains('a', firstReport.name).click();
+
+            cy.contains('button', 'Actions').click();
+            cy.contains('button', 'Edit report').click();
+
+            cy.url().should(
+                'include',
+                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=edit`
+            );
+            cy.get('h1').should('contain', 'Edit report');
+        });
     });
 
     it('navigates to the clone page', () => {
-        cy.get('@reports')
-            .its('response')
-            .then((response) => {
-                const firstReport = response.body.reportConfigs[0];
-                cy.intercept('GET', `/v2/reports/configurations/${firstReport.id}`, firstReport).as(
-                    'reportDetails'
-                );
-
-                cy.get('table .pf-v5-c-menu-toggle').first().click();
+        visitVulnerabilityReports(staticResponseMap).then(([{ response }]) => {
+            const firstReport = response.body.reportConfigs[0];
+            interceptVulnerabilityReport(firstReport.id, firstReport, () => {
+                cy.get('table button[aria-label="Kebab toggle"]').first().click();
                 cy.contains('button', 'Clone report').click();
-
-                cy.wait('@reportDetails');
-                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=clone`);
-                cy.get('h1').should('contain', 'Clone report');
-
-                cy.get('.pf-v5-c-breadcrumb__link').click();
-                cy.contains('a', firstReport.name).click();
-
-                cy.contains('button', 'Actions').click();
-                cy.contains('button', 'Clone report').click();
-
-                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=clone`);
-                cy.get('h1').should('contain', 'Clone report');
             });
+
+            cy.url().should(
+                'include',
+                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=clone`
+            );
+            cy.get('h1').should('contain', 'Clone report');
+
+            cy.get('nav[aria-label="Breadcrumb"] a').click();
+            cy.contains('a', firstReport.name).click();
+
+            cy.contains('button', 'Actions').click();
+            cy.contains('button', 'Clone report').click();
+
+            cy.url().should(
+                'include',
+                `${vulnerabilityReportsBasePath}/${firstReport.id}?action=clone`
+            );
+            cy.get('h1').should('contain', 'Clone report');
+        });
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
@@ -1,0 +1,104 @@
+import withAuth from '../../../helpers/basicAuth';
+
+const reportingBasePath = '/main/vulnerabilities/reports';
+
+const reportsFixture = 'vulnerabilities/vulnerabilityReporting/vulnerabilityReports.json';
+
+describe('Vulnerability Reporting Navigation', () => {
+    withAuth();
+
+    beforeEach(() => {
+        cy.intercept(
+            {
+                method: 'GET',
+                pathname: '/v2/reports/configurations',
+            },
+            { fixture: reportsFixture }
+        ).as('reports');
+
+        cy.visit(reportingBasePath);
+        cy.wait('@reports');
+    });
+
+    it('navigates to the index page', () => {
+        cy.url().should('include', reportingBasePath);
+        cy.get('h1').should('contain', 'Vulnerability reporting');
+    });
+
+    it('navigates to the create page', () => {
+        cy.contains('button', 'Create report').click();
+        cy.url().should('include', `${reportingBasePath}?action=create`);
+        cy.get('h1').should('contain', 'Create report');
+    });
+
+    it('navigates to the details page', () => {
+        cy.get('@reports')
+            .its('response')
+            .then((response) => {
+                const firstReport = response.body.reportConfigs[0];
+                cy.intercept('GET', `/v2/reports/configurations/${firstReport.id}`, firstReport).as(
+                    'reportDetails'
+                );
+
+                cy.contains('a', firstReport.name).click();
+                cy.wait('@reportDetails');
+
+                cy.url().should('include', `${reportingBasePath}/${firstReport.id}`);
+                cy.get('h1').should('contain', firstReport.name);
+            });
+    });
+
+    it('navigates to the edit page', () => {
+        cy.get('@reports')
+            .its('response')
+            .then((response) => {
+                const firstReport = response.body.reportConfigs[0];
+                cy.intercept('GET', `/v2/reports/configurations/${firstReport.id}`, firstReport).as(
+                    'reportDetails'
+                );
+
+                cy.get('table .pf-v5-c-menu-toggle').first().click();
+                cy.contains('button', 'Edit report').click();
+
+                cy.wait('@reportDetails');
+                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=edit`);
+                cy.get('h1').should('contain', 'Edit report');
+
+                cy.get('.pf-v5-c-breadcrumb__link').click();
+                cy.contains('a', firstReport.name).click();
+
+                cy.contains('button', 'Actions').click();
+                cy.contains('button', 'Edit report').click();
+
+                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=edit`);
+                cy.get('h1').should('contain', 'Edit report');
+            });
+    });
+
+    it('navigates to the clone page', () => {
+        cy.get('@reports')
+            .its('response')
+            .then((response) => {
+                const firstReport = response.body.reportConfigs[0];
+                cy.intercept('GET', `/v2/reports/configurations/${firstReport.id}`, firstReport).as(
+                    'reportDetails'
+                );
+
+                cy.get('table .pf-v5-c-menu-toggle').first().click();
+                cy.contains('button', 'Clone report').click();
+
+                cy.wait('@reportDetails');
+                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=clone`);
+                cy.get('h1').should('contain', 'Clone report');
+
+                cy.get('.pf-v5-c-breadcrumb__link').click();
+                cy.contains('a', firstReport.name).click();
+
+                cy.contains('button', 'Actions').click();
+                cy.contains('button', 'Clone report').click();
+
+                cy.url().should('include', `${reportingBasePath}/${firstReport.id}?action=clone`);
+                cy.get('h1').should('contain', 'Clone report');
+            });
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -42,7 +42,7 @@ function VulnReportingPage() {
             <Route
                 path=":reportId"
                 element={
-                    pageAction === 'create' && hasWriteAccessForReport ? (
+                    pageAction === 'edit' && hasWriteAccessForReport ? (
                         <EditVulnReportPage />
                     ) : pageAction === 'clone' && hasWriteAccessForReport ? (
                         <CloneVulnReportPage />


### PR DESCRIPTION
### Description

Fixes a bug related to the react router v6 upgrade. 

The route with a `:reportId` should handle `edit` instead of `create`.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Added e2e tests for vulnerability reporting routes

## Summary by Sourcery

Fix the routing for vulnerability reporting edit page to correctly handle the 'edit' action in React Router v6

Bug Fixes:
- Corrected the route handling for vulnerability reporting edit page to use 'edit' action instead of 'create'

Enhancements:
- Updated route handling logic to support proper navigation between different vulnerability report actions

Tests:
- Added comprehensive e2e tests for vulnerability reporting navigation routes to verify correct routing behavior