### PR TITLE
fix(ci): allow check collector/scanner failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -296,6 +296,7 @@ jobs:
         echo "collector-version=$(make --quiet --no-print-directory collector-tag)" >> "${GITHUB_OUTPUT}"
 
     - name: Check image exists
+      continue-on-error: true
       uses: stackrox/actions/release/wait-for-image@v1
       with:
         token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
@@ -320,6 +321,7 @@ jobs:
         echo "scanner-version=$(make --quiet --no-print-directory scanner-tag)" >> "${GITHUB_OUTPUT}"
 
     - name: Check image exists
+      continue-on-error: true
       uses: stackrox/actions/release/wait-for-image@v1
       with:
         token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}


### PR DESCRIPTION
### Description

Our `Build / check-collector-images-exist` and `Build / check-scanner-images-exist` cause the release workflows to fail if they fail. See previous runs from this action for examples: https://github.com/stackrox/stackrox/actions/runs/14172544638

I propose we use `continue-on-error` for these jobs, which I _think_ will give us the ability to continue on with the release pipeline, while indicating failures in PRs.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

N/A

#### How I validated my change

I haven't yet.
