### PR TITLE
chore(roxctl): Do not retry on permission denied error

### DIFF
--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -18,7 +18,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const errorMsg = `The remote endpoint failed TLS validation.
+const errorMsg = `The remote endpoint failed TLS validation: %v
+
   Do one of the following:
   1. Obtain a valid certificate for your Central instance/Load Balancer.
   2. Use the --ca option to specify a custom CA certificate (PEM format).
@@ -48,7 +49,7 @@ func (v *insecureVerifierWithError) VerifyPeerCertificate(leaf *x509.Certificate
 		v.logger.InfofLn("%d cert in chain %s, signed by %s (CA %v)", i, c.Subject, c.Issuer, c.IsCA)
 	}
 	if _, err := leaf.Verify(verifyOpts); err != nil {
-		v.logger.ErrfLn(errorMsg)
+		v.logger.ErrfLn(errorMsg, err)
 		return &grpcPermissionDenied{err}
 	}
 	return nil


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->



### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

e2e tests TBD

Manual testing:

**Before**:

```console
sh$ bin/linux_amd64/roxctl central debug dump -e 34.75.173.232:443 --output-dir /tmp/
INFO:	Retrieving debug metrics. This may take a couple of minutes...
INFO:	trying to verify cert for SERIALNUMBER=1056504657214105579,CN=CENTRAL_SERVICE: Central,OU=CENTRAL_SERVICE, signed by SERIALNUMBER=5991849816631250472,CN=StackRox Certificate Authority (CA false)
ERROR:	The remote endpoint failed TLS validation.
  Do one of the following:
  1. Obtain a valid certificate for your Central instance/Load Balancer.
  2. Use the --ca option to specify a custom CA certificate (PEM format).
     This certificate can be obtained by running "roxctl central cert".
  3. Use the --insecure-skip-tls-verify option to suppress this error
     and not validate TLS certificates (NOT RECOMMENDED).

INFO:	trying to verify cert for SERIALNUMBER=1056504657214105579,CN=CENTRAL_SERVICE: Central,OU=CENTRAL_SERVICE, signed by SERIALNUMBER=5991849816631250472,CN=StackRox Certificate Authority (CA false)
ERROR:	The remote endpoint failed TLS validation.
  Do one of the following:
  1. Obtain a valid certificate for your Central instance/Load Balancer.
  2. Use the --ca option to specify a custom CA certificate (PEM format).
     This certificate can be obtained by running "roxctl central cert".
  3. Use the --insecure-skip-tls-verify option to suppress this error
     and not validate TLS certificates (NOT RECOMMENDED).

^C⏎                                                                                                                       
```

**After**:

```console
sh$ bin/linux_amd64/roxctl central debug dump -e 34.75.173.232:443 --output-dir /tmp/
INFO:	Retrieving debug metrics. This may take a couple of minutes...
INFO:	trying to verify cert for SERIALNUMBER=1056504657214105579,CN=CENTRAL_SERVICE: Central,OU=CENTRAL_SERVICE, signed by SERIALNUMBER=5991849816631250472,CN=StackRox Certificate Authority (CA false)
ERROR:	The remote endpoint failed TLS validation: x509: certificate signed by unknown authority

  Do one of the following:
  1. Obtain a valid certificate for your Central instance/Load Balancer.
  2. Use the --ca option to specify a custom CA certificate (PEM format).
     This certificate can be obtained by running "roxctl central cert".
  3. Use the --insecure-skip-tls-verify option to suppress this error
     and not validate TLS certificates (NOT RECOMMENDED).

ERROR:	could not download zip: error when doing http request: GET https://34.75.173.232:443/debug/dump?logs=false giving up after 1 attempt(s): Get "https://34.75.173.232:443/debug/dump?logs=false": x509: certificate signed by unknown authority
```