### PR TITLE
ROX-28320: add IDs option to context scope

### DIFF
--- a/central/graphql/resolvers/image_components_v2_postgres_test.go
+++ b/central/graphql/resolvers/image_components_v2_postgres_test.go
@@ -204,8 +204,7 @@ func (s *GraphQLImageComponentV2TestSuite) TestImageComponentsScoped() {
 }
 
 func (s *GraphQLImageComponentV2TestSuite) TestImageComponentsScopeTree() {
-	// TODO(ROX-28320): Data here needs to be grouped by CVE not the ID when getting vulns by image
-	// as is done in the Image Vulnerabilities resolver.
+
 	s.T().Skip()
 
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -153,7 +153,6 @@ func (resolver *imageResolver) TopImageVulnerability(ctx context.Context, args R
 // ImageVulnerabilities returns, as ImageVulnerabilityResolver, the vulnerabilities for the image
 func (resolver *imageResolver) ImageVulnerabilities(ctx context.Context, args PaginatedQuery) ([]ImageVulnerabilityResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "ImageVulnerabilities")
-	// TODO(ROX-28320): Data here needs to be grouped by CVE not the ID as is done in the Image Vulnerabilities resolver.
 	return resolver.root.ImageVulnerabilities(resolver.withImageScopeContext(ctx), args)
 }
 

--- a/pkg/search/scoped/context.go
+++ b/pkg/search/scoped/context.go
@@ -13,6 +13,7 @@ import (
 // Scope hold an id and scope level for scoping searches.
 type Scope struct {
 	ID     string
+	IDs    []string
 	Level  v1.SearchCategory
 	Parent *Scope
 }
@@ -102,8 +103,14 @@ func GetQueryForAllScopes(ctx context.Context) (*v1.Query, error) {
 			return nil, err
 		}
 		idField := schema.ID()
-		conjuncts = append(conjuncts, searchPkg.NewQueryBuilder().
-			AddExactMatches(searchPkg.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
+		if scope.ID != "" {
+			conjuncts = append(conjuncts, searchPkg.NewQueryBuilder().
+				AddExactMatches(searchPkg.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
+		}
+		if scope.IDs != nil {
+			conjuncts = append(conjuncts, searchPkg.NewQueryBuilder().
+				AddExactMatches(searchPkg.FieldLabel(idField.Search.FieldName), scope.IDs...).ProtoQuery())
+		}
 	}
 	return searchPkg.ConjunctionQuery(conjuncts...), nil
 }

--- a/pkg/search/scoped/context.go
+++ b/pkg/search/scoped/context.go
@@ -107,7 +107,7 @@ func GetQueryForAllScopes(ctx context.Context) (*v1.Query, error) {
 			conjuncts = append(conjuncts, searchPkg.NewQueryBuilder().
 				AddExactMatches(searchPkg.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
 		}
-		if scope.IDs != nil {
+		if len(scope.IDs) > 0 {
 			conjuncts = append(conjuncts, searchPkg.NewQueryBuilder().
 				AddExactMatches(searchPkg.FieldLabel(idField.Search.FieldName), scope.IDs...).ProtoQuery())
 		}

--- a/pkg/search/scoped/postgres/searcher.go
+++ b/pkg/search/scoped/postgres/searcher.go
@@ -54,7 +54,7 @@ func scopeQuery(q *v1.Query, scopes []scoped.Scope) (*v1.Query, error) {
 			conjuncts = append(conjuncts, search.NewQueryBuilder().
 				AddExactMatches(search.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
 		}
-		if scope.IDs != nil {
+		if len(scope.IDs) > 0 {
 			conjuncts = append(conjuncts, search.NewQueryBuilder().
 				AddExactMatches(search.FieldLabel(idField.Search.FieldName), scope.IDs...).ProtoQuery())
 		}

--- a/pkg/search/scoped/postgres/searcher.go
+++ b/pkg/search/scoped/postgres/searcher.go
@@ -50,7 +50,14 @@ func scopeQuery(q *v1.Query, scopes []scoped.Scope) (*v1.Query, error) {
 			return q, nil
 		}
 		idField := schema.ID()
-		conjuncts = append(conjuncts, search.NewQueryBuilder().AddExactMatches(search.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
+		if scope.ID != "" {
+			conjuncts = append(conjuncts, search.NewQueryBuilder().
+				AddExactMatches(search.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
+		}
+		if scope.IDs != nil {
+			conjuncts = append(conjuncts, search.NewQueryBuilder().
+				AddExactMatches(search.FieldLabel(idField.Search.FieldName), scope.IDs...).ProtoQuery())
+		}
 	}
 	ret := search.ConjunctionQuery(conjuncts...)
 	ret.Pagination = pagination

--- a/pkg/search/scoped/postgres/searcher_test.go
+++ b/pkg/search/scoped/postgres/searcher_test.go
@@ -40,14 +40,14 @@ func TestScoping(t *testing.T) {
 			Level: v1.SearchCategory_CLUSTERS,
 		},
 		{
-			ID:    "n1",
+			IDs:   []string{"n1", "n2"},
 			Level: v1.SearchCategory_NAMESPACES,
 		},
 	}
 	expected = search.ConjunctionQuery(
 		query,
 		search.NewQueryBuilder().AddExactMatches(search.ClusterID, "c1").ProtoQuery(),
-		search.NewQueryBuilder().AddExactMatches(search.NamespaceID, "n1").ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.NamespaceID, "n1", "n2").ProtoQuery(),
 	)
 	actual, err = scopeQuery(query, scopes)
 	assert.NoError(t, err)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

With the flattened data model we needed to either pass a specific field in the scope OR to pass an array of IDs with the scope.  After looking into it, adjusting the scope to have a way to take an array of IDs seemed far simpler and less intrusive. 

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Updated unit test.  Much further testing will happen further down this PR stack as this is used.