### PR TITLE
ROX-8333: use enum instead of string

### DIFF
--- a/roxctl/image/scan/cve.go
+++ b/roxctl/image/scan/cve.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"encoding/json"
 	"slices"
 	"sort"
 	"strings"
@@ -25,6 +26,10 @@ const (
 
 func (c cveSeverity) String() string {
 	return [...]string{"LOW", "MODERATE", "IMPORTANT", "CRITICAL"}[c]
+}
+
+func (c cveSeverity) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String()) //nolint:wrapcheck
 }
 
 func cveSeverityFromString(s string) cveSeverity {
@@ -60,12 +65,12 @@ type cveJSONStructure struct {
 }
 
 type cveVulnerabilityJSON struct {
-	CveID                 string `json:"cveId"`
-	CveSeverity           string `json:"cveSeverity"`
-	CveInfo               string `json:"cveInfo"`
-	ComponentName         string `json:"componentName"`
-	ComponentVersion      string `json:"componentVersion"`
-	ComponentFixedVersion string `json:"componentFixedVersion"`
+	CveID                 string      `json:"cveId"`
+	CveSeverity           cveSeverity `json:"cveSeverity"`
+	CveInfo               string      `json:"cveInfo"`
+	ComponentName         string      `json:"componentName"`
+	ComponentVersion      string      `json:"componentVersion"`
+	ComponentFixedVersion string      `json:"componentFixedVersion"`
 }
 
 // newCVESummaryForPrinting creates a cveJSONResult that shall be used for printing and holds
@@ -111,7 +116,7 @@ func getVulnerabilityJSON(vulnerabilities []*storage.EmbeddedVulnerability, comp
 
 		vulnJSON := cveVulnerabilityJSON{
 			CveID:                 vulnerability.GetCve(),
-			CveSeverity:           severity.String(),
+			CveSeverity:           severity,
 			CveInfo:               vulnerability.GetLink(),
 			ComponentName:         comp.GetName(),
 			ComponentVersion:      comp.GetVersion(),

--- a/roxctl/image/scan/cve_test.go
+++ b/roxctl/image/scan/cve_test.go
@@ -41,41 +41,41 @@ func TestNewCVESummaryForPrinting(t *testing.T) {
 
 	// Expected vulns and components without filtering.
 	expectedVulnsComponentA := []cveVulnerabilityJSON{
-		{CveID: "CVE-TEST-1", CveSeverity: "CRITICAL", CveInfo: "cve-link-1", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.2"},
-		{CveID: "CVE-TEST-3", CveSeverity: "IMPORTANT", CveInfo: "cve-link-3", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.3"},
-		{CveID: "CVE-TEST-4", CveSeverity: "MODERATE", CveInfo: "cve-link-4", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.4"},
-		{CveID: "CVE-TEST-2", CveSeverity: "LOW", CveInfo: "cve-link-2", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.0"},
+		{CveID: "CVE-TEST-1", CveSeverity: criticalCVESeverity, CveInfo: "cve-link-1", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.2"},
+		{CveID: "CVE-TEST-3", CveSeverity: importantCVESeverity, CveInfo: "cve-link-3", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.3"},
+		{CveID: "CVE-TEST-4", CveSeverity: moderateCVESeverity, CveInfo: "cve-link-4", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.4"},
+		{CveID: "CVE-TEST-2", CveSeverity: lowCVESeverity, CveInfo: "cve-link-2", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.0"},
 	}
 	expectedVulnsComponentB := []cveVulnerabilityJSON{
-		{CveID: "CVE-TEST-1", CveSeverity: "CRITICAL", CveInfo: "cve-link-1", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.2"},
-		{CveID: "CVE-TEST-3", CveSeverity: "IMPORTANT", CveInfo: "cve-link-3", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.3"},
-		{CveID: "CVE-TEST-4", CveSeverity: "MODERATE", CveInfo: "cve-link-4", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.4"},
-		{CveID: "CVE-TEST-2", CveSeverity: "LOW", CveInfo: "cve-link-2", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.0"},
+		{CveID: "CVE-TEST-1", CveSeverity: criticalCVESeverity, CveInfo: "cve-link-1", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.2"},
+		{CveID: "CVE-TEST-3", CveSeverity: importantCVESeverity, CveInfo: "cve-link-3", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.3"},
+		{CveID: "CVE-TEST-4", CveSeverity: moderateCVESeverity, CveInfo: "cve-link-4", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.4"},
+		{CveID: "CVE-TEST-2", CveSeverity: lowCVESeverity, CveInfo: "cve-link-2", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.0"},
 	}
 	expectedVulnsComponentC := []cveVulnerabilityJSON{
-		{CveID: "CVE-TEST-1", CveSeverity: "CRITICAL", CveInfo: "cve-link-1", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.2"},
-		{CveID: "CVE-TEST-3", CveSeverity: "IMPORTANT", CveInfo: "cve-link-3", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.3"},
-		{CveID: "CVE-TEST-4", CveSeverity: "MODERATE", CveInfo: "cve-link-4", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.4"},
-		{CveID: "CVE-TEST-2", CveSeverity: "LOW", CveInfo: "cve-link-2", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.0"},
+		{CveID: "CVE-TEST-1", CveSeverity: criticalCVESeverity, CveInfo: "cve-link-1", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.2"},
+		{CveID: "CVE-TEST-3", CveSeverity: importantCVESeverity, CveInfo: "cve-link-3", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.3"},
+		{CveID: "CVE-TEST-4", CveSeverity: moderateCVESeverity, CveInfo: "cve-link-4", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.4"},
+		{CveID: "CVE-TEST-2", CveSeverity: lowCVESeverity, CveInfo: "cve-link-2", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.0"},
 	}
 	expectedVulnsComponentD := []cveVulnerabilityJSON{
 		{
-			CveID: "CVE-TEST-10", CveSeverity: "CRITICAL", CveInfo: "cve-link-10", ComponentName: "componentD", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "3.0",
+			CveID: "CVE-TEST-10", CveSeverity: criticalCVESeverity, CveInfo: "cve-link-10", ComponentName: "componentD", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "3.0",
 		},
 	}
 
 	// Expected vulns and components when filtered.
 	expectedVulnsComponentAFiltered := []cveVulnerabilityJSON{
-		{CveID: "CVE-TEST-3", CveSeverity: "IMPORTANT", CveInfo: "cve-link-3", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.3"},
-		{CveID: "CVE-TEST-4", CveSeverity: "MODERATE", CveInfo: "cve-link-4", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.4"},
+		{CveID: "CVE-TEST-3", CveSeverity: importantCVESeverity, CveInfo: "cve-link-3", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.3"},
+		{CveID: "CVE-TEST-4", CveSeverity: moderateCVESeverity, CveInfo: "cve-link-4", ComponentName: "componentA", ComponentVersion: "1.0.0-1", ComponentFixedVersion: "1.4"},
 	}
 	expectedVulnsComponentBFiltered := []cveVulnerabilityJSON{
-		{CveID: "CVE-TEST-3", CveSeverity: "IMPORTANT", CveInfo: "cve-link-3", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.3"},
-		{CveID: "CVE-TEST-4", CveSeverity: "MODERATE", CveInfo: "cve-link-4", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.4"},
+		{CveID: "CVE-TEST-3", CveSeverity: importantCVESeverity, CveInfo: "cve-link-3", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.3"},
+		{CveID: "CVE-TEST-4", CveSeverity: moderateCVESeverity, CveInfo: "cve-link-4", ComponentName: "componentB", ComponentVersion: "1.0.0-2", ComponentFixedVersion: "1.4"},
 	}
 	expectedVulnsComponentCFiltered := []cveVulnerabilityJSON{
-		{CveID: "CVE-TEST-3", CveSeverity: "IMPORTANT", CveInfo: "cve-link-3", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.3"},
-		{CveID: "CVE-TEST-4", CveSeverity: "MODERATE", CveInfo: "cve-link-4", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.4"},
+		{CveID: "CVE-TEST-3", CveSeverity: importantCVESeverity, CveInfo: "cve-link-3", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.3"},
+		{CveID: "CVE-TEST-4", CveSeverity: moderateCVESeverity, CveInfo: "cve-link-4", ComponentName: "componentC", ComponentVersion: "1.0.0-3", ComponentFixedVersion: "1.4"},
 	}
 
 	cases := map[string]struct {
@@ -153,19 +153,19 @@ func TestNewCVESummaryForPrinting(t *testing.T) {
 					Vulnerabilities: []cveVulnerabilityJSON{
 						{
 							CveID:            "CVE-2022-42010",
-							CveSeverity:      "MODERATE",
+							CveSeverity:      moderateCVESeverity,
 							ComponentName:    "dbus",
 							ComponentVersion: "1:1.12.20-6.el9.x86_64",
 						},
 						{
 							CveID:            "CVE-2022-42010",
-							CveSeverity:      "MODERATE",
+							CveSeverity:      moderateCVESeverity,
 							ComponentName:    "dbus-common",
 							ComponentVersion: "1:1.12.20-6.el9.noarch",
 						},
 						{
 							CveID:            "CVE-2022-42010",
-							CveSeverity:      "MODERATE",
+							CveSeverity:      moderateCVESeverity,
 							ComponentName:    "dbus-libs",
 							ComponentVersion: "1:1.12.20-6.el9.x86_64",
 						},


### PR DESCRIPTION
### Description

We can use enum instead of string that will help us with sorting and also keep the type.
- https://github.com/stackrox/stackrox/pull/14803
---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
