### PR TITLE
WIP: fix(pg): combine Delete with DeleteMany

### DIFF
--- a/central/activecomponent/datastore/datastore_impl.go
+++ b/central/activecomponent/datastore/datastore_impl.go
@@ -76,7 +76,7 @@ func (ds *datastoreImpl) DeleteBatch(ctx context.Context, ids ...string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	if err := ds.storage.DeleteMany(ctx, ids); err != nil {
+	if err := ds.storage.Delete(ctx, ids...); err != nil {
 		return errors.Wrap(err, "deleting active components")
 	}
 	return nil

--- a/central/activecomponent/datastore/internal/store/mocks/store.go
+++ b/central/activecomponent/datastore/internal/store/mocks/store.go
@@ -58,18 +58,23 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockStore)(nil).Count), ctx, q)
 }
 
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
+// Delete mocks base method.
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
+// Delete indicates an expected call of Delete.
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.ActiveComponent
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -176,7 +175,7 @@ func copyFromActiveComponents(ctx context.Context, s pgSearch.Deleter, tx *postg
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/activecomponent/datastore/internal/store/postgres/store_test.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ActiveComponentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, activeComponentCount)
 
-	s.NoError(store.DeleteMany(ctx, activeComponentIDs))
+	s.NoError(store.Delete(ctx, activeComponentIDs...))
 
 	activeComponentCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/activecomponent/datastore/internal/store/store.go
+++ b/central/activecomponent/datastore/internal/store/store.go
@@ -18,5 +18,5 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.ActiveComponent, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ActiveComponent, []int, error)
 	UpsertMany(ctx context.Context, activeComponents []*storage.ActiveComponent) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/administration/events/datastore/datastore.go
+++ b/central/administration/events/datastore/datastore.go
@@ -58,5 +58,5 @@ func UpsertTestEvents(ctx context.Context, _ testing.TB, datastore DataStore,
 // This is required for test cleanups, since the datastore doesn't expose functionality to remove events for clients.
 func RemoveTestEvents(ctx context.Context, _ testing.TB, datastore DataStore,
 	ids ...string) error {
-	return datastore.(*datastoreImpl).store.DeleteMany(ctx, ids)
+	return datastore.(*datastoreImpl).store.Delete(ctx, ids...)
 }

--- a/central/administration/events/datastore/internal/store/mocks/store.go
+++ b/central/administration/events/datastore/internal/store/mocks/store.go
@@ -57,18 +57,23 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockStore)(nil).Count), ctx, q)
 }
 
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, identifiers []string) error {
+// Delete mocks base method.
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, identifiers)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, identifiers any) *gomock.Call {
+// Delete indicates an expected call of Delete.
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, identifiers)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/administration/events/datastore/internal/store/postgres/store.go
+++ b/central/administration/events/datastore/internal/store/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.AdministrationEvent
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -166,7 +165,7 @@ func copyFromAdministrationEvents(ctx context.Context, s pgSearch.Deleter, tx *p
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/administration/events/datastore/internal/store/postgres/store_test.go
+++ b/central/administration/events/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *AdministrationEventsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, administrationEventCount)
 
-	s.NoError(store.DeleteMany(ctx, administrationEventIDs))
+	s.NoError(store.Delete(ctx, administrationEventIDs...))
 
 	administrationEventCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/administration/events/datastore/internal/store/store.go
+++ b/central/administration/events/datastore/internal/store/store.go
@@ -15,6 +15,6 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.AdministrationEvent, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.AdministrationEvent, error)
 	UpsertMany(ctx context.Context, objs []*storage.AdministrationEvent) error
-	DeleteMany(ctx context.Context, identifiers []string) error
+	Delete(ctx context.Context, id ...string) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storage.AdministrationEvent, []int, error)
 }

--- a/central/administration/usage/store/postgres/store.go
+++ b/central/administration/usage/store/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.SecuredUnits
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -154,7 +153,7 @@ func copyFromSecuredUnits(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/administration/usage/store/postgres/store_test.go
+++ b/central/administration/usage/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *SecuredUnitsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, securedUnitsCount)
 
-	s.NoError(store.DeleteMany(ctx, securedUnitsIDs))
+	s.NoError(store.Delete(ctx, securedUnitsIDs...))
 
 	securedUnitsCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -217,7 +217,7 @@ func (ds *datastoreImpl) DeleteAlerts(ctx context.Context, ids ...string) error 
 		return sac.ErrResourceAccessDenied
 	}
 
-	if err := ds.storage.DeleteMany(ctx, ids); err != nil {
+	if err := ds.storage.Delete(ctx, ids...); err != nil {
 		return errors.Wrap(err, "deleting alert")
 	}
 	return nil

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -59,31 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.Alert
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -258,7 +257,7 @@ func copyFromAlerts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *AlertsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, alertCount)
 
-	s.NoError(store.DeleteMany(ctx, alertIDs))
+	s.NoError(store.Delete(ctx, alertIDs...))
 
 	alertCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *AlertsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -22,7 +22,6 @@ type Store interface {
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error)
 	Upsert(ctx context.Context, alert *storage.Alert) error
 	UpsertMany(ctx context.Context, alerts []*storage.Alert) error
-	Delete(ctx context.Context, id string) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 	PruneMany(ctx context.Context, ids []string) error
 }

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.TokenMetadata
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -150,7 +149,7 @@ func copyFromAPITokens(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/apitoken/datastore/internal/store/postgres/store_test.go
+++ b/central/apitoken/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *APITokensStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, tokenMetadataCount)
 
-	s.NoError(store.DeleteMany(ctx, tokenMetadataIDs))
+	s.NoError(store.Delete(ctx, tokenMetadataIDs...))
 
 	tokenMetadataCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/auth/store/postgres/store.go
+++ b/central/auth/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.AuthMachineToMachineConfig
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -172,7 +171,7 @@ func copyFromAuthMachineToMachineConfigs(ctx context.Context, s pgSearch.Deleter
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/auth/store/postgres/store_test.go
+++ b/central/auth/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *AuthMachineToMachineConfigsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, authMachineToMachineConfigCount)
 
-	s.NoError(store.DeleteMany(ctx, authMachineToMachineConfigIDs))
+	s.NoError(store.Delete(ctx, authMachineToMachineConfigIDs...))
 
 	authMachineToMachineConfigCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/auth/store/store.go
+++ b/central/auth/store/store.go
@@ -12,7 +12,7 @@ import (
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.AuthMachineToMachineConfig, bool, error)
 	Upsert(ctx context.Context, obj *storage.AuthMachineToMachineConfig) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	GetAll(ctx context.Context) ([]*storage.AuthMachineToMachineConfig, error)
 	Begin(ctx context.Context) (context.Context, *pgPkg.Tx, error)
 }
@@ -21,32 +21,16 @@ type Store interface {
 // The reason for requiring this is that we also have an in-memory store for the auth machine to machine config,
 // and require rollbacks for upsert and delete.
 type storeWrapper struct {
-	db    pgPkg.DB
-	store authPGStore.Store
+	db pgPkg.DB
+	authPGStore.Store
 }
 
 // New creates a new store.
 func New(db pgPkg.DB) Store {
 	return &storeWrapper{
 		db:    db,
-		store: authPGStore.New(db),
+		Store: authPGStore.New(db),
 	}
-}
-
-func (s *storeWrapper) Get(ctx context.Context, id string) (*storage.AuthMachineToMachineConfig, bool, error) {
-	return s.store.Get(ctx, id)
-}
-
-func (s *storeWrapper) Upsert(ctx context.Context, obj *storage.AuthMachineToMachineConfig) error {
-	return s.store.Upsert(ctx, obj)
-}
-
-func (s *storeWrapper) Delete(ctx context.Context, id string) error {
-	return s.store.Delete(ctx, id)
-}
-
-func (s *storeWrapper) GetAll(ctx context.Context) ([]*storage.AuthMachineToMachineConfig, error) {
-	return s.store.GetAll(ctx)
 }
 
 // Begin begins a transaction, returning the transaction context from the given context and the transaction itself.

--- a/central/authprovider/datastore/internal/store/mocks/store.go
+++ b/central/authprovider/datastore/internal/store/mocks/store.go
@@ -44,17 +44,22 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.AuthProvider
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -147,7 +146,7 @@ func copyFromAuthProviders(ctx context.Context, s pgSearch.Deleter, tx *postgres
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/authprovider/datastore/internal/store/postgres/store_test.go
+++ b/central/authprovider/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *AuthProvidersStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, authProviderCount)
 
-	s.NoError(store.DeleteMany(ctx, authProviderIDs))
+	s.NoError(store.Delete(ctx, authProviderIDs...))
 
 	authProviderCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/authprovider/datastore/internal/store/store.go
+++ b/central/authprovider/datastore/internal/store/store.go
@@ -19,5 +19,5 @@ type Store interface {
 
 	Exists(ctx context.Context, id string) (bool, error)
 	Upsert(ctx context.Context, obj *storage.AuthProvider) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.Blob
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, name string) error
+	Delete(ctx context.Context, name ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -150,7 +149,7 @@ func copyFromBlobs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/blob/datastore/store/postgres/store_test.go
+++ b/central/blob/datastore/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *BlobsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, blobCount)
 
-	s.NoError(store.DeleteMany(ctx, blobIDs))
+	s.NoError(store.Delete(ctx, blobIDs...))
 
 	blobCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/cloudsources/datastore/internal/store/mocks/store.go
+++ b/central/cloudsources/datastore/internal/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.CloudSource
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -160,7 +159,7 @@ func copyFromCloudSources(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/cloudsources/datastore/internal/store/postgres/store_test.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *CloudSourcesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, cloudSourceCount)
 
-	s.NoError(store.DeleteMany(ctx, cloudSourceIDs))
+	s.NoError(store.Delete(ctx, cloudSourceIDs...))
 
 	cloudSourceCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/cloudsources/datastore/internal/store/store.go
+++ b/central/cloudsources/datastore/internal/store/store.go
@@ -18,5 +18,5 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.CloudSource, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error)
 	Upsert(ctx context.Context, obj *storage.CloudSource) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/cluster/store/cluster/mocks/store.go
+++ b/central/cluster/store/cluster/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.Cluster
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ClustersStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, clusterCount)
 
