### PR TITLE
ROX-28941: use RunQueryForSchemaFn in GetByQuery

### DIFF
--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -187,7 +187,7 @@ func (s *genericStore[T, PT]) Search(ctx context.Context, q *v1.Query) ([]search
 }
 
 func (s *genericStore[T, PT]) walkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
-	return RunQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
+	return RunCursorQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
 }
 
 // Walk iterates over all the objects in the store and applies the closure.

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -222,7 +222,7 @@ func (s *genericStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, err
 func (s *genericStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
 
-	rows := make([]*T, 0, query.GetPagination().GetLimit())
+	rows := make([]*T, 0, max(10, query.GetPagination().GetLimit()))
 	err := RunQueryForSchemaFn(ctx, s.schema, query, s.db, func(obj PT) error {
 		rows = append(rows, obj)
 		return nil

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -269,15 +269,21 @@ func (s *genericStore[T, PT]) GetMany(ctx context.Context, identifiers []string)
 
 	q := search.NewQueryBuilder().AddDocIDs(identifiers...).ProtoQuery()
 
-	resultsByID := make(map[string]PT, len(identifiers))
-	err := RunQueryForSchemaFn(ctx, s.schema, q, s.db, func(msg PT) error {
-		resultsByID[s.pkGetter(msg)] = msg
-		return nil
-	})
+	rows, err := RunGetManyQueryForSchema[T, PT](ctx, s.schema, q, s.db)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			missingIndices := make([]int, 0, len(identifiers))
+			for i := range identifiers {
+				missingIndices = append(missingIndices, i)
+			}
+			return nil, missingIndices, nil
+		}
 		return nil, nil, err
 	}
-
+	resultsByID := make(map[string]PT, len(rows))
+	for _, msg := range rows {
+		resultsByID[s.pkGetter(msg)] = msg
+	}
 	missingIndices := make([]int, 0, len(identifiers)-len(resultsByID))
 	// It is important that the elems are populated in the same order as the input identifiers
 	// slice, since some calling code relies on that to maintain order.

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -222,7 +222,7 @@ func (s *genericStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, err
 func (s *genericStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
 
-	rows := make([]*T, 0, 10)
+	rows := make([]*T, 0, query.GetPagination().GetLimit())
 	err := RunQueryForSchemaFn(ctx, s.schema, query, s.db, func(obj PT) error {
 		rows = append(rows, obj)
 		return nil

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -222,7 +222,7 @@ func (s *genericStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, err
 func (s *genericStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
 
-	rows := make([]*T, 0, query.GetPagination().GetLimit())
+	rows := make([]*T, 0, 10)
 	err := RunQueryForSchemaFn(ctx, s.schema, query, s.db, func(obj PT) error {
 		rows = append(rows, obj)
 		return nil


### PR DESCRIPTION
### Description

`RunQueryForSchemaFn` allows us to prealocate the memory when querying with limits or by ids. It also make it possible to not iterate twice over results in `GetMany`.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI

## Summary by Sourcery

Optimize database query methods by changing the query execution approach to use a callback-based walk method instead of fetching all rows at once

Bug Fixes:
- Improve pagination handling by automatically setting a default limit when querying by IDs

Enhancements:
- Refactor database query methods to use a more memory-efficient approach by processing rows incrementally using a callback function