### PR TITLE
ROX-28813:  Remove scope.ID in favor of using scope.IDs

### DIFF
--- a/central/cluster/datastore/datastore_impl_postgres_test.go
+++ b/central/cluster/datastore/datastore_impl_postgres_test.go
@@ -1059,56 +1059,56 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search clusters with cluster scope",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c1ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.EmptyQuery(),
 
 			expectedIDs: []string{c1ID},
 		},
 		{
 			desc:  "Search clusters with cluster scope and in-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c1ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
 
 			expectedIDs: []string{c1ID},
 		},
 		{
 			desc:  "Search clusters with cluster scope and out-of-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c1ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
 
 			expectedIDs: []string{},
 		},
 		{
 			desc:  "Search clusters with cluster scope and in-scope namespace query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c1ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").ProtoQuery(),
 
 			expectedIDs: []string{c1ID},
 		},
 		{
 			desc:  "Search clusters with cluster scope and out-of-scope namespace query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c2ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c2ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
 
 			expectedIDs: []string{},
 		},
 		{
 			desc:  "Search clusters with namespace scope",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.EmptyQuery(),
 
 			expectedIDs: []string{c1ID},
 		},
 		{
 			desc:  "Search clusters with namespace scope and in-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
 
 			expectedIDs: []string{c1ID},
 		},
 		{
 			desc:  "Search clusters with namespace scope and out-of-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
 
 			expectedIDs: []string{},
@@ -1147,7 +1147,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespace with namespace scope",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.EmptyQuery(),
 
 			expectedIDs: []string{ns1C1.Id},
@@ -1155,7 +1155,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespace with namespace scope and in-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
 
 			expectedIDs: []string{ns1C1.Id},
@@ -1163,7 +1163,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespace with namespace scope and out-of-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
 
 			expectedIDs: []string{},
@@ -1171,7 +1171,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespace with namespace scope and in-scope namespace query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").ProtoQuery(),
 
 			expectedIDs: []string{ns1C1.Id},
@@ -1179,7 +1179,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespace with namespace scope and out-of-scope namespace query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: ns1C1.Id, Level: v1.SearchCategory_NAMESPACES}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{ns1C1.Id}, Level: v1.SearchCategory_NAMESPACES}),
 			query: pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
 
 			expectedIDs: []string{},
@@ -1187,7 +1187,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespaces with cluster scope",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c1ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.EmptyQuery(),
 
 			expectedIDs: []string{ns1C1.Id, ns2C1.Id},
@@ -1195,7 +1195,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespaces with cluster scope and in-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c1ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "prod").ProtoQuery(),
 
 			expectedIDs: []string{ns1C1.Id, ns2C1.Id},
@@ -1203,7 +1203,7 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:  "Search namespaces with cluster scope and out-of-scope cluster query",
-			ctx:   scoped.Context(ctx, scoped.Scope{ID: c1ID, Level: v1.SearchCategory_CLUSTERS}),
+			ctx:   scoped.Context(ctx, scoped.Scope{IDs: []string{c1ID}, Level: v1.SearchCategory_CLUSTERS}),
 			query: pkgSearch.NewQueryBuilder().AddMapQuery(pkgSearch.ClusterLabel, "env", "test").ProtoQuery(),
 
 			expectedIDs: []string{},