-	s.NoError(store.DeleteMany(ctx, clusterIDs))
+	s.NoError(store.Delete(ctx, clusterIDs...))
 
 	clusterCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -366,10 +366,10 @@ func (s *ClustersStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/cluster/store/cluster/store.go
+++ b/central/cluster/store/cluster/store.go
@@ -16,7 +16,7 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Get(ctx context.Context, id string) (*storage.Cluster, bool, error)
 	Upsert(ctx context.Context, obj *storage.Cluster) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	GetMany(ctx context.Context, ids []string) ([]*storage.Cluster, []int, error)
 
 	Walk(ctx context.Context, fn func(obj *storage.Cluster) error) error

--- a/central/cluster/store/clusterhealth/mocks/store.go
+++ b/central/cluster/store/clusterhealth/mocks/store.go
@@ -59,31 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.ClusterHealthStatus
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -163,7 +162,7 @@ func copyFromClusterHealthStatuses(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/cluster/store/clusterhealth/postgres/store_test.go
+++ b/central/cluster/store/clusterhealth/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ClusterHealthStatusesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, clusterHealthStatusCount)
 
-	s.NoError(store.DeleteMany(ctx, clusterHealthStatusIDs))
+	s.NoError(store.Delete(ctx, clusterHealthStatusIDs...))
 
 	clusterHealthStatusCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/cluster/store/clusterhealth/store.go
+++ b/central/cluster/store/clusterhealth/store.go
@@ -18,10 +18,9 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.ClusterHealthStatus, bool, error)
 	Upsert(ctx context.Context, obj *storage.ClusterHealthStatus) error
 	UpsertMany(ctx context.Context, objs []*storage.ClusterHealthStatus) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ClusterHealthStatus, []int, error)
-	DeleteMany(ctx context.Context, ids []string) error
 
 	Walk(ctx context.Context, fn func(obj *storage.ClusterHealthStatus) error) error
 }

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.InitBundleMeta
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -150,7 +149,7 @@ func copyFromClusterInitBundles(ctx context.Context, s pgSearch.Deleter, tx *pos
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/clusterinit/store/postgres/store_test.go
+++ b/central/clusterinit/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ClusterInitBundlesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, initBundleMetaCount)
 
-	s.NoError(store.DeleteMany(ctx, initBundleMetaIDs))
+	s.NoError(store.Delete(ctx, initBundleMetaIDs...))
 
 	initBundleMetaCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/clusterinit/store/store.go
+++ b/central/clusterinit/store/store.go
@@ -33,7 +33,7 @@ type UnderlyingStore interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	Get(ctx context.Context, id string) (*storage.InitBundleMeta, bool, error)
 	Upsert(ctx context.Context, obj *storage.InitBundleMeta) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.InitBundleMeta) error) error
 }
 

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceConfig
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, standardID string) error
+	Delete(ctx context.Context, standardID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromComplianceConfigs(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceConfigsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceConfigCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceConfigIDs))
+	s.NoError(store.Delete(ctx, complianceConfigIDs...))
 
 	complianceConfigCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceDomain
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -143,7 +142,7 @@ func copyFromComplianceDomains(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/compliance/datastore/internal/store/postgres/domain/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceDomainsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceDomainCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceDomainIDs))
+	s.NoError(store.Delete(ctx, complianceDomainIDs...))
 
 	complianceDomainCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -42,9 +42,8 @@ type storeType = storage.ComplianceRunMetadata
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, runID string) error
+	Delete(ctx context.Context, runID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -174,7 +173,7 @@ func copyFromComplianceRunMetadata(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -100,7 +100,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceRunMetadataCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceRunMetadataIDs))
+	s.NoError(store.Delete(ctx, complianceRunMetadataIDs...))
 
 	complianceRunMetadataCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -366,10 +366,10 @@ func (s *ComplianceRunMetadataStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetRunId(),
 				objB.GetRunId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -42,9 +42,8 @@ type storeType = storage.ComplianceRunResults
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, runMetadataRunID string) error
+	Delete(ctx context.Context, runMetadataRunID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -174,7 +173,7 @@ func copyFromComplianceRunResults(ctx context.Context, s pgSearch.Deleter, tx *p
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -100,7 +100,7 @@ func (s *ComplianceRunResultsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceRunResultsCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceRunResultsIDs))
+	s.NoError(store.Delete(ctx, complianceRunResultsIDs...))
 
 	complianceRunResultsCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -366,10 +366,10 @@ func (s *ComplianceRunResultsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetRunMetadata().GetRunId(),
 				objB.GetRunMetadata().GetRunId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceStrings
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromComplianceStrings(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/compliance/datastore/internal/store/postgres/strings/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceStringsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceStringsCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceStringsIDs))
+	s.NoError(store.Delete(ctx, complianceStringsIDs...))
 
 	complianceStringsCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceOperatorCheckResult
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromComplianceOperatorCheckResults(ctx context.Context, s pgSearch.Dele
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/checkresults/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceOperatorCheckResultsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorCheckResultCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorCheckResultIDs))
+	s.NoError(store.Delete(ctx, complianceOperatorCheckResultIDs...))
 
 	complianceOperatorCheckResultCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/checkresults/store/store.go
+++ b/central/complianceoperator/checkresults/store/store.go
@@ -9,6 +9,6 @@ import (
 // Store provides the interface to the underlying storage
 type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorCheckResult) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorCheckResult) error) error
 }

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceOperatorProfile
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromComplianceOperatorProfiles(ctx context.Context, s pgSearch.Deleter,
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/profiles/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceOperatorProfilesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorProfileCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorProfileIDs))
+	s.NoError(store.Delete(ctx, complianceOperatorProfileIDs...))
 
 	complianceOperatorProfileCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/profiles/store/store.go
+++ b/central/complianceoperator/profiles/store/store.go
@@ -9,6 +9,6 @@ import (
 // Store provides the interface to the underlying storage
 type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorProfile) error) error
 }

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceOperatorRule
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromComplianceOperatorRules(ctx context.Context, s pgSearch.Deleter, tx
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/rules/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceOperatorRulesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorRuleCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorRuleIDs))
+	s.NoError(store.Delete(ctx, complianceOperatorRuleIDs...))
 
 	complianceOperatorRuleCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/rules/store/store.go
+++ b/central/complianceoperator/rules/store/store.go
@@ -10,6 +10,6 @@ import (
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.ComplianceOperatorRule, bool, error)
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorRule) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorRule) error) error
 }

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceOperatorScan
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromComplianceOperatorScans(ctx context.Context, s pgSearch.Deleter, tx
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/scans/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceOperatorScansStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorScanCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorScanIDs))
+	s.NoError(store.Delete(ctx, complianceOperatorScanIDs...))
 
 	complianceOperatorScanCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/scans/store/store.go
+++ b/central/complianceoperator/scans/store/store.go
@@ -9,6 +9,6 @@ import (
 // Store provides the interface to the underlying storage
 type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorScan) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorScan) error) error
 }

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ComplianceOperatorScanSettingBinding
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromComplianceOperatorScanSettingBindings(ctx context.Context, s pgSear
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ComplianceOperatorScanSettingBindingsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorScanSettingBindingCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorScanSettingBindingIDs))
+	s.NoError(store.Delete(ctx, complianceOperatorScanSettingBindingIDs...))
 
 	complianceOperatorScanSettingBindingCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/scansettingbinding/store/store.go
+++ b/central/complianceoperator/scansettingbinding/store/store.go
@@ -9,6 +9,6 @@ import (
 // Store provides the interface to the underlying storage
 type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorScanSettingBinding) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorScanSettingBinding) error) error
 }

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.ComplianceOperatorBenchmarkV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -179,7 +178,7 @@ func copyFromComplianceOperatorBenchmarkV2(ctx context.Context, s pgSearch.Delet
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store_test.go
@@ -104,7 +104,7 @@ func (s *ComplianceOperatorBenchmarkV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorBenchmarkV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorBenchmarkV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorBenchmarkV2IDs...))
 
 	complianceOperatorBenchmarkV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.ComplianceOperatorCheckResultV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -195,7 +194,7 @@ func copyFromComplianceOperatorCheckResultV2(ctx context.Context, s pgSearch.Del
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorCheckResultV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorCheckResultV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorCheckResultV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorCheckResultV2IDs...))
 
 	complianceOperatorCheckResultV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorCheckResultV2StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/integration/store/postgres/store.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ComplianceIntegration
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -176,7 +175,7 @@ func copyFromComplianceIntegrations(ctx context.Context, s pgSearch.Deleter, tx 
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/integration/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ComplianceIntegrationsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceIntegrationCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceIntegrationIDs))
+	s.NoError(store.Delete(ctx, complianceIntegrationIDs...))
 
 	complianceIntegrationCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -366,10 +366,10 @@ func (s *ComplianceIntegrationsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ComplianceOperatorProfileV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -210,7 +209,7 @@ func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorProfileV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorProfileV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorProfileV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorProfileV2IDs...))
 
 	complianceOperatorProfileV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorProfileV2StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/remediations/store/postgres/store.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ComplianceOperatorRemediationV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -173,7 +172,7 @@ func copyFromComplianceOperatorRemediationV2(ctx context.Context, s pgSearch.Del
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/remediations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorRemediationV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorRemediationV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorRemediationV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorRemediationV2IDs...))
 
 	complianceOperatorRemediationV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorRemediationV2StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/report/store/postgres/store.go
