### PR TITLE
ROX-28215: increase wait time

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -49,7 +49,7 @@ class DeclarativeConfigTest extends BaseSpecification {
 
     static final private int RETRIES = 60
     static final private int DELETION_RETRIES = 60
-    static final private int PAUSE_SECS = 3
+    static final private int PAUSE_SECS = 5
     // The AuthProvider reconciliation flow performs HTTP calls that can increase
     // the time needed for reconciliation errors to surface. The number of retries
     // here is increased accordingly.


### PR DESCRIPTION
### Description

In tests where only one declarative config test fails the other passed but with a low retry margin (57 out of 60)
Let's increase wait time to fix issues on OCP.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI

## Summary by Sourcery

Enhancements:
- Increased pause time from 3 to 5 seconds in test configuration to provide more margin for test stability