### PR TITLE
fix(sensor): optimize YAML loading by reading directly from reader

### DIFF
--- a/sensor/upgrader/bundle/instantiator.go
+++ b/sensor/upgrader/bundle/instantiator.go
@@ -2,7 +2,6 @@ package bundle
 
 import (
 	"bufio"
-	"bytes"
 	"io"
 	"strings"
 
@@ -89,14 +88,9 @@ func (i *instantiator) loadObjectsFromYAML(openFn func() (io.ReadCloser, error))
 	}
 	defer utils.IgnoreError(reader.Close)
 
-	contents, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-
 	var objects []*unstructured.Unstructured
 
-	yamlReader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewBuffer(contents)))
+	yamlReader := yaml.NewYAMLReader(bufio.NewReader(reader))
 	yamlDoc, err := yamlReader.Read()
 	for ; err == nil; yamlDoc, err = yamlReader.Read() {
 		// First, test if the document is empty. We cannot simply trim spaces and check for an empty slice,


### PR DESCRIPTION
### Description

When we load yamls from reader there is no need to load them into memory first as buffered reader could be created from reader.


- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI

## Summary by Sourcery

Optimize YAML loading by removing unnecessary memory buffering when reading YAML files

Bug Fixes:
- Eliminate redundant memory allocation by reading YAML directly from the input reader instead of loading entire contents into memory first

Enhancements:
- Improve memory efficiency in YAML parsing by using buffered reader directly on the input stream