+++ b/central/complianceoperator/v2/report/store/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.ComplianceOperatorReportSnapshotV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, reportID string) error
+	Delete(ctx context.Context, reportID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -198,7 +197,7 @@ func copyFromComplianceOperatorReportSnapshotV2(ctx context.Context, s pgSearch.
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/rules/store/postgres/store.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ComplianceOperatorRuleV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -205,7 +204,7 @@ func copyFromComplianceOperatorRuleV2(ctx context.Context, s pgSearch.Deleter, t
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorRuleV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorRuleV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorRuleV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorRuleV2IDs...))
 
 	complianceOperatorRuleV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorRuleV2StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.ComplianceOperatorClusterScanConfigStatus
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -174,7 +173,7 @@ func copyFromComplianceOperatorClusterScanConfigStatuses(ctx context.Context, s 
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorClusterScanConfigStatusCount)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorClusterScanConfigStatusIDs))
+	s.NoError(store.Delete(ctx, complianceOperatorClusterScanConfigStatusIDs...))
 
 	complianceOperatorClusterScanConfigStatusCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestSACDeleteMan
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.ComplianceOperatorScanConfigurationV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -221,7 +220,7 @@ func copyFromComplianceOperatorScanConfigurationV2(ctx context.Context, s pgSear
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store_test.go
@@ -104,7 +104,7 @@ func (s *ComplianceOperatorScanConfigurationV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorScanConfigurationV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorScanConfigurationV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorScanConfigurationV2IDs...))
 
 	complianceOperatorScanConfigurationV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.ComplianceOperatorScanV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -189,7 +188,7 @@ func copyFromComplianceOperatorScanV2(ctx context.Context, s pgSearch.Deleter, t
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorScanV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorScanV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorScanV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorScanV2IDs...))
 
 	complianceOperatorScanV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorScanV2StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ComplianceOperatorScanSettingBindingV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -173,7 +172,7 @@ func copyFromComplianceOperatorScanSettingBindingV2(ctx context.Context, s pgSea
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorScanSettingBindingV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorScanSettingBindingV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorScanSettingBindingV2IDs...))
 
 	complianceOperatorScanSettingBindingV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/suites/datastore/datastore_impl_test.go
@@ -82,7 +82,7 @@ func (s *complianceSuiteDataStoreTestSuite) TestGetSuite() {
 
 	// Delayed clean up
 	defer func() {
-		s.Require().NoError(s.storage.DeleteMany(s.testContexts[sacTestUtils.UnrestrictedReadWriteCtx], suiteIDs))
+		s.Require().NoError(s.storage.Delete(s.testContexts[sacTestUtils.UnrestrictedReadWriteCtx], suiteIDs...))
 	}()
 
 	testCases := []struct {
@@ -238,7 +238,7 @@ func (s *complianceSuiteDataStoreTestSuite) TestUpsertSuites() {
 		}
 
 		// Clean up
-		s.Require().NoError(s.storage.DeleteMany(s.testContexts[sacTestUtils.UnrestrictedReadWriteCtx], allSuiteIDs))
+		s.Require().NoError(s.storage.Delete(s.testContexts[sacTestUtils.UnrestrictedReadWriteCtx], allSuiteIDs...))
 	}
 }
 

--- a/central/complianceoperator/v2/suites/store/postgres/store.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ComplianceOperatorSuiteV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -170,7 +169,7 @@ func copyFromComplianceOperatorSuiteV2(ctx context.Context, s pgSearch.Deleter, 
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/complianceoperator/v2/suites/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store_test.go
@@ -107,7 +107,7 @@ func (s *ComplianceOperatorSuiteV2StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, complianceOperatorSuiteV2Count)
 
-	s.NoError(store.DeleteMany(ctx, complianceOperatorSuiteV2IDs))
+	s.NoError(store.Delete(ctx, complianceOperatorSuiteV2IDs...))
 
 	complianceOperatorSuiteV2Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -373,10 +373,10 @@ func (s *ComplianceOperatorSuiteV2StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.ClusterCVE
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -174,7 +173,7 @@ func copyFromClusterCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/cve/cluster/datastore/store/postgres/store_test.go
+++ b/central/cve/cluster/datastore/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ClusterCvesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, clusterCVECount)
 
-	s.NoError(store.DeleteMany(ctx, clusterCVEIDs))
+	s.NoError(store.Delete(ctx, clusterCVEIDs...))
 
 	clusterCVECount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.ImageCVE
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -177,7 +176,7 @@ func copyFromImageCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/cve/image/datastore/store/postgres/store_test.go
+++ b/central/cve/image/datastore/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ImageCvesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, imageCVECount)
 
-	s.NoError(store.DeleteMany(ctx, imageCVEIDs))
+	s.NoError(store.Delete(ctx, imageCVEIDs...))
 
 	imageCVECount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.ImageCVEV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -192,7 +191,7 @@ func copyFromImageCvesV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.NodeCVE
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -180,7 +179,7 @@ func copyFromNodeCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/cve/node/datastore/store/postgres/store_test.go
+++ b/central/cve/node/datastore/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *NodeCvesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, nodeCVECount)
 
-	s.NoError(store.DeleteMany(ctx, nodeCVEIDs))
+	s.NoError(store.Delete(ctx, nodeCVEIDs...))
 
 	nodeCVECount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.DeclarativeConfigHealth
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -143,7 +142,7 @@ func copyFromDeclarativeConfigHealths(ctx context.Context, s pgSearch.Deleter, t
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/declarativeconfig/health/datastore/store/postgres/store_test.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *DeclarativeConfigHealthsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, declarativeConfigHealthCount)
 
-	s.NoError(store.DeleteMany(ctx, declarativeConfigHealthIDs))
+	s.NoError(store.Delete(ctx, declarativeConfigHealthIDs...))
 
 	declarativeConfigHealthCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/declarativeconfig/health/datastore/store/store.go
+++ b/central/declarativeconfig/health/datastore/store/store.go
@@ -10,6 +10,6 @@ import (
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.DeclarativeConfigHealth, bool, error)
 	Upsert(ctx context.Context, obj *storage.DeclarativeConfigHealth) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.DeclarativeConfigHealth) error) error
 }

--- a/central/deployment/datastore/internal/store/mocks/store.go
+++ b/central/deployment/datastore/internal/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.Deployment
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -400,7 +399,7 @@ func copyFromDeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/deployment/datastore/internal/store/postgres/store_test.go
+++ b/central/deployment/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *DeploymentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, deploymentCount)
 
-	s.NoError(store.DeleteMany(ctx, deploymentIDs))
+	s.NoError(store.Delete(ctx, deploymentIDs...))
 
 	deploymentCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *DeploymentsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/deployment/datastore/internal/store/store.go
+++ b/central/deployment/datastore/internal/store/store.go
@@ -23,7 +23,7 @@ type Store interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Upsert(ctx context.Context, deployment *storage.Deployment) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 
 	GetIDs(ctx context.Context) ([]string, error)
 }

--- a/central/discoveredclusters/datastore/internal/store/postgres/store.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.DiscoveredCluster
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -163,7 +162,7 @@ func copyFromDiscoveredClusters(ctx context.Context, s pgSearch.Deleter, tx *pos
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/discoveredclusters/datastore/internal/store/postgres/store_test.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *DiscoveredClustersStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, discoveredClusterCount)
 
-	s.NoError(store.DeleteMany(ctx, discoveredClusterIDs))
+	s.NoError(store.Delete(ctx, discoveredClusterIDs...))
 
 	discoveredClusterCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/externalbackups/internal/store/mocks/store.go
+++ b/central/externalbackups/internal/store/mocks/store.go
@@ -42,17 +42,22 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ExternalBackup
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -143,7 +142,7 @@ func copyFromExternalBackups(ctx context.Context, s pgSearch.Deleter, tx *postgr
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/externalbackups/internal/store/postgres/store_test.go
+++ b/central/externalbackups/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ExternalBackupsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, externalBackupCount)
 
-	s.NoError(store.DeleteMany(ctx, externalBackupIDs))
+	s.NoError(store.Delete(ctx, externalBackupIDs...))
 
 	externalBackupCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/externalbackups/internal/store/store.go
