### PR TITLE
ROX-28863: Fix inconsistent names in VulnMgmt

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.jsx
@@ -28,7 +28,7 @@ const entityMenuTypes = [
     entityTypes.IMAGE_COMPONENT,
 ];
 
-const VulnDashboardPage = () => {
+const VulnMgmtDashboardPage = () => {
     const navigate = useNavigate();
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
@@ -131,4 +131,4 @@ const VulnDashboardPage = () => {
     );
 };
 
-export default VulnDashboardPage;
+export default VulnMgmtDashboardPage;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtEntityCluster.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtEntityCluster.jsx
@@ -15,7 +15,7 @@ import {
 import VulnMgmtClusterOverview from './VulnMgmtClusterOverview';
 import EntityList from '../../List/VulnMgmtList';
 
-const VulmMgmtEntityCluster = ({
+const VulnMgmtEntityCluster = ({
     entityId,
     entityListType,
     search,
@@ -103,7 +103,7 @@ const VulmMgmtEntityCluster = ({
     );
 };
 
-VulmMgmtEntityCluster.propTypes = entityComponentPropTypes;
-VulmMgmtEntityCluster.defaultProps = entityComponentDefaultProps;
+VulnMgmtEntityCluster.propTypes = entityComponentPropTypes;
+VulnMgmtEntityCluster.defaultProps = entityComponentDefaultProps;
 
-export default VulmMgmtEntityCluster;
+export default VulnMgmtEntityCluster;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.jsx
@@ -60,7 +60,7 @@ function getCVETypeFromStack(worklowStateStack) {
     return undefined;
 }
 
-const VulmMgmtCve = ({ entityId, entityListType, search, entityContext, sort, page }) => {
+const VulnMgmtEntityCve = ({ entityId, entityListType, search, entityContext, sort, page }) => {
     const workflowState = useContext(workflowStateContext);
     const worklowStateStack = workflowState.getStateStack();
     const cveType = getCVETypeFromStack(worklowStateStack) || entityTypes.IMAGE_CVE;
@@ -132,7 +132,7 @@ const VulmMgmtCve = ({ entityId, entityListType, search, entityContext, sort, pa
     );
 };
 
-VulmMgmtCve.propTypes = workflowEntityPropTypes;
-VulmMgmtCve.defaultProps = workflowEntityDefaultProps;
+VulnMgmtEntityCve.propTypes = workflowEntityPropTypes;
+VulnMgmtEntityCve.defaultProps = workflowEntityDefaultProps;
 
-export default VulmMgmtCve;
+export default VulnMgmtEntityCve;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtEntityDeployment.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtEntityDeployment.jsx
@@ -16,7 +16,7 @@ import {
     tryUpdateQueryWithVulMgmtPolicyClause,
 } from '../VulnMgmtPolicyQueryUtil';
 
-const VulmMgmtDeployment = ({
+const VulnMgmtEntityDeployment = ({
     entityId,
     entityListType,
     search,
@@ -125,7 +125,7 @@ const VulmMgmtDeployment = ({
     );
 };
 
-VulmMgmtDeployment.propTypes = workflowEntityPropTypes;
-VulmMgmtDeployment.defaultProps = workflowEntityDefaultProps;
+VulnMgmtEntityDeployment.propTypes = workflowEntityPropTypes;
+VulnMgmtEntityDeployment.defaultProps = workflowEntityDefaultProps;
 
-export default VulmMgmtDeployment;
+export default VulnMgmtEntityDeployment;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtEntityImage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtEntityImage.jsx
@@ -19,7 +19,7 @@ import {
     getScopeQuery,
 } from '../VulnMgmtPolicyQueryUtil';
 
-const VulnMgmtImage = ({
+const VulnMgmtEntityImage = ({
     entityId,
     entityListType,
     search,
@@ -135,7 +135,7 @@ const VulnMgmtImage = ({
     );
 };
 
-VulnMgmtImage.propTypes = workflowEntityPropTypes;
-VulnMgmtImage.defaultProps = workflowEntityDefaultProps;
+VulnMgmtEntityImage.propTypes = workflowEntityPropTypes;
+VulnMgmtEntityImage.defaultProps = workflowEntityDefaultProps;
 
-export default VulnMgmtImage;
+export default VulnMgmtEntityImage;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.jsx
@@ -15,7 +15,7 @@ import {
     getScopeQuery,
 } from '../VulnMgmtPolicyQueryUtil';
 
-const VulnMgmtNamespace = ({
+const VulnMgmtEntityNamespace = ({
     entityId,
     entityListType,
     search,
@@ -97,7 +97,7 @@ const VulnMgmtNamespace = ({
     );
 };
 
-VulnMgmtNamespace.propTypes = workflowEntityPropTypes;
-VulnMgmtNamespace.defaultProps = workflowEntityDefaultProps;
+VulnMgmtEntityNamespace.propTypes = workflowEntityPropTypes;
+VulnMgmtEntityNamespace.defaultProps = workflowEntityDefaultProps;
 
-export default VulnMgmtNamespace;
+export default VulnMgmtEntityNamespace;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtEntityNode.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtEntityNode.jsx
@@ -15,7 +15,7 @@ import {
     tryUpdateQueryWithVulMgmtPolicyClause,
 } from '../VulnMgmtPolicyQueryUtil';
 
-const VulmMgmtNode = ({
+const VulnMgmtEntityNode = ({
     entityId,
     entityListType,
     search,
@@ -119,7 +119,7 @@ const VulmMgmtNode = ({
     );
 };
 
-VulmMgmtNode.propTypes = workflowEntityPropTypes;
-VulmMgmtNode.defaultProps = workflowEntityDefaultProps;
+VulnMgmtEntityNode.propTypes = workflowEntityPropTypes;
+VulnMgmtEntityNode.defaultProps = workflowEntityDefaultProps;
 
-export default VulmMgmtNode;
+export default VulnMgmtEntityNode;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.jsx
@@ -29,7 +29,7 @@ export const defaultClusterSort = [
     },
 ];
 
-const VulnMgmtClusters = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+const VulnMgmtListClusters = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     const query = gql`
         query getClusters(
             $query: String
@@ -240,7 +240,7 @@ const VulnMgmtClusters = ({ selectedRowId, search, sort, page, data, totalResult
     );
 };
 
-VulnMgmtClusters.propTypes = workflowListPropTypes;
-VulnMgmtClusters.defaultProps = workflowListDefaultProps;
+VulnMgmtListClusters.propTypes = workflowListPropTypes;
+VulnMgmtListClusters.defaultProps = workflowListDefaultProps;
 
-export default VulnMgmtClusters;
+export default VulnMgmtListClusters;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.jsx
@@ -204,7 +204,7 @@ export function getComponentTableColumns(workflowState, isFeatureFlagEnabled) {
     return removeEntityContextColumns(componentColumnsBasedOnContext, workflowState);
 }
 
-const VulnMgmtComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+const VulnMgmtListComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     const query = gql`
         query getComponents($query: String, $pagination: Pagination) {
             results: components(query: $query, pagination: $pagination) {
@@ -240,7 +240,7 @@ const VulnMgmtComponents = ({ selectedRowId, search, sort, page, data, totalResu
     );
 };
 
-VulnMgmtComponents.propTypes = workflowListPropTypes;
-VulnMgmtComponents.defaultProps = workflowListDefaultProps;
+VulnMgmtListComponents.propTypes = workflowListPropTypes;
+VulnMgmtListComponents.defaultProps = workflowListDefaultProps;
 
-export default VulnMgmtComponents;
+export default VulnMgmtListComponents;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.jsx
@@ -186,7 +186,7 @@ export function getCurriedDeploymentTableColumns() {
     };
 }
 
-const VulnMgmtDeployments = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+const VulnMgmtListDeployments = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     const query = gql`
         query getDeployments($query: String, $policyQuery: String, $pagination: Pagination) {
             results: deployments(query: $query, pagination: $pagination) {
@@ -224,7 +224,7 @@ const VulnMgmtDeployments = ({ selectedRowId, search, sort, page, data, totalRes
     );
 };
 
-VulnMgmtDeployments.propTypes = workflowListPropTypes;
-VulnMgmtDeployments.defaultProps = workflowListDefaultProps;
+VulnMgmtListDeployments.propTypes = workflowListPropTypes;
+VulnMgmtListDeployments.defaultProps = workflowListDefaultProps;
 
-export default VulnMgmtDeployments;
+export default VulnMgmtListDeployments;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.jsx
@@ -204,7 +204,7 @@ export function getComponentTableColumns() {
     };
 }
 
-const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+const VulnMgmtListImageComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     const query = gql`
         query getImageComponents($query: String, $pagination: Pagination) {
             results: imageComponents(query: $query, pagination: $pagination) {
@@ -242,7 +242,7 @@ const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, total
     );
 };
 
-VulnMgmtNodeComponents.propTypes = workflowListPropTypes;
-VulnMgmtNodeComponents.defaultProps = workflowListDefaultProps;
+VulnMgmtListImageComponents.propTypes = workflowListPropTypes;
+VulnMgmtListImageComponents.defaultProps = workflowListDefaultProps;
 
-export default VulnMgmtNodeComponents;
+export default VulnMgmtListImageComponents;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.jsx
@@ -185,7 +185,7 @@ export function getCurriedImageTableColumns() {
     };
 }
 
-const VulnMgmtImages = ({
+const VulnMgmtListImages = ({
     selectedRowId,
     search,
     sort,
@@ -235,14 +235,14 @@ const VulnMgmtImages = ({
     );
 };
 
-VulnMgmtImages.propTypes = {
+VulnMgmtListImages.propTypes = {
     ...workflowListPropTypes,
     refreshTrigger: PropTypes.number,
 };
 
-VulnMgmtImages.defaultProps = {
+VulnMgmtListImages.defaultProps = {
     ...workflowListDefaultProps,
     refreshTrigger: 0,
 };
 
-export default VulnMgmtImages;
+export default VulnMgmtListImages;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.jsx
@@ -28,7 +28,7 @@ export const defaultNamespaceSort = [
     },
 ];
 
-const VulnMgmtNamespaces = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+const VulnMgmtListNamespaces = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     function getNamespaceTableColumns(workflowState) {
         const tableColumns = [
             {
@@ -205,7 +205,7 @@ const VulnMgmtNamespaces = ({ selectedRowId, search, sort, page, data, totalResu
     );
 };
 
-VulnMgmtNamespaces.propTypes = workflowListPropTypes;
-VulnMgmtNamespaces.defaultProps = workflowListDefaultProps;
+VulnMgmtListNamespaces.propTypes = workflowListPropTypes;
+VulnMgmtListNamespaces.defaultProps = workflowListDefaultProps;
 
-export default VulnMgmtNamespaces;
+export default VulnMgmtListNamespaces;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.jsx
@@ -173,7 +173,7 @@ export function getComponentTableColumns() {
     };
 }
 
-const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+const VulnMgmtListNodeComponents = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     const query = gql`
         query getNodeComponents($query: String, $pagination: Pagination) {
             results: nodeComponents(query: $query, pagination: $pagination) {
@@ -211,7 +211,7 @@ const VulnMgmtNodeComponents = ({ selectedRowId, search, sort, page, data, total
     );
 };
 
-VulnMgmtNodeComponents.propTypes = workflowListPropTypes;
-VulnMgmtNodeComponents.defaultProps = workflowListDefaultProps;
+VulnMgmtListNodeComponents.propTypes = workflowListPropTypes;
+VulnMgmtListNodeComponents.defaultProps = workflowListDefaultProps;
 
-export default VulnMgmtNodeComponents;
+export default VulnMgmtListNodeComponents;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.jsx
@@ -189,7 +189,7 @@ export function getNodeTableColumns() {
 }
 
 // TODO: set getNodes query to get real nodes list
-const VulnMgmtNodes = ({ selectedRowId, search, sort, page, data, totalResults }) => {
+const VulnMgmtListNodes = ({ selectedRowId, search, sort, page, data, totalResults }) => {
     const tableSort = sort || defaultNodeSort;
     const queryOptions = {
         variables: {
@@ -216,7 +216,7 @@ const VulnMgmtNodes = ({ selectedRowId, search, sort, page, data, totalResults }
     );
 };
 
-VulnMgmtNodes.propTypes = workflowListPropTypes;
-VulnMgmtNodes.defaultProps = workflowListDefaultProps;
+VulnMgmtListNodes.propTypes = workflowListPropTypes;
+VulnMgmtListNodes.defaultProps = workflowListDefaultProps;
 
-export default VulnMgmtNodes;
+export default VulnMgmtListNodes;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.jsx
@@ -30,7 +30,7 @@ const entityComponentMap = {
     [entityTypes.NODE]: VulnMgmtListNodes,
 };
 
-const VulnMgmtEntityList = (props) => {
+const VulnMgmtList = (props) => {
     const { entityListType } = props;
     const Component = entityComponentMap[entityListType];
     if (!Component) {
@@ -44,4 +44,4 @@ const VulnMgmtEntityList = (props) => {
     return <Component {...props} />;
 };
 
-export default VulnMgmtEntityList;
+export default VulnMgmtList;


### PR DESCRIPTION
### Description

Prerequisite for future `export-default-react` generic lint rule.

Rename components according to file name.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI

## Summary by Sourcery

Enhancements:
- Standardize component naming across VulnMgmt module to improve code consistency and readability