### PR TITLE
feat(fake-workload): Add bool option for generating unclosed endpoints

### DIFF
--- a/scale/workloads/10-sensors.yaml
+++ b/scale/workloads/10-sensors.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 5000
   flowInterval: 30s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/active-vulnmgmt.yaml
+++ b/scale/workloads/active-vulnmgmt.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 1s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 500
 rbacWorkload:

--- a/scale/workloads/default.yaml
+++ b/scale/workloads/default.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 1s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/high-alert.yaml
+++ b/scale/workloads/high-alert.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 1s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/long-running.yaml
+++ b/scale/workloads/long-running.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 1s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/np-load.yaml
+++ b/scale/workloads/np-load.yaml
@@ -40,6 +40,7 @@ networkPolicyWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 1s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/okr-single-load.yaml
+++ b/scale/workloads/okr-single-load.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 500
   flowInterval: 24h
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/rbac.yaml
+++ b/scale/workloads/rbac.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 30s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 100
 rbacWorkload:

--- a/scale/workloads/sample.yaml
+++ b/scale/workloads/sample.yaml
@@ -56,4 +56,6 @@ networkWorkload:
   flowInterval: 60s
   # ...create this many random connections between IP addresses in the cluster
   batchSize: 500
+  # whether to generate endpoints that will never be marked as closed
+  generateUnclosedEndpoints: true
 

--- a/scale/workloads/scale-test.yaml
+++ b/scale/workloads/scale-test.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 1s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/small.yaml
+++ b/scale/workloads/small.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 30s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 100
 rbacWorkload:

--- a/scale/workloads/vulnmgmt.yaml
+++ b/scale/workloads/vulnmgmt.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 100
   flowInterval: 0
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/xlarge.yaml
+++ b/scale/workloads/xlarge.yaml
@@ -16,6 +16,7 @@ deploymentWorkload:
 networkWorkload:
   batchSize: 500
   flowInterval: 1s
+  generateUnclosedEndpoints: true
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -323,7 +323,7 @@ func (w *WorkloadManager) getFakeNetworkConnectionInfo(workload NetworkWorkload)
 			endpointPool.add(networkEndpoint)
 		}
 		if workload.GenerateUnclosedEndpoints {
-			// Rouge endpoints will not be closed - i.e., CloseTimestamp will be always nil.
+			// Those endpoints will not be closed - i.e., CloseTimestamp will be always nil.
 			networkEndpoints = append(networkEndpoints, networkEndpoint)
 		}
 	}

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -323,7 +323,7 @@ func (w *WorkloadManager) getFakeNetworkConnectionInfo(workload NetworkWorkload)
 			endpointPool.add(networkEndpoint)
 		}
 		if workload.GenerateUnclosedEndpoints {
-			// Those endpoints will not be closed - i.e., CloseTimestamp will be always nil.
+			// These endpoints will not be closed - i.e., CloseTimestamp will be always nil.
 			networkEndpoints = append(networkEndpoints, networkEndpoint)
 		}
 	}

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -322,7 +322,10 @@ func (w *WorkloadManager) getFakeNetworkConnectionInfo(workload NetworkWorkload)
 		if endpointPool.Size < endpointPool.Capacity {
 			endpointPool.add(networkEndpoint)
 		}
-		networkEndpoints = append(networkEndpoints, networkEndpoint)
+		if workload.GenerateUnclosedEndpoints {
+			// Rouge endpoints will not be closed - i.e., CloseTimestamp will be always nil.
+			networkEndpoints = append(networkEndpoints, networkEndpoint)
+		}
 	}
 
 	for _, endpoint := range endpointPool.EndpointsToBeClosed {

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -42,8 +42,9 @@ type ProcessWorkload struct {
 
 // NetworkWorkload defines the rate and size of network flows
 type NetworkWorkload struct {
-	FlowInterval time.Duration `yaml:"flowInterval"`
-	BatchSize    int           `yaml:"batchSize"`
+	FlowInterval              time.Duration `yaml:"flowInterval"`
+	BatchSize                 int           `yaml:"batchSize"`
+	GenerateUnclosedEndpoints bool          `yaml:"generateUnclosedEndpoints"`
 }
 
 // PodWorkload defines the workload and lifecycle of the pods within a deployment


### PR DESCRIPTION
### Description

Generating unclosed endpoints in the fake-workload is meant to stress-load Central in a situation when many ports are opened for listening in the cluster. They are not closed on purpose to not trigger any cleanups.
The presence of the unclosed endpoints had actually stressed the memory of Sensor that lead to OOMs (ROX-28242). That load on Sensor was caused by "improper" handling of the endpoint data during enrichment of processes:  some endpoints were never removed from the input to the enrichment loop on purpose, whereas others were kept there by accident.  The fix for that is proposed in https://github.com/stackrox/stackrox/pull/14538.

In this PR, I add an option to disable the generation of unclosed endpoints in the fake workloads. This option is enabled by default (no change to the previous state), but it can be disabled for some workflows.
Disabling this option was helpful in investigating Sensor OOMs, so I think there is a value in persisting it.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
    - [X] This is not a production code change - when the option is disabled, it affects only the long-running clusters with fake workloads. 
- [ ] CI results are inspected

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Deployed a long running cluster, toggle the newly added option in the config map and observed sensor's metrics regarding the enrichment of endpoints.

## Summary by Sourcery

Add a configurable option to control the generation of unclosed network endpoints in fake workloads

New Features:
- Introduce a new boolean option `GenerateUnclosedEndpoints` in network workload configuration to control the generation of unclosed network endpoints

Enhancements:
- Modify fake workload generation to conditionally create unclosed network endpoints based on the new configuration option

Chores:
- Update multiple workload configuration YAML files to explicitly set the new `generateUnclosedEndpoints` flag to true