@@ -1213,10 +1213,10 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 			desc: "Search namespaces with cluster+namespace scope",
 			ctx: scoped.Context(ctx,
 				scoped.Scope{
-					ID:    ns1C1.Id,
+					IDs:   []string{ns1C1.Id},
 					Level: v1.SearchCategory_NAMESPACES,
 					Parent: &scoped.Scope{
-						ID:    c1ID,
+						IDs:   []string{c1ID},
 						Level: v1.SearchCategory_CLUSTERS,
 					},
 				},
@@ -1230,10 +1230,10 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 			desc: "Search namespaces with cluster+namespace scope and out-of-scope cluster query",
 			ctx: scoped.Context(ctx,
 				scoped.Scope{
-					ID:    ns1C1.Id,
+					IDs:   []string{ns1C1.Id},
 					Level: v1.SearchCategory_NAMESPACES,
 					Parent: &scoped.Scope{
-						ID:    c1ID,
+						IDs:   []string{c1ID},
 						Level: v1.SearchCategory_CLUSTERS,
 					},
 				},

--- a/central/cve/common/csv/handler.go
+++ b/central/cve/common/csv/handler.go
@@ -129,7 +129,7 @@ func (h *HandlerImpl) GetScopeContext(ctx context.Context, query *v1.Query) (con
 
 		// Add searchWrapper only if we get exactly one match. Currently only scoping by one resource is supported in search.
 		if len(result) == 1 {
-			return scoped.Context(ctx, scoped.Scope{Level: searchWrapper.category, ID: result[0].ID}), nil
+			return scoped.Context(ctx, scoped.Scope{Level: searchWrapper.category, IDs: []string{result[0].ID}}), nil
 		}
 	}
 	return ctx, nil

--- a/central/cve/common/csv/handler_test.go
+++ b/central/cve/common/csv/handler_test.go
@@ -85,7 +85,7 @@ func (suite *CVEScopingTestSuite) TestSingleResourceQuery() {
 
 	expected := scoped.Context(suite.ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGES,
-		ID:    imgSha,
+		IDs:   []string{imgSha},
 	})
 	actual, err := suite.handler.GetScopeContext(suite.ctx, query)
 	suite.NoError(err)
@@ -106,7 +106,7 @@ func (suite *CVEScopingTestSuite) TestMultipleResourceQuery() {
 
 	expected := scoped.Context(suite.ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGES,
-		ID:    imgSha,
+		IDs:   []string{imgSha},
 	})
 	// Lowest resource scope should be applied.
 	actual, err := suite.handler.GetScopeContext(suite.ctx, query)
@@ -140,7 +140,7 @@ func (suite *CVEScopingTestSuite) TestNoReScope() {
 
 	expected := scoped.Context(suite.ctx, scoped.Scope{
 		Level: v1.SearchCategory_DEPLOYMENTS,
-		ID:    "dep",
+		IDs:   []string{"dep"},
 	})
 	actual, err := suite.handler.GetScopeContext(expected, query)
 	suite.NoError(err)

--- a/central/cve/edgefields/searcher_impl_test.go
+++ b/central/cve/edgefields/searcher_impl_test.go
@@ -73,7 +73,7 @@ func TestGetCVEEdgeQuery(t *testing.T) {
 
 func TestSnoozedQueryHandler(t *testing.T) {
 	scopedCtx := scoped.Context(context.Background(), scoped.Scope{
-		ID:    "img1",
+		IDs:   []string{"img1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	snoozedCVEsQuery := search.NewQueryBuilder().AddBools(search.CVESuppressed, true).ProtoQuery()

--- a/central/deployment/datastore/datastore_impl_postgres_test.go
+++ b/central/deployment/datastore/datastore_impl_postgres_test.go
@@ -127,56 +127,56 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:         "Search deployments with deployment scope",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep1.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep1.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.EmptyQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{dep1.Id},
 		},
 		{
 			desc:         "Search deployments with deployments scope and in-scope deployments query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep1.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep1.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, dep1.Namespace).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{dep1.Id},
 		},
 		{
 			desc:         "Search deployments with deployments scope and out-of-scope deployments query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep1.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep1.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, dep2.Namespace).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{},
 		},
 		{
 			desc:         "Search deployments with deployment scope and in-scope image query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep2.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep2.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ImageOS, img2.GetScan().GetOperatingSystem()).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{dep2.Id},
 		},
 		{
 			desc:         "Search deployments with deployment scope and out-of-scope image query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep2.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep2.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ImageOS, img3.GetScan().GetOperatingSystem()).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{},
 		},
 		{
 			desc:         "Search deployments with image scope",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: img2.Id, Level: v1.SearchCategory_IMAGES}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{img2.Id}, Level: v1.SearchCategory_IMAGES}),
 			query:        pkgSearch.EmptyQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{dep2.Id},
 		},
 		{
 			desc:         "Search deployments with image scope and in-scope deployment query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: img2.Id, Level: v1.SearchCategory_IMAGES}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{img2.Id}, Level: v1.SearchCategory_IMAGES}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, dep2.GetNamespace()).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{dep2.Id},
 		},
 		{
 			desc:         "Search deployments with image scope and out-of-scope deployment query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: img2.Id, Level: v1.SearchCategory_IMAGES}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{img2.Id}, Level: v1.SearchCategory_IMAGES}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, dep3.GetNamespace()).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{},
@@ -184,10 +184,10 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		{
 			desc: "Search deployments with image component scope",
 			ctx: scoped.Context(ctx, scoped.Scope{
-				ID: scancomponent.ComponentID(
+				IDs: []string{scancomponent.ComponentID(
 					img2.GetScan().GetComponents()[0].GetName(),
 					img2.GetScan().GetComponents()[0].GetVersion(),
-					img2.GetScan().GetOperatingSystem()),
+					img2.GetScan().GetOperatingSystem())},
 				Level: v1.SearchCategory_IMAGE_COMPONENTS,
 			}),
 			query:        pkgSearch.EmptyQuery(),
@@ -197,9 +197,9 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		{
 			desc: "Search deployments with image vuln scope",
 			ctx: scoped.Context(ctx, scoped.Scope{
-				ID: cve.ID(
+				IDs: []string{cve.ID(
 					img1.GetScan().GetComponents()[0].GetVulns()[0].GetCve(),
-					img1.GetScan().GetOperatingSystem()),
+					img1.GetScan().GetOperatingSystem())},
 				Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
 			}),
 			query:        pkgSearch.EmptyQuery(),
@@ -240,7 +240,7 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:         "Search images with image scope and in-scope deployment query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: img2.Id, Level: v1.SearchCategory_IMAGES}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{img2.Id}, Level: v1.SearchCategory_IMAGES}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, dep2.GetNamespace()).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{img2.Id},
@@ -248,7 +248,7 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:         "Search images with deployment scope",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep1.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep1.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.EmptyQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{img1.Id},
@@ -256,7 +256,7 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:         "Search images with image scope and out-of-scope deployment query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: img2.Id, Level: v1.SearchCategory_IMAGES}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{img2.Id}, Level: v1.SearchCategory_IMAGES}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, dep1.GetNamespace()).ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{},
@@ -264,7 +264,7 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:         "Search images with deployment scope and in-scope deployment query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep1.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep1.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n1").ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{img1.Id},
@@ -272,7 +272,7 @@ func (s *DeploymentPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 		},
 		{
 			desc:         "Search images with deployment scope and out-of-scope deployment query",
-			ctx:          scoped.Context(ctx, scoped.Scope{ID: dep1.Id, Level: v1.SearchCategory_DEPLOYMENTS}),
+			ctx:          scoped.Context(ctx, scoped.Scope{IDs: []string{dep1.Id}, Level: v1.SearchCategory_DEPLOYMENTS}),
 			query:        pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.Namespace, "n2").ProtoQuery(),
 			orderMatters: false,
 			expectedIDs:  []string{},

--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -271,7 +271,7 @@ func (resolver *clusterCVEResolver) clusterVulnerabilityScopeContext(ctx context
 		resolver.ctx = ctx
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 		Level: v1.SearchCategory_CLUSTER_VULNERABILITIES,
 	})
 }
@@ -319,7 +319,7 @@ func (resolver *clusterCVEResolver) EnvImpact(ctx context.Context) (float64, err
 		return 0, err
 	}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 		Level: v1.SearchCategory_CLUSTER_VULNERABILITIES,
 	})
 	scopedCount, err := resolver.root.ClusterCount(ctx, RawQuery{})
@@ -339,7 +339,7 @@ func (resolver *clusterCVEResolver) FixedByVersion(ctx context.Context) (string,
 		return "", nil
 	}
 
-	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, scope.ID).AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, scope.IDs...).AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
 	edges, err := resolver.root.ClusterCVEEdgeDataStore.SearchRawEdges(resolver.ctx, query)
 	if err != nil || len(edges) == 0 {
 		return "", err

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -584,7 +584,7 @@ func (resolver *clusterResolver) clusterScopeContext(ctx context.Context) contex
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_CLUSTERS,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 }
 
