### PR TITLE
ROX-26663: CI fix - retry delegated scan on 502 Bad Gateway

### DIFF
--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -912,6 +912,13 @@ func (ts *DelegatedScanningSuite) scanWithRetries(ctx context.Context, service v
 		// ex:
 		// - no connection to "a21b168a-280e-40d1-a175-e84d14ed8232"
 		"no connection to",
+
+		// A registry having gateway issues (Quay.io in particular) may return a 502 (Bad Gateway)
+		// message along with some HTML, retry when this happens.
+		//
+		// ex:
+		// - http: non-successful response (status=502 body="<!doctype html>...<HTML HERE>...")
+		"non-successful response (status=502",
 	}
 
 	retryFunc := func() error {


### PR DESCRIPTION
### Description

Adds a retry when 502 (Bad Gateway) is returned from quay in the delegated scanning e2e 'ad hoc' tests.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI