### PR TITLE
ROX-28419: Persist indexer/matcher endpoints to DB

### DIFF
--- a/central/imageintegration/store/defaults.go
+++ b/central/imageintegration/store/defaults.go
@@ -7,6 +7,7 @@ import (
 	registryTypes "github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/scanners"
 	"github.com/stackrox/rox/pkg/scanners/clairify"
+	"github.com/stackrox/rox/pkg/scanners/scannerv4"
 	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
 )
 
@@ -137,7 +138,8 @@ var DefaultScannerV4Integration = &storage.ImageIntegration{
 	},
 	IntegrationConfig: &storage.ImageIntegration_ScannerV4{
 		ScannerV4: &storage.ScannerV4Config{
-			// Use integration default values.
+			IndexerEndpoint: scannerv4.DefaultIndexerEndpoint,
+			MatcherEndpoint: scannerv4.DefaultMatcherEndpoint,
 		},
 	},
 }


### PR DESCRIPTION
### Description

When viewing the Scanner V4 integration in the UI the indexer/matcher endpoints are blank (defaults will be used).

The UI shows the endpoints as stored in Central DB.  This change will add the default endpoints to the Scanner V4 integration stored in the DB when it is first created.

Note this will have NO effect on Scanner V4 integrations that had been previously created or if the endpoint is cleared in the future.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality


- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

No tests modified or added.

#### How I validated my change

Enabled scanner v4 on fresh install, and saw endpoints populated, and verified scans were working.

<img width="933" alt="image" src="https://github.com/user-attachments/assets/5b184691-0efd-42eb-831a-4472f57bf2d0" />

Cleared an endpoint and confirmed scans were still working with the implied default

<img width="935" alt="image" src="https://github.com/user-attachments/assets/5ea35d81-2bc4-44ab-a56a-21547d672700" />

Also set a non-default value, confirmed scans broke, and restarted central to confirm the non-default value persisted.

