### PR TITLE
ROX-28574: Fix race condition breaking delegated scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-28263: New `roxctl` help formatting.
 - ROX-24500: Certificate validation failure in `roxctl` is now an error.
 - ROX-27885: Aligned data in old Compliance across tables and widgets
+- ROX-28574: Fixed a Sensor race condition that would occasionally disable delegated scanning when Sensor reconnected to Central.
 
 ## [4.7.0]
 

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -678,6 +678,9 @@ func (c *sensorConnection) getImageIntegrationMsg(ctx context.Context) (*central
 		Msg: &central.MsgToSensor_ImageIntegrations{
 			ImageIntegrations: &central.ImageIntegrations{
 				UpdatedIntegrations: imageIntegrations,
+				// On initial/repeat connections to Sensor any previous stored image integrations
+				// should be replaced by these (potentially) new ones.
+				Refresh: true,
 			},
 		},
 	}, nil

--- a/central/sensor/service/connection/connection_test.go
+++ b/central/sensor/service/connection/connection_test.go
@@ -672,6 +672,7 @@ func (s *testSuite) TestImageIntegrationsOnRun() {
 				s.Len(imgInts.UpdatedIntegrations, 1)
 				s.Equal(imgInts.UpdatedIntegrations[0].Name, "valid")
 				s.Equal(imgInts.UpdatedIntegrations[0].Id, "id1")
+				s.True(imgInts.Refresh)
 				return
 			}
 		}

