### PR TITLE
ROX-28473: Add tabs within VM Reporting

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
@@ -46,6 +46,8 @@ const routeMatcherMapForWizardStep2 = {
 };
 
 export const vulnerabilityReportsBasePath = '/main/vulnerabilities/reports';
+export const vulnerabilityReportsConfigurationPath = `${vulnerabilityReportsBasePath}/configuration`;
+export const vulnerabilityReportsOnDemandPath = `${vulnerabilityReportsBasePath}/on-demand`;
 
 // visit
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
@@ -1,7 +1,6 @@
 import withAuth from '../../../helpers/basicAuth';
 import {
     visitVulnerabilityReports,
-    vulnerabilityReportsBasePath,
     vulnerabilityReportsConfigurationPath,
 } from './VulnerabilityReporting.helpers';
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/vulnerabilityReportingNav.test.ts
@@ -2,6 +2,7 @@ import withAuth from '../../../helpers/basicAuth';
 import {
     visitVulnerabilityReports,
     vulnerabilityReportsBasePath,
+    vulnerabilityReportsConfigurationPath,
 } from './VulnerabilityReporting.helpers';
 
 const staticResponseMap = {
@@ -22,7 +23,7 @@ describe('Vulnerability Reporting Navigation', () => {
 
     it('navigates to the index page', () => {
         visitVulnerabilityReports(staticResponseMap);
-        cy.location('pathname').should('eq', vulnerabilityReportsBasePath);
+        cy.location('pathname').should('eq', vulnerabilityReportsConfigurationPath);
         cy.get('h1').should('contain', 'Vulnerability reporting');
     });
 
@@ -30,7 +31,7 @@ describe('Vulnerability Reporting Navigation', () => {
         visitVulnerabilityReports(staticResponseMap);
         cy.contains('button', 'Create report').click();
         cy.location().should((location) => {
-            expect(location.pathname).to.eq(vulnerabilityReportsBasePath);
+            expect(location.pathname).to.eq(vulnerabilityReportsConfigurationPath);
             expect(location.search).to.include('action=create');
         });
         cy.get('h1').should('contain', 'Create report');
@@ -46,7 +47,7 @@ describe('Vulnerability Reporting Navigation', () => {
 
             cy.location('pathname').should(
                 'eq',
-                `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                `${vulnerabilityReportsConfigurationPath}/${firstReport.id}`
             );
             cy.get('h1').should('contain', firstReport.name);
         });
@@ -62,7 +63,7 @@ describe('Vulnerability Reporting Navigation', () => {
 
             cy.location().should((location) => {
                 expect(location.pathname).to.eq(
-                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                    `${vulnerabilityReportsConfigurationPath}/${firstReport.id}`
                 );
                 expect(location.search).to.include('action=edit');
             });
@@ -76,7 +77,7 @@ describe('Vulnerability Reporting Navigation', () => {
 
             cy.location().should((location) => {
                 expect(location.pathname).to.eq(
-                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                    `${vulnerabilityReportsConfigurationPath}/${firstReport.id}`
                 );
                 expect(location.search).to.include('action=edit');
             });
@@ -94,7 +95,7 @@ describe('Vulnerability Reporting Navigation', () => {
 
             cy.location().should((location) => {
                 expect(location.pathname).to.eq(
-                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                    `${vulnerabilityReportsConfigurationPath}/${firstReport.id}`
                 );
                 expect(location.search).to.include('action=clone');
             });
@@ -108,7 +109,7 @@ describe('Vulnerability Reporting Navigation', () => {
 
             cy.location().should((location) => {
                 expect(location.pathname).to.eq(
-                    `${vulnerabilityReportsBasePath}/${firstReport.id}`
+                    `${vulnerabilityReportsConfigurationPath}/${firstReport.id}`
                 );
                 expect(location.search).to.include('action=clone');
             });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -14,7 +14,7 @@ import {
 import { Wizard } from '@patternfly/react-core/deprecated';
 import isEmpty from 'lodash/isEmpty';
 
-import { vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import useReportFormValues from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 import useCreateReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useCreateReport';
 import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport';
@@ -48,7 +48,7 @@ function CloneVulnReportPage() {
     } = useCreateReport({
         onCompleted: () => {
             formik.resetForm();
-            navigate(vulnerabilityReportsPath);
+            navigate(vulnerabilityConfigurationReportsPath);
         },
     });
 
@@ -87,7 +87,7 @@ function CloneVulnReportPage() {
     }
 
     function onClose() {
-        navigate(vulnerabilityReportsPath);
+        navigate(vulnerabilityConfigurationReportsPath);
     }
 
     const wizardSteps = [
@@ -114,7 +114,7 @@ function CloneVulnReportPage() {
                 title="Error fetching the report configuration"
                 message={error}
                 actionText="Go to reports"
-                url={vulnerabilityReportsPath}
+                url={vulnerabilityConfigurationReportsPath}
             />
         );
     }
@@ -133,7 +133,7 @@ function CloneVulnReportPage() {
             <ReportFormErrorAlert error={createError} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={vulnerabilityReportsPath}>
+                    <BreadcrumbItemLink to={vulnerabilityConfigurationReportsPath}>
                         Vulnerability reporting
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>Clone report</BreadcrumbItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
@@ -12,7 +12,7 @@ import {
 import { Wizard, WizardStep } from '@patternfly/react-core/deprecated';
 import isEmpty from 'lodash/isEmpty';
 
-import { vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import useReportFormValues from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 
 import PageTitle from 'Components/PageTitle';
@@ -37,7 +37,7 @@ function CreateVulnReportPage() {
     const { isLoading, error, createReport } = useCreateReport({
         onCompleted: () => {
             formik.resetForm();
-            navigate(vulnerabilityReportsPath);
+            navigate(vulnerabilityConfigurationReportsPath);
         },
     });
 
@@ -46,7 +46,7 @@ function CreateVulnReportPage() {
     }
 
     function onClose() {
-        navigate(vulnerabilityReportsPath);
+        navigate(vulnerabilityConfigurationReportsPath);
     }
 
     // @TODO: This is reused in the Edit and Clone components so we can try to refactor this soon
@@ -91,7 +91,7 @@ function CreateVulnReportPage() {
             <ReportFormErrorAlert error={error} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={vulnerabilityReportsPath}>
+                    <BreadcrumbItemLink to={vulnerabilityConfigurationReportsPath}>
                         Vulnerability reporting
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>Create report</BreadcrumbItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -14,7 +14,7 @@ import {
 import { Wizard } from '@patternfly/react-core/deprecated';
 import isEmpty from 'lodash/isEmpty';
 
-import { vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import useReportFormValues from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 import useSaveReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useSaveReport';
 import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport';
@@ -44,7 +44,7 @@ function EditVulnReportPage() {
     const { isSaving, saveError, saveReport } = useSaveReport({
         onCompleted: () => {
             formik.resetForm();
-            navigate(vulnerabilityReportsPath);
+            navigate(vulnerabilityConfigurationReportsPath);
         },
     });
 
@@ -80,7 +80,7 @@ function EditVulnReportPage() {
     }
 
     function onClose() {
-        navigate(vulnerabilityReportsPath);
+        navigate(vulnerabilityConfigurationReportsPath);
     }
 
     const wizardSteps = [
@@ -107,7 +107,7 @@ function EditVulnReportPage() {
                 title="Error fetching the report configuration"
                 message={error}
                 actionText="Go to reports"
-                url={vulnerabilityReportsPath}
+                url={vulnerabilityConfigurationReportsPath}
             />
         );
     }
@@ -126,7 +126,7 @@ function EditVulnReportPage() {
             <ReportFormErrorAlert error={saveError} />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={vulnerabilityReportsPath}>
+                    <BreadcrumbItemLink to={vulnerabilityConfigurationReportsPath}>
                         Vulnerability reporting
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>Edit report</BreadcrumbItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -27,8 +27,8 @@ import {
 } from '@patternfly/react-core/deprecated';
 import { CaretDownIcon } from '@patternfly/react-icons';
 
-import { vulnerabilityReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
-import { vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityConfigurationReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import { getReportFormValuesFromConfiguration } from 'Containers/Vulnerabilities/VulnerablityReporting/utils';
 import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport';
 import useDeleteModal, {
@@ -90,7 +90,7 @@ function ViewVulnReportPage() {
         deleteResults,
     } = useDeleteModal({
         onCompleted: () => {
-            navigate(vulnerabilityReportsPath);
+            navigate(vulnerabilityConfigurationReportsPath);
         },
     });
 
@@ -131,12 +131,12 @@ function ViewVulnReportPage() {
                 title="Error fetching the report configuration"
                 message={fetchError || 'No data available'}
                 actionText="Go to reports"
-                url={vulnerabilityReportsPath}
+                url={vulnerabilityConfigurationReportsPath}
             />
         );
     }
 
-    const vulnReportPageURL = generatePath(vulnerabilityReportPath, {
+    const vulnReportPageURL = generatePath(vulnerabilityConfigurationReportPath, {
         reportId: reportConfiguration.id,
     });
 
@@ -173,7 +173,7 @@ function ViewVulnReportPage() {
             <PageTitle title="View vulnerability report" />
             <PageSection variant="light" className="pf-v5-u-py-md">
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={vulnerabilityReportsPath}>
+                    <BreadcrumbItemLink to={vulnerabilityConfigurationReportsPath}>
                         Vulnerability reporting
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>{reportConfiguration.name}</BreadcrumbItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '@patternfly/react-core/deprecated';
 import { CaretDownIcon } from '@patternfly/react-icons';
 
-import { vulnerabilityConfigurationReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
+import { vulnerabilityConfigurationReportDetailsPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import { getReportFormValuesFromConfiguration } from 'Containers/Vulnerabilities/VulnerablityReporting/utils';
 import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReport';
@@ -136,7 +136,7 @@ function ViewVulnReportPage() {
         );
     }
 
-    const vulnReportPageURL = generatePath(vulnerabilityConfigurationReportPath, {
+    const vulnReportPageURL = generatePath(vulnerabilityConfigurationReportDetailsPath, {
         reportId: reportConfiguration.id,
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -26,6 +26,7 @@ function VulnReportingPage() {
         hasReadAccess('Image') && // for vulnerabilities
         hasReadAccess('Integration'); // for notifiers
 
+    // TODO: Modify routing for edge cases - https://github.com/stackrox/stackrox/pull/14873#discussion_r2042672432
     return (
         <Routes>
             <Route

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -4,13 +4,14 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 
 import usePageAction from 'hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
-import { vulnerabilityReportsPath } from 'routePaths';
 
-import VulnReportsPage from './VulnReports/VulnReportsPage';
 import CreateVulnReportPage from './ModifyVulnReport/CreateVulnReportPage';
 import EditVulnReportPage from './ModifyVulnReport/EditVulnReportPage';
 import CloneVulnReportPage from './ModifyVulnReport/CloneVulnReportPage';
 import ViewVulnReportPage from './ViewVulnReport/ViewVulnReportPage';
+import ConfigReportsTab from './VulnReports/ConfigReportsTab';
+import OnDemandReportsTab from './VulnReports/OnDemandReportsTab';
+import VulnReportingLayout from './VulnReports/VulnReportingLayout';
 
 import './VulnReportingPage.css';
 
@@ -28,19 +29,20 @@ function VulnReportingPage() {
     return (
         <Routes>
             <Route
-                index
                 element={
                     pageAction === 'create' && hasWriteAccessForReport ? (
                         <CreateVulnReportPage />
-                    ) : !pageAction ? (
-                        <VulnReportsPage />
                     ) : (
-                        <Navigate to={vulnerabilityReportsPath} replace />
+                        <VulnReportingLayout />
                     )
                 }
-            />
+            >
+                <Route index element={<Navigate to="configuration" replace />} />
+                <Route path="configuration" element={<ConfigReportsTab />} />
+                <Route path="on-demand" element={<OnDemandReportsTab />} />
+            </Route>
             <Route
-                path=":reportId"
+                path="/configuration/:reportId"
                 element={
                     pageAction === 'edit' && hasWriteAccessForReport ? (
                         <EditVulnReportPage />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
@@ -6,7 +6,6 @@ import {
     AlertActionCloseButton,
     AlertGroup,
     PageSection,
-    Title,
     Flex,
     FlexItem,
     Button,
@@ -29,8 +28,8 @@ import { DropdownItem } from '@patternfly/react-core/deprecated';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { ExclamationCircleIcon, FileIcon, SearchIcon } from '@patternfly/react-icons';
 
-import { vulnerabilityReportsPath } from 'routePaths';
-import { vulnerabilityReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
+import { vulnerabilityConfigurationReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
 import useFetchReports from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
@@ -60,7 +59,7 @@ import { reportDownloadURL } from 'services/ReportsService';
 
 const CreateReportsButton = () => {
     return (
-        <Link to={`${vulnerabilityReportsPath}?action=create`}>
+        <Link to={`${vulnerabilityConfigurationReportsPath}?action=create`}>
             <Button variant="primary">Create report</Button>
         </Link>
     );
@@ -75,7 +74,7 @@ const sortOptions = {
 
 const emptyReportArray = [];
 
-function VulnReportsPage() {
+function ConfigReportsTab() {
     const navigate = useNavigate();
     const { currentUser } = useAuthStatus();
 
@@ -182,31 +181,22 @@ function VulnReportsPage() {
                     </Alert>
                 ))}
             </AlertGroup>
-            <PageTitle title="Vulnerability reporting" />
-            {runError && <Alert variant="danger" isInline title={runError} component="p" />}
+            <PageTitle title="Vulnerability reporting - Report configurations" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                {runError && <Alert variant="danger" isInline title={runError} component="p" />}
                 <Flex
                     direction={{ default: 'row' }}
                     alignItems={{ default: 'alignItemsCenter' }}
                     className="pf-v5-u-py-lg pf-v5-u-px-lg"
                 >
-                    <FlexItem flex={{ default: 'flex_1' }}>
-                        <Flex direction={{ default: 'column' }}>
-                            <FlexItem>
-                                <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-                                    <Title headingLevel="h1">Vulnerability reporting</Title>
-                                </Flex>
-                            </FlexItem>
-                            <FlexItem>
-                                Configure reports, define collections, and assign delivery
-                                destinations to report on vulnerabilities across the organization.
-                            </FlexItem>
-                        </Flex>
-                    </FlexItem>
+                    <Text>
+                        Configure reports, define collections, and assign delivery destinations to
+                        report on vulnerabilities across the organization.
+                    </Text>
                     {reportConfigurations &&
                         reportConfigurations.length > 0 &&
                         hasWriteAccessForReport && (
-                            <FlexItem>
+                            <FlexItem align={{ default: 'alignRight' }}>
                                 <CreateReportsButton />
                             </FlexItem>
                         )}
@@ -410,7 +400,7 @@ function VulnReportsPage() {
                                         )}
                                     {reportConfigurations.map((report, rowIndex) => {
                                         const vulnReportURL = generatePath(
-                                            vulnerabilityReportPath,
+                                            vulnerabilityConfigurationReportPath,
                                             {
                                                 reportId: report.id,
                                             }
@@ -615,4 +605,4 @@ function VulnReportsPage() {
     );
 }
 
-export default VulnReportsPage;
+export default ConfigReportsTab;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
@@ -29,7 +29,7 @@ import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/reac
 import { ExclamationCircleIcon, FileIcon, SearchIcon } from '@patternfly/react-icons';
 
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
-import { vulnerabilityConfigurationReportPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
+import { vulnerabilityConfigurationReportDetailsPath } from 'Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting';
 import useFetchReports from 'Containers/Vulnerabilities/VulnerablityReporting/api/useFetchReports';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
@@ -400,7 +400,7 @@ function ConfigReportsTab() {
                                         )}
                                     {reportConfigurations.map((report, rowIndex) => {
                                         const vulnReportURL = generatePath(
-                                            vulnerabilityConfigurationReportPath,
+                                            vulnerabilityConfigurationReportDetailsPath,
                                             {
                                                 reportId: report.id,
                                             }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/OnDemandReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/OnDemandReportsTab.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PageTitle from 'Components/PageTitle';
+
+function OnDemandReportsTab() {
+    return (
+        <>
+            <PageTitle title="Vulnerability reporting - On-demand reports" />
+        </>
+    );
+}
+
+export default OnDemandReportsTab;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { PageSection, Title, Tabs, Tab } from '@patternfly/react-core';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import PageTitle from 'Components/PageTitle';
+import {
+    vulnerabilityConfigurationReportsPath,
+    vulnerabilityOnDemandReportsPath,
+} from 'routePaths';
+
+const tabs = [
+    {
+        id: 'report-configuration',
+        title: 'Report configurations',
+        path: vulnerabilityConfigurationReportsPath,
+    },
+    { id: 'on-demand-reports', title: 'On-demand reports', path: vulnerabilityOnDemandReportsPath },
+];
+
+function VulnReportingLayout() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isOnDemandReportsEnabled = isFeatureFlagEnabled('ROX_VULNERABILITY_ON_DEMAND_REPORTS');
+
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const activeTabIndex = tabs.findIndex((tab) => location.pathname.startsWith(tab.path));
+
+    const onTabSelect = (_event, tabIndex) => {
+        navigate(tabs[tabIndex].path);
+    };
+
+    return (
+        <>
+            <PageTitle title="Vulnerability reporting" />
+            <PageSection
+                variant="light"
+                className={`${!isOnDemandReportsEnabled && 'pf-v5-u-pb-0'}`}
+            >
+                <Title headingLevel="h1">Vulnerability reporting</Title>
+            </PageSection>
+            {isOnDemandReportsEnabled && (
+                <PageSection
+                    variant="light"
+                    padding={{ default: 'noPadding' }}
+                    className="pf-v5-u-pl-lg pf-v5-u-background-color-100"
+                >
+                    <Tabs activeKey={activeTabIndex} onSelect={onTabSelect}>
+                        {tabs.map((tab, index) => (
+                            <Tab
+                                key={tab.id}
+                                eventKey={index}
+                                title={tab.title}
+                                tabContentId={`${tab.id}-tab-content`}
+                            />
+                        ))}
+                    </Tabs>
+                </PageSection>
+            )}
+            <PageSection padding={{ default: 'noPadding' }}>
+                <Outlet />
+            </PageSection>
+        </>
+    );
+}
+
+export default VulnReportingLayout;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting.ts
@@ -1,3 +1,3 @@
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
-export const vulnerabilityConfigurationReportPath = `${vulnerabilityConfigurationReportsPath}/:reportId`;
+export const vulnerabilityConfigurationReportDetailsPath = `${vulnerabilityConfigurationReportsPath}/:reportId`;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/pathsForVulnerabilityReporting.ts
@@ -1,3 +1,3 @@
-import { vulnerabilityReportsPath } from 'routePaths';
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
-export const vulnerabilityReportPath = `${vulnerabilityReportsPath}/:reportId`;
+export const vulnerabilityConfigurationReportPath = `${vulnerabilityConfigurationReportsPath}/:reportId`;

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -89,6 +89,8 @@ export const vulnerabilitiesImagesWithoutCvesPath = `${vulnerabilitiesBasePath}/
 export const vulnerabilitiesViewPath = `${vulnerabilitiesBasePath}/results/:viewTemplate/:viewId`;
 
 export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
+export const vulnerabilityConfigurationReportsPath = `${vulnerabilityReportsPath}/configuration`;
+export const vulnerabilityOnDemandReportsPath = `${vulnerabilityReportsPath}/on-demand`;
 
 // Vulnerability Management 1.0 path for links from Dashboard:
 


### PR DESCRIPTION
### Description

This PR adds the "Report configurations" and "On-demand reports" tabs. Essentially, the core code to render the content for Report configurations in `VulnReportsPage` was moved to `ConfigReportsTab`. `VulnReportsPage` was removed and a new file called "VulnReportingLayout" is used to display the page header, tabs, and content. There is a new `OnDemandReportsTab` component too. For now, it'll be empty. We'll add the content for that section in future PRs. The routing was also adjusted.

<img width="1537" alt="Screenshot 2025-04-03 at 1 30 17 PM" src="https://github.com/user-attachments/assets/8fbcf2f4-1e7e-49b6-883b-41ca3ff343cf" />
<img width="1537" alt="Screenshot 2025-04-03 at 1 30 31 PM" src="https://github.com/user-attachments/assets/88285a0f-b108-485b-be93-9f9bc9ddbd47" />
<img width="1537" alt="Screenshot 2025-04-03 at 1 30 46 PM" src="https://github.com/user-attachments/assets/1adaa6f3-811b-49c3-816b-bd327334a20f" />
<img width="1537" alt="Screenshot 2025-04-03 at 1 31 05 PM" src="https://github.com/user-attachments/assets/6abafe25-3b33-4580-b9ea-4c693380a3ba" />
<img width="1537" alt="Screenshot 2025-04-03 at 1 31 23 PM" src="https://github.com/user-attachments/assets/6964feec-fe5b-42d6-8d38-7a4aac21d2ed" />


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [x] added regression tests
- [x] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual checking
