### PR TITLE
chore(ui): Use e2e and Chrome browser as default local Cypress options

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -104,7 +104,7 @@
         "lint": "eslint --quiet .",
         "lint:fix": "eslint --fix --quiet .",
         "tsc": "tsc",
-        "cypress-open": "DISABLE_ESLINT_PLUGIN=true ./scripts/cypress.sh open --config defaultCommandTimeout=8000",
+        "cypress-open": "DISABLE_ESLINT_PLUGIN=true ./scripts/cypress.sh open --e2e --config defaultBrowser=chrome defaultCommandTimeout=8000",
         "cypress-spec": "DISABLE_ESLINT_PLUGIN=true ./scripts/cypress.sh run --spec",
         "cypress-component": "DISABLE_ESLINT_PLUGIN=true ./scripts/cypress-component.sh open --component",
         "test-e2e": "DISABLE_ESLINT_PLUGIN=true ./scripts/cypress.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js",


### PR DESCRIPTION
### Description

Tired of having to spend the time to make two whole additional clicks when running e2e tests via a browser locally? Tired of having to wait a couple of seconds for Chrome to open? Fear not, now `npm run cypress-open` understands your intentions and does it for you (AI not included).

This change will automatically assume that `npm run cypress-open` is being used for e2e tests, which it always is, and assumes you want to run tests in Chrome, which we almost always do.

You can override these options via the CLI if needed: `npm run cypress-open -- --config defaultBrowser=firefox`.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

`cypress-open` locally and see the window automatically transition to the test suite view.