### PR TITLE
fix(pac): Added check to ensure cluster name or ID was set

### DIFF
--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -249,13 +249,15 @@ func (p SecurityPolicySpec) ToProtobuf(caches map[CacheType]map[string]string) (
 
 			scope := exclusion.Deployment.Scope
 			if scope != (Scope{}) {
-				clusterID, err := getClusterID(scope.Cluster, caches)
-				if err != nil {
-					return nil, errors.New(fmt.Sprintf("Cluster '%s' does not exist", scope.Cluster))
-				}
 				protoExclusion.Deployment.Scope = &storage.Scope{
-					Cluster:   clusterID,
 					Namespace: scope.Namespace,
+				}
+				if scope.Cluster != "" {
+					clusterID, err := getClusterID(scope.Cluster, caches)
+					if err != nil {
+						return nil, errors.New(fmt.Sprintf("Cluster '%s' does not exist", scope.Cluster))
+					}
+					protoExclusion.Deployment.Scope.Cluster = clusterID
 				}
 			}
 
@@ -272,13 +274,15 @@ func (p SecurityPolicySpec) ToProtobuf(caches map[CacheType]map[string]string) (
 	}
 
 	for _, scope := range p.Scope {
-		clusterID, err := getClusterID(scope.Cluster, caches)
-		if err != nil {
-			return nil, errors.New(fmt.Sprintf("Cluster '%s' does not exist", scope.Cluster))
-		}
 		protoScope := &storage.Scope{
-			Cluster:   clusterID,
 			Namespace: scope.Namespace,
+		}
+		if scope.Cluster != "" {
+			clusterID, err := getClusterID(scope.Cluster, caches)
+			if err != nil {
+				return nil, errors.New(fmt.Sprintf("Cluster '%s' does not exist", scope.Cluster))
+			}
+			protoScope.Cluster = clusterID
 		}
 
 		if scope.Label != (Label{}) {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Previously the scope cluster name resolution didn't check if the cluster name or ID was actually passed in before attempting to resolve it, and this would return an exception if you passed in a scope that wasn't scoping to a cluster.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!

## Summary by Sourcery

Bug Fixes:
- Prevent potential errors when processing policy scopes by adding a null check for cluster name before attempting to resolve cluster ID