### PR TITLE
ROX-26884: do not delete ca file

### DIFF
--- a/roxctl/central/initbundles/fetch_ca.go
+++ b/roxctl/central/initbundles/fetch_ca.go
@@ -37,13 +37,9 @@ func fetchCAConfig(cliEnvironment environment.Environment, outputFile string,
 	if err != nil {
 		return errors.Wrap(err, "opening output file for writing CA config")
 	}
-	defer func() {
-		if bundleOutput != nil {
-			_ = bundleOutput.Close()
-			utils.Should(os.Remove(outputFile))
-		}
-	}()
 	if err := writeCA(ctx, svc, bundleOutput); err != nil {
+		_ = bundleOutput.Close()
+		utils.Should(os.Remove(outputFile))
 		return err
 	}
 	cliEnvironment.Logger().InfofLn("The CA configuration has been written to file %q.", outputFile)

--- a/tests/roxctl/bats-tests/cluster/central-init-bundles.bats
+++ b/tests/roxctl/bats-tests/cluster/central-init-bundles.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load "../helpers.bash"
+
+output_dir=""
+
+setup_file() {
+  local -r roxctl_version="$(roxctl-development version || true)"
+  echo "Testing roxctl version: '${roxctl_version}'" >&3
+
+  [[ -n "${API_ENDPOINT}" ]] || fail "Environment variable 'API_ENDPOINT' required"
+  [[ -n "${ROX_ADMIN_PASSWORD}" ]] || fail "Environment variable 'ROX_ADMIN_PASSWORD' required"
+}
+
+setup() {
+  output_dir="$(mktemp -d -u)"
+}
+
+teardown() {
+  rm -rf "${output_dir}"
+}
+
+@test "roxctl central init-bundles fetch-ca" {
+  run roxctl_authenticated central init-bundles fetch-ca --output ${output_dir}/ca-config.yaml
+  assert_success
+  assert_file_exist "${output_dir}/ca-config.yaml"
+}


### PR DESCRIPTION
### Description

This PR fixes a bug: when we wrote ca to a file at the end we delete the file. Instead we should delete the file only when we could not write to it but after we created it. This was introduced in:

- https://github.com/stackrox/stackrox/commit/bf1809b75373953ac7d0228e41dcf58bb256cb43#diff-4a33bdfced9de1c5d2ab61ceb745355aded4d2c25013f9418648c2b2e5a12ef4R36

---


- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
