### PR TITLE
fix(Aggregator): Fix network flow deduplication again

### DIFF
--- a/central/networkgraph/aggregator/aggregator.go
+++ b/central/networkgraph/aggregator/aggregator.go
@@ -47,6 +47,6 @@ func NewDuplicateNameExtSrcConnAggregator() NetworkConnsAggregator {
 	return &aggregateExternalConnByNameImpl{}
 }
 
-func NewAllAggregator() NetworkConnsAggregator {
-	return &aggregateAllImpl{}
+func NewLatestTimestampAggregator() NetworkConnsAggregator {
+	return &aggregateLatestTimestampImpl{}
 }

--- a/central/networkgraph/aggregator/aggregator.go
+++ b/central/networkgraph/aggregator/aggregator.go
@@ -46,3 +46,7 @@ func NewDefaultToCustomExtSrcConnAggregator(networkTree tree.ReadOnlyNetworkTree
 func NewDuplicateNameExtSrcConnAggregator() NetworkConnsAggregator {
 	return &aggregateExternalConnByNameImpl{}
 }
+
+func NewAllAggregator() NetworkConnsAggregator {
+	return &aggregateAllImpl{}
+}

--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -234,6 +234,10 @@ func (a *aggregateLatestTimestampImpl) Aggregate(flows []*storage.NetworkFlow) [
 	ret := make([]*storage.NetworkFlow, 0, len(flows))
 
 	for _, flow := range flows {
+		if flow.GetProps() == nil {
+			continue
+		}
+
 		srcEntity, dstEntity := flow.GetProps().GetSrcEntity(), flow.GetProps().GetDstEntity()
 		// This is essentially an invalid connection.
 		if srcEntity == nil || dstEntity == nil {
@@ -241,11 +245,7 @@ func (a *aggregateLatestTimestampImpl) Aggregate(flows []*storage.NetworkFlow) [
 			continue
 		}
 
-		flow = flow.CloneVT()
-
-		if flow.GetProps() == nil {
-			continue
-		}
+		//flow = flow.CloneVT()
 
 		connID := networkgraph.GetNetworkConnIndicator(flow)
 		if storedFlow := normalizedConns[connID]; storedFlow != nil {

--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -245,7 +245,7 @@ func (a *aggregateLatestTimestampImpl) Aggregate(flows []*storage.NetworkFlow) [
 			continue
 		}
 
-		//flow = flow.CloneVT()
+		flow = flow.CloneVT()
 
 		connID := networkgraph.GetNetworkConnIndicator(flow)
 		if storedFlow := normalizedConns[connID]; storedFlow != nil {

--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -227,7 +227,8 @@ func (a *aggregateExternalConnByNameImpl) Aggregate(flows []*storage.NetworkFlow
 
 type aggregateLatestTimestampImpl struct{}
 
-// Aggregate aggregates deduplicates all connections into a single connection.
+// Aggregate aggregates flows by their latest timestamp. For one or more similar flows,
+// only the most recent is returned.
 func (a *aggregateLatestTimestampImpl) Aggregate(flows []*storage.NetworkFlow) []*storage.NetworkFlow {
 	normalizedConns := make(map[networkgraph.NetworkConnIndicator]*storage.NetworkFlow)
 	ret := make([]*storage.NetworkFlow, 0, len(flows))

--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -225,10 +225,10 @@ func (a *aggregateExternalConnByNameImpl) Aggregate(flows []*storage.NetworkFlow
 	return ret
 }
 
-type aggregateAllImpl struct{}
+type aggregateLatestTimestampImpl struct{}
 
 // Aggregate aggregates deduplicates all connections into a single connection.
-func (a *aggregateAllImpl) Aggregate(flows []*storage.NetworkFlow) []*storage.NetworkFlow {
+func (a *aggregateLatestTimestampImpl) Aggregate(flows []*storage.NetworkFlow) []*storage.NetworkFlow {
 	normalizedConns := make(map[networkgraph.NetworkConnIndicator]*storage.NetworkFlow)
 	ret := make([]*storage.NetworkFlow, 0, len(flows))
 

--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -236,14 +236,13 @@ func (a *aggregateAllImpl) Aggregate(flows []*storage.NetworkFlow) []*storage.Ne
 		srcEntity, dstEntity := flow.GetProps().GetSrcEntity(), flow.GetProps().GetDstEntity()
 		// This is essentially an invalid connection.
 		if srcEntity == nil || dstEntity == nil {
-			utils.Should(errors.Errorf("network conn %s without endpoints is unexpected", networkgraph.GetNetworkConnIndicator(flow).String()))
+			utils.Should(errors.Errorf("network flow %s without endpoints is unexpected", networkgraph.GetNetworkConnIndicator(flow).String()))
 			continue
 		}
 
 		flow = flow.CloneVT()
 
-		flowProps := flow.GetProps()
-		if flowProps == nil {
+		if flow.GetProps() == nil {
 			continue
 		}
 

--- a/central/networkgraph/aggregator/aggregator_impl.go
+++ b/central/networkgraph/aggregator/aggregator_impl.go
@@ -245,8 +245,6 @@ func (a *aggregateLatestTimestampImpl) Aggregate(flows []*storage.NetworkFlow) [
 			continue
 		}
 
-		flow = flow.CloneVT()
-
 		connID := networkgraph.GetNetworkConnIndicator(flow)
 		if storedFlow := normalizedConns[connID]; storedFlow != nil {
 			if protocompat.CompareTimestamps(storedFlow.GetLastSeenTimestamp(), flow.GetLastSeenTimestamp()) < 0 {

--- a/central/networkgraph/aggregator/aggregator_test.go
+++ b/central/networkgraph/aggregator/aggregator_test.go
@@ -252,14 +252,14 @@ func TestLatestTimestampAggregator(t *testing.T) {
 	f1 := testutils.GetNetworkFlow(d1, e, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts1)
 	f2 := testutils.GetNetworkFlow(d1, e, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts2)
 	f3 := testutils.GetNetworkFlow(internet, d1, 8000, storage.L4Protocol_L4_PROTOCOL_UNKNOWN, &ts1)
-	f4 := testutils.GetNetworkFlow(d1, d2, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts1)
-	f5 := testutils.GetNetworkFlow(d1, d2, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts2)
+	f4 := testutils.GetNetworkFlow(d1, d2, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts2)
+	f5 := testutils.GetNetworkFlow(d1, d2, 8000, storage.L4Protocol_L4_PROTOCOL_TCP, &ts1)
 	f6 := testutils.GetNetworkFlow(d1, d2, 8001, storage.L4Protocol_L4_PROTOCOL_TCP, &ts3)
 	f7 := testutils.GetNetworkFlow(d1, d2, 8001, storage.L4Protocol_L4_PROTOCOL_UDP, &ts4)
 
 	flows := []*storage.NetworkFlow{f1, f2, f3, f4, f5, f6, f7}
 
-	expected := []*storage.NetworkFlow{f2, f3, f5, f6, f7}
+	expected := []*storage.NetworkFlow{f2, f3, f4, f6, f7}
 
 	aggr := NewLatestTimestampAggregator()
 	actual := aggr.Aggregate(flows)

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -541,8 +541,8 @@ func (s *serviceImpl) addDeploymentFlowsToGraph(
 	flows = aggregator.NewDuplicateNameExtSrcConnAggregator().Aggregate(flows)
 	missingInfoFlows = aggregator.NewDuplicateNameExtSrcConnAggregator().Aggregate(missingInfoFlows)
 
-	flows = aggregator.NewAllAggregator().Aggregate(flows)
-	missingInfoFlows = aggregator.NewAllAggregator().Aggregate(missingInfoFlows)
+	flows = aggregator.NewLatestTimestampAggregator().Aggregate(flows)
+	missingInfoFlows = aggregator.NewLatestTimestampAggregator().Aggregate(missingInfoFlows)
 
 	graphBuilder.AddFlows(flows)
 

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -540,6 +540,10 @@ func (s *serviceImpl) addDeploymentFlowsToGraph(
 	// Aggregate all external flows by node names to control the number of external nodes.
 	flows = aggregator.NewDuplicateNameExtSrcConnAggregator().Aggregate(flows)
 	missingInfoFlows = aggregator.NewDuplicateNameExtSrcConnAggregator().Aggregate(missingInfoFlows)
+
+	flows = aggregator.NewAllAggregator().Aggregate(flows)
+	missingInfoFlows = aggregator.NewAllAggregator().Aggregate(missingInfoFlows)
+
 	graphBuilder.AddFlows(flows)
 
 	filteredFlows, visibleNeighbors, maskedDeployments, err := filterFlowsAndMaskScopeAlienDeployments(ctx,

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -258,14 +258,14 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraphNormalizedAndUnformalized(
 	}
 
 	internetEntity := &storage.NetworkEntity{
-				Info: &storage.NetworkEntityInfo {
-					Type: storage.NetworkEntityInfo_INTERNET,
-					Id:   networkgraph.InternetExternalSourceID,
-				},
-				Scope: &storage.NetworkEntity_Scope {
-					ClusterId: testCluster,
-				},
-			}
+		Info: &storage.NetworkEntityInfo{
+			Type: storage.NetworkEntityInfo_INTERNET,
+			Id:   networkgraph.InternetExternalSourceID,
+		},
+		Scope: &storage.NetworkEntity_Scope{
+			ClusterId: testCluster,
+		},
+	}
 
 	deployment := &storage.Deployment{
 		Id:        fixtureconsts.Deployment1,


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

There are still cases when duplicate connections with different timestamps appear in the network graph. This results when there is a flow with a connection to `INTERNET` and then the non-anonymized version is added. When anonymizing and deduplicating external connections the connection to `INTERNET` will be skipped and the deduplication will not be done.

This ensures that all connections will be deduplicated, by doing the deduplication in an aggregator which only skips connections when they are invalid, whereas the existing aggregators skip connections that are not of interest to the aggregator. This may be more memory and CPU intensive, but guarantees that there are no duplicate connections.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Ran the e2e test here https://github.com/stackrox/stackrox/pull/13098

A new unit test also validates the change. The unit test fails without the code difference.