+++ b/central/externalbackups/internal/store/store.go
@@ -13,5 +13,5 @@ type Store interface {
 	GetAll(ctx context.Context) ([]*storage.ExternalBackup, error)
 	Get(ctx context.Context, id string) (*storage.ExternalBackup, bool, error)
 	Upsert(ctx context.Context, backup *storage.ExternalBackup) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -195,7 +195,7 @@ func (ds *dataStoreImpl) Mutate(ctx context.Context, remove, update, add []*stor
 		idsToRemove = append(idsToRemove, groupID)
 	}
 	if len(remove) > 0 {
-		if err := ds.storage.DeleteMany(ctx, idsToRemove); err != nil {
+		if err := ds.storage.Delete(ctx, idsToRemove...); err != nil {
 			return err
 		}
 	}

--- a/central/group/datastore/datastore_impl_test.go
+++ b/central/group/datastore/datastore_impl_test.go
@@ -308,7 +308,7 @@ func (s *groupDataStoreTestSuite) TestAllowsUpdate() {
 
 func (s *groupDataStoreTestSuite) TestEnforcesMutate() {
 	s.storage.EXPECT().UpsertMany(gomock.Any(), gomock.Any()).Times(0)
-	s.storage.EXPECT().DeleteMany(gomock.Any(), gomock.Any()).Times(0)
+	s.storage.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(0)
 
 	grp := &storage.Group{Props: &storage.GroupProperties{
 		AuthProviderId: "123",
@@ -331,7 +331,7 @@ func (s *groupDataStoreTestSuite) TestEnforcesMutate() {
 
 func (s *groupDataStoreTestSuite) TestAllowsMutate() {
 	s.storage.EXPECT().UpsertMany(gomock.Any(), gomock.Any()).Return(nil).Times(2) // two calls * two operations (add, update)
-	s.storage.EXPECT().DeleteMany(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.storage.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(fixtures.GetGroupWithMutability(storage.Traits_ALLOW_MUTATE), true, nil).Times(2)
 	s.validRoleAndAuthProvider("123", "123", storage.Traits_IMPERATIVE, 2)
 
@@ -364,7 +364,7 @@ func (s *groupDataStoreTestSuite) TestMutate() {
 	gomock.InOrder(
 		s.storage.EXPECT().UpsertMany(gomock.Any(), toAdd),
 		s.storage.EXPECT().UpsertMany(gomock.Any(), []*storage.Group{toUpdate}),
-		s.storage.EXPECT().DeleteMany(gomock.Any(), []string{toRemove.GetProps().GetId()}),
+		s.storage.EXPECT().Delete(gomock.Any(), toRemove.GetProps().GetId()),
 	)
 
 	s.NoError(s.dataStore.Mutate(s.hasWriteCtx, []*storage.Group{toRemove}, []*storage.Group{toUpdate}, toAdd, false))
@@ -756,7 +756,7 @@ func (s *groupDataStoreTestSuite) TestMutateGroupForce() {
 		s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(immutableGroup, true, nil),
 	)
 	s.storage.EXPECT().UpsertMany(gomock.Any(), []*storage.Group{mutableGroup}).Return(nil).Times(1)
-	s.storage.EXPECT().DeleteMany(gomock.Any(), []string{immutableGroup.GetProps().GetId()}).Return(nil).Times(1)
+	s.storage.EXPECT().Delete(gomock.Any(), immutableGroup.GetProps().GetId()).Return(nil).Times(1)
 	err := s.dataStore.Mutate(s.hasWriteCtx, []*storage.Group{immutableGroup}, []*storage.Group{mutableGroup}, nil, true)
 	s.NoError(err)
 
@@ -766,7 +766,7 @@ func (s *groupDataStoreTestSuite) TestMutateGroupForce() {
 		s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(mutableGroup, true, nil),
 	)
 	s.storage.EXPECT().UpsertMany(gomock.Any(), []*storage.Group{immutableGroup}).Return(nil).Times(1)
-	s.storage.EXPECT().DeleteMany(gomock.Any(), []string{mutableGroup.GetProps().GetId()}).Return(nil).Times(1)
+	s.storage.EXPECT().Delete(gomock.Any(), mutableGroup.GetProps().GetId()).Return(nil).Times(1)
 	err = s.dataStore.Mutate(s.hasWriteCtx, []*storage.Group{mutableGroup}, []*storage.Group{immutableGroup}, nil, true)
 	s.NoError(err)
 }
@@ -940,7 +940,7 @@ func (s *groupDataStoreTestSuite) TestMutateGroupViaConfig() {
 	gomock.InOrder(
 		s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(declarativeGroup, true, nil),
 	)
-	s.storage.EXPECT().DeleteMany(gomock.Any(), []string{declarativeGroup.GetProps().GetId()}).Return(nil).Times(1)
+	s.storage.EXPECT().Delete(gomock.Any(), declarativeGroup.GetProps().GetId()).Return(nil).Times(1)
 	err = s.dataStore.Mutate(s.hasWriteDeclarativeCtx, []*storage.Group{declarativeGroup}, nil, nil, true)
 	s.NoError(err)
 }

--- a/central/group/datastore/internal/store/mocks/store.go
+++ b/central/group/datastore/internal/store/mocks/store.go
@@ -42,31 +42,22 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, propsID string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, propsID)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, propsID any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, propsID)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.Group
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, propsID string) error
+	Delete(ctx context.Context, propsID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -155,7 +154,7 @@ func copyFromGroups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/group/datastore/internal/store/postgres/store_test.go
+++ b/central/group/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *GroupsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, groupCount)
 
-	s.NoError(store.DeleteMany(ctx, groupIDs))
+	s.NoError(store.Delete(ctx, groupIDs...))
 
 	groupCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/group/datastore/internal/store/store.go
+++ b/central/group/datastore/internal/store/store.go
@@ -15,6 +15,5 @@ type Store interface {
 	Walk(ctx context.Context, fn func(group *storage.Group) error) error
 	Upsert(ctx context.Context, group *storage.Group) error
 	UpsertMany(ctx context.Context, groups []*storage.Group) error
-	Delete(ctx context.Context, propsID string) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.Hash
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, clusterID string) error
+	Delete(ctx context.Context, clusterID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromHashes(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/hash/datastore/store/postgres/store_test.go
+++ b/central/hash/datastore/store/postgres/store_test.go
@@ -104,7 +104,7 @@ func (s *HashesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, hashCount)
 
-	s.NoError(store.DeleteMany(ctx, hashIDs))
+	s.NoError(store.Delete(ctx, hashIDs...))
 
 	hashCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ImageComponent
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -164,7 +163,7 @@ func copyFromImageComponents(ctx context.Context, s pgSearch.Deleter, tx *postgr
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/imagecomponent/datastore/store/postgres/store_test.go
+++ b/central/imagecomponent/datastore/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ImageComponentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, imageComponentCount)
 
-	s.NoError(store.DeleteMany(ctx, imageComponentIDs))
+	s.NoError(store.Delete(ctx, imageComponentIDs...))
 
 	imageComponentCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/imagecomponent/v2/datastore/store/postgres/store.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ImageComponentV2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -170,7 +169,7 @@ func copyFromImageComponentV2(ctx context.Context, s pgSearch.Deleter, tx *postg
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/imageintegration/store/mocks/store.go
+++ b/central/imageintegration/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.ImageIntegration
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -160,7 +159,7 @@ func copyFromImageIntegrations(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/imageintegration/store/postgres/store_test.go
+++ b/central/imageintegration/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ImageIntegrationsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, imageIntegrationCount)
 
-	s.NoError(store.DeleteMany(ctx, imageIntegrationIDs))
+	s.NoError(store.Delete(ctx, imageIntegrationIDs...))
 
 	imageIntegrationCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/imageintegration/store/store.go
+++ b/central/imageintegration/store/store.go
@@ -18,6 +18,6 @@ type Store interface {
 	GetAll(ctx context.Context) ([]*storage.ImageIntegration, error)
 	Upsert(ctx context.Context, integration *storage.ImageIntegration) error
 	UpsertMany(ctx context.Context, objs []*storage.ImageIntegration) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 }

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.IntegrationHealth
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromIntegrationHealths(ctx context.Context, s pgSearch.Deleter, tx *pos
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/integrationhealth/store/postgres/store_test.go
+++ b/central/integrationhealth/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *IntegrationHealthsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, integrationHealthCount)
 
-	s.NoError(store.DeleteMany(ctx, integrationHealthIDs))
+	s.NoError(store.Delete(ctx, integrationHealthIDs...))
 
 	integrationHealthCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/integrationhealth/store/store.go
+++ b/central/integrationhealth/store/store.go
@@ -10,6 +10,6 @@ import (
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.IntegrationHealth, bool, error)
 	Upsert(ctx context.Context, obj *storage.IntegrationHealth) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.IntegrationHealth) error) error
 }

--- a/central/logimbue/store/mocks/store.go
+++ b/central/logimbue/store/mocks/store.go
@@ -41,18 +41,23 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
+// Delete mocks base method.
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
+// Delete indicates an expected call of Delete.
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // GetAll mocks base method.

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.LogImbue
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -147,7 +146,7 @@ func copyFromLogImbues(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/logimbue/store/postgres/store_test.go
+++ b/central/logimbue/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *LogImbuesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, logImbueCount)
 
-	s.NoError(store.DeleteMany(ctx, logImbueIDs))
+	s.NoError(store.Delete(ctx, logImbueIDs...))
 
 	logImbueCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/logimbue/store/store.go
+++ b/central/logimbue/store/store.go
@@ -13,7 +13,7 @@ type Store interface {
 	GetAll(ctx context.Context) ([]*storage.LogImbue, error)
 	Upsert(ctx context.Context, log *storage.LogImbue) error
 
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Walk(ctx context.Context, fn func(obj *storage.LogImbue) error) error
 }

--- a/central/namespace/datastore/internal/store/mocks/store.go
+++ b/central/namespace/datastore/internal/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/namespace/datastore/internal/store/postgres/store.go
+++ b/central/namespace/datastore/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.NamespaceMetadata
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -189,7 +188,7 @@ func copyFromNamespaces(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/namespace/datastore/internal/store/postgres/store_test.go
+++ b/central/namespace/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *NamespacesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, namespaceMetadataCount)
 
-	s.NoError(store.DeleteMany(ctx, namespaceMetadataIDs))
+	s.NoError(store.Delete(ctx, namespaceMetadataIDs...))
 
 	namespaceMetadataCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *NamespacesStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/namespace/datastore/internal/store/store.go
+++ b/central/namespace/datastore/internal/store/store.go
@@ -17,6 +17,6 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.NamespaceMetadata, bool, error)
 	Walk(context.Context, func(namespace *storage.NamespaceMetadata) error) error
 	Upsert(context.Context, *storage.NamespaceMetadata) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	GetMany(ctx context.Context, ids []string) ([]*storage.NamespaceMetadata, []int, error)
 }

--- a/central/networkbaseline/datastore/datastore_impl.go
+++ b/central/networkbaseline/datastore/datastore_impl.go
@@ -142,7 +142,7 @@ func (ds *dataStoreImpl) DeleteNetworkBaselines(ctx context.Context, deploymentI
 		}
 	}
 
-	if err := ds.storage.DeleteMany(ctx, deploymentIDs); err != nil {
+	if err := ds.storage.Delete(ctx, deploymentIDs...); err != nil {
 		return errors.Wrapf(err, "deleting network baselines %q from storage", deploymentIDs)
 	}
 

--- a/central/networkbaseline/store/mocks/store.go
+++ b/central/networkbaseline/store/mocks/store.go
@@ -42,31 +42,22 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.NetworkBaseline
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, deploymentID string) error
+	Delete(ctx context.Context, deploymentID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -170,7 +169,7 @@ func copyFromNetworkBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *NetworkBaselinesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkBaselineCount)
 
-	s.NoError(store.DeleteMany(ctx, networkBaselineIDs))
+	s.NoError(store.Delete(ctx, networkBaselineIDs...))
 
 	networkBaselineCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *NetworkBaselinesStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetDeploymentId(),
 				objB.GetDeploymentId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/networkbaseline/store/store.go
+++ b/central/networkbaseline/store/store.go
@@ -18,8 +18,7 @@ type Store interface {
 
 	Upsert(ctx context.Context, baseline *storage.NetworkBaseline) error
 	UpsertMany(ctx context.Context, baselines []*storage.NetworkBaseline) error
-	Delete(ctx context.Context, id string) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Walk(ctx context.Context, fn func(baseline *storage.NetworkBaseline) error) error
 }

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.NetworkGraphConfig
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromNetworkGraphConfigs(ctx context.Context, s pgSearch.Deleter, tx *po
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *NetworkGraphConfigsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkGraphConfigCount)
 
-	s.NoError(store.DeleteMany(ctx, networkGraphConfigIDs))
+	s.NoError(store.Delete(ctx, networkGraphConfigIDs...))
 
 	networkGraphConfigCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/networkgraph/entity/datastore/datastore_impl.go
+++ b/central/networkgraph/entity/datastore/datastore_impl.go
@@ -420,7 +420,7 @@ func (ds *dataStoreImpl) DeleteExternalNetworkEntitiesForCluster(ctx context.Con
 		return err
 	}
 
-	if err := ds.storage.DeleteMany(ctx, ids); err != nil {
+	if err := ds.storage.Delete(ctx, ids...); err != nil {
 		return errors.Wrapf(err, "deleting network entities for cluster %s from storage", clusterID)
 	}
 

--- a/central/networkgraph/entity/datastore/internal/store/mocks/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/mocks/store.go
@@ -43,31 +43,22 @@ func (m *MockEntityStore) EXPECT() *MockEntityStoreMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockEntityStore) Delete(ctx context.Context, id string) error {
+func (m *MockEntityStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockEntityStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockEntityStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEntityStore)(nil).Delete), ctx, id)
-}
-
-// DeleteMany mocks base method.
-func (m *MockEntityStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockEntityStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockEntityStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEntityStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.NetworkEntity
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, infoID string) error
+	Delete(ctx context.Context, infoID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -152,7 +151,7 @@ func copyFromNetworkEntities(ctx context.Context, s pgSearch.Deleter, tx *postgr
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *NetworkEntitiesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkEntityCount)
 
-	s.NoError(store.DeleteMany(ctx, networkEntityIDs))
+	s.NoError(store.Delete(ctx, networkEntityIDs...))
 
 	networkEntityCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/networkgraph/entity/datastore/internal/store/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/store.go
@@ -18,8 +18,7 @@ type EntityStore interface {
 
 	Upsert(ctx context.Context, entity *storage.NetworkEntity) error
 	UpsertMany(ctx context.Context, objs []*storage.NetworkEntity) error
-	Delete(ctx context.Context, id string) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Walk(ctx context.Context, fn func(obj *storage.NetworkEntity) error) error
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storage.NetworkEntity) error) error

--- a/central/networkpolicies/datastore/internal/store/mocks/store.go
+++ b/central/networkpolicies/datastore/internal/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.NetworkPolicy
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -170,7 +169,7 @@ func copyFromNetworkpolicies(ctx context.Context, s pgSearch.Deleter, tx *postgr
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *NetworkpoliciesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkPolicyCount)
 
-	s.NoError(store.DeleteMany(ctx, networkPolicyIDs))
+	s.NoError(store.Delete(ctx, networkPolicyIDs...))
 
 	networkPolicyCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *NetworkpoliciesStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/networkpolicies/datastore/internal/store/store.go
+++ b/central/networkpolicies/datastore/internal/store/store.go
@@ -17,7 +17,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.NetworkPolicy, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkPolicy, error)
 	Upsert(ctx context.Context, obj *storage.NetworkPolicy) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Walk(ctx context.Context, fn func(obj *storage.NetworkPolicy) error) error
 }

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.NetworkPolicyApplicationUndoDeploymentRecord
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, deploymentID string) error
+	Delete(ctx context.Context, deploymentID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -143,7 +142,7 @@ func copyFromNetworkpoliciesundodeployments(ctx context.Context, s pgSearch.Dele
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *NetworkpoliciesundodeploymentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkPolicyApplicationUndoDeploymentRecordCount)
 
-	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoDeploymentRecordIDs))
+	s.NoError(store.Delete(ctx, networkPolicyApplicationUndoDeploymentRecordIDs...))
 
 	networkPolicyApplicationUndoDeploymentRecordCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.NetworkPolicyApplicationUndoRecord
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, clusterID string) error
+	Delete(ctx context.Context, clusterID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -143,7 +142,7 @@ func copyFromNetworkpolicyapplicationundorecords(ctx context.Context, s pgSearch
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *NetworkpolicyapplicationundorecordsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, networkPolicyApplicationUndoRecordCount)
 
-	s.NoError(store.DeleteMany(ctx, networkPolicyApplicationUndoRecordIDs))
+	s.NoError(store.Delete(ctx, networkPolicyApplicationUndoRecordIDs...))
 
 	networkPolicyApplicationUndoRecordCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.NodeComponent
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -161,7 +160,7 @@ func copyFromNodeComponents(ctx context.Context, s pgSearch.Deleter, tx *postgre
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/nodecomponent/datastore/store/postgres/store_test.go
+++ b/central/nodecomponent/datastore/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *NodeComponentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, nodeComponentCount)
 
-	s.NoError(store.DeleteMany(ctx, nodeComponentIDs))
+	s.NoError(store.Delete(ctx, nodeComponentIDs...))
 
 	nodeComponentCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/notifier/datastore/internal/store/mocks/store.go
+++ b/central/notifier/datastore/internal/store/mocks/store.go
@@ -42,17 +42,22 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.Notifier
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -146,7 +145,7 @@ func copyFromNotifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/notifier/datastore/internal/store/postgres/store_test.go
+++ b/central/notifier/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *NotifiersStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, notifierCount)
 