@@ -673,7 +673,7 @@ func (resolver *clusterResolver) Policies(ctx context.Context, args PaginatedQue
 	for _, policyResolver := range policyResolvers {
 		policyResolver.ctx = scoped.Context(ctx, scoped.Scope{
 			Level: v1.SearchCategory_CLUSTERS,
-			ID:    resolver.data.GetId(),
+			IDs:   []string{resolver.data.GetId()},
 		})
 	}
 	return paginate(pagination, policyResolvers, nil)
@@ -739,7 +739,7 @@ func (resolver *clusterResolver) PolicyStatus(ctx context.Context, args RawQuery
 
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_CLUSTERS,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 
 	if len(alerts) == 0 {

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -224,7 +224,7 @@ func (resolver *deploymentResolver) Policies(ctx context.Context, args Paginated
 	for _, policyResolver := range policyResolvers {
 		policyResolver.ctx = scoped.Context(ctx, scoped.Scope{
 			Level: v1.SearchCategory_DEPLOYMENTS,
-			ID:    resolver.data.GetId(),
+			IDs:   []string{resolver.data.GetId()},
 		})
 	}
 
@@ -304,7 +304,7 @@ func (resolver *deploymentResolver) FailingPolicies(ctx context.Context, args Pa
 	for _, policyResolver := range policyResolvers {
 		policyResolver.ctx = scoped.Context(ctx, scoped.Scope{
 			Level: v1.SearchCategory_DEPLOYMENTS,
-			ID:    resolver.data.GetId(),
+			IDs:   []string{resolver.data.GetId()},
 		})
 	}
 
@@ -562,7 +562,7 @@ func (resolver *deploymentResolver) withDeploymentScopeContext(ctx context.Conte
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_DEPLOYMENTS,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 }
 
@@ -573,7 +573,7 @@ func (resolver *deploymentResolver) PolicyStatus(ctx context.Context, args RawQu
 	var err error
 	var q *v1.Query
 	if scope, hasScope := scoped.GetScope(resolver.ctx); hasScope && scope.Level == v1.SearchCategory_POLICIES {
-		q = search.NewQueryBuilder().AddExactMatches(search.PolicyID, scope.ID).ProtoQuery()
+		q = search.NewQueryBuilder().AddExactMatches(search.PolicyID, scope.IDs...).ProtoQuery()
 	} else {
 		if q, err = args.AsV1QueryOrEmpty(); err != nil {
 			return "", err
@@ -701,7 +701,7 @@ func (resolver *deploymentResolver) LatestViolation(ctx context.Context, args Ra
 	var err error
 	var q *v1.Query
 	if scope, hasScope := scoped.GetScope(resolver.ctx); hasScope && scope.Level == v1.SearchCategory_POLICIES {
-		q = search.NewQueryBuilder().AddExactMatches(search.PolicyID, scope.ID).ProtoQuery()
+		q = search.NewQueryBuilder().AddExactMatches(search.PolicyID, scope.IDs...).ProtoQuery()
 	} else {
 		if q, err = args.AsV1QueryOrEmpty(); err != nil {
 			return nil, err

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -225,7 +225,7 @@ func (resolver *imageComponentResolver) imageComponentScopeContext(ctx context.C
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 }
 
@@ -255,7 +255,10 @@ func getDeploymentIDFromQuery(q *v1.Query) string {
 func getDeploymentScope(scopeQuery *v1.Query, contexts ...context.Context) string {
 	for _, ctx := range contexts {
 		if scope, ok := scoped.GetScope(ctx); ok && scope.Level == v1.SearchCategory_DEPLOYMENTS {
-			return scope.ID
+			if len(scope.IDs) != 1 {
+				return ""
+			}
+			return scope.IDs[0]
 		} else if deploymentID := deploymentctx.FromContext(ctx); deploymentID != "" {
 			return deploymentID
 		}
@@ -271,7 +274,10 @@ func getImageIDFromScope(contexts ...context.Context) string {
 	var hasScope bool
 	for _, ctx := range contexts {
 		if scope, hasScope = scoped.GetScopeAtLevel(ctx, v1.SearchCategory_IMAGES); hasScope {
-			return scope.ID
+			if len(scope.IDs) != 1 {
+				return ""
+			}
+			return scope.IDs[0]
 		}
 	}
 	return ""
@@ -573,7 +579,7 @@ func (resolver *imageComponentResolver) LayerIndex() (*int32, error) {
 		return nil, err
 	}
 	if len(edges) == 0 || len(edges) > 1 {
-		return nil, errors.Errorf("Unexpected number of image-component edge matched for image %s and component %s. Expected 1 edge.", scope.ID, resolver.data.GetId())
+		return nil, errors.Errorf("Unexpected number of image-component edge matched for image %s and component %s. Expected 1 edge.", scope.IDs, resolver.data.GetId())
 	}
 
 	w, ok := edges[0].GetHasLayerIndex().(*storage.ImageComponentEdge_LayerIndex)
@@ -758,6 +764,6 @@ func (resolver *imageComponentV2Resolver) imageComponentScopeContext(ctx context
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS_V2,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 }

--- a/central/graphql/resolvers/image_vulnerabilities_test.go
+++ b/central/graphql/resolvers/image_vulnerabilities_test.go
@@ -199,7 +199,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilitiesFixedByVers
 
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS,
-		ID:    "comp1#0.9#",
+		IDs:   []string{"comp1#0.9#"},
 	})
 	vuln := s.getImageVulnerabilityResolver(scopedCtx, "cve-2018-1#")
 
@@ -209,7 +209,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilitiesFixedByVers
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS,
-		ID:    "comp2#1.1#",
+		IDs:   []string{"comp2#1.1#"},
 	})
 	vuln = s.getImageVulnerabilityResolver(scopedCtx, "cve-2018-1#")
 
@@ -219,7 +219,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilitiesFixedByVers
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS,
-		ID:    "comp2#1.1#",
+		IDs:   []string{"comp2#1.1#"},
 	})
 	vuln = s.getImageVulnerabilityResolver(scopedCtx, "cve-2017-1#")
 
@@ -478,7 +478,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilityExceptionCoun
 func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilityExceptionCountAllWithImageScope() {
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -511,7 +511,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilityExceptionCoun
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	status := []*string{pointers.String(storage.RequestStatus_PENDING.String())}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -546,7 +546,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilityExceptionCoun
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	status := []*string{pointers.String(storage.RequestStatus_APPROVED.String())}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -579,7 +579,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilityExceptionCoun
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	status := []*string{pointers.String(storage.RequestStatus_APPROVED_PENDING_UPDATE.String())}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha2",
+		IDs:   []string{"sha2"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -624,7 +624,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilityExceptionCoun
 	s.Equal(int32(1), count)
 
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 
@@ -635,7 +635,7 @@ func (s *GraphQLImageVulnerabilityTestSuite) TestImageVulnerabilityExceptionCoun
 
 	ctx = SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha3",
+		IDs:   []string{"sha3"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 

--- a/central/graphql/resolvers/image_vulnerabilities_v2_test.go
+++ b/central/graphql/resolvers/image_vulnerabilities_v2_test.go
@@ -237,7 +237,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilitiesFixedByVe
 
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS_V2,
-		ID:    componentIDMap[comp11],
+		IDs:   []string{componentIDMap[comp11]},
 	})
 	vuln := s.getImageVulnerabilityResolver(scopedCtx, cveIDMap[cve111])
 	fixedBy, err := vuln.FixedByVersion(ctx)
@@ -246,7 +246,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilitiesFixedByVe
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS_V2,
-		ID:    componentIDMap[comp21],
+		IDs:   []string{componentIDMap[comp21]},
 	})
 	vuln = s.getImageVulnerabilityResolver(scopedCtx, cveIDMap[cve121])
 
@@ -256,7 +256,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilitiesFixedByVe
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGE_COMPONENTS_V2,
-		ID:    componentIDMap[comp42],
+		IDs:   []string{componentIDMap[comp12]},
 	})
 	vuln = s.getImageVulnerabilityResolver(scopedCtx, cveIDMap[cve442])
 
@@ -533,7 +533,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityExceptionCo
 
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -569,7 +569,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityExceptionCo
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	status := []*string{pointers.String(storage.RequestStatus_PENDING.String())}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -607,7 +607,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityExceptionCo
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	status := []*string{pointers.String(storage.RequestStatus_APPROVED.String())}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -643,7 +643,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityExceptionCo
 	ctx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	status := []*string{pointers.String(storage.RequestStatus_APPROVED_PENDING_UPDATE.String())}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha2",
+		IDs:   []string{"sha2"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	args := struct {
@@ -691,7 +691,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityExceptionCo
 	s.Equal(int32(1), count)
 
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha1",
+		IDs:   []string{"sha1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 
@@ -702,7 +702,7 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityExceptionCo
 
 	ctx = SetAuthorizerOverride(s.ctx, allow.Anonymous())
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    "sha3",
+		IDs:   []string{"sha3"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -210,7 +210,7 @@ func (resolver *imageResolver) withImageScopeContext(ctx context.Context) contex
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_IMAGES,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 }
 

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -372,7 +372,7 @@ func (resolver *namespaceResolver) Policies(ctx context.Context, args PaginatedQ
 	for _, policyResolver := range policyResolvers {
 		policyResolver.ctx = scoped.Context(ctx, scoped.Scope{
 			Level: v1.SearchCategory_NAMESPACES,
-			ID:    resolver.data.GetMetadata().GetId(),
+			IDs:   []string{resolver.data.GetMetadata().GetId()},
 		})
 	}
 
@@ -423,7 +423,7 @@ func (resolver *namespaceResolver) PolicyStatus(ctx context.Context, args RawQue
 
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_NAMESPACES,
-		ID:    resolver.data.GetMetadata().GetId(),
+		IDs:   []string{resolver.data.GetMetadata().GetId()},
 	})
 
 	if len(alerts) == 0 {
@@ -505,7 +505,7 @@ func (resolver *namespaceResolver) namespaceScopeContext(ctx context.Context) co
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_NAMESPACES,
-		ID:    resolver.data.GetMetadata().GetId(),
+		IDs:   []string{resolver.data.GetMetadata().GetId()},
 	})
 }
 

--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -156,7 +156,7 @@ func (resolver *nodeComponentResolver) nodeComponentScopeContext(ctx context.Con
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_NODE_COMPONENTS,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 }
 

--- a/central/graphql/resolvers/node_components_postgres_test.go
+++ b/central/graphql/resolvers/node_components_postgres_test.go
@@ -252,7 +252,7 @@ func (s *GraphQLNodeComponentTestSuite) TestNodeComponentLastScanned() {
 	// Component queried with node scope
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_NODES,
-		ID:    fixtureconsts.Node1,
+		IDs:   []string{fixtureconsts.Node1},
 	})
 	comp = getNodeComponentResolver(scopedCtx, s.T(), s.resolver, componentID)
 	node = getNodeResolver(ctx, s.T(), s.resolver, fixtureconsts.Node1)

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -243,7 +243,7 @@ func (resolver *nodeCVEResolver) nodeVulnerabilityScopeContext(ctx context.Conte
 		resolver.ctx = ctx
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 }
@@ -261,7 +261,7 @@ func (resolver *nodeCVEResolver) EnvImpact(ctx context.Context) (float64, error)
 		return 0, err
 	}
 	ctx = scoped.Context(ctx, scoped.Scope{
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	scopedCount, err := resolver.root.NodeCount(ctx, RawQuery{})
@@ -287,7 +287,7 @@ func (resolver *nodeCVEResolver) FixedByVersion(ctx context.Context) (string, er
 	if !hasScope {
 		return "", nil
 	}
-	query := search.NewQueryBuilder().AddExactMatches(search.ComponentID, scope.ID).AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.ComponentID, scope.IDs...).AddExactMatches(search.CVEID, resolver.data.GetId()).ProtoQuery()
 	edges, err := resolver.root.NodeComponentCVEEdgeDataStore.SearchRawEdges(resolver.ctx, query)
 	if err != nil || len(edges) == 0 {
 		return "", err

--- a/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
+++ b/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
@@ -207,7 +207,7 @@ func (s *GraphQLNodeVulnerabilityTestSuite) TestNodeVulnerabilitiesFixedByVersio
 
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_NODE_COMPONENTS,
-		ID:    "comp1#0.9#",
+		IDs:   []string{"comp1#0.9#"},
 	})
 	vuln := getNodeVulnerabilityResolver(scopedCtx, s.T(), s.resolver, "cve-2018-1#")
 
@@ -217,7 +217,7 @@ func (s *GraphQLNodeVulnerabilityTestSuite) TestNodeVulnerabilitiesFixedByVersio
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_NODE_COMPONENTS,
-		ID:    "comp2#1.1#",
+		IDs:   []string{"comp2#1.1#"},
 	})
 	vuln = getNodeVulnerabilityResolver(scopedCtx, s.T(), s.resolver, "cve-2018-1#")
 
@@ -227,7 +227,7 @@ func (s *GraphQLNodeVulnerabilityTestSuite) TestNodeVulnerabilitiesFixedByVersio
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_NODE_COMPONENTS,
-		ID:    "comp2#1.1#",
+		IDs:   []string{"comp2#1.1#"},
 	})
 	vuln = getNodeVulnerabilityResolver(scopedCtx, s.T(), s.resolver, "cve-2017-1#")
 

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -394,7 +394,7 @@ func (resolver *nodeResolver) nodeScopeContext(ctx context.Context) context.Cont
 	}
 	return scoped.Context(resolver.ctx, scoped.Scope{
 		Level: v1.SearchCategory_NODES,
-		ID:    resolver.data.GetId(),
+		IDs:   []string{resolver.data.GetId()},
 	})
 }
 

