### PR TITLE
test: Fix errexit logic by spawning test functions in a sub shell

### DIFF
--- a/scripts/ci/jobs/check-generated.sh
+++ b/scripts/ci/jobs/check-generated.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd)"
 source "$ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail
+export SHELLOPTS
 
 go mod tidy
 

--- a/scripts/ci/jobs/check-generated.sh
+++ b/scripts/ci/jobs/check-generated.sh
@@ -34,7 +34,6 @@ function generated_files-are-up-to-date() {
     fi
 }
 export -f generated_files-are-up-to-date
-
 bash -c generated_files-are-up-to-date || {
     save_junit_failure "Check_Generated_Files" \
         "Found new untracked files after running \`make proto-generated-srcs\` and \`make go-generated-srcs\`" \
@@ -57,7 +56,6 @@ function check-operator-generated-files-up-to-date() {
     git diff --exit-code HEAD
 }
 export -f check-operator-generated-files-up-to-date
-
 bash -c check-operator-generated-files-up-to-date || {
     save_junit_failure "Check_Operator_Generated_Files" \
         "Operator generated files are not up to date" \
@@ -74,7 +72,6 @@ function check-config-controller-generated-files-up-to-date() {
     git diff --exit-code HEAD
 }
 export -f check-config-controller-generated-files-up-to-date
-
 bash -c check-config-controller-generated-files-up-to-date || {
     save_junit_failure "Check_Config_Controller_Generated_Files" \
         "Config controller generated files are not up to date" \
@@ -93,7 +90,6 @@ function check-containerignore-is-in-sync() {
     > diff.txt
 }
 export -f check-containerignore-is-in-sync
-
 bash -c check-containerignore-is-in-sync || {
     save_junit_failure "Check_Containerignore_File" \
         ".containerignore file is not in sync with .dockerignore" \
@@ -114,7 +110,6 @@ function check-shellcheck-failing-list() {
     fi
 }
 export -f check-shellcheck-failing-list
-
 bash -c check-shellcheck-failing-list || {
     save_junit_failure "Check_Shellcheck_Skip_List" \
         "Check if a script that is listed in scripts/style/shellcheck_skip.txt is now free from shellcheck errors" \

--- a/scripts/ci/jobs/check-generated.sh
+++ b/scripts/ci/jobs/check-generated.sh
@@ -33,7 +33,9 @@ function generated_files-are-up-to-date() {
         return 1
     fi
 }
-generated_files-are-up-to-date || {
+export -f generated_files-are-up-to-date
+
+bash -c generated_files-are-up-to-date || {
     save_junit_failure "Check_Generated_Files" \
         "Found new untracked files after running \`make proto-generated-srcs\` and \`make go-generated-srcs\`" \
         "$(cat /tmp/untracked-new)"
@@ -54,7 +56,9 @@ function check-operator-generated-files-up-to-date() {
     echo 'needs to change due to formatting changes in the generated files.'
     git diff --exit-code HEAD
 }
-check-operator-generated-files-up-to-date || {
+export -f check-operator-generated-files-up-to-date
+
+bash -c check-operator-generated-files-up-to-date || {
     save_junit_failure "Check_Operator_Generated_Files" \
         "Operator generated files are not up to date" \
         "$(git diff HEAD || true)"
@@ -69,7 +73,9 @@ function check-config-controller-generated-files-up-to-date() {
     echo 'Checking for diffs after making config-controller-gen...'
     git diff --exit-code HEAD
 }
-check-config-controller-generated-files-up-to-date || {
+export -f check-config-controller-generated-files-up-to-date
+
+bash -c check-config-controller-generated-files-up-to-date || {
     save_junit_failure "Check_Config_Controller_Generated_Files" \
         "Config controller generated files are not up to date" \
         "$(git diff HEAD || true)"
@@ -86,7 +92,9 @@ function check-containerignore-is-in-sync() {
         <(grep -vF -e '/.git/' -e '/image/' -e '/qa-tests-backend/' .dockerignore) \
     > diff.txt
 }
-check-containerignore-is-in-sync || {
+export -f check-containerignore-is-in-sync
+
+bash -c check-containerignore-is-in-sync || {
     save_junit_failure "Check_Containerignore_File" \
         ".containerignore file is not in sync with .dockerignore" \
         "$(cat diff.txt)"
@@ -105,7 +113,9 @@ function check-shellcheck-failing-list() {
             && git reset --hard HEAD
     fi
 }
-check-shellcheck-failing-list || {
+export -f check-shellcheck-failing-list
+
+bash -c check-shellcheck-failing-list || {
     save_junit_failure "Check_Shellcheck_Skip_List" \
         "Check if a script that is listed in scripts/style/shellcheck_skip.txt is now free from shellcheck errors" \
         "$(git diff HEAD || true)"


### PR DESCRIPTION
Fix errexit logic by spawning test functions in a sub shell which has `set -e` activated.

### Description

In the `check-generated.sh` script we use the following pattern:

```
set -euo pipefail

foo() {
    echo "doing something"
    false # Failure
    echo "continuing as if everything is ok"
}
foo || echo "error handling..."
```

This won't work, it will print

```
doing something
continuing as if everything is ok
```

This is so because the `... || error handling` construct causes the `set -e` to be deactivated in the shell function. In this PR I am transforming this code to

```
set -euo pipefail
export SHELLOPTS

foo() {
    echo "doing something"
    false # Failure
    echo "continuing as if everything is ok"
}
export -f foo
bash -c foo || echo "error handling..."
```

This works as expected and will allow us to do the error handling at the top level and the early error return still works as expected in the sub shell.

