### PR TITLE
ROX-20769: Use PG15 to run CI

### DIFF
--- a/image/postgres/Dockerfile
+++ b/image/postgres/Dockerfile
@@ -1,4 +1,4 @@
-ARG PG_VERSION=13
+ARG PG_VERSION=15
 FROM quay.io/sclorg/postgresql-${PG_VERSION}-c8s:latest AS final
 
 USER root

--- a/image/postgres/download.sh
+++ b/image/postgres/download.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-postgres_major=13
+postgres_major=15
 pg_rhel_major=8
 
 arch="$(uname -m)"

--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.redhat.io/rhel8/postgresql-15:latest AS final
+ARG PG_VERSION=15
+FROM registry.redhat.io/rhel8/postgresql-${PG_VERSION}:latest AS final
 
 USER root
 

--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel8/postgresql-13:latest AS final
+FROM registry.redhat.io/rhel8/postgresql-15:latest AS final
 
 USER root
 

--- a/image/rhel/download.sh
+++ b/image/rhel/download.sh
@@ -39,7 +39,7 @@ if [[ "$arch" == "s390x" ]]; then
   mv /tmp/postgresql-private-libs-*.rpm "${output_dir}/rpms/postgres-libs.rpm"
   mv /tmp/postgresql-*.rpm "${output_dir}/rpms/postgres.rpm"
 else
-  postgres_major=13
+  postgres_major=15
   pg_rhel_major=8
   postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-${pg_rhel_major}-${arch}/pgdg-redhat-repo-latest.noarch.rpm"
   dnf install --disablerepo='*' -y "${postgres_repo_url}"

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -1,4 +1,5 @@
 ARG FINAL_STAGE_PATH="/mnt/final"
+ARG PG_VERSION=15
 
 # TODO(ROX-20312): we can't pin image tag or digest because currently there's no mechanism to auto-update that.
 FROM registry.access.redhat.com/ubi8/ubi:latest AS ubi-base
@@ -9,6 +10,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS final-base
 FROM ubi-base AS rpm-installer
 
 ARG FINAL_STAGE_PATH
+ARG PG_VERSION
 COPY --from=final-base / "$FINAL_STAGE_PATH"
 
 COPY ./.konflux/scripts/subscription-manager/* /tmp/.konflux/
@@ -16,7 +18,7 @@ RUN /tmp/.konflux/subscription-manager-bro.sh register "$FINAL_STAGE_PATH"
 
 # Install packages for the final stage.
 RUN dnf -y --installroot="$FINAL_STAGE_PATH" upgrade --nobest && \
-    dnf -y --installroot="$FINAL_STAGE_PATH" module enable postgresql:15 && \
+    dnf -y --installroot="$FINAL_STAGE_PATH" module enable postgresql:${PG_VERSION} && \
     # find is used in /stackrox/import-additional-cas \
     dnf -y --installroot="$FINAL_STAGE_PATH" install findutils postgresql && \
     # We can do usual cleanup while we're here: remove packages that would trigger violations. \

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -16,7 +16,7 @@ RUN /tmp/.konflux/subscription-manager-bro.sh register "$FINAL_STAGE_PATH"
 
 # Install packages for the final stage.
 RUN dnf -y --installroot="$FINAL_STAGE_PATH" upgrade --nobest && \
-    dnf -y --installroot="$FINAL_STAGE_PATH" module enable postgresql:13 && \
+    dnf -y --installroot="$FINAL_STAGE_PATH" module enable postgresql:15 && \
     # find is used in /stackrox/import-additional-cas \
     dnf -y --installroot="$FINAL_STAGE_PATH" install findutils postgresql && \
     # We can do usual cleanup while we're here: remove packages that would trigger violations. \

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -287,7 +287,9 @@ force_rollback_to_previous_postgres() {
 
     kubectl -n stackrox patch configmap/central-config -p "$config_patch"
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$FORCE_ROLLBACK_VERSION"
-    kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$FORCE_ROLLBACK_VERSION"
+
+    # Do not rollback central-db image, since downgrade from PG15 to PG13 is
+    # not possible.
 }
 
 deploy_scaled_workload() {


### PR DESCRIPTION
### Description

Use PostgreSQL 15 for central-db. Benefit from https://github.com/stackrox/stackrox/pull/14447 to handle upgrade scenarios.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

CI is sufficient.