-	s.NoError(store.DeleteMany(ctx, notifierIDs))
+	s.NoError(store.Delete(ctx, notifierIDs...))
 
 	notifierCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/notifier/datastore/internal/store/store.go
+++ b/central/notifier/datastore/internal/store/store.go
@@ -16,5 +16,5 @@ type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	Upsert(ctx context.Context, obj *storage.Notifier) error
 	UpsertMany(ctx context.Context, objs []*storage.Notifier) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/pod/datastore/internal/store/mocks/store.go
+++ b/central/pod/datastore/internal/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/pod/datastore/internal/store/postgres/store.go
+++ b/central/pod/datastore/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.Pod
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -211,7 +210,7 @@ func copyFromPods(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/pod/datastore/internal/store/postgres/store_test.go
+++ b/central/pod/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *PodsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, podCount)
 
-	s.NoError(store.DeleteMany(ctx, podIDs))
+	s.NoError(store.Delete(ctx, podIDs...))
 
 	podCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *PodsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/pod/datastore/internal/store/store.go
+++ b/central/pod/datastore/internal/store/store.go
@@ -22,5 +22,5 @@ type Store interface {
 	WalkByQuery(ctx context.Context, q *v1.Query, fn func(pod *storage.Pod) error) error
 
 	Upsert(ctx context.Context, pod *storage.Pod) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/policy/store/mocks/store.go
+++ b/central/policy/store/mocks/store.go
@@ -76,31 +76,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.Policy
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -178,7 +177,7 @@ func copyFromPolicies(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/policy/store/postgres/store_test.go
+++ b/central/policy/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *PoliciesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, policyCount)
 
-	s.NoError(store.DeleteMany(ctx, policyIDs))
+	s.NoError(store.Delete(ctx, policyIDs...))
 
 	policyCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/policy/store/store.go
+++ b/central/policy/store/store.go
@@ -24,62 +24,21 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.Policy) error
 	UpsertMany(ctx context.Context, objs []*storage.Policy) error
 
-	Delete(ctx context.Context, id string) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Begin(ctx context.Context) (context.Context, *pgPkg.Tx, error)
 }
 
 type storeWrapper struct {
-	db    pgPkg.DB
-	store policyPGStore.Store
+	db pgPkg.DB
+	policyPGStore.Store
 }
 
 func New(db pgPkg.DB) Store {
 	return &storeWrapper{
 		db:    db,
-		store: policyPGStore.New(db),
+		Store: policyPGStore.New(db),
 	}
-}
-
-func (s *storeWrapper) Count(ctx context.Context, q *v1.Query) (int, error) {
-	return s.store.Count(ctx, q)
-}
-
-func (s *storeWrapper) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
-	return s.store.Search(ctx, q)
-}
-
-func (s *storeWrapper) Get(ctx context.Context, id string) (*storage.Policy, bool, error) {
-	return s.store.Get(ctx, id)
-}
-
-func (s *storeWrapper) GetMany(ctx context.Context, ids []string) ([]*storage.Policy, []int, error) {
-	return s.store.GetMany(ctx, ids)
-}
-
-func (s *storeWrapper) GetAll(ctx context.Context) ([]*storage.Policy, error) {
-	return s.store.GetAll(ctx)
-}
-
-func (s *storeWrapper) GetIDs(ctx context.Context) ([]string, error) {
-	return s.store.GetIDs(ctx)
-}
-
-func (s *storeWrapper) Upsert(ctx context.Context, obj *storage.Policy) error {
-	return s.store.Upsert(ctx, obj)
-}
-
-func (s *storeWrapper) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
-	return s.store.UpsertMany(ctx, objs)
-}
-
-func (s *storeWrapper) Delete(ctx context.Context, id string) error {
-	return s.store.Delete(ctx, id)
-}
-
-func (s *storeWrapper) DeleteMany(ctx context.Context, ids []string) error {
-	return s.store.DeleteMany(ctx, ids)
 }
 
 func (s *storeWrapper) Begin(ctx context.Context) (context.Context, *pgPkg.Tx, error) {

--- a/central/policycategory/store/mocks/store.go
+++ b/central/policycategory/store/mocks/store.go
@@ -59,31 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.PolicyCategory
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -147,7 +146,7 @@ func copyFromPolicyCategories(ctx context.Context, s pgSearch.Deleter, tx *postg
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/policycategory/store/postgres/store_test.go
+++ b/central/policycategory/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *PolicyCategoriesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, policyCategoryCount)
 
-	s.NoError(store.DeleteMany(ctx, policyCategoryIDs))
+	s.NoError(store.Delete(ctx, policyCategoryIDs...))
 
 	policyCategoryCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/policycategory/store/store.go
+++ b/central/policycategory/store/store.go
@@ -21,7 +21,6 @@ type Store interface {
 	GetAll(ctx context.Context) ([]*storage.PolicyCategory, error)
 	Upsert(ctx context.Context, obj *storage.PolicyCategory) error
 	UpsertMany(ctx context.Context, objs []*storage.PolicyCategory) error
-	Delete(ctx context.Context, id string) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.PolicyCategory) error) error
 }

--- a/central/policycategoryedge/datastore/datastore_impl.go
+++ b/central/policycategoryedge/datastore/datastore_impl.go
@@ -113,7 +113,7 @@ func (ds *datastoreImpl) DeleteMany(ctx context.Context, ids ...string) error {
 		return sac.ErrResourceAccessDenied
 	}
 
-	return ds.storage.DeleteMany(ctx, ids)
+	return ds.storage.Delete(ctx, ids...)
 }
 
 func (ds *datastoreImpl) DeleteByQuery(ctx context.Context, q *v1.Query) error {

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.PolicyCategoryEdge
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -150,7 +149,7 @@ func copyFromPolicyCategoryEdges(ctx context.Context, s pgSearch.Deleter, tx *po
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/policycategoryedge/store/store.go
+++ b/central/policycategoryedge/store/store.go
@@ -16,10 +16,9 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.PolicyCategoryEdge, bool, error)
 	Upsert(ctx context.Context, obj *storage.PolicyCategoryEdge) error
 	UpsertMany(ctx context.Context, objs []*storage.PolicyCategoryEdge) error
-	Delete(ctx context.Context, id string) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.PolicyCategoryEdge, []int, error)
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategoryEdge, error)
 	GetAll(ctx context.Context) ([]*storage.PolicyCategoryEdge, error)
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)

