### PR TITLE
ROX-28779: Fix incorrect cluster items in delegated image scanning

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -71,10 +71,11 @@ describe('Delegated Image Scanning', () => {
         cy.get('[aria-label="Select default cluster"] + .pf-v5-c-menu .pf-v5-c-menu__list-item')
             .last()
             .then(($lastCluster) => {
+                // Beware that in local deployment and some CI environments, None is only option.
                 const lastClusterName = $lastCluster.text();
                 cy.log('lastClusterName', lastClusterName);
 
-                $lastCluster.click();
+                cy.wrap($lastCluster).click();
 
                 cy.get('[aria-label="Select default cluster"]').should(
                     'have.text',

--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -57,16 +57,18 @@ describe('Delegated Image Scanning', () => {
         getInputByLabel('Specified registries').should('be.checked');
 
         // None shoudl be value for default cluster
-        cy.get('.cluster-select').should('have.text', 'None').should('have.value', '');
+        cy.get('[aria-label="Select default cluster"]')
+            .should('have.text', 'None')
+            .should('have.value', '');
 
         // choose the first cluster in the list as the default
-        cy.get('.cluster-select').click();
-        cy.get('.cluster-select .pf-v5-c-select__menu .pf-v5-c-select__menu-item').then(
-            ($clusterNames) => {
-                expect($clusterNames.length).to.be.gte(0);
-            }
-        );
-        cy.get('.cluster-select .pf-v5-c-select__menu .pf-v5-c-select__menu-item')
+        cy.get('[aria-label="Select default cluster"]').click();
+        cy.get(
+            '[aria-label="Select default cluster"] + .pf-v5-c-menu .pf-v5-c-menu__list-item'
+        ).then(($clusterNames) => {
+            expect($clusterNames.length).to.be.gte(0);
+        });
+        cy.get('[aria-label="Select default cluster"] + .pf-v5-c-menu .pf-v5-c-menu__list-item')
             .last()
             .then(($lastCluster) => {
                 const lastClusterName = $lastCluster.text();
@@ -74,7 +76,10 @@ describe('Delegated Image Scanning', () => {
 
                 $lastCluster.click();
 
-                cy.get('.cluster-select').should('have.text', lastClusterName);
+                cy.get('[aria-label="Select default cluster"]').should(
+                    'have.text',
+                    lastClusterName
+                );
 
                 // save the configuration
                 saveDelegatedRegistryConfig();

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -37,12 +37,16 @@ function DelegatedRegistriesTable({
         setRowOpen(-1);
     }
 
+    const defaultClusterName =
+        selectedClusterId === ''
+            ? 'None'
+            : (clusters.find(({ id }) => id === selectedClusterId)?.name ?? selectedClusterId);
+    const defaultClusterItem = `Default cluster (${defaultClusterName})`;
+
     const clusterSelectOptions: JSX.Element[] = clusters.map((cluster) => {
-        const optionLabel =
-            cluster.id === selectedClusterId ? `${cluster.name} (default)` : cluster.name;
         return (
             <SelectOption key={cluster.id} value={cluster.id}>
-                <span>{optionLabel}</span>
+                {cluster.name}
             </SelectOption>
         );
     });
@@ -62,9 +66,11 @@ function DelegatedRegistriesTable({
             </Thead>
             <Tbody>
                 {registries.map((registry, rowIndex) => {
-                    const selectedClusterName =
-                        clusters.find((cluster) => registry.clusterId === cluster.id)?.name ??
-                        'None';
+                    const selectedClusterItem =
+                        registry.clusterId === ''
+                            ? defaultClusterItem
+                            : (clusters.find((cluster) => registry.clusterId === cluster.id)
+                                  ?.name ?? registry.clusterId);
 
                     // Even path and clusterId combined is not a unique key.
                     /* eslint-disable react/no-array-index-key */
@@ -82,21 +88,15 @@ function DelegatedRegistriesTable({
                             </Td>
                             <Td dataLabel="Destination cluster (CLI/API only)">
                                 <Select
-                                    className="cluster-select"
-                                    placeholderText={
-                                        <span style={{ position: 'relative', top: '1px' }}>
-                                            None
-                                        </span>
-                                    }
                                     toggleAriaLabel="Select a cluster"
                                     onToggle={() => toggleSelect(rowIndex)}
                                     onSelect={(_, value) => onSelect(rowIndex, value)}
                                     isOpen={openRow === rowIndex}
                                     isDisabled={!isEditing}
-                                    selections={selectedClusterName}
+                                    selections={selectedClusterItem}
                                 >
-                                    <SelectOption key="no-cluster-selected" value="" isPlaceholder>
-                                        <span>None</span>
+                                    <SelectOption key="" value="">
+                                        {defaultClusterItem}
                                     </SelectOption>
                                     <>{clusterSelectOptions}</>
                                 </Select>

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -53,7 +53,6 @@ function DelegatedScanningSettings({
             <Flex>
                 <FlexItem>
                     <Select
-                        className="cluster-select"
                         onOpenChange={setIsOpen}
                         onSelect={onClusterSelect}
                         isOpen={isOpen}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -85,8 +85,8 @@ function DelegateScanningPage() {
     function fetchClusters() {
         fetchDelegatedRegistryClusters()
             .then((clusters) => {
-                const validClusters = clusters.filter((cluster) => cluster.isValid);
-                setDelegatedRegistryClusters(validClusters);
+                // Components are reponsible for lazy filtering of invalid clusters.
+                setDelegatedRegistryClusters(clusters);
                 setHasLoadedClusters(true);
             })
             .catch((error) => {

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/cluster.ts
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/cluster.ts
@@ -1,0 +1,13 @@
+import { DelegatedRegistryCluster } from 'services/DelegatedRegistryConfigService';
+
+/* eslint-disable no-nested-ternary */
+// Caller is responsible to handle special case of empty string.
+export function getClusterName(clusters: DelegatedRegistryCluster[], clusterId: string) {
+    const cluster = clusters.find((cluster) => cluster.id === clusterId);
+    return cluster === undefined
+        ? clusterId
+        : cluster.isValid
+          ? cluster.name
+          : `${cluster.name} (Not available for scanning)`;
+}
+/* eslint-enable no-nested-ternary */


### PR DESCRIPTION
### Description

This is a separate task for incorrect text (which corresponds to small change) that I separated from the original bug which paired it with unclear text (which needs more time in mental slow cooker, and then review).

### Problem

Reported and patiently explained by **David Caravello**

**Destination cluster** list is incorrect:
1. **None** with `value` of empty string, but it corresponds to **Default cluster to delegate to**
2. **cluster (default)** with `value` of cluster id, but it corresponds to an explicit cluster, even if it is default at this moment

### Solution (part 1)

1. **Default cluster (whatever)** with `value` of empty string corresponds to **Default cluster to delegate to** and **whatever** is either:
    * **None** if no default cluster
    * cluster name (or **Not available** if valid clusters does not include id)
2. **whichever** with `value` of cluster id has cluster name independent of whether it is **Default cluster to delegate to** or not

For both, add fallback to render id to accelerate troubleshooting, in case it no longer corresponds to a valid cluster.

### Solution (part 2)

After discussion with **David Caravello** (see comments) made the following changes:
1. Replace filter for `clusters` in page state with lazy filter in `Select` element.
    Purpose: more robust rendering in case cluster id corresponds to a cluster that is not (currently) valid:
    * UNHEALTHY
    * UNINITIALIZED (unlikely)
    * Not configured for delegated scanning
2. Factor out `getClusterName` function.
3. Replace deprecated `Select` element for which `selections` prop referred to the rendered text with `Select` element for which `selected` prop refers to `value` prop.
    Purpose: more robust rendering in case of **None** or **Default cluster** plus cluster id not valid

### Residue

1. Encapsulate `Select` element for **Destination cluster**.
2. In addition to disable **Save** button, display validation error for required **Source registry** field.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed yet

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4701584 - 4701584
        total -104 = 11705367 - 11705471
    * `ls -al build/static/js/*.js | wc`
        files 0 = 179 - 179
6. `npm run start` in ui/apps/platform

#### Manual testing

1. Visit /main/clusters/delegated-image-scanning, click **Edit**, click **All registries**, and then click **Add registry**.

    Before changes, see incorrect **None** in **Destination cluster**
    ![staging_None](https://github.com/user-attachments/assets/f7e0b7c3-8f39-4da9-90d4-48c93c609d3d)

    After changes, see correct **Default cluster (whatever)** in **Destination cluster**
    ![staging_Default_cluster](https://github.com/user-attachments/assets/4ce34978-94e9-45c6-bb50-d89c2e174c30)

2. Select a different cluster, and then click **Save**

    See error because `path` is empty (see **Residue**).
    ![path_error](https://github.com/user-attachments/assets/cd561f73-b3cc-421a-ad87-8c2847001bd1)
