### PR TITLE
ROX-28953: GetByIDs in image

### DIFF
--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -156,12 +156,12 @@ func (ds *datastoreImpl) canReadImage(ctx context.Context, sha string) (bool, er
 
 // GetManyImageMetadata gets the image data without the scan.
 func (ds *datastoreImpl) GetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, error) {
-	imgs, missingIdx, err := ds.storage.GetManyImageMetadata(ctx, ids)
+	imgs, err := ds.storage.GetManyImageMetadata(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
-	if len(missingIdx) > 0 {
-		log.Errorf("Could not fetch %d/%d some images", len(missingIdx), len(ids))
+	if len(imgs) != len(ids) {
+		log.Errorf("Could not fetch %d/%d some images", len(ids)-len(imgs), len(ids))
 	}
 	for _, img := range imgs {
 		ds.updateImagePriority(img)

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -204,7 +204,7 @@ func (ds *datastoreImpl) GetImagesBatch(ctx context.Context, shas []string) ([]*
 	if ok, err := imagesSAC.ReadAllowed(ctx); err != nil {
 		return nil, err
 	} else if ok {
-		imgs, _, err = ds.storage.GetMany(ctx, shas)
+		imgs, err = ds.storage.GetByIDs(ctx, shas)
 		if err != nil {
 			return nil, err
 		}

--- a/central/image/datastore/search/searcher_impl_v2.go
+++ b/central/image/datastore/search/searcher_impl_v2.go
@@ -69,7 +69,7 @@ func (s *searcherImplV2) SearchRawImages(ctx context.Context, q *v1.Query) ([]*s
 		return nil, err
 	}
 
-	images, _, err := s.storage.GetMany(ctx, search.ResultsToIDs(results))
+	images, err := s.storage.GetByIDs(ctx, search.ResultsToIDs(results))
 	if err != nil {
 		return nil, err
 	}

--- a/central/image/datastore/store/mocks/store.go
+++ b/central/image/datastore/store/mocks/store.go
@@ -103,6 +103,21 @@ func (mr *MockStoreMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
+// GetByIDs mocks base method.
+func (m *MockStore) GetByIDs(ctx context.Context, ids []string) ([]*storage.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByIDs", ctx, ids)
+	ret0, _ := ret[0].([]*storage.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByIDs indicates an expected call of GetByIDs.
+func (mr *MockStoreMockRecorder) GetByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIDs", reflect.TypeOf((*MockStore)(nil).GetByIDs), ctx, ids)
+}
+
 // GetImageMetadata mocks base method.
 func (m *MockStore) GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error) {
 	m.ctrl.T.Helper()
@@ -119,30 +134,13 @@ func (mr *MockStoreMockRecorder) GetImageMetadata(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageMetadata", reflect.TypeOf((*MockStore)(nil).GetImageMetadata), ctx, id)
 }
 
-// GetMany mocks base method.
-func (m *MockStore) GetMany(ctx context.Context, ids []string) ([]*storage.Image, []int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMany", ctx, ids)
-	ret0, _ := ret[0].([]*storage.Image)
-	ret1, _ := ret[1].([]int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetMany indicates an expected call of GetMany.
-func (mr *MockStoreMockRecorder) GetMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), ctx, ids)
-}
-
 // GetManyImageMetadata mocks base method.
-func (m *MockStore) GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, []int, error) {
+func (m *MockStore) GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetManyImageMetadata", ctx, id)
 	ret0, _ := ret[0].([]*storage.Image)
-	ret1, _ := ret[1].([]int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetManyImageMetadata indicates an expected call of GetManyImageMetadata.

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -1125,60 +1125,48 @@ func (s *storeImpl) retryableGetIDs(ctx context.Context) ([]string, error) {
 	return ids, nil
 }
 
-// GetMany returns the objects specified by the IDs or the index in the missing indices slice
-func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Image, []int, error) {
+// GetByIDs returns the objects specified by the IDs
+func (s *storeImpl) GetByIDs(ctx context.Context, ids []string) ([]*storage.Image, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "Image")
 
-	return pgutils.Retry3(ctx, func() ([]*storage.Image, []int, error) {
-		return s.retryableGetMany(ctx, ids)
+	return pgutils.Retry2(ctx, func() ([]*storage.Image, error) {
+		return s.retryableGetByIDs(ctx, ids)
 	})
 }
 
-func (s *storeImpl) retryableGetMany(ctx context.Context, ids []string) ([]*storage.Image, []int, error) {
+func (s *storeImpl) retryableGetByIDs(ctx context.Context, ids []string) ([]*storage.Image, error) {
 	conn, release, err := s.acquireConn(ctx, ops.GetMany, "Image")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer release()
 
 	tx, err := conn.Begin(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	resultsByID := make(map[string]*storage.Image)
+	elems := make([]*storage.Image, 0, len(ids))
 	for _, id := range ids {
 		msg, found, err := s.getFullImage(ctx, tx, id)
 		if err != nil {
 			// No changes are made to the database, so COMMIT or ROLLBACK have the same effect.
 			if err := tx.Commit(ctx); err != nil {
-				return nil, nil, err
+				return nil, err
 			}
-			return nil, nil, err
+			return nil, err
 		}
 		if !found {
 			continue
 		}
-		resultsByID[msg.GetId()] = msg
+		elems = append(elems, msg)
 	}
 
 	// No changes are made to the database, so COMMIT or ROLLBACK have the same effect.
 	if err := tx.Commit(ctx); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
-	// It is important that the elems are populated in the same order as the input ids
-	// slice, since some calling code relies on that to maintain order.
-	elems := make([]*storage.Image, 0, len(resultsByID))
-	for i, id := range ids {
-		if result, ok := resultsByID[id]; !ok {
-			missingIndices = append(missingIndices, i)
-		} else {
-			elems = append(elems, result)
-		}
-	}
-	return elems, missingIndices, nil
+	return elems, nil
 }
 
 // WalkByQuery returns the objects specified by the query

--- a/central/image/datastore/store/postgres/store_test.go
+++ b/central/image/datastore/store/postgres/store_test.go
@@ -42,6 +42,14 @@ func (s *ImagesStoreSuite) TestStore() {
 	defer pgtest.CloseGormDB(s.T(), gormDB)
 	store := CreateTableAndNewStore(ctx, pool, gormDB, false)
 
+	metadata, err := store.GetManyImageMetadata(ctx, nil)
+	s.NoError(err)
+	s.Empty(metadata)
+
+	metadata, err = store.GetManyImageMetadata(ctx, []string{"missing id"})
+	s.NoError(err)
+	s.Empty(metadata)
+
 	image := fixtures.GetImage()
 	s.NoError(testutils.FullInit(image, testutils.SimpleInitializer(), testutils.JSONFieldsFilter))
 	for _, comp := range image.GetScan().GetComponents() {

--- a/central/image/datastore/store/store.go
+++ b/central/image/datastore/store/store.go
@@ -22,7 +22,7 @@ type Store interface {
 
 	// GetImageMetadata and GetImageMetadata returns the image without scan/component data.
 	GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error)
-	GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, []int, error)
+	GetManyImageMetadata(ctx context.Context, id []string) ([]*storage.Image, error)
 	WalkByQuery(ctx context.Context, q *v1.Query, fn func(img *storage.Image) error) error
 
 	Upsert(ctx context.Context, image *storage.Image) error

--- a/central/image/datastore/store/store.go
+++ b/central/image/datastore/store/store.go
@@ -18,7 +18,7 @@ type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)
 
 	Get(ctx context.Context, id string) (*storage.Image, bool, error)
-	GetMany(ctx context.Context, ids []string) ([]*storage.Image, []int, error)
+	GetByIDs(ctx context.Context, ids []string) ([]*storage.Image, error)
 
 	// GetImageMetadata and GetImageMetadata returns the image without scan/component data.
 	GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error)

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -817,48 +817,21 @@ func (s *storeImpl) retryableGetImageMetadata(ctx context.Context, id string) (*
 }
 
 // GetManyImageMetadata returns images without scan/component data.
-func (s *storeImpl) GetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, []int, error) {
+func (s *storeImpl) GetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "Image")
 
-	return pgutils.Retry3(ctx, func() ([]*storage.Image, []int, error) {
+	return pgutils.Retry2(ctx, func() ([]*storage.Image, error) {
 		return s.retryableGetManyImageMetadata(ctx, ids)
 	})
 }
 
-func (s *storeImpl) retryableGetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, []int, error) {
+func (s *storeImpl) retryableGetManyImageMetadata(ctx context.Context, ids []string) ([]*storage.Image, error) {
 	if len(ids) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	q := search.NewQueryBuilder().AddExactMatches(search.ImageSHA, ids...).ProtoQuery()
-
-	rows, err := pgSearch.RunGetManyQueryForSchema[storage.Image](ctx, schema, q, s.db)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			missingIndices := make([]int, 0, len(ids))
-			for i := range ids {
-				missingIndices = append(missingIndices, i)
-			}
-			return nil, missingIndices, nil
-		}
-		return nil, nil, err
-	}
-	resultsByID := make(map[string]*storage.Image, len(rows))
-	for _, msg := range rows {
-		resultsByID[msg.GetId()] = msg
-	}
-	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
-	// It is important that the elems are populated in the same order as the input ids
-	// slice, since some calling code relies on that to maintain order.
-	elems := make([]*storage.Image, 0, len(resultsByID))
-	for i, id := range ids {
-		if result, ok := resultsByID[id]; !ok {
-			missingIndices = append(missingIndices, i)
-		} else {
-			elems = append(elems, result)
-		}
-	}
-	return elems, missingIndices, nil
+	return pgSearch.RunGetManyQueryForSchema[storage.Image](ctx, schema, q, s.db)
 }
 
 func (s *storeImpl) UpdateVulnState(ctx context.Context, cve string, imageIDs []string, state storage.VulnerabilityState) error {

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -267,9 +267,8 @@ func (s *ImagesStoreSuite) TestGetManyImageMetadata() {
 	s.True(exists)
 
 	searchedIndexes := []string{image.GetId(), image2.GetId()}
-	returnedImages, notFoundIDs, err := s.store.GetManyImageMetadata(s.ctx, searchedIndexes)
+	returnedImages, err := s.store.GetManyImageMetadata(s.ctx, searchedIndexes)
 	s.NoError(err)
-	s.Empty(notFoundIDs)
 	s.Equal(2, len(returnedImages))
 
 	for _, image := range returnedImages {
@@ -278,10 +277,8 @@ func (s *ImagesStoreSuite) TestGetManyImageMetadata() {
 	}
 
 	searchedIndexes = []string{image.GetId(), image2.GetId(), "nonsense"}
-	returnedImages, notFoundIDs, err = s.store.GetManyImageMetadata(s.ctx, searchedIndexes)
+	returnedImages, err = s.store.GetManyImageMetadata(s.ctx, searchedIndexes)
 	s.NoError(err)
-	s.Contains(notFoundIDs, 2)
-	s.Equal(1, len(notFoundIDs))
 	s.Equal(2, len(returnedImages))
 }
 

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -326,9 +326,8 @@ func (s *ImagesStoreSuite) TestGetMany() {
 	s.True(exists)
 
 	searchedIndexes := []string{image.GetId(), image2.GetId()}
-	returnedImages, notFoundIDs, err := s.store.GetMany(s.ctx, searchedIndexes)
+	returnedImages, err := s.store.GetByIDs(s.ctx, searchedIndexes)
 	s.NoError(err)
-	s.Empty(notFoundIDs)
 	s.Equal(2, len(returnedImages))
 
 	for _, image := range returnedImages {
@@ -337,10 +336,8 @@ func (s *ImagesStoreSuite) TestGetMany() {
 	}
 
 	searchedIndexes = []string{image.GetId(), image2.GetId(), "nonsense"}
-	returnedImages, notFoundIDs, err = s.store.GetMany(s.ctx, searchedIndexes)
+	returnedImages, err = s.store.GetByIDs(s.ctx, searchedIndexes)
 	s.NoError(err)
-	s.Contains(notFoundIDs, 2)
-	s.Equal(1, len(notFoundIDs))
 	s.Equal(2, len(returnedImages))
 }
 


### PR DESCRIPTION
### Description

In Image store we return missing indices that are not used anywhere. This leads to a situation where we compute result that is ignored. Let's remove it.

```
                                    │   old.txt   │              new.txt               │
                                    │   sec/op    │   sec/op     vs base               │
ImageGetMany/GetImagesBatch-8         87.98m ± 2%   86.91m ± 2%       ~ (p=0.052 n=20)
ImageGetMany/GetManyImageMetadata-8   981.3µ ± 1%   967.8µ ± 2%  -1.37% (p=0.006 n=20)
geomean                               9.292m        9.171m       -1.29%

                                    │   old.txt    │               new.txt               │
                                    │     B/op     │     B/op      vs base               │
ImageGetMany/GetImagesBatch-8         7.472Mi ± 0%   7.464Mi ± 0%  -0.10% (p=0.000 n=20)
ImageGetMany/GetManyImageMetadata-8   544.0Ki ± 0%   539.1Ki ± 0%  -0.91% (p=0.000 n=20)
geomean                               1.992Mi        1.982Mi       -0.51%

                                    │   old.txt   │              new.txt               │
                                    │  allocs/op  │  allocs/op   vs base               │
ImageGetMany/GetImagesBatch-8         77.30k ± 0%   77.30k ± 0%  -0.01% (p=0.000 n=20)
ImageGetMany/GetManyImageMetadata-8   6.666k ± 0%   6.663k ± 0%  -0.05% (p=0.000 n=20)
geomean                               22.70k        22.69k       -0.03%
```

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