--- a/central/processbaseline/store/mocks/store.go
+++ b/central/processbaseline/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ProcessBaseline
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -183,7 +182,7 @@ func copyFromProcessBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ProcessBaselinesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, processBaselineCount)
 
-	s.NoError(store.DeleteMany(ctx, processBaselineIDs))
+	s.NoError(store.Delete(ctx, processBaselineIDs...))
 
 	processBaselineCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *ProcessBaselinesStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/processbaseline/store/store.go
+++ b/central/processbaseline/store/store.go
@@ -22,5 +22,5 @@ type Store interface {
 	Upsert(ctx context.Context, baseline *storage.ProcessBaseline) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessBaseline) error
 
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ProcessBaselineResults
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, deploymentID string) error
+	Delete(ctx context.Context, deploymentID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -170,7 +169,7 @@ func copyFromProcessBaselineResults(ctx context.Context, s pgSearch.Deleter, tx 
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, processBaselineResultsCount)
 
-	s.NoError(store.DeleteMany(ctx, processBaselineResultsIDs))
+	s.NoError(store.Delete(ctx, processBaselineResultsIDs...))
 
 	processBaselineResultsCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *ProcessBaselineResultsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetDeploymentId(),
 				objB.GetDeploymentId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/processbaselineresults/datastore/internal/store/store.go
+++ b/central/processbaselineresults/datastore/internal/store/store.go
@@ -8,7 +8,7 @@ import (
 
 // Store implements the interface for process baseline results.
 type Store interface {
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Get(ctx context.Context, id string) (*storage.ProcessBaselineResults, bool, error)
 	Upsert(ctx context.Context, baselineresults *storage.ProcessBaselineResults) error
 }

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -123,7 +123,7 @@ func (ds *datastoreImpl) removeIndicators(ctx context.Context, ids []string) err
 	if len(ids) == 0 {
 		return nil
 	}
-	if err := ds.storage.DeleteMany(ctx, ids); err != nil {
+	if err := ds.storage.Delete(ctx, ids...); err != nil {
 		return err
 	}
 

--- a/central/processindicator/store/mocks/store.go
+++ b/central/processindicator/store/mocks/store.go
@@ -58,6 +58,25 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockStore)(nil).Count), ctx, q)
 }
 
