### PR TITLE
ROX-29022: Enable scanner v4 on nongroovy E2E tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
     - scanner_db_integration
     - sql_integration
     - test_e2e
+    - scanner_e2e
   modules-download-mode: readonly
 output:
   formats:

--- a/deploy/common/ci-values.yaml
+++ b/deploy/common/ci-values.yaml
@@ -43,3 +43,8 @@ scannerV4:
       limits:
         memory: "4Gi"
         cpu: "2000m"
+
+customize:
+  scanner-v4-matcher:
+    envVars:
+      SCANNER_V4_MATCHER_READINESS: vulnerability

--- a/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
@@ -17,6 +17,7 @@ os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
 
 # delegated scanning support in the secured cluster
 os.environ["SENSOR_SCANNER_SUPPORT"] = "true"
+os.environ["ROX_SCANNER_V4"] = "true"
 
 # Enable new CRS-based flow for registering secured clusters
 os.environ["ROX_DEPLOY_SENSOR_WITH_CRS"] = "true"

--- a/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
@@ -18,6 +18,7 @@ os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
 
 # delegated scanning support in the secured cluster
 os.environ["SENSOR_SCANNER_SUPPORT"] = "true"
+os.environ["ROX_SCANNER_V4"] = "true"
 
 # Enable new CRS-based flow for registering secured clusters
 os.environ["ROX_DEPLOY_SENSOR_WITH_CRS"] = "true"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,6 +16,12 @@ compatibility-tests:
 	@GOTAGS=$(GOTAGS),test,test_compatibility $(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v $(shell go list -e ./... | grep -v generated | grep -v vendor) 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=compatibility-tests-results
 
+.PHONY: scanner-e2e-tests
+scanner-e2e-tests:
+	@echo "+ $@"
+	@GOTAGS=$(GOTAGS),test,test_e2e,scanner_e2e ../scripts/go-test.sh -cover $(TESTFLAGS) -v -run TestDelegatedScanning 2>&1 | tee test.log
+	@$(MAKE) report JUNIT_OUT=scanner-e2e-tests-results
+
 .PHONY: destructive-tests
 destructive-tests:
 	@echo "+ $@"

--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e
+//go:build scanner_e2e
 
 package tests
 
@@ -176,6 +176,7 @@ func (ts *DelegatedScanningSuite) SetupSuite() {
 	// Verify the StackRox installation supports delegated scanning, Central and Sensor
 	// must have an active connection for this check to succeed, so wait for that connection.
 	ts.waitForHealthyCentralSensorConn()
+	ts.waitUntilK8sDeploymentReady(ctx, ts.namespace, "scanner-v4-matcher")
 
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewDelegatedRegistryConfigServiceClient(conn)

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -346,6 +346,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_ADMISSION_CONTROLLER_CONFIG'
     customize_envVars+=$'\n        value: "true"'
+    customize_envVars+=$'\n      - name: ROX_SCANNER_V4_MATCHER_READINESS'
+    customize_envVars+=$'\n        value: "vulnerability"'
 
     local scannerV4ScannerComponent="Default"
     case "${ROX_SCANNER_V4:-}" in

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -76,6 +76,14 @@ test_e2e() {
     # Give some time for previous tests to finish up
     wait_for_api
 
+    info "Scanner E2E tests"
+    make -C tests scanner-e2e-tests || touch FAIL
+    store_test_results "tests/scanner-e2e-tests-results" "scanner-e2e-tests-results"
+    [[ ! -f FAIL ]] || die "scanner e2e tests failed"
+
+    # Give some time for previous tests to finish up
+    wait_for_api
+
     info "E2E destructive tests"
     make -C tests destructive-tests || touch FAIL
     store_test_results "tests/destructive-tests-results" "destructive-tests-results"

--- a/tests/e2e/yaml/central-cr-with-scanner-v4.envsubst.yaml
+++ b/tests/e2e/yaml/central-cr-with-scanner-v4.envsubst.yaml
@@ -63,14 +63,6 @@ $centralAdditionalCAIndented
         limits:
           cpu: "6000m"
           memory: "2000Mi"
-    db:
-      resources:
-        requests:
-          cpu: "300m"
-          memory: "500Mi"
-        limits:
-          cpu: "1000m"
-          memory: "1000Mi"
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml
+++ b/tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml
@@ -66,11 +66,3 @@ spec:
         limits:
           cpu: "2000m"
           memory: "2Gi"
-    db:
-      resources:
-        requests:
-          cpu: "200m"
-          memory: "2Gi"
-        limits:
-          cpu: "1000m"
-          memory: "2500Mi"

--- a/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-upload-db.bats
@@ -36,11 +36,11 @@ teardown() {
 }
 
 # TODO(ROX-29096): Make this test pass with Scanner V4 enabled.
-#
-# @test "[zip] roxctl scanner upload-db" {
-#   run curl --retry 30 --retry-max-time 600 --retry-all-errors --show-error --fail --output "${temp_dir}/test-scanner-vuln-updates.zip" --location 'https://install.stackrox.io/scanner/scanner-vuln-updates.zip'
-#   assert_success
+@test "[zip] roxctl scanner upload-db" {
+  if [[ "${ROX_SCANNER_V4}" == "true" ]]; then
+      skip "https://issues.redhat.com/browse/ROX-28949"
+  fi
 
-#   run roxctl_authenticated scanner upload-db --scanner-db-file "${temp_dir}/test-scanner-vuln-updates.zip"
-#   assert_success
-# }
+  run roxctl_authenticated scanner upload-db --scanner-db-file "${temp_dir}/test-scanner-vuln-updates.zip"
+  assert_success
+}


### PR DESCRIPTION
The goal is to be able to successfully run the nongroovy test suite with Scanner v4.

Here are the changes I've made to get the test suite to pass:

* Skipped the `roxctl scanner upload-db` bats test.  This will be addressed in [ROX-28949](https://issues.redhat.com/browse/ROX-28949)
* To avoid scanner-v4-db OOMKills, I removed the resource overrides on the db deployment.  The most important effect was increasing the memory limit to `4Gi`.
* Added a new go build tag `scanner_e2e` to the one nongroovy e2e test that relied on scanner to be fully functional.  (It's expected that there will be more scanner e2e in the future that will need to use this tag.)
* I then had that test execute after most of the tests to allow more time for the vuln definition to be loaded into the DB.
* To ensure that the vulns are loaded before the test executes, I added a check in the set up function of the test to ensure the matcher is ready to scan.

[ROX-28949]: https://redhat.atlassian.net/browse/ROX-28949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