### PR TITLE
ROX-28832: Remove unneeded data from classic compliance queries

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -60,7 +60,7 @@ const opnameForEntities = {
 };
 
 const opnameForEntity = {
-    clusters: 'getCluster',
+    clusters: 'getClusterName',
     deployments: 'getDeployment',
     namespaces: 'getNamespace',
     nodes: 'getNode',

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.js
@@ -1,9 +1,9 @@
 import React, { useContext, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 
 import entityTypes from 'constants/entityTypes';
-import { DEPLOYMENT_QUERY } from 'queries/deployment';
 import Widget from 'Components/Widget';
 import Query from 'Components/CacheFirstQuery';
 import Loader from 'Components/Loader';
@@ -25,6 +25,23 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 
 import Header from './Header';
 import ResourceTabs from './ResourceTabs';
+
+export const DEPLOYMENT_QUERY = gql`
+    query getDeployment($id: ID!) {
+        deployment(id: $id) {
+            id
+            clusterId
+            clusterName
+            labels {
+                key
+                value
+            }
+            name
+            namespace
+            namespaceId
+        }
+    }
+`;
 
 function processData(data) {
     if (!data || !data.deployment) {

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
@@ -1,12 +1,11 @@
 import React, { useContext, useState } from 'react';
 import pluralize from 'pluralize';
+import { gql } from '@apollo/client';
 
 import ComplianceByStandards from 'Containers/Compliance/widgets/ComplianceByStandards';
 import Query from 'Components/CacheFirstQuery';
 import IconWidget from 'Components/IconWidget';
-import CountWidget from 'Components/CountWidget';
 import Cluster from 'images/cluster.svg';
-import { NAMESPACE_QUERY as QUERY } from 'queries/namespace';
 import Widget from 'Components/Widget';
 // TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
 /* eslint-disable-next-line import/no-cycle */
@@ -25,6 +24,24 @@ import searchContext from 'Containers/searchContext';
 
 import Header from './Header';
 import ResourceTabs from './ResourceTabs';
+
+export const QUERY = gql`
+    query getNamespace($id: ID!) {
+        results: namespace(id: $id) {
+            metadata {
+                clusterId
+                clusterName
+                name
+                id
+                labels {
+                    key
+                    value
+                }
+                creationTime
+            }
+        }
+    }
+`;
 
 function processData(data, entityId) {
     const defaultValue = {
@@ -73,7 +90,7 @@ const NamespacePage = ({
                     );
                 }
                 const namespace = processData(data);
-                const { name, id, clusterName, labels, numNetworkPolicies } = namespace;
+                const { name, id, clusterName, labels } = namespace;
                 const pdfClassName = !sidePanelMode ? 'pdf-page' : '';
                 let contents;
 
@@ -134,12 +151,6 @@ const NamespacePage = ({
                                             loading={loading}
                                         />
                                     </div>
-                                    <div className="md:pl-3 pt-3">
-                                        <CountWidget
-                                            title="Network Policies"
-                                            count={numNetworkPolicies}
-                                        />
-                                    </div>
                                 </div>
 
                                 <Widget
@@ -162,13 +173,6 @@ const NamespacePage = ({
                                             <div className="md:pr-3 pt-3">
                                                 <ResourceCount
                                                     entityType={entityTypes.DEPLOYMENT}
-                                                    relatedToResourceType={entityTypes.NAMESPACE}
-                                                    relatedToResource={namespace}
-                                                />
-                                            </div>
-                                            <div className="md:pl-3 pt-3">
-                                                <ResourceCount
-                                                    entityType={entityTypes.SECRET}
                                                     relatedToResourceType={entityTypes.NAMESPACE}
                                                     relatedToResource={namespace}
                                                 />

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
@@ -29,7 +29,6 @@ export const QUERY = gql`
     query getNamespace($id: ID!) {
         results: namespace(id: $id) {
             metadata {
-                clusterId
                 clusterName
                 name
                 id
@@ -37,7 +36,6 @@ export const QUERY = gql`
                     key
                     value
                 }
-                creationTime
             }
         }
     }

--- a/ui/apps/platform/src/queries/cluster.js
+++ b/ui/apps/platform/src/queries/cluster.js
@@ -34,76 +34,11 @@ export const CLUSTERS_QUERY = gql`
     }
 `;
 
-export const CLUSTER_QUERY = gql`
-    query getCluster($id: ID!) {
-        results: cluster(id: $id) {
-            id
-            name
-            admissionController
-            centralApiEndpoint
-            nodes {
-                id
-                name
-            }
-            deployments {
-                id
-                name
-            }
-            namespaces {
-                metadata {
-                    id
-                    name
-                }
-            }
-            subjects {
-                name
-            }
-            k8sRoles {
-                id
-            }
-            serviceAccounts {
-                id
-            }
-            status {
-                orchestratorMetadata {
-                    version
-                    openshiftVersion
-                    buildDate
-                }
-            }
-        }
-    }
-`;
-
 export const CLUSTER_NAME = gql`
     query getClusterName($id: ID!) {
         cluster(id: $id) {
             id
             name
-        }
-    }
-`;
-
-export const CLUSTER_WITH_NAMESPACES = gql`
-    query getCluster($id: ID!) {
-        results: cluster(id: $id) {
-            id
-            name
-            nodes {
-                id
-                name
-            }
-            namespaces {
-                metadata {
-                    clusterId
-                    clusterName
-                    name
-                    labels {
-                        key
-                        value
-                    }
-                }
-            }
         }
     }
 `;

--- a/ui/apps/platform/src/queries/deployment.js
+++ b/ui/apps/platform/src/queries/deployment.js
@@ -57,14 +57,6 @@ export const DEPLOYMENT_FRAGMENT = gql`
         imageCount
     }
 `;
-export const DEPLOYMENT_QUERY = gql`
-    query getDeployment($id: ID!, $query: String) {
-        deployment(id: $id) {
-            ...deploymentFields
-        }
-    }
-    ${DEPLOYMENT_FRAGMENT}
-`;
 
 export const DEPLOYMENT_NAME = gql`
     query getDeployment($id: ID!) {
@@ -91,17 +83,5 @@ export const DEPLOYMENTS_QUERY = gql`
             policyStatus
         }
         count: deploymentCount(query: $query)
-    }
-`;
-
-export const DEPLOYMENTS_WITH_IMAGE = gql`
-    query getDeployments($query: String) {
-        deployments(query: $query) {
-            id
-            name
-            clusterName
-            namespace
-            serviceAccount
-        }
     }
 `;

--- a/ui/apps/platform/src/queries/namespace.js
+++ b/ui/apps/platform/src/queries/namespace.js
@@ -68,73 +68,6 @@ export const NAMESPACES_NO_POLICIES_QUERY = gql`
     ${NAMESPACE_NO_POLICIES_FRAGMENT}
 `;
 
-export const ALL_NAMESPACES = gql`
-    query namespaces {
-        results: namespaces {
-            metadata {
-                name
-                id
-                clusterId
-                clusterName
-                labels {
-                    key
-                    value
-                }
-            }
-            numSecrets: secretCount
-        }
-    }
-`;
-export const NAMESPACES = gql`
-    query namespaces {
-        results: namespaces {
-            metadata {
-                name
-                id
-                clusterId
-                clusterName
-                labels {
-                    key
-                    value
-                }
-            }
-            numSecrets: secretCount
-        }
-    }
-`;
-
-export const NAMESPACE_QUERY = gql`
-    query getNamespace($id: ID!) {
-        results: namespace(id: $id) {
-            metadata {
-                clusterId
-                clusterName
-                name
-                id
-                labels {
-                    key
-                    value
-                }
-                creationTime
-            }
-            numDeployments: deploymentCount
-            numNetworkPolicies: networkPolicyCount
-            numSecrets: secretCount
-            imageCount
-            policyCount
-        }
-    }
-`;
-
-export const RELATED_DEPLOYMENTS = gql`
-    query deployments($query: String) {
-        results: deployments(query: $query) {
-            id
-            name
-        }
-    }
-`;
-
 export const NAMESPACE_NAME = gql`
     query getNamespaceName($id: ID!) {
         namespace(id: $id) {
@@ -142,15 +75,6 @@ export const NAMESPACE_NAME = gql`
                 name
                 id
             }
-        }
-    }
-`;
-
-export const RELATED_SECRETS = gql`
-    query secretsByNamespace($query: String) {
-        results: secrets(query: $query) {
-            id
-            name
         }
     }
 `;


### PR DESCRIPTION
### Description

Delete data that is either:
* left over from intended but abandoned reuse of query with Configuration Management
* irrelevant information for compliance persona

Add conditional rendering in Cluster.js file:
* `ResourceCount` elements for side panel
* `resourceTabs` array for single page

### Residue

1. Investigate over-fetching in `EntityCompliance` element.
2. RBAC for queries is still spooky. With `Cluster` and `Node` resources, cluster single page did not render **Nodes** resource tab because `results: []` until I clicked **Scan environment** again.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

#### Manual testing

1. Visit /main/compliance/clusters and then click a link to open side panel.

    Before changes, with `Cluster` resource, see presence of errors for unused data.
    ![clusters_id_with_errors](https://github.com/user-attachments/assets/1ef4b2e9-ac1b-4d89-a190-8e073645356d)

    After changes, with `Cluster` resource, see:
    * presence of error because other entities in query for `EntityCompliance` element
    * correct conditional rendering for `ResourceCount` elements (not in picture because below the fold)
    ![clusters_id_with_error_EntityCompliance](https://github.com/user-attachments/assets/914e4f63-6122-47f4-bc49-6e46b70a4445)

    After changes, with `Cluster` and other 3 entity resources, see absence of errors.
    ![clusters_id_without_errors](https://github.com/user-attachments/assets/dcbd4e3c-3ea1-4dc3-ba39-ce011842996f)

2. Visit /main/compliance/nodes and then click a link to open side panel.

    Before and after changes, with `Cluster` and `Node` resources, see presence of error because other entities in query for `EntityCompliance` element.
    ![nodes_id_with_error_EntityCompliance](https://github.com/user-attachments/assets/038cc6e6-a3c6-418f-ac6c-754ac69eb8d2)

3. Visit /main/compliance/namespaces and then click a link to open side panel.

    Before changes, with `Cluster`, `Deployment`, and `Namespace` resources, see presence of errors for unused data.
    ![namespaces_id_with_errors](https://github.com/user-attachments/assets/3260862f-26e2-434b-84bb-db77db62110f)

    After changes, with `Cluster`, `Deployment`, and `Namespace` resources, see presence of error because other entities in query for `EntityCompliance` element.
    ![namespaces_id_with_error_EntityCompliance](https://github.com/user-attachments/assets/753631eb-37e0-4bcc-aa2b-de8de2ff6981)

4. Visit /main/compliance/deployments and then click a link to open side panel.

    Before changes, with `Cluster`, `Deployment`, and `Namespace` resources, see presence of errors for unused data.
    ![deployments_id_with_errors](https://github.com/user-attachments/assets/d01bf0b6-5f5e-46bf-ac4e-72e44dfc5f95)

    After changes, with `Cluster`, `Deployment`, and `Namespace` resources, see presence of error because other entities in query for `EntityCompliance` element.
    ![deployments_id_with_error_EntityCompliance](https://github.com/user-attachments/assets/62820870-f2d8-479b-8ab6-bd4062faa11d)
