### PR TITLE
ROX-28693: Direct Helm deployment method in scanner-v4-tests

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -407,14 +407,13 @@ teardown() {
 
     _begin "deploying-old-central"
     info "Deploying StackRox central-services using chart ${old_central_chart}"
-    password_setting=$(cat <<EOT
+    deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$EARLIER_MAIN_IMAGE_TAG" "$old_central_chart" \
+        -f <(cat <<EOT
 central:
   adminPassword:
     value: "$ROX_ADMIN_PASSWORD"
 EOT
     )
-    deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$EARLIER_MAIN_IMAGE_TAG" "$old_central_chart" \
-        -f <(echo "$password_setting")
 
     _step "verify-scanner-V4-not-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1133,6 +1133,8 @@ deploy_central_with_helm() {
 
     if [[ "$use_default_chart" == "true" ]]; then
         image_overwrites=$(cat <<EOT
+image:
+  registry: "$DEFAULT_IMAGE_REGISTRY"
 central:
   db:
     image:
@@ -1283,12 +1285,14 @@ deploy_sensor_with_helm() {
     if [[ "$use_default_chart" == "true" ]]; then
         image_overwrites=$(cat <<EOT
 image:
+  registry: "$DEFAULT_IMAGE_REGISTRY"
   main:
     tag: "$main_image_tag"
   scannerV4:
     tag: "$main_image_tag"
   scannerV4DB:
     tag: "$main_image_tag"
+
 EOT
         )
     fi

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -156,6 +156,10 @@ EOT
     if [[ "${ORCHESTRATOR_FLAVOR:-}" == "openshift" ]]; then
       export ROX_OPENSHIFT_VERSION=4
     fi
+    if [[ -z "${ROX_ADMIN_PASSWORD:-}" ]]; then
+        ROX_ADMIN_PASSWORD="$(openssl rand -base64 20 | tr -d '/=+')"
+    fi
+    export ROX_ADMIN_PASSWORD
 
     if ! command -v roxctl >/dev/null; then
         die "roxctl not found, please make sure it can be resolved via PATH."

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1210,9 +1210,6 @@ scannerV4:
     replicas: 1
     autoscaling:
       disable: true
-  db:
-    persistence:
-      none: true
 
 allowNonstandardNamespace: true
 EOT

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -911,7 +911,7 @@ EOT
 get_central_endpoint() {
     local namespace="$1"
     local central_ip="$("${ORCH_CMD}" -n "$CUSTOM_CENTRAL_NAMESPACE" </dev/null get service central-loadbalancer \
-        -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+        -o json | service_get_endpoint"
     echo "${central_ip}:443"
 }
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -878,7 +878,7 @@ EOT
     _end
 }
 
-@test "Upgrade from old version without Scanner V4 support to the version which supports Scanner V4" {
+@test "Upgrade from old version without Scanner V4 to HEAD with Scanner V4 enabled" {
     _begin "deploy-stackrox"
 
     if [[ "$CI" = "true" ]]; then
@@ -889,7 +889,7 @@ EOT
     # shellcheck disable=SC2030,SC2031
     export OUTPUT_FORMAT=""
     info "Using roxctl executable ${EARLIER_ROXCTL_PATH}/roxctl for generating pre-Scanner V4 deployment bundles"
-    PATH="${EARLIER_ROXCTL_PATH}:${PATH}" MAIN_IMAGE_TAG="${EARLIER_MAIN_IMAGE_TAG}" _deploy_stackrox
+    PATH="${EARLIER_ROXCTL_PATH}:${PATH}" MAIN_IMAGE_TAG="${EARLIER_MAIN_IMAGE_TAG}" ROX_SCANNER_V4=false _deploy_stackrox
 
     _step "verify"
 
@@ -901,7 +901,7 @@ EOT
     _step "upgrade-stackrox"
 
     info "Upgrading StackRox using HEAD deployment bundles"
-    _deploy_stackrox
+    ROX_SCANNER_V4=true _deploy_stackrox
 
     _step "verify"
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -911,7 +911,7 @@ EOT
 get_central_endpoint() {
     local namespace="$1"
     local central_ip="$("${ORCH_CMD}" -n "$CUSTOM_CENTRAL_NAMESPACE" </dev/null get service central-loadbalancer \
-        -o json | service_get_endpoint"
+        -o json | service_get_endpoint)"
     echo "${central_ip}:443"
 }
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1118,7 +1118,8 @@ deploy_central_with_helm() {
 
     if [[ "${CI:-}" != "true" ]]; then
         info "Creating namespace and image pull secrets..."
-        "${ORCH_CMD}" </dev/null create namespace "$central_namespace" || true
+        echo '{ "apiVersion": "v1", "kind": "Namespace", "metadata": { "name": "$central_namespace" } }' | "${ORCH_CMD}" apply -f -
+
         "${ROOT}/deploy/common/pull-secret.sh" stackrox quay.io | "${ORCH_CMD}" -n "$central_namespace" apply -f -
     fi
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -405,7 +405,7 @@ teardown() {
     local old_central_chart="${CHART_REPOSITORY}${CHART_BASE}/${EARLIER_CHART_VERSION}/central-services"
     local old_sensor_chart="${CHART_REPOSITORY}${CHART_BASE}/${EARLIER_CHART_VERSION}/secured-cluster-services"
 
-    _begin "deploying-old-central"
+    _begin "deploy-old-central"
     info "Deploying StackRox central-services using chart ${old_central_chart}"
     deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$EARLIER_MAIN_IMAGE_TAG" "$old_central_chart" \
         -f <(cat <<EOT

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -937,7 +937,7 @@ verify_deployment_deletion() {
 
     local deleted
     while [[ -s "$deployment_names_file" ]]; do
-        active_deployments=$("${ORCH_CMD}" -n "$namespace" get deployments -o json)
+        active_deployments=$("${ORCH_CMD}" </dev/null -n "$namespace" get deployments -o json)
         deployment_names=$(cat "$deployment_names_file")
 
         for deployment_name in $deployment_names; do

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -144,7 +144,7 @@ EOT
     export CURRENT_MAIN_IMAGE_TAG=${CURRENT_MAIN_IMAGE_TAG:-} # Setting a tag can be useful for local testing.
     export EARLIER_CHART_VERSION="4.6.0"
     export EARLIER_MAIN_IMAGE_TAG=$EARLIER_CHART_VERSION
-    export USE_LOCAL_ROXCTL=true
+    export USE_LOCAL_ROXCTL="${USE_LOCAL_ROXCTL:-true}"
     export ROX_PRODUCT_BRANDING=RHACS_BRANDING
     export CI=${CI:-false}
     OS="$(uname | tr '[:upper:]' '[:lower:]')"

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -223,7 +223,33 @@ EOT
         export HEAD_HELM_CHART_CENTRAL_SERVICES_DIR
     fi
 
+   if [[ -z "${HEAD_HELM_CHART_SECURED_CLUSTER_SERVICES_DIR:-}" ]]; then
+        HEAD_HELM_CHART_SECURED_CLUSTER_SERVICES_DIR=$(mktemp -d)
+        echo "Rendering fresh secured-cluster-services Helm chart and writing to ${HEAD_HELM_CHART_SECURED_CLUSTER_SERVICES_DIR}..."
+        roxctl helm output secured-cluster-services \
+            --debug --debug-path="${ROOT}/image" \
+            --output-dir="${HEAD_HELM_CHART_SECURED_CLUSTER_SERVICES_DIR}" --remove
+        export HEAD_HELM_CHART_SECURED_CLUSTER_SERVICES_DIR
+    fi
+
+    # For installation testing we don't need to deploy collector per-node, it is sufficient to deploy
+    # collector on a single node.
+    local _worker; _worker=$(select_worker_node)
+
+    echo "Patching node ${_worker} to include label run-collector=true"
+    "${ORCH_CMD}" </dev/null label node "$_worker" run-collector=true
+    echo "collector will only be scheduled on node ${_worker}"
+
     _end
+}
+
+select_worker_node() {
+    local select_filter="true"
+    if [[ "$ORCHESTRATOR_FLAVOR" == "openshift" ]]; then
+        select_filter=".metadata.labels[\"node-role.kubernetes.io/worker\"] != null"
+    fi
+
+    "${ORCH_CMD}" </dev/null get nodes -o json | jq -r ".items | map(select(${select_filter})) | map(.metadata.name) | sort | first"
 }
 
 teardown_file() {
@@ -1178,6 +1204,142 @@ EOT
         echo "Recording build info..."
         record_build_info "${central_namespace}"
     fi
+}
+
+# shellcheck disable=SC2120
+# deploy_sensor_with_helm "<central namespace>" "<sensor namespace>"
+#   "<main image tag>" "<helm chart dir overwrite>"
+#   "<cluster name>" "<central admin password>" "<central endpoint>" [ additional args for helm ... ]
+deploy_sensor_with_helm() {
+    echo "Deploying secured-cluster-services via Helm..."
+    local central_namespace="$1"; shift
+    local sensor_namespace="$1"; shift
+    local main_image_tag="${1:-$MAIN_IMAGE_TAG}"; shift
+    local helm_chart_dir="$HEAD_HELM_CHART_SECURED_CLUSTER_SERVICES_DIR"
+    local use_default_chart="true"
+    if [[ -n "$1" ]]; then
+        # overwrite Helm chart path.
+        helm_chart_dir="$1"
+        use_default_chart="false"
+    fi; shift
+    local cluster_name="$1"; shift
+    local central_password="$1"; shift
+    local central_endpoint="$1"; shift
+
+    local image_overwrites=""
+    local base_helm_values=""
+    local upgrade="false"
+
+    if [[ "$use_default_chart" == "true" ]]; then
+        image_overwrites=$(cat <<EOT
+image:
+  main:
+    tag: "$main_image_tag"
+  scannerV4:
+    tag: "$main_image_tag"
+  scannerV4DB:
+    tag: "$main_image_tag"
+EOT
+        )
+    fi
+
+    command=("install" "--create-namespace")
+    if helm list -n "$sensor_namespace" -o json | jq -e '.[] | select(.name == "stackrox-secured-cluster-services")' > /dev/null 2>&1; then
+        command=("upgrade" "--install" "--reuse-values")
+        upgrade="true"
+    else
+        # Later this will be replaced by CRS.
+        echo "Retrieving init-bundle from Central..."
+        init_bundle="$("${ORCH_CMD}" </dev/null -n "$central_namespace" exec deploy/central -- roxctl \
+            --insecure-skip-tls-verify \
+            -p "$central_password" \
+            -e "central.${central_namespace}.svc:443" \
+            central init-bundles generate "$cluster_name" --output=-)"
+
+        if [[ "${CI:-}" != "true" ]]; then
+            info "Creating image pull secrets..."
+            "${ORCH_CMD}" </dev/null create namespace "$sensor_namespace" || true
+            "${ROOT}/deploy/common/pull-secret.sh" stackrox quay.io | "${ORCH_CMD}" -n "$sensor_namespace" apply -f -
+            "${ROOT}/deploy/common/pull-secret.sh" collector-stackrox quay.io | "${ORCH_CMD}" -n "$sensor_namespace" apply -f -
+        fi
+        base_helm_values=$(cat <<EOT
+clusterName: "$cluster_name"
+centralEndpoint: "$central_endpoint"
+
+scanner:
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "500Mi"
+    limits:
+      cpu: "2000m"
+      memory: "2500Mi"
+  dbResources:
+    requests:
+      cpu: "400m"
+      memory: "512Mi"
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+  replicas: 1
+  autoscaling:
+    disable: true
+
+scannerV4:
+  indexer:
+    replicas: 1
+    autoscaling:
+      disable: true
+  matcher:
+    replicas: 1
+    autoscaling:
+      disable: true
+  db:
+    persistence:
+      none: true
+
+admissionControl:
+  replicas: 1
+
+collector:
+  nodeSelector:
+    run-collector: "true"
+
+allowNonstandardNamespace: true
+EOT
+        )
+    fi
+
+    echo "Deploying stackrox-secured-cluster-services Helm chart \"${helm_chart_dir}\" into namespace ${sensor_namespace} with the following settings:"
+    if [[ -n "$base_helm_values" ]]; then
+        echo "base Helm values:"
+        echo "$base_helm_values" | sed -e 's/^/  |/;'
+    fi
+    if [[ -n "$image_overwrites" ]]; then
+        echo "image overwrites:"
+        echo "$image_overwrites" | sed -e 's/^/  |/;'
+    fi
+    echo "additional arguments:"
+    echo "  | $*"
+
+    helm -n "${sensor_namespace}" "${command[@]}" \
+        -f <(echo "$image_overwrites") \
+        -f <(echo "$base_helm_values") \
+        -f <(echo "$init_bundle") \
+        "$@" \
+        stackrox-secured-cluster-services "${helm_chart_dir}"
+
+    if [[ "$upgrade" == "true" ]]; then
+        # For some reason collector pods don't like to terminate smoothly.
+        echo "Restarting collector pods..."
+        kubectl -n "${sensor_namespace}" delete pod -l app=collector --force --grace-period=0
+        echo "Restarting admission-control pods..."
+        kubectl -n "${sensor_namespace}" delete pod -l app=admission-control --force --grace-period=0
+    fi
+
+    echo "Sensor deployed. Waiting for sensor to be up"
+    sensor_wait "${sensor_namespace}"
+    wait_for_collectors_to_be_operational "${sensor_namespace}"
 }
 
 patch_down_central() {

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -419,7 +419,7 @@ EOT
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_no_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
 
-    _begin "upgrading-to-HEAD-central"
+    _begin "upgrade-to-HEAD-central"
     deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$MAIN_IMAGE_TAG" "" \
         --reuse-values
 
@@ -444,7 +444,7 @@ EOT
     verify_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
 
-    _begin "deploying-old-sensor"
+    _begin "deploy-old-sensor"
     info "Deploying StackRox secured-cluster-services using chart ${old_sensor_chart}"
     local central_endpoint="$(get_central_endpoint "$CUSTOM_CENTRAL_NAMESPACE")"
     local secured_cluster_name="$(get_cluster_name)"
@@ -455,13 +455,13 @@ EOT
     _step "verify-scanner-V4-not-deployed"
     verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
-    _step "upgrading-to-HEAD-sensor"
+    _step "upgrade-to-HEAD-sensor"
     deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" "" "" "" "" ""
 
     _step "verify-scanner-not-deployed"
     verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
-    _begin "enabling-scanner-V4-in-secured-cluster"
+    _begin "enable-scanner-V4-in-secured-cluster"
     # Without creating the scanner-db-password secret manually Scanner V2 doesn't come up.
     # Let's just reuse an existing password for this for simplicity.
     "$ORCH_CMD" </dev/null -n "$CUSTOM_SENSOR_NAMESPACE" create secret generic scanner-db-password \
@@ -732,7 +732,7 @@ EOT
 
     wait_until_central_validation_webhook_is_ready "${CUSTOM_CENTRAL_NAMESPACE}"
 
-    _step "patching-central"
+    _step "patch-central"
 
     # Enable Scanner V4 on central side.
     info "Patching Central"
@@ -778,7 +778,7 @@ EOT
     sleep 60
     "${ORCH_CMD}" </dev/null -n "${CUSTOM_CENTRAL_NAMESPACE}" wait --for=condition=Ready pods -l app=central || true
 
-    _step "patching-secured-cluster"
+    _step "patch-secured-cluster"
 
     info "Patching SecuredCluster"
     # Enable Scanner V4 on secured-cluster side

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -142,7 +142,7 @@ EOT
     info "Using MAIN_IMAGE_TAG=$MAIN_IMAGE_TAG"
 
     export CURRENT_MAIN_IMAGE_TAG=${CURRENT_MAIN_IMAGE_TAG:-} # Setting a tag can be useful for local testing.
-    export EARLIER_CHART_VERSION="4.3.0"
+    export EARLIER_CHART_VERSION="4.6.0"
     export EARLIER_MAIN_IMAGE_TAG=$EARLIER_CHART_VERSION
     export USE_LOCAL_ROXCTL=true
     export ROX_PRODUCT_BRANDING=RHACS_BRANDING

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -214,6 +214,15 @@ EOT
     # have any logs for investigation the situation.
     export BATS_TEST_TIMEOUT=1800 # Seconds
 
+   if [[ -z "${HEAD_HELM_CHART_CENTRAL_SERVICES_DIR:-}" ]]; then
+        HEAD_HELM_CHART_CENTRAL_SERVICES_DIR=$(mktemp -d)
+        echo "Rendering fresh central-services Helm chart and writing to ${HEAD_HELM_CHART_CENTRAL_SERVICES_DIR}..."
+        roxctl helm output central-services \
+            --debug --debug-path="${ROOT}/image" \
+            --output-dir="${HEAD_HELM_CHART_CENTRAL_SERVICES_DIR}" --remove
+        export HEAD_HELM_CHART_CENTRAL_SERVICES_DIR
+    fi
+
     _end
 }
 
@@ -1027,6 +1036,148 @@ _deploy_central() {
     fi
     deploy_central "${central_namespace}"
     patch_down_central "${central_namespace}"
+}
+
+# shellcheck disable=SC2120
+# deploy_central_with_helm "<central namespace>" "<main image tag>" "<helm chart dir overwrite>" [ additional args for helm ... ]
+deploy_central_with_helm() {
+    echo "Deploying central-services via Helm..."
+    local central_namespace="$1"; shift
+    local main_image_tag="$1"; shift
+    local helm_chart_dir="$HEAD_HELM_CHART_CENTRAL_SERVICES_DIR"
+    local use_default_chart="true"
+    if [[ -n "$1" ]]; then
+        # overwrite Helm chart path.
+        helm_chart_dir="$1"
+        use_default_chart="false"
+    fi; shift
+
+    if [[ "${CI:-}" != "true" ]]; then
+        info "Creating namespace and image pull secrets..."
+        "${ORCH_CMD}" </dev/null create namespace "$central_namespace" || true
+        "${ROOT}/deploy/common/pull-secret.sh" stackrox quay.io | "${ORCH_CMD}" -n "$central_namespace" apply -f -
+    fi
+
+    local image_overwrites=""
+    local base_helm_values=""
+    local upgrade="false"
+
+    if [[ "$use_default_chart" == "true" ]]; then
+        image_overwrites=$(cat <<EOT
+central:
+  db:
+    image:
+      tag: "$main_image_tag"
+  image:
+    tag: "$main_image_tag"
+
+scannerV4:
+  image:
+    tag: "$main_image_tag"
+  db:
+    image:
+      tag: "$main_image_tag"
+EOT
+        )
+    fi
+
+    command=("install" "--create-namespace")
+    if helm list -n "$central_namespace" -o json | jq -e '.[] | select(.name == "stackrox-central-services")' > /dev/null 2>&1; then
+        helm_generated_values_file=$(mktemp)
+        "${ORCH_CMD}" -n "$central_namespace" get secrets -o json \
+            </dev/null \
+            | jq -r '.items[] | select(.metadata.name | startswith("stackrox-generated-")) | .data["generated-values.yaml"] | @base64d' \
+            > "$helm_generated_values_file"
+        command=("upgrade" "--install" "--reuse-values" "-f" "$helm_generated_values_file")
+    else
+        base_helm_values=$(cat <<EOT
+central:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+  telemetry:
+    enabled: false
+  exposure:
+    loadBalancer:
+      enabled: true
+  persistence:
+    none: true
+  db:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: 2000m
+        memory: 4Gi
+
+scanner:
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "500Mi"
+    limits:
+      cpu: "2000m"
+      memory: "2500Mi"
+  dbResources:
+    requests:
+      cpu: "400m"
+      memory: "512Mi"
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+  replicas: 1
+  autoscaling:
+    disable: true
+
+scannerV4:
+  indexer:
+    replicas: 1
+    autoscaling:
+      disable: true
+  matcher:
+    replicas: 1
+    autoscaling:
+      disable: true
+  db:
+    persistence:
+      none: true
+
+allowNonstandardNamespace: true
+EOT
+        )
+    fi
+
+    echo "Deploying stackrox-central-services Helm chart \"${helm_chart_dir}\" into namespace ${central_namespace} with the following settings:"
+    if [[ -n "$base_helm_values" ]]; then
+        echo "base Helm values:"
+        echo "$base_helm_values" | sed -e 's/^/  |/;'
+    fi
+    if [[ -n "$image_overwrites" ]]; then
+        echo "image overwrites:"
+        echo "$image_overwrites" | sed -e 's/^/  |/;'
+    fi
+    echo "additional arguments:"
+    echo "  | $*"
+
+    helm -n "${central_namespace}" "${command[@]}" \
+        -f <(echo "$image_overwrites") \
+        -f <(echo "$base_helm_values") \
+        "$@" \
+        stackrox-central-services "${helm_chart_dir}"
+    echo "Waiting for API..."
+    wait_for_api "${central_namespace}"
+
+    if [[ "$upgrade" == "false" ]]; then
+        echo "Setting up client TLS certs..."
+        setup_client_TLS_certs ""
+        echo "Recording build info..."
+        record_build_info "${central_namespace}"
+    fi
 }
 
 patch_down_central() {

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1238,7 +1238,7 @@ EOT
         stackrox-central-services "${helm_chart_dir}"
 
     if [[ "$upgrade" == "true" ]]; then
-        # For some reason pods don't always terminate smoothly after an upgrade.
+        # TODO(ROX-28903): For some reason pods don't always terminate smoothly after an upgrade.
         bounce_pods "${central_namespace}"
     fi
 
@@ -1379,7 +1379,7 @@ EOT
         stackrox-secured-cluster-services "${helm_chart_dir}"
 
     if [[ "$upgrade" == "true" ]]; then
-        # For some reason pods don't always terminate smoothly after an upgrade.
+        # TODO(ROX-28903): For some reason pods don't always terminate smoothly after an upgrade.
         bounce_pods "${sensor_namespace}"
     fi
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1171,8 +1171,6 @@ central:
   exposure:
     loadBalancer:
       enabled: true
-  persistence:
-    none: true
   db:
     resources:
       requests:

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -433,11 +433,7 @@ EOT
     _begin "enable-scanner-V4-in-central"
     deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$MAIN_IMAGE_TAG" "" \
         --reuse-values \
-        -f <(cat <<EOT
-scannerV4:
-  disable: false
-EOT
-    )
+        --set scannerV4.disable=false
 
     _step "verify-scanners-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1391,12 +1391,7 @@ EOT
 bounce_pods() {
     local namespace="$1"
     echo "Bouncing all workload pods..."
-    {
-        "${ORCH_CMD}" </dev/null -n "$namespace" get deployments -o name
-        "${ORCH_CMD}" </dev/null -n "$namespace" get daemonsets -o name
-    } | cut -d / -f 2 | while read -r workload; do
-        "${ORCH_CMD}" </dev/null -n "$namespace" delete pod -l "app=$workload" --force --grace-period=0
-    done
+    "${ORCH_CMD}" </dev/null -n "$namespace" delete pod --all --force --grace-period=0
 }
 
 patch_down_central() {

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -52,6 +52,7 @@ scripts/ci/lib.sh
 sensor/tests/data/policies.json
 sensor/upgrader/preflight/testdata/k8s-1.22.json.gz
 tests/e2e/lib.sh
+tests/e2e/run-scanner-v4-install.bats
 tests/performance/load/package-lock.json
 tests/performance/scale/config/metrics-acs.yml
 tests/performance/scale/config/metrics-full.yml


### PR DESCRIPTION
### Description

See [ROX-28693](https://issues.redhat.com/browse/ROX-28693), which contains an extensive description of this change.

tl,dr: This PR provides a new and much more direct way to trigger Helm-based deployments of our charts. One test has been rewritten to use these new deployment functions.

#### Automated testing

Note that this PR only touches existing testing code.

- [x] modified existing tests

#### How I validated my change

Running the test suite manually against remote clusters.
CI.