--- a/generated/internalapi/central/image.pb.go
+++ b/generated/internalapi/central/image.pb.go
@@ -101,8 +101,11 @@ type ImageIntegrations struct {
 	state                 protoimpl.MessageState      `protogen:"open.v1"`
 	UpdatedIntegrations   []*storage.ImageIntegration `protobuf:"bytes,1,rep,name=updated_integrations,json=updatedIntegrations,proto3" json:"updated_integrations,omitempty"`
 	DeletedIntegrationIds []string                    `protobuf:"bytes,2,rep,name=deleted_integration_ids,json=deletedIntegrationIds,proto3" json:"deleted_integration_ids,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// refresh when true indicates that the updated integrations should replace
+	// any existing integrations.
+	Refresh       bool `protobuf:"varint,3,opt,name=refresh,proto3" json:"refresh,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ImageIntegrations) Reset() {
@@ -149,6 +152,13 @@ func (x *ImageIntegrations) GetDeletedIntegrationIds() []string {
 	return nil
 }
 
+func (x *ImageIntegrations) GetRefresh() bool {
+	if x != nil {
+		return x.Refresh
+	}
+	return false
+}
+
 var File_internalapi_central_image_proto protoreflect.FileDescriptor
 
 const file_internalapi_central_image_proto_rawDesc = "" +
@@ -160,10 +170,11 @@ const file_internalapi_central_image_proto_rawDesc = "" +
 	"\n" +
 	"image_name\x18\x02 \x01(\tR\timageName\x12\x14\n" +
 	"\x05force\x18\x03 \x01(\bR\x05force\x12\x1c\n" +
-	"\tnamespace\x18\x04 \x01(\tR\tnamespace\"\x99\x01\n" +
+	"\tnamespace\x18\x04 \x01(\tR\tnamespace\"\xb3\x01\n" +
 	"\x11ImageIntegrations\x12L\n" +
 	"\x14updated_integrations\x18\x01 \x03(\v2\x19.storage.ImageIntegrationR\x13updatedIntegrations\x126\n" +
-	"\x17deleted_integration_ids\x18\x02 \x03(\tR\x15deletedIntegrationIdsB\x1fZ\x1d./internalapi/central;centralb\x06proto3"
+	"\x17deleted_integration_ids\x18\x02 \x03(\tR\x15deletedIntegrationIds\x12\x18\n" +
+	"\arefresh\x18\x03 \x01(\bR\arefreshB\x1fZ\x1d./internalapi/central;centralb\x06proto3"
 
 var (
 	file_internalapi_central_image_proto_rawDescOnce sync.Once

--- a/generated/internalapi/central/image_vtproto.pb.go
+++ b/generated/internalapi/central/image_vtproto.pb.go
@@ -46,6 +46,7 @@ func (m *ImageIntegrations) CloneVT() *ImageIntegrations {
 		return (*ImageIntegrations)(nil)
 	}
 	r := new(ImageIntegrations)
+	r.Refresh = m.Refresh
 	if rhs := m.UpdatedIntegrations; rhs != nil {
 		tmpContainer := make([]*storage.ImageIntegration, len(rhs))
 		for k, v := range rhs {
@@ -140,6 +141,9 @@ func (this *ImageIntegrations) EqualVT(that *ImageIntegrations) bool {
 		if vx != vy {
 			return false
 		}
+	}
+	if this.Refresh != that.Refresh {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -245,6 +249,16 @@ func (m *ImageIntegrations) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Refresh {
+		i--
+		if m.Refresh {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
 	if len(m.DeletedIntegrationIds) > 0 {
 		for iNdEx := len(m.DeletedIntegrationIds) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.DeletedIntegrationIds[iNdEx])
@@ -329,6 +343,9 @@ func (m *ImageIntegrations) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.Refresh {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -604,6 +621,26 @@ func (m *ImageIntegrations) UnmarshalVT(dAtA []byte) error {
 			}
 			m.DeletedIntegrationIds = append(m.DeletedIntegrationIds, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Refresh", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Refresh = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -912,6 +949,26 @@ func (m *ImageIntegrations) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.DeletedIntegrationIds = append(m.DeletedIntegrationIds, stringValue)
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Refresh", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Refresh = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/internalapi/central/image.proto
+++ b/proto/internalapi/central/image.proto
@@ -26,4 +26,8 @@ message ScanImage {
 message ImageIntegrations {
   repeated storage.ImageIntegration updated_integrations = 1;
   repeated string deleted_integration_ids = 2;
+
+  // refresh when true indicates that the updated integrations should replace
+  // any existing integrations.
+  bool refresh = 3;
 }

--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -173,9 +173,9 @@ func (d *delegatedRegistryImpl) processImageIntegrations(iiReq *central.ImageInt
 	case <-d.stopSig.Done():
 		return errors.New("could not process updated image integrations, stop requested")
 	default:
-		log.Infof("Received %d updated and %d deleted image integrations", len(iiReq.GetUpdatedIntegrations()), len(iiReq.GetDeletedIntegrationIds()))
+		log.Infof("Received %d updated (refresh: %t) and %d deleted image integrations", len(iiReq.GetUpdatedIntegrations()), iiReq.GetRefresh(), len(iiReq.GetDeletedIntegrationIds()))
 
-		d.registryStore.UpsertCentralRegistryIntegrations(iiReq.GetUpdatedIntegrations())
+		d.registryStore.UpsertCentralRegistryIntegrations(iiReq.GetUpdatedIntegrations(), iiReq.GetRefresh())
 		d.registryStore.DeleteCentralRegistryIntegrations(iiReq.GetDeletedIntegrationIds())
 	}
 	return nil

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -117,13 +117,14 @@ func NewRegistryStore(checkTLSFunc CheckTLS) *Store {
 	return store
 }
 
-// Cleanup deletes all entries from store.
+// Cleanup deletes all entries from store that are derived from k8s informers/listeners.
+// The lifecycle of other data in this store will be handled separately, such as the delegated
+// registry config and image integrations synced from Central.
 func (rs *Store) Cleanup() {
 	// Separate cleanup methods are used to ensure only one lock is obtained at a time
 	// to avoid accidental deadlock.
 	rs.cleanupRegistries()
 	rs.cleanupClusterLocalRegistryHosts()
-	rs.cleanupDelegatedRegistryConfig()
 	rs.tlsCheckCache.Cleanup()
 
 	metrics.ResetRegistryMetrics()
@@ -133,7 +134,6 @@ func (rs *Store) Cleanup() {
 
 func (rs *Store) cleanupRegistries() {
 	// These Sets have an internal mutex for controlling access.
-	rs.centralRegistryIntegrations.Clear()
 	rs.globalRegistries.Clear()
 
 	rs.storeMutux.Lock()
@@ -148,13 +148,6 @@ func (rs *Store) cleanupClusterLocalRegistryHosts() {
 	defer rs.clusterLocalRegistryHostsMutex.Unlock()
 
 	rs.clusterLocalRegistryHosts = set.NewStringSet()
-}
-
-func (rs *Store) cleanupDelegatedRegistryConfig() {
-	rs.delegatedRegistryConfigMutex.Lock()
-	defer rs.delegatedRegistryConfigMutex.Unlock()
-
-	rs.delegatedRegistryConfig = nil
 }
 
 func (rs *Store) getRegistries(namespace string) registries.Set {
@@ -366,7 +359,12 @@ func (rs *Store) hasClusterLocalRegistryHost(host string) bool {
 }
 
 // UpsertCentralRegistryIntegrations upserts registry integrations from Central into the store.
-func (rs *Store) UpsertCentralRegistryIntegrations(iis []*storage.ImageIntegration) {
+func (rs *Store) UpsertCentralRegistryIntegrations(iis []*storage.ImageIntegration, refresh bool) {
+	if refresh {
+		// On refresh any existing integrations should be replaced.
+		rs.centralRegistryIntegrations.Clear()
+	}
+
 	for _, ii := range iis {
 		_, err := rs.centralRegistryIntegrations.UpdateImageIntegration(ii)
 		if err != nil {

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -133,7 +133,7 @@ func (rs *Store) Cleanup() {
 }
 
 func (rs *Store) cleanupRegistries() {
-	// These Sets have an internal mutex for controlling access.
+	// This set has an internal mutex for controlling access.
 	rs.globalRegistries.Clear()
 
 	rs.storeMutux.Lock()

--- a/sensor/common/registry/registry_store_test.go
+++ b/sensor/common/registry/registry_store_test.go
@@ -331,17 +331,26 @@ func TestRegistryStore_CentralIntegrations(t *testing.T) {
 	imgName, _, err := utils.GenerateImageNameFromString("example.com/repo/path:tag")
 	require.NoError(t, err)
 
-	regStore.UpsertCentralRegistryIntegrations(iis)
-	assert.Len(t, regStore.centralRegistryIntegrations.GetAll(), 3)
+	regStore.UpsertCentralRegistryIntegrations(iis, true)
+	assert.Len(t, regStore.centralRegistryIntegrations.GetAll(), 3) // a, b, c
 
 	regs := regStore.GetCentralRegistries(imgName)
-	assert.Len(t, regs, 1)
+	assert.Len(t, regs, 1) // c
 
 	regStore.DeleteCentralRegistryIntegrations([]string{"a", "b"})
-	assert.Len(t, regStore.centralRegistryIntegrations.GetAll(), 1)
+	assert.Len(t, regStore.centralRegistryIntegrations.GetAll(), 1) // c
 
 	regs = regStore.GetCentralRegistries(imgName)
-	assert.Len(t, regs, 1)
+	assert.Len(t, regs, 1) // c
+
+	zII := &storage.ImageIntegration{Id: "z", Name: "z", Type: types.DockerType, IntegrationConfig: &storage.ImageIntegration_Docker{}}
+	// When false existing integrations should remain, in this case the 'c' integration.
+	regStore.UpsertCentralRegistryIntegrations([]*storage.ImageIntegration{zII}, false)
+	assert.Len(t, regStore.centralRegistryIntegrations.GetAll(), 2) // c, z
+
+	// When true existing integrations should be replaced, in this case 'z' removed.
+	regStore.UpsertCentralRegistryIntegrations(iis, true)
+	assert.Len(t, regStore.centralRegistryIntegrations.GetAll(), 3) // a, b, c
 }
 
 // TestRegistryStore_CreateImageIntegrationType verifies the type of an image integration
@@ -767,11 +776,11 @@ func TestRegistyStore_Metrics(t *testing.T) {
 			createImageIntegration("http://example.com/1", config.DockerConfigEntry{}, ""),
 			createImageIntegration("http://example.com/2", config.DockerConfigEntry{}, ""),
 		}
-		regStore.UpsertCentralRegistryIntegrations(iis)
+		regStore.UpsertCentralRegistryIntegrations(iis, false)
 		assert.Equal(t, 2.0, testutil.ToFloat64(c))
 
 		// Repeat with same input, gauge should NOT increase.
-		regStore.UpsertCentralRegistryIntegrations(iis)
+		regStore.UpsertCentralRegistryIntegrations(iis, false)
 		assert.Equal(t, 2.0, testutil.ToFloat64(c))
 
 		regStore.DeleteCentralRegistryIntegrations([]string{"http://example.com/1"})


### PR DESCRIPTION
### Description

A race condition was mistakenly disabling delegated scanning (and likely erasing image integrations) when Sensor was reconnecting to Central. The behavior may have starting occurring in https://github.com/stackrox/stackrox/pull/9009.

To fix: the delegated scanning config and image integrations sent from Central are no longer cleared as part of the `registry_store`'s `Cleanup()` method. It seems these store `Cleanup` methods were meant for data derived from k8s informers/listeners, not data sent from Central.

Since the delegated scanning config is always replaced in full, there is no need to clear it.

Image integrations may be deleted via Central while Sensor is disconnected, a new `refresh` flag was added to the `ImageIntegrations MsgToSensor` that will cause Sensor to erase existing integrations before applying the new ones.

To reproduce the race:

- Setup toxiproxy between central/sensor
- Shortened sensor reconnect time

```
k set env deploy/sensor ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL=5s ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL=5s
```
- Set delegated scanning for `ALL`
- Toggled the proxy on/off while tailing logs (removed package name and yyyy/mm/dd to make comparing timestamps easier)

```
$ k logs -f -lapp=sensor | grep -iE "registry store cleared|delegated registry config"

20:35:14.135007 registry_store.go:132: Info: Registry store cleared.
20:35:14.135308 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"

20:35:22.289234 registry_store.go:132: Info: Registry store cleared.
20:35:22.289510 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"

20:35:35.188708 registry_store.go:132: Info: Registry store cleared.
20:35:35.189576 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"

20:35:43.714352 registry_store.go:132: Info: Registry store cleared.
20:35:43.714676 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"

20:35:53.536132 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"
20:35:53.550865 registry_store.go:132: Info: Registry store cleared.    <-- ** CONFIG ERASED **

20:38:47.996902 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"
20:38:48.009796 registry_store.go:132: Info: Registry store cleared.    <-- ** CONFIG ERASED **

20:39:08.611842 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"
20:39:08.626416 registry_store.go:132: Info: Registry store cleared.    <-- ** CONFIG ERASED **

20:39:21.242885 registry_store.go:132: Info: Registry store cleared.
20:39:21.243091 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"
```

- Between attempts would DELETE an active image via `/v1/images` (which triggers a re-scan) and observe where the scan was sent:

```
common/registry: 2025/03/28 21:39:50.102683 registry_store.go:131: Info: Registry store cleared.
common/delegatedregistry: 2025/03/28 21:39:50.102801 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"
common/detector: 2025/03/28 21:41:36.858141 enricher.go:173: Debug: Sending scan to local scanner for image "quay.io/dcaravel/sandbox/main:latest"

common/delegatedregistry: 2025/03/28 21:42:02.981870 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"
common/registry: 2025/03/28 21:42:02.984945 registry_store.go:131: Info: Registry store cleared.
common/detector: 2025/03/28 21:43:23.882587 enricher.go:175: Debug: Sending scan to central for image "quay.io/dcaravel/sandbox/main:latest"
```

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Repeating the same tests as ^^ with the fix in place and observing the scan always being handled via Sensor.

```
common/delegatedregistry: 2025/03/28 22:05:23.210723 delegated_registry_handler.go:99: Info: Upserted delegated registry config: "enabled_for:ALL"
common/delegatedregistry: 2025/03/28 22:05:23.211046 delegated_registry_handler.go:176: Info: Received 12 updated (refresh: true) and 0 deleted image integrations
common/registry: 2025/03/28 22:05:23.217297 registry_store.go:132: Info: Registry store cleared.

common/detector: 2025/03/28 22:06:30.114982 enricher.go:173: Debug: Sending scan to local scanner for image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:65840b94f1745d0474b2475a651ef389dffd14e0e9def0f0816eb87440a264ea"
```

Also tested with fix in Central + no fix in sensor (4.6.3) and vice versa to verify the additional `refresh` field doesn't cause issues on either side of the communication.

Lastly updated an image integration and verified via logs that the 'refresh' flag is not set:

```
common/delegatedregistry: 2025/03/28 22:14:46.387472 delegated_registry_handler.go:176: Info: Received 1 updated (refresh: false) and 0 deleted image integrations
```