### PR TITLE
ROX-28292: Reporting changes for new data model

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/report_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen.go
@@ -5,6 +5,7 @@ import (
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	imageCVEDS "github.com/stackrox/rox/central/cve/image/datastore"
+	imageCVE2DS "github.com/stackrox/rox/central/cve/image/v2/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
@@ -36,6 +37,7 @@ func New(
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
 	imageCVEDatastore imageCVEDS.DataStore,
+	imageCVE2DataStore imageCVE2DS.DataStore,
 	schema *graphql.Schema,
 ) ReportGenerator {
 	return newReportGeneratorImpl(
@@ -49,6 +51,7 @@ func New(
 		clusterDatastore,
 		namespaceDatastore,
 		imageCVEDatastore,
+		imageCVE2DataStore,
 		schema,
 	)
 }
@@ -64,6 +67,7 @@ func newReportGeneratorImpl(
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
 	imageCVEDatastore imageCVEDS.DataStore,
+	imageCVE2Datastore imageCVE2DS.DataStore,
 	schema *graphql.Schema,
 ) *reportGeneratorImpl {
 	return &reportGeneratorImpl{
@@ -75,6 +79,7 @@ func newReportGeneratorImpl(
 		clusterDatastore:        clusterDatastore,
 		namespaceDatastore:      namespaceDatastore,
 		imageCVEDatastore:       imageCVEDatastore,
+		imageCVE2Datastore:      imageCVE2Datastore,
 		blobStore:               blobStore,
 		db:                      db,
 		Schema:                  schema,

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_bench_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_bench_test.go
@@ -93,7 +93,8 @@ func (bts *ReportGeneratorBenchmarkTestSuite) setupTestSuite() {
 	bts.mockCtrl = gomock.NewController(bts.b)
 	bts.testDB = resolvers.SetupTestPostgresConn(bts.b)
 
-	imageDataStore := resolvers.CreateTestImageDatastore(bts.b, bts.testDB, bts.mockCtrl)
+	imageDataStore := resolvers.CreateTestImageV2Datastore(bts.b, bts.testDB, bts.mockCtrl)
+	imageCVE2Datastore := resolvers.CreateTestImageCVEV2Datastore(bts.b, bts.testDB)
 	imageCVEDatastore := resolvers.CreateTestImageCVEDatastore(bts.b, bts.testDB)
 	bts.resolver, bts.schema = resolvers.SetupTestResolver(bts.b,
 		imageDataStore,
@@ -116,7 +117,7 @@ func (bts *ReportGeneratorBenchmarkTestSuite) setupTestSuite() {
 
 	bts.reportGenerator = newReportGeneratorImpl(bts.testDB, nil, bts.resolver.DeploymentDataStore,
 		bts.watchedImageDatastore, bts.collectionQueryResolver, nil, nil, bts.clusterDatastore,
-		bts.namespaceDatastore, imageCVEDatastore, bts.schema)
+		bts.namespaceDatastore, imageCVEDatastore, imageCVE2Datastore, bts.schema)
 }
 
 func (bts *ReportGeneratorBenchmarkTestSuite) upsertManyImages(images []*storage.Image) {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
@@ -58,12 +58,10 @@ func (s *NewDataModelEnhancedReportingTestSuite) TearDownTest() {
 	s.truncateTable(postgresSchema.ImageComponentV2TableName)
 	s.truncateTable(postgresSchema.ImageCvesV2TableName)
 	s.truncateTable(postgresSchema.CollectionsTableName)
-	// os.Setenv("ROX_FLATTEN_CVE_DATA", "false")
 }
 
 func (s *NewDataModelEnhancedReportingTestSuite) SetupSuite() {
-
-	// os.Setenv("ROX_FLATTEN_CVE_DATA", "true")
+	// TODO ROX-28898:enable feature flag by default to run the unit tests
 	if !features.FlattenCVEData.Enabled() {
 		s.T().Skip()
 	}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_new_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_new_data_model_test.go
@@ -1,0 +1,239 @@
+//go:build sql_integration
+
+package reportgenerator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	blobDS "github.com/stackrox/rox/central/blob/datastore"
+	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	"github.com/stackrox/rox/central/graphql/resolvers"
+	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
+	namespaceDSMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	collectionSearch "github.com/stackrox/rox/central/resourcecollection/datastore/search"
+	collectionPostgres "github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres"
+	imagesView "github.com/stackrox/rox/central/views/images"
+	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	postgresSchema "github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	cluster1name   = "cluster1name"
+	cluster2name   = "cluster2name"
+	container1name = "container1name"
+	container2name = "container2name"
+	dep1name       = "dep1name"
+	dep2name       = "dep2name"
+	dep3name       = "dep3name"
+	namespace1name = "namespace1name"
+	namespace2name = "namespace2name"
+)
+
+type vulnReportDataNewDataModel struct {
+	deploymentNames []string
+	imageNames      []string
+	componentNames  []string
+	cveNames        []string
+	cvss            []float64
+}
+
+func TestVulnReportingNewDataModel(t *testing.T) {
+	suite.Run(t, new(NewDataModelEnhancedReportingTestSuite))
+}
+
+type NewDataModelEnhancedReportingTestSuite struct {
+	suite.Suite
+
+	ctx                   context.Context
+	testDB                *pgtest.TestPostgres
+	watchedImageDatastore watchedImageDS.DataStore
+	clusterDatastore      *clusterDSMocks.MockDataStore
+	namespaceDatastore    *namespaceDSMocks.MockDataStore
+	reportGenerator       *reportGeneratorImpl
+}
+
+func (s *NewDataModelEnhancedReportingTestSuite) TearDownTest() {
+	s.truncateTable(postgresSchema.DeploymentsTableName)
+	s.truncateTable(postgresSchema.ImagesTableName)
+	s.truncateTable(postgresSchema.ImageComponentV2TableName)
+	s.truncateTable(postgresSchema.ImageCvesV2TableName)
+	s.truncateTable(postgresSchema.CollectionsTableName)
+	os.Setenv("ROX_FLATTEN_CVE_DATA", "false")
+}
+
+func (s *NewDataModelEnhancedReportingTestSuite) SetupSuite() {
+
+	os.Setenv("ROX_FLATTEN_CVE_DATA", "true")
+	if !features.FlattenCVEData.Enabled() {
+		s.T().Skip()
+	}
+
+	s.ctx = loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
+	mockCtrl := gomock.NewController(s.T())
+	s.testDB = pgtest.ForT(s.T())
+
+	//set up tables
+	imageDataStore := resolvers.CreateTestImageV2Datastore(s.T(), s.testDB, mockCtrl)
+	s.watchedImageDatastore = watchedImageDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	resolver, schema := resolvers.SetupTestResolver(s.T(),
+		imagesView.NewImageView(s.testDB.DB),
+		imageDataStore,
+		resolvers.CreateTestImageComponentV2Datastore(s.T(), s.testDB, mockCtrl),
+		resolvers.CreateTestImageCVEV2Datastore(s.T(), s.testDB),
+		resolvers.CreateTestDeploymentDatastore(s.T(), s.testDB, mockCtrl, imageDataStore),
+	)
+	collectionStore := collectionPostgres.CreateTableAndNewStore(s.ctx, s.testDB.DB, s.testDB.GetGormDB(s.T()))
+	_, collectionQueryResolver, err := collectionDS.New(collectionStore, collectionSearch.New(collectionStore))
+	s.NoError(err)
+	s.clusterDatastore = clusterDSMocks.NewMockDataStore(mockCtrl)
+	s.namespaceDatastore = namespaceDSMocks.NewMockDataStore(mockCtrl)
+
+	// Add Test Data to DataStores
+	clusters := []*storage.Cluster{
+		{Id: uuid.NewV4().String(), Name: "c1"},
+		{Id: uuid.NewV4().String(), Name: "c2"},
+	}
+
+	namespaces := testNamespaces(clusters, 2)
+	deployments, images := testDeploymentsWithImages(namespaces, 1)
+	//insert deployments in deployment table
+	for _, dep := range deployments {
+		err := resolver.DeploymentDataStore.UpsertDeployment(s.ctx, dep)
+		s.NoError(err)
+	}
+	//upsert deployed image in image table
+	for _, image := range images {
+		err := resolver.ImageDataStore.UpsertImage(s.ctx, image)
+		s.NoError(err)
+	}
+
+	//upsert watched images
+	watchedImages := testWatchedImages(2)
+	for _, image := range watchedImages {
+		err := resolver.ImageDataStore.UpsertImage(s.ctx, image)
+		s.NoError(err)
+	}
+	s.upsertManyWatchedImages(watchedImages)
+
+	s.clusterDatastore.EXPECT().GetClusters(gomock.Any()).
+		Return(clusters, nil).AnyTimes()
+
+	s.namespaceDatastore.EXPECT().GetAllNamespaces(gomock.Any()).
+		Return(namespaces, nil).AnyTimes()
+
+	blobStore := blobDS.NewTestDatastore(s.T(), s.testDB.DB)
+
+	s.reportGenerator = newReportGeneratorImpl(s.testDB, nil, resolver.DeploymentDataStore,
+		s.watchedImageDatastore, collectionQueryResolver, nil, blobStore, s.clusterDatastore,
+		s.namespaceDatastore, resolver.ImageCVEDataStore, resolver.ImageCVEV2DataStore, schema)
+
+	for _, img := range images {
+		for _, component := range img.GetScan().GetComponents() {
+			for _, vuln := range component.GetVulns() {
+				cve, _, err := resolver.ImageCVEV2DataStore.Get(s.ctx, vuln.GetCve())
+				fmt.Printf("cve is %s err is %s", cve, err)
+			}
+		}
+	}
+}
+func (s *NewDataModelEnhancedReportingTestSuite) upsertManyWatchedImages(images []*storage.Image) {
+	for _, img := range images {
+		err := s.watchedImageDatastore.UpsertWatchedImage(s.ctx, img.Name.FullName)
+		s.NoError(err)
+	}
+}
+
+func (s *NewDataModelEnhancedReportingTestSuite) truncateTable(name string) {
+	sql := fmt.Sprintf("TRUNCATE %s CASCADE", name)
+	_, err := s.testDB.Exec(s.ctx, sql)
+	s.NoError(err)
+}
+
+func (s *NewDataModelEnhancedReportingTestSuite) TestGetReportData() {
+
+	testCases := []struct {
+		name       string
+		collection *storage.ResourceCollection
+		fixability storage.VulnerabilityReportFilters_Fixability
+		severities []storage.VulnerabilitySeverity
+		imageTypes []storage.VulnerabilityReportFilters_ImageType
+		scopeRules []*storage.SimpleAccessScope_Rules
+		expected   *vulnReportDataNewDataModel
+	}{
+		{
+			name:       "Include all deployments; CVEs with both fixabilities and all severities; Nil scope rules",
+			collection: testCollection("col1", "", "", ""),
+			fixability: storage.VulnerabilityReportFilters_BOTH,
+			severities: allSeverities(),
+			imageTypes: []storage.VulnerabilityReportFilters_ImageType{storage.VulnerabilityReportFilters_DEPLOYED},
+			scopeRules: nil,
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			reportSnap := testReportSnapshot(tc.collection.GetId(), tc.fixability, tc.severities, tc.imageTypes, tc.scopeRules)
+			// Test get data using SQF
+			reportData, err := s.reportGenerator.getReportDataSQF(reportSnap, tc.collection, time.Time{})
+			fmt.Sprintf("error is %s", err)
+			s.NoError(err)
+			collected := collectVulnReportDataSQFNewDataModel(reportData.CVEResponses)
+			s.ElementsMatch(tc.expected.deploymentNames, collected.deploymentNames)
+			s.ElementsMatch(tc.expected.imageNames, collected.imageNames)
+			s.ElementsMatch(tc.expected.componentNames, collected.componentNames)
+			s.ElementsMatch(tc.expected.cveNames, collected.cveNames)
+			s.Equal(len(tc.expected.cveNames), reportData.NumDeployedImageResults+reportData.NumWatchedImageResults)
+			s.Equal(len(tc.expected.cveNames), len(collected.cvss))
+		})
+	}
+
+}
+
+func collectVulnReportDataSQFNewDataModel(cveResponses []*ImageCVEQueryResponse) *vulnReportDataNewDataModel {
+	deploymentNames := set.NewStringSet()
+	imageNames := set.NewStringSet()
+	componentNames := set.NewStringSet()
+	cveNames := make([]string, 0)
+	cvss := make([]float64, 0)
+
+	for _, res := range cveResponses {
+		if res.GetDeployment() != "" {
+			deploymentNames.Add(res.GetDeployment())
+		}
+		imageNames.Add(res.GetImage())
+		componentNames.Add(res.GetComponent())
+		cveNames = append(cveNames, res.GetCVE())
+		cvss = append(cvss, res.GetCVSS())
+	}
+	return &vulnReportDataNewDataModel{
+		deploymentNames: deploymentNames.AsSlice(),
+		imageNames:      imageNames.AsSlice(),
+		componentNames:  componentNames.AsSlice(),
+		cveNames:        cveNames,
+		cvss:            cvss,
+	}
+}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_test.go
@@ -90,7 +90,7 @@ func (s *EnhancedReportingTestSuite) SetupSuite() {
 	s.blobStore = blobDS.NewTestDatastore(s.T(), s.testDB.DB)
 	s.reportGenerator = newReportGeneratorImpl(s.testDB, nil, s.resolver.DeploymentDataStore,
 		s.watchedImageDatastore, s.collectionQueryResolver, nil, s.blobStore, s.clusterDatastore,
-		s.namespaceDatastore, imageCVEDatastore, s.schema)
+		s.namespaceDatastore, imageCVEDatastore, s.resolver.ImageCVEV2DataStore, s.schema)
 }
 
 func (s *EnhancedReportingTestSuite) TearDownTest() {

--- a/central/reports/scheduler/v2/reportgenerator/singleton.go
+++ b/central/reports/scheduler/v2/reportgenerator/singleton.go
@@ -5,6 +5,7 @@ import (
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	imageCVEDS "github.com/stackrox/rox/central/cve/image/datastore"
+	imageCVE2DS "github.com/stackrox/rox/central/cve/image/v2/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/graphql/resolvers"
@@ -36,6 +37,7 @@ func initialize() {
 		clusterDS.Singleton(),
 		namespaceDS.Singleton(),
 		imageCVEDS.Singleton(),
+		imageCVE2DS.Singleton(),
 		schema,
 	)
 }


### PR DESCRIPTION
This  PR adds reporting change  for the new data model. report regenerator is modified to use new data store and schema when flatten data model feature flag is used
[RHACS_Vulnerability_Report_Test_03_April_2025.csv](https://github.com/user-attachments/files/19594099/RHACS_Vulnerability_Report_Test_03_April_2025.csv)

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality
This PR is tested manually and unit tests are added 
Manual Testing Steps:
1. export ROX_FLATTEN_CVE_DATA=true
2. export MAIN_IMAGE_TAG=4.8.x-361-g9908d8062b
3. ./deploy/k8s/deploy.sh 
4.  Create vuln report config and download report


#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!

## Summary by Sourcery

Modify reporting generator to support a new data model for vulnerability reporting when the flatten CVE data feature flag is enabled

New Features:
- Add support for a new data model in vulnerability reporting using a feature flag

Enhancements:
- Introduce a flexible schema selection mechanism based on feature flag
- Create an interface to support both old and new CVE data models
- Update report generation logic to work with the new data model

Tests:
- Add integration tests for the new data model reporting
- Add benchmark tests for the new data model reporting
- Modify existing test suites to support the new data model