### PR TITLE
fix(pg): do not read rows on context error

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1038,6 +1038,9 @@ func RunCursorQueryForSchemaFn[T any, PT pgutils.Unmarshaler[T]](ctx context.Con
 
 		var data []byte
 		tag, err := pgx.ForEachRow(rows, []any{&data}, func() error {
+			if ctx.Err() != nil {
+				return errors.Wrap(ctx.Err(), "iterating over rows")
+			}
 			msg := new(T)
 			if err := PT(msg).UnmarshalVTUnsafe(data); err != nil {
 				return err

--- a/pkg/search/postgres/common_pg_test.go
+++ b/pkg/search/postgres/common_pg_test.go
@@ -1,0 +1,42 @@
+//go:build sql_integration
+
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/tools/generate-helpers/pg-table-bindings/multitest/postgres"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContexCancellationInWalk(t *testing.T) {
+	t.Parallel()
+
+	ctx := sac.WithAllAccess(context.Background())
+	testDB := pgtest.ForT(t)
+
+	store := postgres.New(testDB.DB)
+
+	testStructs := getTestStructs()
+
+	for _, s := range testStructs {
+		require.NoError(t, store.Upsert(ctx, s))
+	}
+
+	ctxWithCancel, cancel := context.WithCancelCause(ctx)
+
+	count := 0
+	err := store.Walk(ctxWithCancel, func(obj *storage.TestStruct) error {
+		cancel(fmt.Errorf("cancelling context on the first read"))
+		count++
+		return nil
+	})
+	assert.Equal(t, 1, count)
+	assert.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
### Description

This PR checks if context is cancelled when walking before processing every object.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI

## Summary by Sourcery

Improve context cancellation handling in database row iteration to properly stop processing when the context is canceled

Bug Fixes:
- Add a check to stop row processing immediately when the context is canceled, preventing unnecessary work and potential resource leaks

Tests:
- Add an integration test to verify that context cancellation interrupts row walking and returns the correct error