### PR TITLE
feat(sensor): Enable the detector buffer and the buffered stream

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -76,7 +76,7 @@ var (
 	// 20000 * 1000 = 20 MB
 	// Notice: the actual size of each item is ~40 bytes since it holds pointers to the actual objects.
 	// Multiple items can hold a pointer to the same object (e.g. same Deployment) so these numbers are pessimistic because we assume all items hold different objects.
-	DetectorDeploymentBufferSize = RegisterIntegerSetting("ROX_SENSOR_DETECTOR_DEPLOYMENT_BUFFER_SIZE", 0)
+	DetectorDeploymentBufferSize = RegisterIntegerSetting("ROX_SENSOR_DETECTOR_DEPLOYMENT_BUFFER_SIZE", 20000)
 
 	// BufferScaleCeiling sets the upper limit queue.ScaleSize will scale buffers and queues to.
 	// In its default, the ceiling is defined as triple the relative size.
@@ -92,5 +92,5 @@ var (
 
 	// ResponsesChannelBufferSize defines how many messages to central are we buffering before dropping messages
 	// Setting this variable to zero will disable this feature.
-	ResponsesChannelBufferSize = RegisterIntegerSetting("ROX_RESPONSES_CHANNEL_BUFFER_SIZE", 0)
+	ResponsesChannelBufferSize = RegisterIntegerSetting("ROX_RESPONSES_CHANNEL_BUFFER_SIZE", 100000)
 )

--- a/sensor/common/sensor/buffered_stream.go
+++ b/sensor/common/sensor/buffered_stream.go
@@ -1,6 +1,9 @@
 package sensor
 
 import (
+	"time"
+
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
@@ -10,6 +13,10 @@ import (
 
 const (
 	loggingRateLimiter = "buffered-stream"
+)
+
+var (
+	stopTimeout = 10 * time.Second
 )
 
 type bufferedStream struct {
@@ -31,10 +38,10 @@ func (s bufferedStream) Send(msg *central.MsgFromSensor) error {
 	return nil
 }
 
-func NewBufferedStream(stream messagestream.SensorMessageStream, msgC chan *central.MsgFromSensor, stopC concurrency.ReadOnlyErrorSignal) (messagestream.SensorMessageStream, <-chan error) {
+func NewBufferedStream(stream messagestream.SensorMessageStream, msgC chan *central.MsgFromSensor, stopC concurrency.ReadOnlyErrorSignal) (messagestream.SensorMessageStream, <-chan error, func() error) {
 	// if the capacity of the buffer is zero then we just return the inner stream
 	if cap(msgC) == 0 {
-		return stream, nil
+		return stream, nil, nil
 	}
 	ret := bufferedStream{
 		buffer: msgC,
@@ -42,7 +49,19 @@ func NewBufferedStream(stream messagestream.SensorMessageStream, msgC chan *cent
 		stream: stream,
 	}
 	errC := ret.run()
-	return ret, errC
+	return ret, errC, func() error {
+		for {
+			select {
+			case _, ok := <-errC:
+				if !ok {
+					return nil
+				}
+			case <-time.After(stopTimeout):
+				// If we reach this timeout we could have a deadlock in the gRPC stream
+				return errors.New("timeout waiting for the buffered stream to stop")
+			}
+		}
+	}
 }
 
 func (s bufferedStream) run() <-chan error {

--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -63,6 +63,13 @@ func (s *centralSenderImpl) send(stream central.SensorService_CommunicateClient,
 				log.Warn(err)
 			}
 		}
+		// We need to wait for the buffered stream to stop (errC is closed)
+		// before signaling that the centralSender is finished. Otherwise,
+		// we can have a race between CloseSend and Send.
+		// CentralCommunication closes the inner gRPC stream (CloseSend) once
+		// centralSender and centralReceiver are finished. If this happens
+		// before the buffered stream is stopped,  the buffered stream could
+		// call Send after CloseSend is called.
 		s.finished.Done()
 	}()
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR enables two buffers that were added in 4.7 but they were disabled by default since they can silently drop messages and it was too close to the release date of 4.7 to have them tested in master. We enable them now to tests through the 4.8 release.

- Enables the buffer in the deployment path in the detector add in #14082
- Enables the buffer in the gRPC stream added in #13925

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

This changes were tested in their respective PRs

## Summary by Sourcery

Enable default buffering for sensor deployment and response channels

New Features:
- Enabled default buffer for detector deployment with a size of 20,000 items
- Enabled default buffer for responses channel with a capacity of 100,000 messages