+// Delete mocks base method.
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
+}
+
 // DeleteByQuery mocks base method.
 func (m *MockStore) DeleteByQuery(ctx context.Context, query *v1.Query) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -71,20 +90,6 @@ func (m *MockStore) DeleteByQuery(ctx context.Context, query *v1.Query) ([]strin
 func (mr *MockStoreMockRecorder) DeleteByQuery(ctx, query any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByQuery", reflect.TypeOf((*MockStore)(nil).DeleteByQuery), ctx, query)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, id []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, id)
 }
 
 // Get mocks base method.

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.ProcessIndicator
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -201,7 +200,7 @@ func copyFromProcessIndicators(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ProcessIndicatorsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, processIndicatorCount)
 
-	s.NoError(store.DeleteMany(ctx, processIndicatorIDs))
+	s.NoError(store.Delete(ctx, processIndicatorIDs...))
 
 	processIndicatorCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *ProcessIndicatorsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -20,7 +20,7 @@ type Store interface {
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
 
 	UpsertMany(context.Context, []*storage.ProcessIndicator) error
-	DeleteMany(ctx context.Context, id []string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Walk(context.Context, func(pi *storage.ProcessIndicator) error) error
 	DeleteByQuery(ctx context.Context, query *v1.Query) ([]string, error)

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -312,7 +312,7 @@ func (ds *datastoreImpl) removePLOP(ctx context.Context, ids []string) error {
 		return nil
 	}
 
-	return ds.storage.DeleteMany(ctx, ids)
+	return ds.storage.Delete(ctx, ids...)
 }
 
 // fetchExistingPLOPs: Query already existing PLOP objects belonging to the

--- a/central/processlisteningonport/store/mocks/store.go
+++ b/central/processlisteningonport/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // DeleteByQuery mocks base method.
@@ -85,20 +90,6 @@ func (m *MockStore) DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, e
 func (mr *MockStoreMockRecorder) DeleteByQuery(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByQuery", reflect.TypeOf((*MockStore)(nil).DeleteByQuery), ctx, q)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, identifiers []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, identifiers)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, identifiers any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, identifiers)
 }
 
 // Exists mocks base method.

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.ProcessListeningOnPortStorage
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -192,7 +191,7 @@ func copyFromListeningEndpoints(ctx context.Context, s pgSearch.Deleter, tx *pos
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/processlisteningonport/store/postgres/store_test.go
+++ b/central/processlisteningonport/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ListeningEndpointsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, processListeningOnPortStorageCount)
 
-	s.NoError(store.DeleteMany(ctx, processListeningOnPortStorageIDs))
+	s.NoError(store.Delete(ctx, processListeningOnPortStorageIDs...))
 
 	processListeningOnPortStorageCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *ListeningEndpointsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/processlisteningonport/store/store.go
+++ b/central/processlisteningonport/store/store.go
@@ -14,9 +14,8 @@ import (
 type Store interface {
 	Upsert(ctx context.Context, obj *storage.ProcessListeningOnPortStorage) error
 	UpsertMany(ctx context.Context, objs []*storage.ProcessListeningOnPortStorage) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.K8SRole
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -185,7 +184,7 @@ func copyFromK8sRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *K8sRolesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, k8SRoleCount)
 
-	s.NoError(store.DeleteMany(ctx, k8SRoleIDs))
+	s.NoError(store.Delete(ctx, k8SRoleIDs...))
 
 	k8SRoleCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *K8sRolesStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/rbac/k8srole/internal/store/store.go
+++ b/central/rbac/k8srole/internal/store/store.go
@@ -18,5 +18,5 @@ type Store interface {
 	Walk(ctx context.Context, fn func(role *storage.K8SRole) error) error
 
 	Upsert(ctx context.Context, role *storage.K8SRole) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.K8SRoleBinding
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -214,7 +213,7 @@ func copyFromRoleBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *RoleBindingsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, k8SRoleBindingCount)
 
-	s.NoError(store.DeleteMany(ctx, k8SRoleBindingIDs))
+	s.NoError(store.Delete(ctx, k8SRoleBindingIDs...))
 
 	k8SRoleBindingCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *RoleBindingsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/rbac/k8srolebinding/internal/store/store.go
+++ b/central/rbac/k8srolebinding/internal/store/store.go
@@ -16,5 +16,5 @@ type Store interface {
 	GetMany(ctx context.Context, ids []string) ([]*storage.K8SRoleBinding, []int, error)
 	Walk(ctx context.Context, fn func(binding *storage.K8SRoleBinding) error) error
 	Upsert(ctx context.Context, rolebinding *storage.K8SRoleBinding) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/reports/config/store/mocks/store.go
+++ b/central/reports/config/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/reports/config/store/postgres/store.go
+++ b/central/reports/config/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ReportConfiguration
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -183,7 +182,7 @@ func copyFromReportConfigurations(ctx context.Context, s pgSearch.Deleter, tx *p
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/reports/config/store/postgres/store_test.go
+++ b/central/reports/config/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *ReportConfigurationsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, reportConfigurationCount)
 
-	s.NoError(store.DeleteMany(ctx, reportConfigurationIDs))
+	s.NoError(store.Delete(ctx, reportConfigurationIDs...))
 
 	reportConfigurationCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/reports/config/store/store.go
+++ b/central/reports/config/store/store.go
@@ -20,5 +20,5 @@ type Store interface {
 	Walk(context.Context, func(reportConfig *storage.ReportConfiguration) error) error
 
 	Upsert(ctx context.Context, reportConfig *storage.ReportConfiguration) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.ReportSnapshot
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, reportID string) error
+	Delete(ctx context.Context, reportID ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -172,7 +171,7 @@ func copyFromReportSnapshots(ctx context.Context, s pgSearch.Deleter, tx *postgr
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/resourcecollection/datastore/store/mocks/store.go
+++ b/central/resourcecollection/datastore/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ResourceCollection
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -177,7 +176,7 @@ func copyFromCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/resourcecollection/datastore/store/postgres/store_test.go
+++ b/central/resourcecollection/datastore/store/postgres/store_test.go
@@ -99,7 +99,7 @@ func (s *CollectionsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, resourceCollectionCount)
 
-	s.NoError(store.DeleteMany(ctx, resourceCollectionIDs))
+	s.NoError(store.Delete(ctx, resourceCollectionIDs...))
 
 	resourceCollectionCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/resourcecollection/datastore/store/store.go
+++ b/central/resourcecollection/datastore/store/store.go
@@ -20,7 +20,7 @@ type Store interface {
 	GetMany(ctx context.Context, ids []string) ([]*storage.ResourceCollection, []int, error)
 
 	Upsert(context.Context, *storage.ResourceCollection) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Walk(ctx context.Context, fn func(obj *storage.ResourceCollection) error) error
 }

--- a/central/risk/datastore/internal/store/mocks/store.go
+++ b/central/risk/datastore/internal/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.Risk
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -176,7 +175,7 @@ func copyFromRisks(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *RisksStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, riskCount)
 
-	s.NoError(store.DeleteMany(ctx, riskIDs))
+	s.NoError(store.Delete(ctx, riskIDs...))
 
 	riskCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *RisksStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/risk/datastore/internal/store/store.go
+++ b/central/risk/datastore/internal/store/store.go
@@ -18,5 +18,5 @@ type Store interface {
 	GetMany(ctx context.Context, ids []string) ([]*storage.Risk, []int, error)
 	Walk(context.Context, func(risk *storage.Risk) error) error
 	Upsert(ctx context.Context, risk *storage.Risk) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/role/store/mocks/store.go
+++ b/central/role/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockPermissionSetStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockPermissionSetStore) Delete(ctx context.Context, id string) error {
+func (m *MockPermissionSetStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockPermissionSetStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockPermissionSetStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPermissionSetStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPermissionSetStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.
@@ -185,17 +190,22 @@ func (mr *MockSimpleAccessScopeStoreMockRecorder) Count(ctx, q any) *gomock.Call
 }
 
 // Delete mocks base method.
-func (m *MockSimpleAccessScopeStore) Delete(ctx context.Context, id string) error {
+func (m *MockSimpleAccessScopeStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockSimpleAccessScopeStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockSimpleAccessScopeStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSimpleAccessScopeStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSimpleAccessScopeStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.
@@ -326,17 +336,22 @@ func (mr *MockRoleStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockRoleStore) Delete(ctx context.Context, id string) error {
+func (m *MockRoleStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockRoleStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockRoleStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRoleStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRoleStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.PermissionSet
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -146,7 +145,7 @@ func copyFromPermissionSets(ctx context.Context, s pgSearch.Deleter, tx *postgre
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/role/store/permissionset/postgres/store_test.go
+++ b/central/role/store/permissionset/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *PermissionSetsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, permissionSetCount)
 
-	s.NoError(store.DeleteMany(ctx, permissionSetIDs))
+	s.NoError(store.Delete(ctx, permissionSetIDs...))
 
 	permissionSetCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.Role
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, name string) error
+	Delete(ctx context.Context, name ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/role/store/role/postgres/store_test.go
+++ b/central/role/store/role/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *RolesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, roleCount)
 
-	s.NoError(store.DeleteMany(ctx, roleIDs))
+	s.NoError(store.Delete(ctx, roleIDs...))
 
 	roleCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.SimpleAccessScope
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -146,7 +145,7 @@ func copyFromSimpleAccessScopes(ctx context.Context, s pgSearch.Deleter, tx *pos
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/role/store/simpleaccessscope/postgres/store_test.go
+++ b/central/role/store/simpleaccessscope/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *SimpleAccessScopesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, simpleAccessScopeCount)
 
-	s.NoError(store.DeleteMany(ctx, simpleAccessScopeIDs))
+	s.NoError(store.Delete(ctx, simpleAccessScopeIDs...))
 
 	simpleAccessScopeCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/role/store/store.go
+++ b/central/role/store/store.go
@@ -17,7 +17,7 @@ type PermissionSetStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Upsert(ctx context.Context, obj *storage.PermissionSet) error
 	UpsertMany(ctx context.Context, obj []*storage.PermissionSet) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error
 }
 
@@ -31,7 +31,7 @@ type SimpleAccessScopeStore interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error
 	UpsertMany(ctx context.Context, obj []*storage.SimpleAccessScope) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.SimpleAccessScope) error) error
 }
 
@@ -44,6 +44,6 @@ type RoleStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Upsert(ctx context.Context, obj *storage.Role) error
 	UpsertMany(ctx context.Context, obj []*storage.Role) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.Role) error) error
 }

--- a/central/secret/internal/store/mocks/store.go
+++ b/central/secret/internal/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Get mocks base method.

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -42,9 +42,8 @@ type storeType = storage.Secret
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -232,7 +231,7 @@ func copyFromSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, o
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *SecretsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, secretCount)
 
-	s.NoError(store.DeleteMany(ctx, secretIDs))
+	s.NoError(store.Delete(ctx, secretIDs...))
 
 	secretCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *SecretsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/secret/internal/store/store.go
+++ b/central/secret/internal/store/store.go
@@ -19,5 +19,5 @@ type Store interface {
 	Walk(context.Context, func(secret *storage.Secret) error) error
 
 	Upsert(ctx context.Context, secret *storage.Secret) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -41,9 +41,8 @@ type storeType = storage.ServiceAccount
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -182,7 +181,7 @@ func copyFromServiceAccounts(ctx context.Context, s pgSearch.Deleter, tx *postgr
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ServiceAccountsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, serviceAccountCount)
 
-	s.NoError(store.DeleteMany(ctx, serviceAccountIDs))
+	s.NoError(store.Delete(ctx, serviceAccountIDs...))
 
 	serviceAccountCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -367,10 +367,10 @@ func (s *ServiceAccountsStoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				objA.GetId(),
 				objB.GetId(),
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/central/serviceaccount/internal/store/store.go
+++ b/central/serviceaccount/internal/store/store.go
@@ -17,5 +17,5 @@ type Store interface {
 	Walk(context.Context, func(sa *storage.ServiceAccount) error) error
 
 	Upsert(ctx context.Context, serviceaccount *storage.ServiceAccount) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.ServiceIdentity
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, serialStr string) error
+	Delete(ctx context.Context, serialStr ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -143,7 +142,7 @@ func copyFromServiceIdentities(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/serviceidentities/internal/store/postgres/store_test.go
+++ b/central/serviceidentities/internal/store/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *ServiceIdentitiesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, serviceIdentityCount)
 
-	s.NoError(store.DeleteMany(ctx, serviceIdentityIDs))
+	s.NoError(store.Delete(ctx, serviceIdentityIDs...))
 
 	serviceIdentityCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/signatureintegration/store/mocks/store.go
+++ b/central/signatureintegration/store/mocks/store.go
@@ -59,17 +59,22 @@ func (mr *MockSignatureIntegrationStoreMockRecorder) Count(ctx, q any) *gomock.C
 }
 
 // Delete mocks base method.
-func (m *MockSignatureIntegrationStore) Delete(ctx context.Context, id string) error {
+func (m *MockSignatureIntegrationStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockSignatureIntegrationStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockSignatureIntegrationStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSignatureIntegrationStore)(nil).Delete), ctx, id)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSignatureIntegrationStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.SignatureIntegration
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -154,7 +153,7 @@ func copyFromSignatureIntegrations(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/signatureintegration/store/postgres/store_test.go
+++ b/central/signatureintegration/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *SignatureIntegrationsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, signatureIntegrationCount)
 
-	s.NoError(store.DeleteMany(ctx, signatureIntegrationIDs))
+	s.NoError(store.Delete(ctx, signatureIntegrationIDs...))
 
 	signatureIntegrationCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/signatureintegration/store/store.go
+++ b/central/signatureintegration/store/store.go
@@ -17,6 +17,6 @@ type SignatureIntegrationStore interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Upsert(ctx context.Context, obj *storage.SignatureIntegration) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	Walk(ctx context.Context, fn func(obj *storage.SignatureIntegration) error) error
 }

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
@@ -420,7 +420,7 @@ func (ds *datastoreImpl) RemoveRequestsInternal(ctx context.Context, ids []strin
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-	if err := ds.store.DeleteMany(ctx, ids); err != nil {
+	if err := ds.store.Delete(ctx, ids...); err != nil {
 		return err
 	}
 	ds.pendingReqCache.RemoveMany(ids...)

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/mocks/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/mocks/store.go
@@ -59,31 +59,22 @@ func (mr *MockStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockStore) Delete(ctx context.Context, id string) error {
+func (m *MockStore) Delete(ctx context.Context, id ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	varargs := []any{ctx}
+	for _, a := range id {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockStoreMockRecorder) Delete(ctx any, id ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), ctx, id)
-}
-
-// DeleteMany mocks base method.
-func (m *MockStore) DeleteMany(ctx context.Context, ids []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMany", ctx, ids)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMany indicates an expected call of DeleteMany.
-func (mr *MockStoreMockRecorder) DeleteMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMany", reflect.TypeOf((*MockStore)(nil).DeleteMany), ctx, ids)
+	varargs := append([]any{ctx}, id...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStore)(nil).Delete), varargs...)
 }
 
 // Exists mocks base method.

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -38,9 +38,8 @@ type storeType = storage.VulnerabilityRequest
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -269,7 +268,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *VulnerabilityRequestsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, vulnerabilityRequestCount)
 
-	s.NoError(store.DeleteMany(ctx, vulnerabilityRequestIDs))
+	s.NoError(store.Delete(ctx, vulnerabilityRequestIDs...))
 
 	vulnerabilityRequestCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/store.go
@@ -22,6 +22,5 @@ type Store interface {
 	GetMany(ctx context.Context, ids []string) ([]*storage.VulnerabilityRequest, []int, error)
 
 	Upsert(ctx context.Context, req *storage.VulnerabilityRequest) error
-	Delete(ctx context.Context, id string) error
-	DeleteMany(ctx context.Context, ids []string) error
+	Delete(ctx context.Context, id ...string) error
 }

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -37,9 +37,8 @@ type storeType = storage.WatchedImage
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, name string) error
+	Delete(ctx context.Context, name ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -142,7 +141,7 @@ func copyFromWatchedImages(ctx context.Context, s pgSearch.Deleter, tx *postgres
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/central/watchedimage/datastore/internal/store/postgres/store_test.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *WatchedImagesStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, watchedImageCount)
 
-	s.NoError(store.DeleteMany(ctx, watchedImageIDs))
+	s.NoError(store.Delete(ctx, watchedImageIDs...))
 
 	watchedImageCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/central/watchedimage/datastore/internal/store/store.go
+++ b/central/watchedimage/datastore/internal/store/store.go
@@ -10,6 +10,6 @@ import (
 type Store interface {
 	Upsert(ctx context.Context, obj *storage.WatchedImage) error
 	Walk(ctx context.Context, fn func(obj *storage.WatchedImage) error) error
-	Delete(ctx context.Context, name string) error
+	Delete(ctx context.Context, name ...string) error
 	Exists(ctx context.Context, name string) (bool, error)
 }

--- a/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/previous/store.go
+++ b/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/previous/store.go
@@ -192,7 +192,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/updated/store.go
+++ b/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/updated/store.go
@@ -196,7 +196,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/previous/store.go
+++ b/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/previous/store.go
@@ -192,7 +192,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/updated/store.go
+++ b/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/updated/store.go
@@ -33,8 +33,7 @@ type storeType = storage.VulnerabilityRequest
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
-	DeleteMany(ctx context.Context, identifiers []string) error
+	Delete(ctx context.Context, id ...string) error
 
 	Exists(ctx context.Context, id string) (bool, error)
 
@@ -209,7 +208,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/authproviders/store.go
+++ b/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/authproviders/store.go
@@ -117,7 +117,7 @@ func copyFromAuthProviders(ctx context.Context, s pgSearch.Deleter, tx *postgres
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/groups/store.go
+++ b/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/groups/store.go
@@ -123,7 +123,7 @@ func copyFromGroups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/stores/rules/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/stores/rules/store.go
@@ -155,7 +155,7 @@ func copyFromComplianceOperatorRuleV2(ctx context.Context, s pgSearch.Deleter, t
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/profiles/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/profiles/store.go
@@ -159,7 +159,7 @@ func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/results/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/results/store.go
@@ -141,7 +141,7 @@ func copyFromComplianceOperatorCheckResultV2(ctx context.Context, s pgSearch.Del
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/rules/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/rules/store.go
@@ -153,7 +153,7 @@ func copyFromComplianceOperatorRuleV2(ctx context.Context, s pgSearch.Deleter, t
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/scans/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/scans/store.go
@@ -138,7 +138,7 @@ func copyFromComplianceOperatorScanV2(ctx context.Context, s pgSearch.Deleter, t
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/store/store.go
+++ b/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/store/store.go
@@ -239,7 +239,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecveedges/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecveedges/store.go
@@ -117,7 +117,7 @@ func copyFromImageCveEdges(ctx context.Context, s pgSearch.Deleter, tx *postgres
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecves/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecves/store.go
@@ -135,7 +135,7 @@ func copyFromImageCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/images/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/images/store.go
@@ -154,7 +154,7 @@ func copyFromImages(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/vulnerabilityrequests/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/vulnerabilityrequests/store.go
@@ -235,7 +235,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/pkg/search/postgres/store_cache_test.go
+++ b/pkg/search/postgres/store_cache_test.go
@@ -154,7 +154,7 @@ func TestCachedDeleteMany(t *testing.T) {
 	assert.False(t, missingFoundBefore)
 	assert.NoError(t, missingErrBefore)
 
-	assert.NoError(t, store.DeleteMany(cachedStoreCtx, identifiersToRemove))
+	assert.NoError(t, store.Delete(cachedStoreCtx, identifiersToRemove...))
 
 	for _, obj := range objectBatch {
 		key := pkGetterForCache(obj)
@@ -674,7 +674,7 @@ func copyFromTestSingleKeyStructsWithCache(ctx context.Context, s Deleter, tx *p
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and values for the next batch

--- a/pkg/search/postgres/store_test.go
+++ b/pkg/search/postgres/store_test.go
@@ -154,7 +154,7 @@ func TestDeleteMany(t *testing.T) {
 	assert.False(t, missingFoundBefore)
 	assert.NoError(t, missingErrBefore)
 
-	assert.NoError(t, store.DeleteMany(ctx, identifiersToRemove))
+	assert.NoError(t, store.Delete(ctx, identifiersToRemove...))
 
 	for _, obj := range objectBatch {
 		key := pkGetter(obj)
@@ -660,7 +660,7 @@ func copyFromTestSingleKeyStructs(ctx context.Context, s Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and values for the next batch

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.TestStruct
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, key1 string) error
+	Delete(ctx context.Context, key1 ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -214,7 +213,7 @@ func copyFromTestStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store_test.go
@@ -97,7 +97,7 @@ func (s *TestStructsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testStructCount)
 
-	s.NoError(store.DeleteMany(ctx, testStructIDs))
+	s.NoError(store.Delete(ctx, testStructIDs...))
 
 	testStructCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -56,9 +56,8 @@ type Store interface {
 {{- if not .JoinTable }}
     Upsert(ctx context.Context, obj *storeType) error
     UpsertMany(ctx context.Context, objs []*storeType) error
-    Delete(ctx context.Context, {{$primaryKeyName}} {{$primaryKeyType}}) error
+    Delete(ctx context.Context, {{$primaryKeyName}} ...{{$primaryKeyType}}) error
     DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-    DeleteMany(ctx context.Context, identifiers []{{$primaryKeyType}}) error
     PruneMany(ctx context.Context, identifiers []{{$primaryKeyType}}) error
 {{- end }}
 
@@ -285,7 +284,7 @@ func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.D
             // copy does not upsert so have to delete first.  parent deletion cascades so only need to
             // delete for the top level parent
             {{if not $schema.Parent }}
-            if err := s.DeleteMany(ctx, deletes); err != nil {
+            if err := s.Delete(ctx, deletes...); err != nil {
                 return err
             }
             // clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -138,7 +138,7 @@ func (s *{{$namePrefix}}StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, {{.TrimmedType|lowerCamelCase}}Count)
 
-	s.NoError(store.DeleteMany(ctx, {{$name}}IDs))
+	s.NoError(store.Delete(ctx, {{$name}}IDs...))
 
 	{{.TrimmedType|lowerCamelCase}}Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
@@ -418,10 +418,10 @@ func (s *{{$namePrefix}}StoreSuite) TestSACDeleteMany() {
 			s.NoError(s.store.Upsert(withAllAccessCtx, objA))
 			s.NoError(s.store.Upsert(withAllAccessCtx, objB))
 
-			assert.NoError(t, s.store.DeleteMany(testCase.context, []string{
+			assert.NoError(t, s.store.Delete(testCase.context,
 				{{ (index .Schema.PrimaryKeys 0).Getter "objA"}},
 				{{ (index .Schema.PrimaryKeys 0).Getter "objB"}},
-			}))
+			))
 
 			count, err := s.store.Count(withAllAccessCtx, search.EmptyQuery())
 			assert.NoError(t, err)

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.TestSingleKeyStruct
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, key string) error
+	Delete(ctx context.Context, key ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -176,7 +175,7 @@ func copyFromTestSingleKeyStructs(ctx context.Context, s pgSearch.Deleter, tx *p
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *TestSingleKeyStructsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testSingleKeyStructCount)
 
-	s.NoError(store.DeleteMany(ctx, testSingleKeyStructIDs))
+	s.NoError(store.Delete(ctx, testSingleKeyStructIDs...))
 
 	testSingleKeyStructCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestChild1
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -146,7 +145,7 @@ func copyFromTestChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store_test.go
@@ -97,7 +97,7 @@ func (s *TestChild1StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testChild1Count)
 
-	s.NoError(store.DeleteMany(ctx, testChild1IDs))
+	s.NoError(store.Delete(ctx, testChild1IDs...))
 
 	testChild1Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -38,9 +38,8 @@ type storeType = storage.TestChild1P4
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -150,7 +149,7 @@ func copyFromTestChild1P4(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -38,9 +38,8 @@ type storeType = storage.TestChild2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -153,7 +152,7 @@ func copyFromTestChild2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestG2GrandChild1
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -152,7 +151,7 @@ func copyFromTestG2GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestG3GrandChild1
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -146,7 +145,7 @@ func copyFromTestG3GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store_test.go
@@ -97,7 +97,7 @@ func (s *TestG3GrandChild1StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testG3GrandChild1Count)
 
-	s.NoError(store.DeleteMany(ctx, testG3GrandChild1IDs))
+	s.NoError(store.Delete(ctx, testG3GrandChild1IDs...))
 
 	testG3GrandChild1Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestGGrandChild1
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -146,7 +145,7 @@ func copyFromTestGGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postg
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store_test.go
@@ -97,7 +97,7 @@ func (s *TestGGrandChild1StoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testGGrandChild1Count)
 
-	s.NoError(store.DeleteMany(ctx, testGGrandChild1IDs))
+	s.NoError(store.Delete(ctx, testGGrandChild1IDs...))
 
 	testGGrandChild1Count, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestGrandChild1
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -152,7 +151,7 @@ func copyFromTestGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgr
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestGrandparent
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -203,7 +202,7 @@ func copyFromTestGrandparents(ctx context.Context, s pgSearch.Deleter, tx *postg
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store_test.go
@@ -97,7 +97,7 @@ func (s *TestGrandparentsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testGrandparentCount)
 
-	s.NoError(store.DeleteMany(ctx, testGrandparentIDs))
+	s.NoError(store.Delete(ctx, testGrandparentIDs...))
 
 	testGrandparentCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestParent1
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -177,7 +176,7 @@ func copyFromTestParent1(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -38,9 +38,8 @@ type storeType = storage.TestParent2
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -150,7 +149,7 @@ func copyFromTestParent2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestParent3
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -149,7 +148,7 @@ func copyFromTestParent3(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -38,9 +38,8 @@ type storeType = storage.TestParent4
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -150,7 +149,7 @@ func copyFromTestParent4(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -37,9 +37,8 @@ type storeType = storage.TestShortCircuit
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -149,7 +148,7 @@ func copyFromTestShortCircuits(ctx context.Context, s pgSearch.Deleter, tx *post
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store_test.go
@@ -97,7 +97,7 @@ func (s *TestShortCircuitsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testShortCircuitCount)
 
-	s.NoError(store.DeleteMany(ctx, testShortCircuitIDs))
+	s.NoError(store.Delete(ctx, testShortCircuitIDs...))
 
 	testShortCircuitCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -39,9 +39,8 @@ type storeType = storage.TestSingleUUIDKeyStruct
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
-	Delete(ctx context.Context, key string) error
+	Delete(ctx context.Context, key ...string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
-	DeleteMany(ctx context.Context, identifiers []string) error
 	PruneMany(ctx context.Context, identifiers []string) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
@@ -176,7 +175,7 @@ func copyFromTestSingleUUIDKeyStructs(ctx context.Context, s pgSearch.Deleter, t
 			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
 			// delete for the top level parent
 
-			if err := s.DeleteMany(ctx, deletes); err != nil {
+			if err := s.Delete(ctx, deletes...); err != nil {
 				return err
 			}
 			// clear the inserts and vals for the next batch

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store_test.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store_test.go
@@ -100,7 +100,7 @@ func (s *TestSingleUUIDKeyStructsStoreSuite) TestStore() {
 	s.NoError(err)
 	s.Equal(200, testSingleUUIDKeyStructCount)
 
-	s.NoError(store.DeleteMany(ctx, testSingleUUIDKeyStructIDs))
+	s.NoError(store.Delete(ctx, testSingleUUIDKeyStructIDs...))
 
 	testSingleUUIDKeyStructCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)


### PR DESCRIPTION
### Description

This PR aims to reduce our store interface by combining `Delete` and `DeleteMany` using variadic args. Eventually we should have just a single implementation of delete that handles SAC and transactions. For now it's just the first phase.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
