### PR TITLE
ROX-28795: Delete unreachable code in classic compliance

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.js
@@ -12,7 +12,7 @@ import searchContext from 'Containers/searchContext';
 import { entityNounOrdinaryCase } from '../entitiesForCompliance';
 import LinkListWidget from './LinkListWidget';
 
-const ControlRelatedEntitiesList = ({
+const ControlRelatedResourceList = ({
     listEntityType,
     pageEntityType,
     pageEntity,
@@ -127,7 +127,7 @@ const ControlRelatedEntitiesList = ({
     );
 };
 
-ControlRelatedEntitiesList.propTypes = {
+ControlRelatedResourceList.propTypes = {
     listEntityType: PropTypes.string.isRequired,
     pageEntityType: PropTypes.string.isRequired,
     pageEntity: PropTypes.shape({
@@ -139,10 +139,10 @@ ControlRelatedEntitiesList.propTypes = {
     className: PropTypes.string,
 };
 
-ControlRelatedEntitiesList.defaultProps = {
+ControlRelatedResourceList.defaultProps = {
     pageEntity: null,
     limit: 10,
     className: '',
 };
 
-export default ControlRelatedEntitiesList;
+export default ControlRelatedResourceList;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.js
@@ -18,7 +18,7 @@ import searchContext from 'Containers/searchContext';
 
 import { entityNounSentenceCaseSingular } from '../entitiesForCompliance';
 
-const ResourceCount = ({ entityType, relatedToResourceType, relatedToResource, count }) => {
+const ResourceCount = ({ entityType, relatedToResourceType, relatedToResource }) => {
     const searchParam = useContext(searchContext);
     const match = useWorkflowMatch();
     const location = useLocation();
@@ -64,13 +64,6 @@ const ResourceCount = ({ entityType, relatedToResourceType, relatedToResource, c
     const headerText = `${entityNounSentenceCaseSingular[entityType]} Count`;
     const url = getUrl();
 
-    if (count || count === 0) {
-        return (
-            <Widget header={headerText} bodyClassName="p-2">
-                <CountWidget title={headerText} count={count} linkUrl={url} />;
-            </Widget>
-        );
-    }
     return (
         <Query query={QUERY} variables={variables}>
             {({ loading, data }) => {
@@ -91,20 +84,17 @@ const ResourceCount = ({ entityType, relatedToResourceType, relatedToResource, c
 };
 
 ResourceCount.propTypes = {
-    entityType: PropTypes.string,
+    entityType: PropTypes.string.isRequired,
     relatedToResourceType: PropTypes.string.isRequired,
     relatedToResource: PropTypes.shape({
         id: PropTypes.string,
         name: PropTypes.string,
         clusterName: PropTypes.string,
     }),
-    count: PropTypes.number,
 };
 
 ResourceCount.defaultProps = {
-    entityType: null,
     relatedToResource: null,
-    count: null,
 };
 
 export default ResourceCount;

--- a/ui/apps/platform/src/queries/image.js
+++ b/ui/apps/platform/src/queries/image.js
@@ -55,15 +55,6 @@ export const IMAGE_NAME = gql`
     }
 `;
 
-export const IMAGE_QUERY = gql`
-    query image($id: ID!) {
-        image(id: $id) {
-            ...imageFields
-        }
-    }
-    ${IMAGE_FRAGMENT}
-`;
-
 export const IMAGES_QUERY = gql`
     query images($query: String, $pagination: Pagination) {
         images(query: $query, pagination: $pagination) {

--- a/ui/apps/platform/src/queries/policy.js
+++ b/ui/apps/platform/src/queries/policy.js
@@ -30,14 +30,7 @@ export const POLICY_FRAGMENT = gql`
         }
     }
 `;
-export const POLICY_QUERY = gql`
-    query policy($id: ID!) {
-        policy(id: $id) {
-            ...policyFields
-        }
-    }
-    ${POLICY_FRAGMENT}
-`;
+
 export const POLICY_NAME = gql`
     query getPolicyName($id: ID!) {
         policy(id: $id) {

--- a/ui/apps/platform/src/queries/role.js
+++ b/ui/apps/platform/src/queries/role.js
@@ -26,17 +26,6 @@ export const K8S_ROLE_FRAGMENT = gql`
         clusterId
     }
 `;
-export const K8S_ROLE_QUERY = gql`
-    query k8sRole($id: ID!) {
-        clusters {
-            id
-            k8sRole(role: $id) {
-                ...k8RoleFields
-            }
-        }
-    }
-    ${K8S_ROLE_FRAGMENT}
-`;
 
 export const ROLE_NAME = gql`
     query k8sRole($id: ID!) {

--- a/ui/apps/platform/src/queries/secret.js
+++ b/ui/apps/platform/src/queries/secret.js
@@ -46,14 +46,6 @@ export const SECRET_FRAGMENT = gql`
         clusterId
     }
 `;
-export const SECRET_QUERY = gql`
-    query secret($id: ID!) {
-        secret(id: $id) {
-            ...secretFields
-        }
-    }
-    ${SECRET_FRAGMENT}
-`;
 
 export const SECRET_NAME = gql`
     query getSecretName($id: ID!) {

--- a/ui/apps/platform/src/queries/serviceAccount.js
+++ b/ui/apps/platform/src/queries/serviceAccount.js
@@ -76,12 +76,3 @@ export const SERVICE_ACCOUNT_NAME = gql`
         }
     }
 `;
-
-export const SERVICE_ACCOUNT_QUERY = gql`
-    query serviceAccount($id: ID!) {
-        serviceAccount(id: $id) {
-            ...serviceAccountFields
-        }
-    }
-    ${SERVICE_ACCOUNT_FRAGMENT}
-`;

--- a/ui/apps/platform/src/queries/subject.js
+++ b/ui/apps/platform/src/queries/subject.js
@@ -74,33 +74,3 @@ export const SUBJECT_NAME = gql`
         }
     }
 `;
-
-export const SUBJECT_QUERY = gql`
-    query subject($id: String!) {
-        clusters {
-            id
-            name
-            subject(name: $id) {
-                id: name
-                subject {
-                    name
-                    kind
-                    namespace
-                }
-                type
-                scopedPermissions {
-                    scope
-                    permissions {
-                        key
-                        values
-                    }
-                }
-                clusterAdmin
-                roles {
-                    id
-                    name
-                }
-            }
-        }
-    }
-`;

--- a/ui/apps/platform/src/utils/queryMap.js
+++ b/ui/apps/platform/src/utils/queryMap.js
@@ -1,50 +1,18 @@
 import entityTypes from 'constants/entityTypes';
-import {
-    SERVICE_ACCOUNTS_QUERY,
-    SERVICE_ACCOUNT_QUERY,
-    SERVICE_ACCOUNT_NAME,
-} from 'queries/serviceAccount';
-import { DEPLOYMENT_QUERY, DEPLOYMENTS_QUERY, DEPLOYMENT_NAME } from 'queries/deployment';
-import { K8S_ROLES_QUERY, K8S_ROLE_QUERY, ROLE_NAME } from 'queries/role';
-import { SECRET_QUERY, SECRETS_QUERY, SECRET_NAME } from 'queries/secret';
-import { CLUSTER_QUERY, CLUSTERS_QUERY, CLUSTER_NAME } from 'queries/cluster';
+import { SERVICE_ACCOUNT_NAME } from 'queries/serviceAccount';
+import { DEPLOYMENT_NAME } from 'queries/deployment';
+import { ROLE_NAME } from 'queries/role';
+import { SECRET_NAME } from 'queries/secret';
+import { CLUSTER_NAME } from 'queries/cluster';
 import { CVE_NAME, IMAGE_CVE_NAME, NODE_CVE_NAME, CLUSTER_CVE_NAME } from 'queries/cve';
-import { NAMESPACE_QUERY, NAMESPACES_QUERY, NAMESPACE_NAME } from 'queries/namespace';
-import { POLICY_QUERY, POLICIES_QUERY, POLICY_NAME } from 'queries/policy';
-import { CONTROL_QUERY, CONTROL_NAME } from 'queries/controls';
-import { IMAGE_QUERY, IMAGES_QUERY, IMAGE_NAME } from 'queries/image';
-import { NODES_QUERY, NODE_QUERY, NODE_NAME } from 'queries/node';
-import { SUBJECTS_QUERY, SUBJECT_QUERY, SUBJECT_NAME } from 'queries/subject';
+import { NAMESPACE_NAME } from 'queries/namespace';
+import { POLICY_NAME } from 'queries/policy';
+import { CONTROL_NAME } from 'queries/controls';
+import { IMAGE_NAME } from 'queries/image';
+import { NODE_NAME } from 'queries/node';
+import { SUBJECT_NAME } from 'queries/subject';
 
 import { COMPONENT_NAME, NODE_COMPONENT_NAME, IMAGE_COMPONENT_NAME } from 'queries/components';
-
-export const entityQueryMap = {
-    [entityTypes.SERVICE_ACCOUNT]: SERVICE_ACCOUNT_QUERY,
-    [entityTypes.SECRET]: SECRET_QUERY,
-    [entityTypes.DEPLOYMENT]: DEPLOYMENT_QUERY,
-    [entityTypes.CLUSTER]: CLUSTER_QUERY,
-    [entityTypes.NAMESPACE]: NAMESPACE_QUERY,
-    [entityTypes.ROLE]: K8S_ROLE_QUERY,
-    [entityTypes.NODE]: NODE_QUERY,
-    [entityTypes.CONTROL]: CONTROL_QUERY,
-    [entityTypes.IMAGE]: IMAGE_QUERY,
-    [entityTypes.POLICY]: POLICY_QUERY,
-    [entityTypes.SUBJECT]: SUBJECT_QUERY,
-};
-
-export const entityListQueryMap = {
-    [entityTypes.SERVICE_ACCOUNT]: SERVICE_ACCOUNTS_QUERY,
-    [entityTypes.DEPLOYMENT]: DEPLOYMENTS_QUERY,
-    [entityTypes.CLUSTER]: CLUSTERS_QUERY,
-    [entityTypes.NAMESPACE]: NAMESPACES_QUERY,
-    [entityTypes.ROLE]: K8S_ROLES_QUERY,
-    [entityTypes.SECRET]: SECRETS_QUERY,
-    [entityTypes.POLICY]: POLICIES_QUERY,
-    [entityTypes.IMAGE]: IMAGES_QUERY,
-    [entityTypes.NODE]: NODES_QUERY,
-    [entityTypes.NAMESPACE]: NAMESPACES_QUERY,
-    [entityTypes.SUBJECT]: SUBJECTS_QUERY,
-};
 
 export const entityNameQueryMap = {
     [entityTypes.CVE]: CVE_NAME,


### PR DESCRIPTION
### Description

Prerequisite to understand what is used where, so we can remove unneeded data from queries to solve problems with role-based access control.

Because this is the third time that I misinterpreted Find in Files to mean that this component is not used, replace `ControlRelatedEntityList` with `ControlRelatedResourceList` so internal name of component is consistent:
* with its file name
* with its default import name

### Residue

1. Verify that the following entity types are obsolete from before postgres:
    * `COMPONENT`
    * `CVE`

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js 0 = 4701584 - 4701584
        total -1954 = 11703517 - 11705471
    * `ls -al build/static/js/*.js | wc`
        files 0 = 179 - 179
3. `npm run start` in ui/apps/platform