### PR TITLE
chore(pg): cleanup storeWrapper

### DIFF
--- a/central/auth/store/store.go
+++ b/central/auth/store/store.go
@@ -21,32 +21,16 @@ type Store interface {
 // The reason for requiring this is that we also have an in-memory store for the auth machine to machine config,
 // and require rollbacks for upsert and delete.
 type storeWrapper struct {
-	db    pgPkg.DB
-	store authPGStore.Store
+	db pgPkg.DB
+	authPGStore.Store
 }
 
 // New creates a new store.
 func New(db pgPkg.DB) Store {
 	return &storeWrapper{
 		db:    db,
-		store: authPGStore.New(db),
+		Store: authPGStore.New(db),
 	}
-}
-
-func (s *storeWrapper) Get(ctx context.Context, id string) (*storage.AuthMachineToMachineConfig, bool, error) {
-	return s.store.Get(ctx, id)
-}
-
-func (s *storeWrapper) Upsert(ctx context.Context, obj *storage.AuthMachineToMachineConfig) error {
-	return s.store.Upsert(ctx, obj)
-}
-
-func (s *storeWrapper) Delete(ctx context.Context, id string) error {
-	return s.store.Delete(ctx, id)
-}
-
-func (s *storeWrapper) GetAll(ctx context.Context) ([]*storage.AuthMachineToMachineConfig, error) {
-	return s.store.GetAll(ctx)
 }
 
 // Begin begins a transaction, returning the transaction context from the given context and the transaction itself.

--- a/central/policy/store/store.go
+++ b/central/policy/store/store.go
@@ -31,55 +31,15 @@ type Store interface {
 }
 
 type storeWrapper struct {
-	db    pgPkg.DB
-	store policyPGStore.Store
+	db pgPkg.DB
+	policyPGStore.Store
 }
 
 func New(db pgPkg.DB) Store {
 	return &storeWrapper{
 		db:    db,
-		store: policyPGStore.New(db),
+		Store: policyPGStore.New(db),
 	}
-}
-
-func (s *storeWrapper) Count(ctx context.Context, q *v1.Query) (int, error) {
-	return s.store.Count(ctx, q)
-}
-
-func (s *storeWrapper) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
-	return s.store.Search(ctx, q)
-}
-
-func (s *storeWrapper) Get(ctx context.Context, id string) (*storage.Policy, bool, error) {
-	return s.store.Get(ctx, id)
-}
-
-func (s *storeWrapper) GetMany(ctx context.Context, ids []string) ([]*storage.Policy, []int, error) {
-	return s.store.GetMany(ctx, ids)
-}
-
-func (s *storeWrapper) GetAll(ctx context.Context) ([]*storage.Policy, error) {
-	return s.store.GetAll(ctx)
-}
-
-func (s *storeWrapper) GetIDs(ctx context.Context) ([]string, error) {
-	return s.store.GetIDs(ctx)
-}
-
-func (s *storeWrapper) Upsert(ctx context.Context, obj *storage.Policy) error {
-	return s.store.Upsert(ctx, obj)
-}
-
-func (s *storeWrapper) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
-	return s.store.UpsertMany(ctx, objs)
-}
-
-func (s *storeWrapper) Delete(ctx context.Context, id string) error {
-	return s.store.Delete(ctx, id)
-}
-
-func (s *storeWrapper) DeleteMany(ctx context.Context, ids []string) error {
-	return s.store.DeleteMany(ctx, ids)
 }
 
 func (s *storeWrapper) Begin(ctx context.Context) (context.Context, *pgPkg.Tx, error) {


### PR DESCRIPTION
### Description

`storeWrapper` decorates the store with `Begin` method. It's implementation is OK but we can remove duplicated code by including store into the struct instead of using a field. This allow use to use store interface and extend it with necessary method without implementing all store methods.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
