### PR TITLE
ROX-28778: Conditionally render classic compliance dashboard

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/complianceRBAC.ts
+++ b/ui/apps/platform/src/Containers/Compliance/complianceRBAC.ts
@@ -1,0 +1,49 @@
+import { HasReadAccess } from 'hooks/usePermissions';
+import { ResourceName } from 'types/roleResources';
+
+// Apply subset of patterns from routePaths.ts file.
+
+type ResourcePredicate = (hasReadAccess: HasReadAccess) => boolean;
+
+type ResourceItem = ResourceName | ResourcePredicate;
+
+// Given array of resource names, higher-order function returns predicate function.
+function everyResource(resourceItems: ResourceItem[]): ResourcePredicate {
+    return (hasReadAccess: HasReadAccess) =>
+        resourceItems.every((resourceItem) => evaluateItem(resourceItem, hasReadAccess));
+}
+
+// Given either predicate or name, does it have read access?
+function evaluateItem(resourceItem: ResourceItem, hasReadAccess: HasReadAccess) {
+    if (typeof resourceItem === 'function') {
+        return resourceItem(hasReadAccess);
+    }
+
+    return hasReadAccess(resourceItem);
+}
+
+// Semicolon on separate line following the strings prevents an extra changed line to add a string at the end.
+// prettier-ignore
+type ComplianceRouteKey =
+    | 'compliance/clusters'
+    | 'compliance/deployments'
+    | 'compliance/namespaces'
+    | 'compliance/nodes'
+    ;
+
+// Add properties in same order as route keys to minimize merge conflicts when multiple people add strings.
+const routeRequirementsMap: Record<ComplianceRouteKey, ResourcePredicate> = {
+    'compliance/clusters': everyResource(['Cluster']),
+    'compliance/deployments': everyResource(['Cluster', 'Deployment', 'Namespace']),
+    'compliance/namespaces': everyResource(['Cluster', 'Deployment', 'Namespace']),
+    'compliance/nodes': everyResource(['Cluster', 'Node']),
+};
+
+// Component provides hasReadAccess function from usePermissions hook.
+export function isComplianceRouteEnabled(
+    hasReadAccess: HasReadAccess,
+    routeKey: ComplianceRouteKey
+) {
+    const resourcePredicate = routeRequirementsMap[routeKey];
+    return resourcePredicate(hasReadAccess);
+}


### PR DESCRIPTION
### Description

Practice pattern for classic dashboard widgets, althouth manual testing steps suggest that role-based access control is inconsistent between scans themselves and queries for scanned data. Therefore, render according to stricter scan requirements.

By the way, **Scan environment** button has `READ_WRITE_ACCESS` level for `Compliance` resource only:
* even though that is not sufficient for classic scans
* in case it might be sufficient to display results from Compliance Operator
    For similar scenario, **Passing standards across clusters** does **not** have `Cluster` as additional resource requirements beyond `Compliance` for route.

### Residue

1. Remove unneeded data from queries for side panels.
2. Conditionally render secondary data on side panels and single pages.
3. Conditionally render routes according to minimum requirements.
4. Investigate resource requirements for **Compliance by standard** on main dashboard.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed yet

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run build` in ui/apps/platform and then compute branch - master for the following
    * `wc build/static/js/*.js`
        main.js -8 = 4701576 - 4701584
        total 515 = 11705986 - 11705471
    * `ls -al build/static/js/*.js | wc`
        files 0 = 179 - 179
3. `npm run start` in ui/apps/platform

### Manual testing

Thank you **David Vail** for recipe to test user role permissions.

### Before classic compliance scan

1. Visit /main/compliance with `READ_ACCESS` level for `Compliance` resource.

    See absence of **Scan environment** button.

2. Replace `READ_WRITE_ACCESS` level for `Compliance` resource.

    Click **Scan environment** button, but see absence of data.

3. Add `READ_ACCESS` level for `Cluster` resource, and then click **Scan environment** button.

    See **Compliance scanning in progress** and then data for cluster count and 2 cluster cards.
    ![scan_Cluster](https://github.com/user-attachments/assets/82de7566-30bd-4f48-ab7b-6acbf82cca98)

5. Add `READ_ACCESS` level for `Deployment` and `Namespace` resources, and then click **Scan environment** button.
    By the way, `Namespace` by itself is not enough.

    See **Compliance scanning in progress** and then data for namespace and deployment counts and namespace card.
    ![scan_Cluster_Deployment_Namespace](https://github.com/user-attachments/assets/22cc128c-5e59-4b57-a273-9bd971488a3b)

6. Replace with `READ_ACCESS` level for `Node` resource, and then click **Scan environment** button.

    See **Compliance scanning in progress** and then data for node count and node card.
    ![scan_Cluster_Node](https://github.com/user-attachments/assets/7fac5b2c-5973-4148-8c2d-8fa48673987c)

### after classic compliance scan

![scanned_before_changes](https://github.com/user-attachments/assets/93e3f2fd-e03d-4526-bd2f-e943170e3540)

In some situations, queries have data with only `READ_ACCESS` level for `Compliance` but immediately after step 5, **Passing standards across namespaces** did not have data even with all 5 resources, until I scanned with all 5 permissions.

![scanned_inconsistent_compliance_dashboard](https://github.com/user-attachments/assets/dd7e6d04-16ad-468c-8f86-46683df821ae)

### with conditional rendering

Visit /main/compliance

1. with `Compliance` resource only for minimum
    ![scanned_minimum](https://github.com/user-attachments/assets/2b297b51-47c7-4ec0-aab6-4072b337dc19)

2. plus `Cluster` resource
    ![scanned_Cluster](https://github.com/user-attachments/assets/e3d1bb16-d3c8-464c-9456-26206e1338a1)

3. plus `Deployment` and `Namespace` resource
    ![scanned_Cluster_Deployment_Namespace](https://github.com/user-attachments/assets/e8835135-14eb-4f66-b3b1-4b678a354ce3)

4. replace with `Node` resource
    ![scanned_Cluster_Node](https://github.com/user-attachments/assets/0ce1f094-6a3b-4c10-9517-a31d3a41b173)

5. plus `Deployment` and `Namespace` resource again for maximum
    ![scanned_maximum](https://github.com/user-attachments/assets/095e1891-7270-45ff-853b-8f70baa2606c)

### main dashboard residue

1. with `Compliance` resource only
    ![scanned_inconsistent_main_dashboard](https://github.com/user-attachments/assets/207a8a70-0b24-40f2-bac7-518fa337d6ce)

2. with `Compliance` and also `Cluster` `Deployment` `Namespace` `Node` resources
    ![scanned_consistent_main_dashboard](https://github.com/user-attachments/assets/6afb766b-3cc7-42af-bc25-0a14c36d9c0b)
