### PR TITLE
ROX-28931: Re-add Content-Length headers to our API responses

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -426,6 +426,7 @@ func (a *apiImpl) muxer(localConn *grpc.ClientConn) http.Handler {
 				},
 			}},
 		),
+		runtime.WithWriteContentLength(),
 		runtime.WithErrorHandler(errorHandler),
 	)
 	if localConn != nil {


### PR DESCRIPTION
### Description
In 4.7.1, a version bump of the `github.com/grpc-ecosystem/grpc-gateway/v2` dependency, resulted in the `Content-Length` header to be missing from our successful API responses. 
In the Release Notes > What's Changed section, 
Only write `Content-Length` if the `runtime.WithWriteContentLength()` option is specified by [{{@​joshgarnett}}](https://github.com/joshgarnett) in [grpc-ecosystem/grpc-gateway#5151](https://redirect.github.com/grpc-ecosystem/grpc-gateway/pull/5151)

Shout out to @vjwilson for finding the issue! 

This PR adds the `runtime.WithWriteContentLength()` option to our grpc server configuration.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Manual testing by hitting the API endpoint mentioned in the JIRA to verify Content-Length header is received in the response.

And, look who's back?

```
$  curl -v -k -H 'Authorization: Bearer '<some-token>' https://localhost:8000/v1/images | more
< HTTP/2 200 
< cache-control: no-store, no-cache
< content-type: application/json
< grpc-metadata-content-type: application/grpc
< vary: Accept-Encoding
< content-length: 16574
< date: Thu, 10 Apr 2025 23:15:44 GMT
< 
```


## Summary by Sourcery

Enhancements:
- Modify gRPC server configuration to include Content-Length headers in API responses