### PR TITLE
ROX-28879: Update ScannerV2&Collector Konflux image checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -329,8 +329,6 @@ jobs:
   build-and-push-main:
     runs-on: ubuntu-latest
     needs:
-      - check-collector-images-exist
-      - check-scanner-images-exist
       - define-job-matrix
       - pre-build-ui
       - pre-build-cli

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -279,53 +279,6 @@ jobs:
           path: |
             image/rhel/docs
 
-  check-collector-images-exist:
-    # This job ensures that COLLECTOR_VERSION cannot be updated to a version for which
-    # the image was not successfully built on Konflux.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tag_suffix: ["-fast"]
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-
-    - name: Get COLLECTOR_VERSION
-      id: collector-version
-      run: |
-        echo "collector-version=$(make --quiet --no-print-directory collector-tag)" >> "${GITHUB_OUTPUT}"
-
-    - name: Check image exists
-      uses: stackrox/actions/release/wait-for-image@v1
-      with:
-        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-        image: rhacs-eng/collector:${{ steps.collector-version.outputs.collector-version }}${{ matrix.tag_suffix }}
-        limit: 300
-
-  check-scanner-images-exist:
-    # This job ensures that SCANNER_VERSION cannot be updated to a version for which
-    # the image was not successfully built on Konflux.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image: ["scanner", "scanner-slim", "scanner-db", "scanner-db-slim"]
-        tag_suffix: ["-fast"]
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-
-    - name: Get SCANNER_VERSION
-      id: scanner-version
-      run: |
-        echo "scanner-version=$(make --quiet --no-print-directory scanner-tag)" >> "${GITHUB_OUTPUT}"
-
-    - name: Check image exists
-      uses: stackrox/actions/release/wait-for-image@v1
-      with:
-        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-        image: rhacs-eng/${{ matrix.image }}:${{ steps.scanner-version.outputs.scanner-version }}${{ matrix.tag_suffix }}
-        limit: 300
-
   build-and-push-main:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag_suffix: ["", "-fast"]
