### PR TITLE
chore(deps): remove unused docker-java dependency

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -87,8 +87,6 @@ dependencies {
 
     implementation 'io.kubernetes:client-java:23.0.0-legacy'
 
-    implementation group: 'com.github.docker-java', name: 'docker-java', version: '3.4.2'
-
     implementation group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
 


### PR DESCRIPTION
### Description

The dependency was added in https://github.com/stackrox/stackrox/commit/037d4d4966e19f9cdf702c915208971bc0880935
but then the use was removed in 5e307f31d054403121609b508e6c9c697ffd96c0
but the dependency was left and it's time to remove it.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
