### PR TITLE
ROX-28876: Add button to Clusters page to manage CRS

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.test.ts
+++ b/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.test.ts
@@ -2,8 +2,7 @@ import withAuth from '../../../helpers/basicAuth';
 import { readFileFromDownloads } from '../../../helpers/file';
 import { getInputByLabel } from '../../../helpers/formHelpers';
 
-// TODO The entry point for this functionality will change once the removal from integrations is complete
-import { visitIntegrationsDashboardFromLeftNav } from '../../integrations/integrations.helpers';
+import { visitClusters } from '../Clusters.helpers';
 
 import { cleanupClusterRegistrationSecretsWithName } from './ClusterRegistrationSecrets.helpers';
 
@@ -21,12 +20,9 @@ describe('Cluster registration secrets', () => {
     });
 
     it('should create a new Cluster registration secret and then view and delete', () => {
-        visitIntegrationsDashboardFromLeftNav();
+        visitClusters();
 
-        cy.get('section:contains("Authentication Tokens")').scrollIntoView();
-        cy.get(
-            'section:contains("Authentication Tokens") a:contains("Cluster Registration Secret")'
-        ).click();
+        cy.get('a:contains("Cluster registration secrets")').click();
 
         const crsLinkInTableSelector = `td[data-label="Name"] a:contains("${testCrsName}")`;
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -57,6 +57,7 @@ import {
     clustersInitBundlesPath,
     clustersSecureClusterPath,
     clustersSecureClusterCrsPath,
+    clustersClusterRegistrationSecretsPath,
 } from 'routePaths';
 
 import AutoUpgradeToggle from './Components/AutoUpgradeToggle';
@@ -369,7 +370,11 @@ function ClustersTablePanel({
                 <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-pb-0">
                     <ToolbarContent>
                         <Title headingLevel="h1">Clusters</Title>
-                        <ToolbarGroup variant="button-group" align={{ default: 'alignRight' }}>
+                        <ToolbarGroup
+                            className="pf-v5-u-flex-wrap"
+                            variant="button-group"
+                            align={{ default: 'alignRight' }}
+                        >
                             {hasReadAccessForAdministration && (
                                 <ToolbarItem>
                                     <Button
@@ -400,6 +405,17 @@ function ClustersTablePanel({
                                         href={clustersInitBundlesPath}
                                     >
                                         Init bundles
+                                    </Button>
+                                </ToolbarItem>
+                            )}
+                            {hasAdminRole && (
+                                <ToolbarItem>
+                                    <Button
+                                        variant="secondary"
+                                        component={LinkShim}
+                                        href={clustersClusterRegistrationSecretsPath}
+                                    >
+                                        Cluster registration secrets
                                     </Button>
                                 </ToolbarItem>
                             )}


### PR DESCRIPTION
### Description

Adds a button to the Clusters page that links to the CRS table.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit cluster page:
![image](https://github.com/user-attachments/assets/13b8d94a-fe39-4f01-826f-c01a6ae87096)
Click the button:
![image](https://github.com/user-attachments/assets/b6ef1e6f-eee1-4d29-9b0d-73290cbae3c2)
Test that the multitude of buttons does not break layout on small screens:
![image](https://github.com/user-attachments/assets/57bc1e77-9884-4d00-80fa-db218d3a3a0c)
