### PR TITLE
ROX-28793: Add Cypress e2e test for cluster reg secrets

### DIFF
--- a/ui/apps/platform/cypress/helpers/file.ts
+++ b/ui/apps/platform/cypress/helpers/file.ts
@@ -1,0 +1,5 @@
+import path from 'path';
+
+export function readFileFromDownloads(filename: string) {
+    return cy.readFile(path.join(Cypress.config('downloadsFolder'), filename));
+}

--- a/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
+++ b/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
@@ -1,0 +1,12 @@
+export function cleanupClusterRegistrationSecretsWithName(nameToDelete: string) {
+    // Clean up existing CRSs, if they exist
+    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+
+    cy.request({ url: '/v1/cluster-init/crs', auth }).as('listCrs');
+
+    return cy.get('@listCrs').then((res: any) => {
+        const automationTokens = res.body.items.filter(({ name }) => name === nameToDelete);
+        const body = { ids: automationTokens.map(({ id }) => id) };
+        return cy.request({ url: '/v1/cluster-init/crs/revoke', body, auth, method: 'PATCH' });
+    });
+}

--- a/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.test.ts
+++ b/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.test.ts
@@ -1,0 +1,60 @@
+import withAuth from '../../../helpers/basicAuth';
+import { readFileFromDownloads } from '../../../helpers/file';
+import { getInputByLabel } from '../../../helpers/formHelpers';
+
+// TODO The entry point for this functionality will change once the removal from integrations is complete
+import { visitIntegrationsDashboardFromLeftNav } from '../../integrations/integrations.helpers';
+
+import { cleanupClusterRegistrationSecretsWithName } from './ClusterRegistrationSecrets.helpers';
+
+describe('Cluster registration secrets', () => {
+    withAuth();
+
+    const testCrsName = 'CYPRESS-E2E-TEST-CRS';
+
+    beforeEach(() => {
+        cleanupClusterRegistrationSecretsWithName(testCrsName);
+    });
+
+    afterEach(() => {
+        cleanupClusterRegistrationSecretsWithName(testCrsName);
+    });
+
+    it('should create a new Cluster registration secret and then view and delete', () => {
+        visitIntegrationsDashboardFromLeftNav();
+
+        cy.get('section:contains("Authentication Tokens")').scrollIntoView();
+        cy.get(
+            'section:contains("Authentication Tokens") a:contains("Cluster Registration Secret")'
+        ).click();
+
+        const crsLinkInTableSelector = `td[data-label="Name"] a:contains("${testCrsName}")`;
+
+        // Verify that old CRS from Cypress tests are not present
+        cy.get('table');
+        cy.get(crsLinkInTableSelector).should('not.exist');
+
+        // Create a new CRS and verify that the YAML is downloaded and the secret appears in the table
+        // TODO dv 2025-04-01
+        // From a user's point of view, this is a "button". It would be nice if we had a unified way to
+        // click a button without needing to know the underlying HTML element used by the component.
+        cy.get('a:contains("Create cluster registration secret")').click();
+
+        cy.get('button:contains("Download")').should('be.disabled');
+        getInputByLabel('Name').clear().type(testCrsName);
+        cy.get('button:contains("Download")').click();
+
+        readFileFromDownloads(`${testCrsName}-cluster-registration-secret.yaml`).should('exist');
+
+        // Revoke the secret
+        cy.get('table');
+        cy.get(`tr:has(${crsLinkInTableSelector}) button[aria-label="Kebab toggle"]`).click();
+        // The Revoke button in the table menu
+        cy.get('ul[role="menu"] button:contains("Revoke cluster registration secret")').click();
+        // The Revoke confirmation button in the modal
+        cy.get('div[role="dialog"] button:contains("Revoke cluster registration secret")').click();
+
+        cy.get('table');
+        cy.get(crsLinkInTableSelector).should('not.exist');
+    });
+});


### PR DESCRIPTION
### Description

Although the overall UX for CRS is going to chanage in how we present the feature, the core functionality will remain mostly the same. This test will give us a regression benchmark as further changes are made.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Local Cypress run, CI
