### PR TITLE
test: Add "FAILED:" marker in test output

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -293,6 +293,7 @@ teardown() {
 
     if [[ "${BATS_TEST_COMPLETED:-}" != "1" ]]; then
         # Previous test failed.
+        echo "FAILED: Test \"$BATS_TEST_DESCRIPTION\" failed. Look above for the test steps that have led to this failure."
         if [[ "${ABORT_ON_FAILURE:-}" == "true" ]]; then
             TEST_SUITE_ABORTED="true"
             echo "Aborting due to test failure." >&3


### PR DESCRIPTION
### Description

The scanner-v4-install tests contain a log of output which is due to the teardown cleanup between test steps (including collecting service logs, etc.).

So, currently when analysing test failures I usually look for the "not ok" message from Bats and then right above that there is usually a very long "tear-down" block. I scroll up until I reach the beginning of this block and there is the actual cause for the test failure to be found.

It would be much nicer if one could just look for a simple string, e.g. `FAILED:` and this would be exactly the place where something went sideways.

This PR does that, it adds this marker log line which allows for quick identifying of the problematic test steps.

I decided to use `FAILED:`, because this is also what the Go unit tests output on specific test case failures.

In order to make the included remark "look above for the test steps that have led to this failure" less of a lie I also added a simple waiting mechanism which should make sure to sequence the spawned output post processors, thereby reducing the occurrence of interleaved test step logs.

