### PR TITLE
ROX-28946: Add lint rule for version of PatternFly variable or class

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -147,6 +147,68 @@ const rules = {
             };
         },
     },
+    'version-variable-class': {
+        // Require consistent version of PatternFly variable or class.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Require consistent version of PatternFly variable or class',
+            },
+            schema: [],
+        },
+        create(context) {
+            const findErrorMessage = (value) => {
+                const versionExpected = '5';
+                // Include capturing group for digits in each regular expression.
+                const variableRegExpArray = [
+                    /^var\(--pf-v(\d+)-/, // variable inside var (at beginning of string)
+                    /^--pf-v(\d+)-/, // variable outside var (at beginning of string)
+                    /^pf-v(\d+)-/, // class (at beginning of string)
+                    / pf-v(\d+)-/, // class (in middle of string)
+                ];
+                for (let i = 0; i !== variableRegExpArray.length; i += 1) {
+                    const variableRegExp = variableRegExpArray[i];
+                    const result = variableRegExp.exec(value);
+                    if (Array.isArray(result)) {
+                        const [, versionReceived] = result;
+                        if (versionReceived !== versionExpected) {
+                            return `PatternFly variable or class ${value} has inconsistent version ${versionReceived} instead of ${versionExpected}`;
+                        }
+                    }
+                }
+                return undefined;
+            };
+
+            return {
+                Literal(node) {
+                    if (typeof node.value === 'string') {
+                        const message = findErrorMessage(node.value);
+                        if (typeof message === 'string') {
+                            context.report({
+                                node,
+                                message,
+                            });
+                        }
+                    }
+                },
+                TemplateLiteral(node) {
+                    if (Array.isArray(node.quasis)) {
+                        node.quasis.forEach((quasi) => {
+                            if (typeof quasi.value?.cooked === 'string') {
+                                const message = findErrorMessage(quasi.value.cooked);
+                                if (typeof message === 'string') {
+                                    context.report({
+                                        node,
+                                        message,
+                                    });
+                                }
+                            }
+                        });
+                    }
+                },
+            };
+        },
+    },
 
     // ESLint naming convention for negative rules.
     // If your rule only disallows something, prefix it with no.


### PR DESCRIPTION
### Description

Especially when PatternFly is a major version ahead, reduce the risk to have inconsistent version number when we adapt examples.

For example:
https://github.com/stackrox/stackrox/pull/14951#discussion_r2039370285
https://github.com/stackrox/stackrox/pull/14951/commits/7d1b79ab1519271ff5214ec61d9a462da5903b0c

Find in Files for `pf-(\d+)-` with RegExp: 2067 results in 458 files

### Resource

Especially for template literal ;)

typescript-eslint playground: https://typescript-eslint.io/play/#ts=5.8.2&showAST=es&fileType=.tsx

### Residue

1. Investigate whether `files` glob in lint config for product files should match src/react-app-env.d.ts file.
2. Lint .css files?
    https://eslint.org/blog/2025/02/eslint-css-support/

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform folder