### PR TITLE
chore: Add `job-preamble` to jobs in `style.yml` where missing

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -173,6 +173,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/job-preamble
+        with:
+          gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
       - name: Get image tag from COLLECTOR|SCANNER_VERSION file
         id: image-tag
         run: |
@@ -201,6 +205,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/job-preamble
+        with:
+          gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/2ab3a12c7848f6c15faca9a92612ef4261d0e370/scripts/download-actionlint.bash) 1.6.27
@@ -213,6 +220,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/job-preamble
+        with:
+          gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       - name: Check scripts with shellcheck
         run: shellcheck -P SCRIPTDIR -x ./.github/workflows/scripts/*.sh
 


### PR DESCRIPTION
### Description

This follows up on https://github.com/stackrox/stackrox/pull/14922 as I've noticed the jobs I moved don't get registered in BigQuery.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No change

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

1. CI is still green.
2. New data is arriving.

```sql
select *
from `acs-san-stackroxci.ci_metrics.stackrox_jobs`
where pr_number=14952
and name in ('check-collector-and-scanner-images-exist', 'github-actions-lint', 'github-actions-shellcheck')
```
![image](https://github.com/user-attachments/assets/3460398e-57dd-4db7-aea8-2a6562e8b69c)


## Summary by Sourcery

CI:
- Add `.github/actions/job-preamble` step to multiple GitHub Actions workflow jobs to improve job tracking and monitoring

## Summary by Sourcery

CI:
- Add `.github/actions/job-preamble` step to multiple GitHub Actions workflow jobs to enable better job tracking in BigQuery