--- a/central/graphql/resolvers/policies.go
+++ b/central/graphql/resolvers/policies.go
@@ -116,7 +116,7 @@ func (resolver *policyResolver) Deployments(ctx context.Context, args PaginatedQ
 	deploymentFilterQuery := search.EmptyQuery()
 	if scope, hasScope := scoped.GetScope(ctx); hasScope {
 		if field, ok := idField[scope.Level]; ok {
-			deploymentFilterQuery = search.NewQueryBuilder().AddExactMatches(field, scope.ID).ProtoQuery()
+			deploymentFilterQuery = search.NewQueryBuilder().AddExactMatches(field, scope.IDs...).ProtoQuery()
 		}
 	} else {
 		if deploymentFilterQuery, err = args.AsV1QueryOrEmpty(); err != nil {
@@ -155,7 +155,7 @@ func (resolver *policyResolver) Deployments(ctx context.Context, args PaginatedQ
 	for _, deploymentResolver := range deploymentResolvers {
 		deploymentResolver.ctx = scoped.Context(ctx, scoped.Scope{
 			Level: v1.SearchCategory_POLICIES,
-			ID:    resolver.data.GetId(),
+			IDs:   []string{resolver.data.GetId()},
 		})
 	}
 	return deploymentResolvers, nil
@@ -210,7 +210,7 @@ func (resolver *policyResolver) failingDeployments(ctx context.Context, q *v1.Qu
 	for _, deploymentResolver := range deploymentResolvers {
 		deploymentResolver.ctx = scoped.Context(ctx, scoped.Scope{
 			Level: v1.SearchCategory_POLICIES,
-			ID:    resolver.data.GetId(),
+			IDs:   []string{resolver.data.GetId()},
 		})
 	}
 	return deploymentResolvers, nil
@@ -264,7 +264,7 @@ func (resolver *policyResolver) PolicyStatus(ctx context.Context, args RawQuery)
 	q := search.EmptyQuery()
 	if scope, hasScope := scoped.GetScope(resolver.ctx); hasScope {
 		if field, ok := idField[scope.Level]; ok {
-			q = search.NewQueryBuilder().AddExactMatches(field, scope.ID).ProtoQuery()
+			q = search.NewQueryBuilder().AddExactMatches(field, scope.IDs...).ProtoQuery()
 		}
 	} else {
 		if q, err = args.AsV1QueryOrEmpty(); err != nil {
@@ -312,7 +312,7 @@ func (resolver *policyResolver) LatestViolation(ctx context.Context, args RawQue
 	q := search.EmptyQuery()
 	if scope, hasScope := scoped.GetScope(resolver.ctx); hasScope {
 		if field, ok := idField[scope.Level]; ok {
-			q = search.NewQueryBuilder().AddExactMatches(field, scope.ID).ProtoQuery()
+			q = search.NewQueryBuilder().AddExactMatches(field, scope.IDs...).ProtoQuery()
 		}
 	} else {
 		if q, err = args.AsV1QueryOrEmpty(); err != nil {

--- a/central/graphql/resolvers/service_accounts.go
+++ b/central/graphql/resolvers/service_accounts.go
@@ -246,7 +246,7 @@ func (resolver *serviceAccountResolver) getEvaluators(ctx context.Context) (map[
 
 	ctx = scoped.Context(ctx, scoped.Scope{
 		Level: v1.SearchCategory_CLUSTERS,
-		ID:    saClusterID,
+		IDs:   []string{saClusterID},
 	})
 
 	namespaces, err := resolver.root.Namespaces(ctx, PaginatedQuery{})

--- a/central/graphql/resolvers/vulnerabilities_v1.go
+++ b/central/graphql/resolvers/vulnerabilities_v1.go
@@ -354,7 +354,7 @@ func (evr *EmbeddedVulnerabilityResolver) getEnvImpactComponentsForNodes(ctx con
 
 func (evr *EmbeddedVulnerabilityResolver) scopeContext(ctx context.Context) context.Context {
 	return scoped.Context(ctx, scoped.Scope{
-		ID:    evr.data.GetCve(),
+		IDs:   []string{evr.data.GetCve()},
 		Level: v1.SearchCategory_VULNERABILITIES,
 	})
 }

--- a/central/graphql/resolvers/vulnerability_requests.go
+++ b/central/graphql/resolvers/vulnerability_requests.go
@@ -556,7 +556,10 @@ func unExpiredExceptionQuery(ctx context.Context, filters exceptionQueryFilters)
 	var imageID string
 	scope, hasScope := scoped.GetScopeAtLevel(ctx, v1.SearchCategory_IMAGES)
 	if hasScope {
-		imageID = scope.ID
+		if len(scope.IDs) != 1 {
+			return nil, errors.New("invalid request, only a single image is allowed")
+		}
+		imageID = scope.IDs[0]
 	}
 	// Return query with scope part.
 	if imageID == "" {

--- a/central/image/datastore/datastore_impl_postgres_test.go
+++ b/central/image/datastore/datastore_impl_postgres_test.go
@@ -173,7 +173,7 @@ func (s *ImagePostgresDataStoreTestSuite) TestSearchWithPostgres() {
 
 	// Scope search by image.
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
-		ID:    image.GetId(),
+		IDs:   []string{image.GetId()},
 		Level: v1.SearchCategory_IMAGES,
 	})
 	results, err = s.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -183,7 +183,7 @@ func (s *ImagePostgresDataStoreTestSuite) TestSearchWithPostgres() {
 
 	// Scope search by vulns.
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    "cve3#blah",
+		IDs:   []string{"cve3#blah"},
 		Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
 	})
 	results, err = s.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())

--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -198,7 +198,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestBasicSearch() {
 	suite.Len(results, 1)
 
 	scopedCtx := scoped.Context(allowAllCtx, scoped.Scope{
-		ID:    node.GetId(),
+		IDs:   []string{node.GetId()},
 		Level: v1.SearchCategory_NODES,
 	})
 
@@ -259,7 +259,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 
 	// Search by CVE.
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve1", "ubuntu"),
+		IDs:   []string{cve.ID("cve1", "ubuntu")},
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err := suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -267,7 +267,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 	suite.Len(results, 2)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve3", "ubuntu"),
+		IDs:   []string{cve.ID("cve3", "ubuntu")},
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -276,7 +276,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 	suite.Equal(fixtureconsts.Node2, results[0].ID)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve4", "ubuntu"),
+		IDs:   []string{cve.ID("cve4", "ubuntu")},
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -287,7 +287,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 
 	// Ensure search does not find anything.
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve1", "ubuntu"),
+		IDs:   []string{cve.ID("cve1", "ubuntu")},
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -295,7 +295,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByVuln() {
 	suite.Empty(results)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    cve.ID("cve3", "ubuntu"),
+		IDs:   []string{cve.ID("cve3", "ubuntu")},
 		Level: v1.SearchCategory_NODE_VULNERABILITIES,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -316,7 +316,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 
 	// Search by Component.
 	scopedCtx := scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp1", "ver1", "ubuntu"),
+		IDs:   []string{scancomponent.ComponentID("comp1", "ver1", "ubuntu")},
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err := suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -324,7 +324,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 	suite.Len(results, 2)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp3", "ver1", "ubuntu"),
+		IDs:   []string{scancomponent.ComponentID("comp3", "ver1", "ubuntu")},
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -333,7 +333,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 	suite.Equal(fixtureconsts.Node2, results[0].ID)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp4", "ver1", "ubuntu"),
+		IDs:   []string{scancomponent.ComponentID("comp4", "ver1", "ubuntu")},
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -344,7 +344,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 
 	// Ensure search does not find anything.
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp1", "ver1", "ubuntu"),
+		IDs:   []string{scancomponent.ComponentID("comp1", "ver1", "ubuntu")},
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())
@@ -352,7 +352,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSearchByComponent() {
 	suite.Empty(results)
 
 	scopedCtx = scoped.Context(ctx, scoped.Scope{
-		ID:    scancomponent.ComponentID("comp3", "ver1", "ubuntu"),
+		IDs:   []string{scancomponent.ComponentID("comp3", "ver1", "ubuntu")},
 		Level: v1.SearchCategory_NODE_COMPONENTS,
 	})
 	results, err = suite.datastore.Search(scopedCtx, pkgSearch.EmptyQuery())

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -604,7 +604,7 @@ func (s *ImageCVEViewTestSuite) testCases() []testCase {
 		{
 			desc: "search one cve w/ image scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
+				IDs:   []string{"sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c"},
 				Level: v1.SearchCategory_IMAGES,
 			}),
 			q: search.NewQueryBuilder().
@@ -622,10 +622,10 @@ func (s *ImageCVEViewTestSuite) testCases() []testCase {
 		{
 			desc: "search critical severity w/ cve & image scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
+				IDs:   []string{"sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c"},
 				Level: v1.SearchCategory_IMAGES,
 				Parent: &scoped.Scope{
-					ID:    cve.ID("CVE-2022-1552", "debian:8"),
+					IDs:   []string{cve.ID("CVE-2022-1552", "debian:8")},
 					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
 				},
 			}),

--- a/central/views/imagecveflat/view_test.go
+++ b/central/views/imagecveflat/view_test.go
@@ -499,7 +499,7 @@ func (s *ImageCVEFlatViewTestSuite) testCases() []testCase {
 		{
 			desc: "search one cve w/ image scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
+				IDs:   []string{"sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c"},
 				Level: v1.SearchCategory_IMAGES,
 			}),
 			q: search.NewQueryBuilder().
@@ -517,10 +517,10 @@ func (s *ImageCVEFlatViewTestSuite) testCases() []testCase {
 		{
 			desc: "search critical severity w/ cve & image scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    "sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c",
+				IDs:   []string{"sha256:6ef31316f4f9e0c31a8f4e602ba287a210d66934f91b1616f1c9b957201d025c"},
 				Level: v1.SearchCategory_IMAGES,
 				Parent: &scoped.Scope{
-					ID:    cve.IDV2("CVE-2022-1552", scancomponent.ComponentIDV2("postgresql-libs", "8.4.20-6.el6", "", "sha256:05dd8ed5c76ad3c9f06481770828cf17b8c89f1e406c91d548426dd70fe94560"), "20"),
+					IDs:   []string{cve.IDV2("CVE-2022-1552", scancomponent.ComponentIDV2("postgresql-libs", "8.4.20-6.el6", "", "sha256:05dd8ed5c76ad3c9f06481770828cf17b8c89f1e406c91d548426dd70fe94560"), "20")},
 					Level: v1.SearchCategory_IMAGE_VULNERABILITIES,
 				},
 			}),

--- a/central/views/nodecve/view_test.go
+++ b/central/views/nodecve/view_test.go
@@ -554,7 +554,7 @@ func (s *NodeCVEViewTestSuite) testCases() []testCase {
 		{
 			desc: "search one cve w/ cluster scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    s.nodeMap[fixtureconsts.Node1].ClusterId,
+				IDs:   []string{s.nodeMap[fixtureconsts.Node1].ClusterId},
 				Level: v1.SearchCategory_CLUSTERS,
 			}),
 			q: search.NewQueryBuilder().
@@ -571,7 +571,7 @@ func (s *NodeCVEViewTestSuite) testCases() []testCase {
 		{
 			desc: "search one cve w/ node scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    s.nodeMap[fixtureconsts.Node2].Id,
+				IDs:   []string{s.nodeMap[fixtureconsts.Node2].Id},
 				Level: v1.SearchCategory_NODES,
 			}),
 			q: search.NewQueryBuilder().

--- a/central/views/platformcve/view_test.go
+++ b/central/views/platformcve/view_test.go
@@ -558,7 +558,7 @@ func (s *PlatformCVEViewTestSuite) testCases() []testCase {
 		{
 			desc: "search one cve w/ cluster scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    s.clusterNameToIDMap["kubernetes-1"],
+				IDs:   []string{s.clusterNameToIDMap["kubernetes-1"]},
 				Level: v1.SearchCategory_CLUSTERS,
 			}),
 			q: search.NewQueryBuilder().
@@ -575,10 +575,10 @@ func (s *PlatformCVEViewTestSuite) testCases() []testCase {
 		{
 			desc: "search fixable w/ cve & cluster scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    s.clusterNameToIDMap["openshift4-2"],
+				IDs:   []string{s.clusterNameToIDMap["openshift4-2"]},
 				Level: v1.SearchCategory_CLUSTERS,
 				Parent: &scoped.Scope{
-					ID:    pkgCVE.ID("cve-2", storage.CVE_OPENSHIFT_CVE.String()),
+					IDs:   []string{pkgCVE.ID("cve-2", storage.CVE_OPENSHIFT_CVE.String())},
 					Level: v1.SearchCategory_CLUSTER_VULNERABILITIES,
 				},
 			}),

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -709,7 +709,7 @@ func TestSelectQueries(t *testing.T) {
 		{
 			desc: "base schema; select w/ where; image scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    "fake-image",
+				IDs:   []string{"fake-image"},
 				Level: v1.SearchCategory_IMAGES,
 			}),
 			q: search.NewQueryBuilder().
@@ -723,10 +723,10 @@ func TestSelectQueries(t *testing.T) {
 		{
 			desc: "base schema; select w/ multiple scopes",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    uuid.NewV4().String(),
+				IDs:   []string{uuid.NewV4().String()},
 				Level: v1.SearchCategory_NAMESPACES,
 				Parent: &scoped.Scope{
-					ID:    uuid.NewV4().String(),
+					IDs:   []string{uuid.NewV4().String()},
 					Level: v1.SearchCategory_CLUSTERS,
 				},
 			}),
@@ -933,7 +933,7 @@ func TestDeleteQueries(t *testing.T) {
 		{
 			desc: "base schema; delete w/ where; image scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    "fake-image",
+				IDs:   []string{"fake-image"},
 				Level: v1.SearchCategory_IMAGES,
 			}),
 			q: search.NewQueryBuilder().
@@ -945,10 +945,10 @@ func TestDeleteQueries(t *testing.T) {
 		{
 			desc: "base schema; delete w/ multiple scopes",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    uuid.NewV4().String(),
+				IDs:   []string{uuid.NewV4().String()},
 				Level: v1.SearchCategory_NAMESPACES,
 				Parent: &scoped.Scope{
-					ID:    uuid.NewV4().String(),
+					IDs:   []string{uuid.NewV4().String()},
 					Level: v1.SearchCategory_CLUSTERS,
 				},
 			}),
@@ -1098,7 +1098,7 @@ func TestDeleteReturningIDsQueries(t *testing.T) {
 		{
 			desc: "base schema; delete w/ where; image scope",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    "fake-image",
+				IDs:   []string{"fake-image"},
 				Level: v1.SearchCategory_IMAGES,
 			}),
 			q: search.NewQueryBuilder().
@@ -1111,10 +1111,10 @@ func TestDeleteReturningIDsQueries(t *testing.T) {
 		{
 			desc: "base schema; delete w/ multiple scopes",
 			ctx: scoped.Context(context.Background(), scoped.Scope{
-				ID:    uuid.NewV4().String(),
+				IDs:   []string{uuid.NewV4().String()},
 				Level: v1.SearchCategory_NAMESPACES,
 				Parent: &scoped.Scope{
-					ID:    uuid.NewV4().String(),
+					IDs:   []string{uuid.NewV4().String()},
 					Level: v1.SearchCategory_CLUSTERS,
 				},
 			}),

--- a/pkg/search/scoped/context.go
+++ b/pkg/search/scoped/context.go
@@ -12,7 +12,6 @@ import (
 
 // Scope hold an id and scope level for scoping searches.
 type Scope struct {
-	ID     string
 	IDs    []string
 	Level  v1.SearchCategory
 	Parent *Scope
@@ -103,10 +102,6 @@ func GetQueryForAllScopes(ctx context.Context) (*v1.Query, error) {
 			return nil, err
 		}
 		idField := schema.ID()
-		if scope.ID != "" {
-			conjuncts = append(conjuncts, searchPkg.NewQueryBuilder().
-				AddExactMatches(searchPkg.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
-		}
 		if len(scope.IDs) > 0 {
 			conjuncts = append(conjuncts, searchPkg.NewQueryBuilder().
 				AddExactMatches(searchPkg.FieldLabel(idField.Search.FieldName), scope.IDs...).ProtoQuery())

--- a/pkg/search/scoped/context_test.go
+++ b/pkg/search/scoped/context_test.go
@@ -20,19 +20,19 @@ type scopedContextTestSuite struct {
 func (s *scopedContextTestSuite) TestGetScopeAtLevel() {
 	ctx := context.Background()
 	ctx = Context(ctx, Scope{
-		ID:    "image-1",
+		IDs:   []string{"image-1"},
 		Level: v1.SearchCategory_IMAGES,
 	})
 
 	ctx = Context(ctx, Scope{
-		ID:    "component-1",
+		IDs:   []string{"component-1"},
 		Level: v1.SearchCategory_IMAGE_COMPONENTS,
 	})
 
 	imageScope, hasImageScope := GetScopeAtLevel(ctx, v1.SearchCategory_IMAGES)
 	s.Equal(true, hasImageScope)
 	s.Equal(Scope{
-		ID:     "image-1",
+		IDs:    []string{"image-1"},
 		Level:  v1.SearchCategory_IMAGES,
 		Parent: nil,
 	}, imageScope)
@@ -40,10 +40,10 @@ func (s *scopedContextTestSuite) TestGetScopeAtLevel() {
 	componentScope, hasCompScope := GetScopeAtLevel(ctx, v1.SearchCategory_IMAGE_COMPONENTS)
 	s.Equal(true, hasCompScope)
 	s.Equal(Scope{
-		ID:    "component-1",
+		IDs:   []string{"component-1"},
 		Level: v1.SearchCategory_IMAGE_COMPONENTS,
 		Parent: &Scope{
-			ID:     "image-1",
+			IDs:    []string{"image-1"},
 			Level:  v1.SearchCategory_IMAGES,
 			Parent: nil,
 		},
@@ -57,11 +57,11 @@ func (s *scopedContextTestSuite) TestGetScopeAtLevel() {
 func (s *scopedContextTestSuite) TestGetAllScopes() {
 	ctx := context.Background()
 	clusterScope := Scope{
-		ID:    "c1",
+		IDs:   []string{"c1"},
 		Level: v1.SearchCategory_CLUSTERS,
 	}
 	nsScope := Scope{
-		ID:    "n1",
+		IDs:   []string{"n1"},
 		Level: v1.SearchCategory_NAMESPACES,
 	}
 
@@ -78,7 +78,7 @@ func (s *scopedContextTestSuite) TestGetAllScopes() {
 	s.ElementsMatch([]Scope{clusterScope, nsScope}, scopes)
 
 	deploymentScope := Scope{
-		ID:    "d1",
+		IDs:   []string{"d1"},
 		Level: v1.SearchCategory_DEPLOYMENTS,
 	}
 	depCtx := Context(nsCtx, deploymentScope)

--- a/pkg/search/scoped/postgres/searcher.go
+++ b/pkg/search/scoped/postgres/searcher.go
@@ -50,10 +50,6 @@ func scopeQuery(q *v1.Query, scopes []scoped.Scope) (*v1.Query, error) {
 			return q, nil
 		}
 		idField := schema.ID()
-		if scope.ID != "" {
-			conjuncts = append(conjuncts, search.NewQueryBuilder().
-				AddExactMatches(search.FieldLabel(idField.Search.FieldName), scope.ID).ProtoQuery())
-		}
 		if len(scope.IDs) > 0 {
 			conjuncts = append(conjuncts, search.NewQueryBuilder().
 				AddExactMatches(search.FieldLabel(idField.Search.FieldName), scope.IDs...).ProtoQuery())

--- a/pkg/search/scoped/postgres/searcher_test.go
+++ b/pkg/search/scoped/postgres/searcher_test.go
@@ -22,7 +22,7 @@ func TestScoping(t *testing.T) {
 	query := search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "dep").ProtoQuery()
 	scopes := []scoped.Scope{
 		{
-			ID:    "c1",
+			IDs:   []string{"c1"},
 			Level: v1.SearchCategory_CLUSTERS,
 		},
 	}
@@ -36,7 +36,7 @@ func TestScoping(t *testing.T) {
 
 	scopes = []scoped.Scope{
 		{
-			ID:    "c1",
+			IDs:   []string{"c1"},
 			Level: v1.SearchCategory_CLUSTERS,
 		},
 		{


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

#14832 added IDs to the context search scope but that resulted in having and ID and an IDs.  So this change updates that to collapse that into just IDs as it is perfectly valid to have an array of 1.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI

## Summary by Sourcery

Enhancements:
- Update scoping mechanism to use an array of IDs instead of a single ID, improving flexibility and consistency in search scoping