### PR TITLE
ROX-26854: move postgres flowstore tests to subdir

### DIFF
--- a/central/networkgraph/flow/datastore/internal/store/postgres/tests/flow_impl_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/tests/flow_impl_test.go
@@ -1,10 +1,11 @@
 //go:build sql_integration
 
-package postgres
+package tests
 
 import (
 	"testing"
 
+	postgresFlowStore "github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store/testcommon"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stretchr/testify/suite"
@@ -14,7 +15,7 @@ func TestFlowStore(t *testing.T) {
 	testDB := pgtest.ForT(t)
 	defer testDB.DB.Close()
 
-	store := NewClusterStore(testDB.DB)
+	store := postgresFlowStore.NewClusterStore(testDB.DB)
 	flowSuite := testcommon.NewFlowStoreTest(store)
 	suite.Run(t, flowSuite)
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
@@ -1,12 +1,13 @@
 //go:build sql_integration
 
-package postgres
+package tests
 
 import (
 	"context"
 	"testing"
 	"time"
 
+	postgresFlowStore "github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/networkgraph/testhelper"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
@@ -28,7 +29,7 @@ const (
 
 type NetworkflowStoreSuite struct {
 	suite.Suite
-	store  FlowStore
+	store  postgresFlowStore.FlowStore
 	ctx    context.Context
 	pool   postgres.DB
 	gormDB *gorm.DB
@@ -50,14 +51,14 @@ func (s *NetworkflowStoreSuite) SetupSuite() {
 }
 
 func (s *NetworkflowStoreSuite) SetupTest() {
-	Destroy(s.ctx, s.pool)
-	s.store = CreateTableAndNewStore(s.ctx, s.pool, s.gormDB, clusterID)
+	postgresFlowStore.Destroy(s.ctx, s.pool)
+	s.store = postgresFlowStore.CreateTableAndNewStore(s.ctx, s.pool, s.gormDB, clusterID)
 }
 
 func (s *NetworkflowStoreSuite) TearDownTest() {
 	if s.pool != nil {
 		// Clean up
-		Destroy(s.ctx, s.pool)
+		postgresFlowStore.Destroy(s.ctx, s.pool)
 	}
 }
 
@@ -72,7 +73,7 @@ func (s *NetworkflowStoreSuite) TearDownSuite() {
 
 func (s *NetworkflowStoreSuite) TestStore() {
 	secondCluster := fixtureconsts.Cluster2
-	store2 := New(s.pool, secondCluster)
+	store2 := postgresFlowStore.New(s.pool, secondCluster)
 
 	networkFlow := &storage.NetworkFlow{
 		Props: &storage.NetworkFlowProperties{


### PR DESCRIPTION
### Description

The test files for `central/networkgraph/flow/datastore/internal/store/postgres` are currently located in the same package as the tested object. This causes circular dependencies when the tests make use of packages having a transitive dependency on the store.

We propose to move the tests to a dedicated sub package.

### Testing and quality

- [ ] CI results are inspected