+        tag_suffix: ["-fast"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -309,7 +309,7 @@ jobs:
     strategy:
       matrix:
         image: ["scanner", "scanner-slim", "scanner-db", "scanner-db-slim"]
-        tag_suffix: ["", "-fast"]
+        tag_suffix: ["-fast"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -162,12 +162,13 @@ jobs:
       run: make golangci-lint-cache-status
 
   check-collector-images-exist:
-    # This job ensures that COLLECTOR_VERSION cannot be updated to a version for which
-    # the image was not successfully built on Konflux.
+    # This job ensures that COLLECTOR_VERSION cannot be updated to a version for which the image was not successfully
+    # built on Konflux (tag_suffix: "-fast"). It also verifies that GHA-built image is there (tag_suffix: "") so that
+    # the failure also happens in this job.
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag_suffix: ["-fast"]
+        tag_suffix: ["", "-fast"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -185,13 +186,14 @@ jobs:
           limit: 300
 
   check-scanner-images-exist:
-    # This job ensures that SCANNER_VERSION cannot be updated to a version for which
-    # the image was not successfully built on Konflux.
+    # This job ensures that SCANNER_VERSION cannot be updated to a version for which the image was not successfully
+    # built on Konflux (tag_suffix: "-fast"). It also verifies that GHA-built image is there (tag_suffix: "") so that
+    # the failure also happens in this job.
     runs-on: ubuntu-latest
     strategy:
       matrix:
         image: ["scanner", "scanner-slim", "scanner-db", "scanner-db-slim"]
-        tag_suffix: ["-fast"]
+        tag_suffix: ["", "-fast"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -161,6 +161,53 @@ jobs:
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status
 
+  check-collector-images-exist:
+    # This job ensures that COLLECTOR_VERSION cannot be updated to a version for which
+    # the image was not successfully built on Konflux.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tag_suffix: ["-fast"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Get COLLECTOR_VERSION
+        id: collector-version
+        run: |
+          echo "collector-version=$(make --quiet --no-print-directory collector-tag)" >> "${GITHUB_OUTPUT}"
+
+      - name: Check image exists
+        uses: stackrox/actions/release/wait-for-image@v1
+        with:
+          token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+          image: rhacs-eng/collector:${{ steps.collector-version.outputs.collector-version }}${{ matrix.tag_suffix }}
+          limit: 300
+
+  check-scanner-images-exist:
+    # This job ensures that SCANNER_VERSION cannot be updated to a version for which
+    # the image was not successfully built on Konflux.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["scanner", "scanner-slim", "scanner-db", "scanner-db-slim"]
+        tag_suffix: ["-fast"]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Get SCANNER_VERSION
+        id: scanner-version
+        run: |
+          echo "scanner-version=$(make --quiet --no-print-directory scanner-tag)" >> "${GITHUB_OUTPUT}"
+
+      - name: Check image exists
+        uses: stackrox/actions/release/wait-for-image@v1
+        with:
+          token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+          image: rhacs-eng/${{ matrix.image }}:${{ steps.scanner-version.outputs.scanner-version }}${{ matrix.tag_suffix }}
+          limit: 300
+
   slack-on-style-failure:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -162,38 +162,39 @@ jobs:
       run: make golangci-lint-cache-status
 
   check-collector-and-scanner-images-exist:
-    # This job ensures that COLLECTOR_VERSION or SCANNER_VERSION file cannot be updated to a version for which the image
-    # was not successfully built on Konflux (tag_suffix: "-fast"). It also verifies that GHA-built image is there
-    # (tag_suffix: "") so that the failure also happens in this job.
+    # This job ensures that COLLECTOR_VERSION or SCANNER_VERSION files cannot be updated to a version for which the
+    # image was not successfully built on Konflux (suffix "-fast"). It also verifies that GHA-built image is there (no
+    # suffix) so that the failure also happens in this job.
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag_suffix: ["", "-fast"]
-        include:
-          - image: collector
-            target: collector-tag
-          - image: scanner
-            target: scanner-tag
-          - image: scanner-slim
-            target: scanner-tag
-          - image: scanner-db
-            target: scanner-tag
-          - image: scanner-db-slim
-            target: scanner-tag
+        image: ["collector", "scanner", "scanner-slim", "scanner-db", "scanner-db-slim"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Get image tag from COLLECTOR|SCANNER_VERSION
+      - name: Get image tag from COLLECTOR|SCANNER_VERSION file
         id: image-tag
         run: |
-          echo "image-tag=$(make --quiet --no-print-directory ${{ matrix.target }})" >> "${GITHUB_OUTPUT}"
+          if [[ "${{ matrix.image }}" == "collector" ]]; then
+            makefile_target="collector-tag"
+          else
+            makefile_target="scanner-tag"
+          fi
+          echo "image-tag=$(make --quiet --no-print-directory "${makefile_target}")" >> "${GITHUB_OUTPUT}"
 
-      - name: Check image exists
+      - name: Check GHA-built image exists
         uses: stackrox/actions/release/wait-for-image@v1
         with:
           token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-          image: rhacs-eng/${{ matrix.image }}:${{ steps.image-tag.outputs.image-tag }}${{ matrix.tag_suffix }}
+          image: rhacs-eng/${{ matrix.image }}:${{ steps.image-tag.outputs.image-tag }}
+          limit: 300
+
+      - name: Check Konflux-built image exists
+        uses: stackrox/actions/release/wait-for-image@v1
+        with:
+          token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+          image: rhacs-eng/${{ matrix.image }}:${{ steps.image-tag.outputs.image-tag }}-fast
           limit: 300
 
   slack-on-style-failure:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -161,53 +161,39 @@ jobs:
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status
 
-  check-collector-images-exist:
-    # This job ensures that COLLECTOR_VERSION cannot be updated to a version for which the image was not successfully
-    # built on Konflux (tag_suffix: "-fast"). It also verifies that GHA-built image is there (tag_suffix: "") so that
-    # the failure also happens in this job.
+  check-collector-and-scanner-images-exist:
+    # This job ensures that COLLECTOR_VERSION or SCANNER_VERSION file cannot be updated to a version for which the image
+    # was not successfully built on Konflux (tag_suffix: "-fast"). It also verifies that GHA-built image is there
+    # (tag_suffix: "") so that the failure also happens in this job.
     runs-on: ubuntu-latest
     strategy:
       matrix:
         tag_suffix: ["", "-fast"]
+        include:
+          - image: collector
+            target: collector-tag
+          - image: scanner
+            target: scanner-tag
+          - image: scanner-slim
+            target: scanner-tag
+          - image: scanner-db
+            target: scanner-tag
+          - image: scanner-db-slim
+            target: scanner-tag
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Get COLLECTOR_VERSION
-        id: collector-version
+      - name: Get image tag from COLLECTOR|SCANNER_VERSION
+        id: image-tag
         run: |
-          echo "collector-version=$(make --quiet --no-print-directory collector-tag)" >> "${GITHUB_OUTPUT}"
+          echo "image-tag=$(make --quiet --no-print-directory ${{ matrix.target }})" >> "${GITHUB_OUTPUT}"
 
       - name: Check image exists
         uses: stackrox/actions/release/wait-for-image@v1
         with:
           token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-          image: rhacs-eng/collector:${{ steps.collector-version.outputs.collector-version }}${{ matrix.tag_suffix }}
-          limit: 300
-
-  check-scanner-images-exist:
-    # This job ensures that SCANNER_VERSION cannot be updated to a version for which the image was not successfully
-    # built on Konflux (tag_suffix: "-fast"). It also verifies that GHA-built image is there (tag_suffix: "") so that
-    # the failure also happens in this job.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image: ["scanner", "scanner-slim", "scanner-db", "scanner-db-slim"]
-        tag_suffix: ["", "-fast"]
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Get SCANNER_VERSION
-        id: scanner-version
-        run: |
-          echo "scanner-version=$(make --quiet --no-print-directory scanner-tag)" >> "${GITHUB_OUTPUT}"
-
-      - name: Check image exists
-        uses: stackrox/actions/release/wait-for-image@v1
-        with:
-          token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-          image: rhacs-eng/${{ matrix.image }}:${{ steps.scanner-version.outputs.scanner-version }}${{ matrix.tag_suffix }}
+          image: rhacs-eng/${{ matrix.image }}:${{ steps.image-tag.outputs.image-tag }}${{ matrix.tag_suffix }}
           limit: 300
 
   slack-on-style-failure:
@@ -227,8 +213,7 @@ jobs:
       - misc-checks
       - style-check
       - golangci-lint
-      - check-collector-images-exist
-      - check-scanner-images-exist
+      - check-collector-and-scanner-images-exist
     permissions:
       actions: read
     steps:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -225,6 +225,8 @@ jobs:
       - misc-checks
       - style-check
       - golangci-lint
+      - check-collector-images-exist
+      - check-scanner-images-exist
     permissions:
       actions: read
     steps:


### PR DESCRIPTION
### Description

This follows up on https://github.com/stackrox/stackrox/pull/13502 in the light that some parts of the approach block the release as evidenced in <https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1743438459477049?thread_ts=1742820121.886399&cid=C05TS9N0S7L>.
There's also a discussion in https://github.com/stackrox/stackrox/pull/14825/files#r2022395918 (for the context).

This change can be reviewed by commits which I provided with descriptions.

The future plans are:
- Change branch protection in `master` to respect the new place of the jobs.
- Backport this to 4.6 and 4.7.
- Make the jobs required in release-* branches so that there won't be a similar situation when someone could update pointers without checking the builds.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No change.

#### How I validated my change

Just looking at CI.
