### PR TITLE
feat(networkbaseline): external network baselines API

### DIFF
--- a/central/networkbaseline/manager/manager.go
+++ b/central/networkbaseline/manager/manager.go
@@ -50,5 +50,7 @@ type Manager interface {
 	// ProcessBaselineLockUpdate updates a baseline's lock status. This locks the baseline if lockBaseline is true
 	ProcessBaselineLockUpdate(ctx context.Context, deploymentID string, lockBaseline bool) error
 
+	// GetExternalNetworkPeers returns all external peers for a given deployment, filtered
+	// by the search query and timestamp.
 	GetExternalNetworkPeers(ctx context.Context, deploymentID string, query string, since *time.Time) ([]*v1.NetworkBaselineStatusPeer, error)
 }

--- a/central/networkbaseline/manager/manager.go
+++ b/central/networkbaseline/manager/manager.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -48,4 +49,6 @@ type Manager interface {
 	ProcessNetworkPolicyUpdate(ctx context.Context, action central.ResourceAction, policy *storage.NetworkPolicy) error
 	// ProcessBaselineLockUpdate updates a baseline's lock status. This locks the baseline if lockBaseline is true
 	ProcessBaselineLockUpdate(ctx context.Context, deploymentID string, lockBaseline bool) error
+
+	GetExternalNetworkPeers(ctx context.Context, deploymentID string, query string, since *time.Time) ([]*v1.NetworkBaselineStatusPeer, error)
 }

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -1026,7 +1026,7 @@ func (m *manager) getEntitiesByQuery(ctx context.Context, clusterId, query strin
 
 	// Retrieves entities where the cluster ID matches the request cluster OR where the cluster ID is empty indicating global entities.
 	clusterMatch := search.DisjunctionQuery(
-		search.MatchFieldQuery(search.ClusterID.String(), search.ExactMatchString(""), false),
+		search.NewQueryBuilder().AddNullField(search.ClusterID).ProtoQuery(),
 		search.MatchFieldQuery(search.ClusterID.String(), search.ExactMatchString(clusterId), false),
 	)
 

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -940,6 +940,8 @@ func (m *manager) GetExternalNetworkPeers(ctx context.Context, deploymentID stri
 	for _, entity := range entities {
 		info := entity.GetInfo()
 		entityFilter.Add(info.GetId())
+
+		// store enriched entities data for lookup later
 		entitiesMap[info.GetId()] = info
 	}
 
@@ -985,18 +987,18 @@ func (m *manager) GetExternalNetworkPeers(ctx context.Context, deploymentID stri
 		if src.GetType() == storage.NetworkEntityInfo_DEPLOYMENT {
 			info := entitiesMap[dst.GetId()]
 			entity = &v1.NetworkBaselinePeerEntity{
-				Id:   dst.GetId(),
-				Type: dst.GetType(),
-				Cidr: info.GetExternalSource().GetCidr(),
-				Name: info.GetExternalSource().GetName(),
+				Id:         dst.GetId(),
+				Type:       dst.GetType(),
+				Name:       info.GetExternalSource().GetName(),
+				Discovered: info.GetExternalSource().GetDiscovered(),
 			}
 		} else {
 			info := entitiesMap[src.GetId()]
 			entity = &v1.NetworkBaselinePeerEntity{
-				Id:   src.GetId(),
-				Type: src.GetType(),
-				Cidr: info.GetExternalSource().GetCidr(),
-				Name: info.GetExternalSource().GetName(),
+				Id:         src.GetId(),
+				Type:       src.GetType(),
+				Name:       info.GetExternalSource().GetName(),
+				Discovered: info.GetExternalSource().GetDiscovered(),
 			}
 			ingress = true
 		}

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -944,6 +944,10 @@ func (m *manager) GetExternalNetworkPeers(ctx context.Context, deploymentID stri
 		src := props.GetSrcEntity()
 		dst := props.GetDstEntity()
 
+		if src.GetId() != deploymentID && dst.GetId() != deploymentID {
+			return false
+		}
+
 		if !networkgraph.AnyExternal(src, dst) || networkgraph.AllExternal(src, dst) {
 			// only looking for external flows, and not external pairs
 			return false
@@ -977,13 +981,13 @@ func (m *manager) GetExternalNetworkPeers(ctx context.Context, deploymentID stri
 
 		if flow.GetProps().GetSrcEntity().GetType() == storage.NetworkEntityInfo_DEPLOYMENT {
 			entity = &v1.NetworkBaselinePeerEntity{
-				Id:   src.GetId(),
-				Type: src.GetType(),
+				Id:   dst.GetId(),
+				Type: dst.GetType(),
 			}
 		} else {
 			entity = &v1.NetworkBaselinePeerEntity{
-				Id:   dst.GetId(),
-				Type: dst.GetType(),
+				Id:   src.GetId(),
+				Type: src.GetType(),
 			}
 			ingress = true
 		}

--- a/central/networkbaseline/manager/mocks/manager.go
+++ b/central/networkbaseline/manager/mocks/manager.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -57,6 +58,21 @@ func (m *MockManager) CreateNetworkBaseline(deploymentID string) error {
 func (mr *MockManagerMockRecorder) CreateNetworkBaseline(deploymentID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkBaseline", reflect.TypeOf((*MockManager)(nil).CreateNetworkBaseline), deploymentID)
+}
+
+// GetExternalNetworkPeers mocks base method.
+func (m *MockManager) GetExternalNetworkPeers(ctx context.Context, deploymentID, query string, since *time.Time) ([]*v1.NetworkBaselineStatusPeer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExternalNetworkPeers", ctx, deploymentID, query, since)
+	ret0, _ := ret[0].([]*v1.NetworkBaselineStatusPeer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExternalNetworkPeers indicates an expected call of GetExternalNetworkPeers.
+func (mr *MockManagerMockRecorder) GetExternalNetworkPeers(ctx, deploymentID, query, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalNetworkPeers", reflect.TypeOf((*MockManager)(nil).GetExternalNetworkPeers), ctx, deploymentID, query, since)
 }
 
 // ProcessBaselineLockUpdate mocks base method.

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -229,6 +229,7 @@ func (s *serviceImpl) anonymizedPeerKey(peer *v1.NetworkBaselineStatusPeer) netw
 			ID:   internet.ID,
 		}
 	}
+
 	return networkgraph.Entity{
 		Type: entity.GetType(),
 		ID:   entity.GetId(),

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -98,7 +98,7 @@ func (s *serviceImpl) GetNetworkBaselineStatusForExternalFlows(ctx context.Conte
 
 	since := protocompat.ConvertTimestampToTimeOrNil(request.GetSince())
 	if since == nil {
-		t := time.Now().Add(defaultSince)
+		t := protocompat.TimestampNow().AsTime().Add(defaultSince)
 		since = &t
 	}
 

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -9,7 +9,6 @@ import (
 	deploymentUtils "github.com/stackrox/rox/central/deployment/utils"
 	"github.com/stackrox/rox/central/networkbaseline/datastore"
 	"github.com/stackrox/rox/central/networkbaseline/manager"
-	flowDatastore "github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -45,8 +44,6 @@ type serviceImpl struct {
 
 	datastore datastore.ReadOnlyDataStore
 	manager   manager.Manager
-
-	flowStore flowDatastore.ClusterDataStore
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.

--- a/central/networkbaseline/service/service_impl_sql_test.go
+++ b/central/networkbaseline/service/service_impl_sql_test.go
@@ -1,0 +1,322 @@
+//go:build sql_integration
+
+package service
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
+	networkBaselineDS "github.com/stackrox/rox/central/networkbaseline/datastore"
+	"github.com/stackrox/rox/central/networkbaseline/manager"
+	"github.com/stackrox/rox/central/networkbaseline/testutils"
+	networkEntityDS "github.com/stackrox/rox/central/networkgraph/entity/datastore"
+	networkFlowDS "github.com/stackrox/rox/central/networkgraph/flow/datastore"
+	networkPolicyDS "github.com/stackrox/rox/central/networkpolicies/datastore"
+	"github.com/stackrox/rox/central/sensor/service/connection"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/networkgraph/externalsrcs"
+	networkgraphTestutils "github.com/stackrox/rox/pkg/networkgraph/testutils"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	testEntityId = "entity-1"
+
+	// the idea is to have some IPs across a filterable
+	// range, to test queries against both 1.1.0.0/16
+	// and 1.1.1.0/24
+	externalIps = []string{
+		"1.1.0.1",
+		"1.1.0.2",
+		"1.1.1.3",
+		"1.1.1.4",
+		"1.1.1.5",
+	}
+)
+
+func TestNetworkBaselinePostgres(t *testing.T) {
+	suite.Run(t, new(networkBaselineServiceSuite))
+}
+
+type networkBaselineServiceSuite struct {
+	suite.Suite
+
+	db *pgtest.TestPostgres
+
+	service Service
+	manager manager.Manager
+
+	deploymentDataStore deploymentDS.DataStore
+	entityDataStore     networkEntityDS.EntityDataStore
+	flowDataStore       networkFlowDS.ClusterDataStore
+	policyDataStore     networkPolicyDS.DataStore
+	baselineDataStore   networkBaselineDS.DataStore
+	connectionManager   connection.Manager
+}
+
+func (s *networkBaselineServiceSuite) SetupTest() {
+	db := pgtest.ForT(s.T())
+
+	var err error
+
+	s.deploymentDataStore, err = deploymentDS.GetTestPostgresDataStore(s.T(), db.DB)
+	s.NoError(err)
+
+	s.entityDataStore = networkEntityDS.GetTestPostgresDataStore(s.T(), db.DB)
+
+	s.flowDataStore, err = networkFlowDS.GetTestPostgresClusterDataStore(s.T(), db.DB)
+	s.NoError(err)
+
+	s.policyDataStore, err = networkPolicyDS.GetTestPostgresDataStore(s.T(), db.DB)
+	s.NoError(err)
+
+	s.baselineDataStore, err = networkBaselineDS.GetTestPostgresDataStore(s.T(), db.DB)
+	s.NoError(err)
+
+	s.connectionManager = connection.ManagerSingleton()
+
+	s.manager, err = manager.New(
+		s.baselineDataStore,
+		s.entityDataStore,
+		s.deploymentDataStore,
+		s.policyDataStore,
+		s.flowDataStore,
+		s.connectionManager,
+	)
+	s.NoError(err)
+
+	s.service = New(s.baselineDataStore, s.manager)
+}
+
+func (s *networkBaselineServiceSuite) setupTablesExternalFlows() {
+	// this baseline is created for fixtureconsts.Deployment1
+	baseline := testutils.GetBaselineWithInternet(fixtureconsts.Cluster1, false, 1234)
+	s.NoError(s.baselineDataStore.UpsertNetworkBaselines(allAllowedCtx, []*storage.NetworkBaseline{baseline}))
+
+	deployment := fixtures.LightweightDeployment()
+	s.NoError(s.deploymentDataStore.UpsertDeployment(allAllowedCtx, deployment))
+
+	var entities []*storage.NetworkEntity
+
+	for _, ip := range externalIps {
+		cidr := fmt.Sprintf("%s/32", ip)
+		id, err := externalsrcs.NewClusterScopedID(fixtureconsts.Cluster1, cidr)
+		s.NoError(err)
+
+		entities = append(entities, networkgraphTestutils.GetExtSrcNetworkEntity(
+			id.String(),
+			ip,
+			cidr,
+			false,
+			fixtureconsts.Cluster1,
+			true,
+		))
+	}
+
+	_, err := s.entityDataStore.CreateExtNetworkEntitiesForCluster(allAllowedCtx, fixtureconsts.Cluster1, entities...)
+	s.NoError(err)
+
+	var flows []*storage.NetworkFlow
+
+	ts := time.Now().Add(-10 * time.Minute)
+
+	deploymentEntity := &storage.NetworkEntityInfo{
+		Id:   fixtureconsts.Deployment1,
+		Type: storage.NetworkEntityInfo_DEPLOYMENT,
+	}
+
+	// for every entity, have a baseline flow and an
+	// anomalous flow (using a different port)
+	for _, entity := range entities {
+		flows = append(flows, networkgraphTestutils.GetNetworkFlow(
+			deploymentEntity,
+			entity.Info,
+			1234,
+			storage.L4Protocol_L4_PROTOCOL_TCP,
+			&ts,
+		))
+
+		flows = append(flows, networkgraphTestutils.GetNetworkFlow(
+			deploymentEntity,
+			entity.Info,
+			4567,
+			storage.L4Protocol_L4_PROTOCOL_TCP,
+			&ts,
+		))
+	}
+
+	fs, err := s.flowDataStore.GetFlowStore(allAllowedCtx, fixtureconsts.Cluster1)
+	s.NoError(err)
+
+	err = fs.UpsertFlows(allAllowedCtx, flows, timestamp.FromGoTime(ts))
+	s.NoError(err)
+}
+
+func (s *networkBaselineServiceSuite) TestExternalStatus() {
+	s.setupTablesExternalFlows()
+
+	req := &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+		Since:        timestamppb.New(time.Now().Add(-1 * time.Hour)),
+	}
+
+	resp, err := s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	// expect len(ips) anomalous flows and len(ips) baseline flows
+	s.Equal(len(externalIps), len(resp.Anomalous))
+	s.Equal(len(externalIps), len(resp.Baseline))
+	s.Equal(int32(len(externalIps)), resp.TotalAnomalous)
+	s.Equal(int32(len(externalIps)), resp.TotalBaseline)
+
+	for _, anomalous := range resp.Anomalous {
+		s.Equal(v1.NetworkBaselinePeerStatus_ANOMALOUS, anomalous.Status)
+	}
+
+	for _, baseline := range resp.Baseline {
+		s.Equal(v1.NetworkBaselinePeerStatus_BASELINE, baseline.Status)
+	}
+}
+
+func (s *networkBaselineServiceSuite) TestExternalStatusPagination() {
+	s.setupTablesExternalFlows()
+
+	req := &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+		Since:        timestamppb.New(time.Now().Add(-1 * time.Hour)),
+		Pagination: &v1.Pagination{
+			Offset: 0,
+			Limit:  2,
+		},
+	}
+
+	resp, err := s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Equal(2, len(resp.Anomalous))
+	s.Equal(2, len(resp.Baseline))
+	s.Equal(int32(len(externalIps)), resp.TotalAnomalous)
+	s.Equal(int32(len(externalIps)), resp.TotalBaseline)
+
+	req.Pagination.Offset = 2
+
+	firstPageAnomalous := resp.Anomalous
+	firstPageBaseline := resp.Baseline
+
+	resp, err = s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Equal(2, len(resp.Anomalous))
+	s.Equal(2, len(resp.Baseline))
+	s.Equal(int32(len(externalIps)), resp.TotalAnomalous)
+	s.Equal(int32(len(externalIps)), resp.TotalBaseline)
+
+	s.NotElementsMatch(firstPageAnomalous, resp.Anomalous)
+	s.NotElementsMatch(firstPageBaseline, resp.Baseline)
+}
+
+func (s *networkBaselineServiceSuite) TestExternalStatusNoExternalFlows() {
+	s.NoError(s.deploymentDataStore.UpsertDeployment(allAllowedCtx, fixtures.LightweightDeployment()))
+
+	req := &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+	}
+
+	resp, err := s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Empty(resp.Anomalous)
+	s.Empty(resp.Baseline)
+	s.Equal(int32(0), resp.TotalAnomalous)
+	s.Equal(int32(0), resp.TotalBaseline)
+}
+
+func (s *networkBaselineServiceSuite) TestExternalStatusCIDRFilter() {
+	s.setupTablesExternalFlows()
+
+	req := &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+		Query:        "External Source Address:1.1.1.0/24",
+	}
+
+	resp, err := s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Equal(3, len(resp.Anomalous))
+	s.Equal(3, len(resp.Baseline))
+	s.Equal(int32(3), resp.TotalAnomalous)
+	s.Equal(int32(3), resp.TotalBaseline)
+
+	for _, anomaly := range append(resp.Baseline, resp.Anomalous...) {
+		// confirm all the CIDRs match the expected range
+		s.True(strings.HasPrefix(anomaly.GetPeer().GetEntity().GetName(), "1.1.1"))
+	}
+
+	req = &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+		Query:        "External Source Address:1.2.3.4/32", // non existent
+	}
+
+	resp, err = s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Equal(0, len(resp.Anomalous))
+	s.Equal(0, len(resp.Baseline))
+	s.Equal(int32(0), resp.TotalAnomalous)
+	s.Equal(int32(0), resp.TotalBaseline)
+
+	// empty query should return everything
+	req = &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+		Query:        "", // non existent
+	}
+
+	resp, err = s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Equal(len(externalIps), len(resp.Anomalous))
+	s.Equal(len(externalIps), len(resp.Baseline))
+	s.Equal(int32(len(externalIps)), resp.TotalAnomalous)
+	s.Equal(int32(len(externalIps)), resp.TotalBaseline)
+}
+
+func (s *networkBaselineServiceSuite) TestExternalStatusSince() {
+	s.setupTablesExternalFlows()
+
+	// very recent timestamp
+	req := &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+		Since:        timestamppb.New(time.Now().Add(-5 * time.Second)),
+	}
+
+	resp, err := s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Equal(0, len(resp.Anomalous))
+	s.Equal(0, len(resp.Baseline))
+	s.Equal(int32(0), resp.TotalAnomalous)
+	s.Equal(int32(0), resp.TotalBaseline)
+
+	// very old timestamp should return everything
+	req = &v1.NetworkBaselineExternalStatusRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+		Since:        timestamppb.New(time.Now().Add(-24 * time.Hour)),
+	}
+
+	resp, err = s.service.GetNetworkBaselineStatusForExternalFlows(allAllowedCtx, req)
+	s.NoError(err)
+
+	s.Equal(len(externalIps), len(resp.Anomalous))
+	s.Equal(len(externalIps), len(resp.Baseline))
+	s.Equal(int32(len(externalIps)), resp.TotalAnomalous)
+	s.Equal(int32(len(externalIps)), resp.TotalBaseline)
+}

--- a/central/networkbaseline/service/service_impl_sql_test.go
+++ b/central/networkbaseline/service/service_impl_sql_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 var (
-	testEntityId = "entity-1"
-
 	// the idea is to have some IPs across a filterable
 	// range, to test queries against both 1.1.0.0/16
 	// and 1.1.1.0/24
@@ -97,6 +95,7 @@ func (s *networkBaselineServiceSuite) SetupTest() {
 	s.NoError(err)
 
 	s.service = New(s.baselineDataStore, s.manager)
+	s.db = db
 }
 
 func (s *networkBaselineServiceSuite) setupTablesExternalFlowsWithDefaultEntity() {

--- a/central/networkbaseline/service/service_impl_test.go
+++ b/central/networkbaseline/service/service_impl_test.go
@@ -53,10 +53,9 @@ func (s *NetworkBaselineServiceTestSuite) TearDownTest() {
 
 func (s *NetworkBaselineServiceTestSuite) getBaselineWithSampleFlow() *storage.NetworkBaseline {
 	entityID, entityClusterID := "entity-id", "another-cluster"
-	entityType := storage.NetworkEntityInfo_DEPLOYMENT
 	flowIsIngress := true
 	flowPort := uint32(8080)
-	return testutils.GetBaselineWithCustomDeploymentFlow(testPeerDeploymentName, entityID, entityClusterID, entityType, flowIsIngress, flowPort)
+	return testutils.GetBaselineWithCustomDeploymentFlow(testPeerDeploymentName, entityID, entityClusterID, flowIsIngress, flowPort)
 }
 
 func (s *NetworkBaselineServiceTestSuite) TestGetNetworkBaselineStatusForFlows() {
@@ -113,7 +112,6 @@ func (s *NetworkBaselineServiceTestSuite) TestGetNetworkBaselineStatusForFlows()
 			testPeerDeploymentName,
 			entityID,
 			baseline.GetClusterId(),
-			peer.GetEntity().GetInfo().GetType(),
 			!isIngress,
 			port)
 	s.baselines.EXPECT().GetNetworkBaseline(gomock.Any(), gomock.Any()).Return(baseline, true, nil)

--- a/central/networkbaseline/testutils/utils.go
+++ b/central/networkbaseline/testutils/utils.go
@@ -1,0 +1,70 @@
+package testutils
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/networkgraph"
+)
+
+func GetBaselineWithCustomDeploymentFlow(
+	deploymentName string,
+	entityID, entityClusterID string,
+	entityType storage.NetworkEntityInfo_Type,
+	flowIsIngress bool,
+	flowPort uint32,
+) *storage.NetworkBaseline {
+	baseline := fixtures.GetNetworkBaseline()
+	baseline.Peers = []*storage.NetworkBaselinePeer{
+		{
+			Entity: &storage.NetworkEntity{
+				Info: &storage.NetworkEntityInfo{
+					Type: entityType,
+					Id:   entityID,
+					Desc: &storage.NetworkEntityInfo_Deployment_{
+						Deployment: &storage.NetworkEntityInfo_Deployment{
+							Name: deploymentName,
+						},
+					},
+				},
+				Scope: &storage.NetworkEntity_Scope{ClusterId: entityClusterID},
+			},
+			Properties: []*storage.NetworkBaselineConnectionProperties{
+				{
+					Ingress:  flowIsIngress,
+					Port:     flowPort,
+					Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+				},
+			},
+		},
+	}
+
+	return baseline
+}
+
+func GetBaselineWithInternet(
+	entityClusterID string,
+	flowIsIngress bool,
+	flowPort uint32,
+) *storage.NetworkBaseline {
+	baseline := fixtures.GetNetworkBaseline()
+	baseline.Peers = []*storage.NetworkBaselinePeer{
+		{
+			Entity: &storage.NetworkEntity{
+				Info: &storage.NetworkEntityInfo{
+					Type: storage.NetworkEntityInfo_INTERNET,
+					Id:   networkgraph.InternetExternalSourceID,
+				},
+				Scope: &storage.NetworkEntity_Scope{ClusterId: entityClusterID},
+			},
+			Properties: []*storage.NetworkBaselineConnectionProperties{
+				{
+					Ingress:  flowIsIngress,
+					Port:     flowPort,
+					Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+				},
+			},
+		},
+	}
+
+	return baseline
+}

--- a/central/networkbaseline/testutils/utils.go
+++ b/central/networkbaseline/testutils/utils.go
@@ -9,7 +9,6 @@ import (
 func GetBaselineWithCustomDeploymentFlow(
 	deploymentName string,
 	entityID, entityClusterID string,
-	entityType storage.NetworkEntityInfo_Type,
 	flowIsIngress bool,
 	flowPort uint32,
 ) *storage.NetworkBaseline {
@@ -18,7 +17,7 @@ func GetBaselineWithCustomDeploymentFlow(
 		{
 			Entity: &storage.NetworkEntity{
 				Info: &storage.NetworkEntityInfo{
-					Type: entityType,
+					Type: storage.NetworkEntityInfo_DEPLOYMENT,
 					Id:   entityID,
 					Desc: &storage.NetworkEntityInfo_Deployment_{
 						Deployment: &storage.NetworkEntityInfo_Deployment{

--- a/generated/api/v1/network_baseline_service.pb.go
+++ b/generated/api/v1/network_baseline_service.pb.go
@@ -11,6 +11,7 @@ import (
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -350,6 +351,142 @@ func (x *NetworkBaselineStatusResponse) GetStatuses() []*NetworkBaselinePeerStat
 	return nil
 }
 
+type NetworkBaselineExternalStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
+	Query         string                 `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
+	Since         *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=since,proto3" json:"since,omitempty"`
+	Pagination    *Pagination            `protobuf:"bytes,4,opt,name=pagination,proto3" json:"pagination,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NetworkBaselineExternalStatusRequest) Reset() {
+	*x = NetworkBaselineExternalStatusRequest{}
+	mi := &file_api_v1_network_baseline_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NetworkBaselineExternalStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NetworkBaselineExternalStatusRequest) ProtoMessage() {}
+
+func (x *NetworkBaselineExternalStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_network_baseline_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NetworkBaselineExternalStatusRequest.ProtoReflect.Descriptor instead.
+func (*NetworkBaselineExternalStatusRequest) Descriptor() ([]byte, []int) {
+	return file_api_v1_network_baseline_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *NetworkBaselineExternalStatusRequest) GetDeploymentId() string {
+	if x != nil {
+		return x.DeploymentId
+	}
+	return ""
+}
+
+func (x *NetworkBaselineExternalStatusRequest) GetQuery() string {
+	if x != nil {
+		return x.Query
+	}
+	return ""
+}
+
+func (x *NetworkBaselineExternalStatusRequest) GetSince() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Since
+	}
+	return nil
+}
+
+func (x *NetworkBaselineExternalStatusRequest) GetPagination() *Pagination {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+type NetworkBaselineExternalStatusResponse struct {
+	state          protoimpl.MessageState       `protogen:"open.v1"`
+	Anomalous      []*NetworkBaselinePeerStatus `protobuf:"bytes,1,rep,name=anomalous,proto3" json:"anomalous,omitempty"`
+	TotalAnomalous int32                        `protobuf:"varint,2,opt,name=total_anomalous,json=totalAnomalous,proto3" json:"total_anomalous,omitempty"`
+	Baseline       []*NetworkBaselinePeerStatus `protobuf:"bytes,3,rep,name=baseline,proto3" json:"baseline,omitempty"`
+	TotalBaseline  int32                        `protobuf:"varint,4,opt,name=total_baseline,json=totalBaseline,proto3" json:"total_baseline,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *NetworkBaselineExternalStatusResponse) Reset() {
+	*x = NetworkBaselineExternalStatusResponse{}
+	mi := &file_api_v1_network_baseline_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NetworkBaselineExternalStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NetworkBaselineExternalStatusResponse) ProtoMessage() {}
+
+func (x *NetworkBaselineExternalStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_network_baseline_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NetworkBaselineExternalStatusResponse.ProtoReflect.Descriptor instead.
+func (*NetworkBaselineExternalStatusResponse) Descriptor() ([]byte, []int) {
+	return file_api_v1_network_baseline_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *NetworkBaselineExternalStatusResponse) GetAnomalous() []*NetworkBaselinePeerStatus {
+	if x != nil {
+		return x.Anomalous
+	}
+	return nil
+}
+
+func (x *NetworkBaselineExternalStatusResponse) GetTotalAnomalous() int32 {
+	if x != nil {
+		return x.TotalAnomalous
+	}
+	return 0
+}
+
+func (x *NetworkBaselineExternalStatusResponse) GetBaseline() []*NetworkBaselinePeerStatus {
+	if x != nil {
+		return x.Baseline
+	}
+	return nil
+}
+
+func (x *NetworkBaselineExternalStatusResponse) GetTotalBaseline() int32 {
+	if x != nil {
+		return x.TotalBaseline
+	}
+	return 0
+}
+
 type ModifyBaselineStatusForPeersRequest struct {
 	state         protoimpl.MessageState       `protogen:"open.v1"`
 	DeploymentId  string                       `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
@@ -360,7 +497,7 @@ type ModifyBaselineStatusForPeersRequest struct {
 
 func (x *ModifyBaselineStatusForPeersRequest) Reset() {
 	*x = ModifyBaselineStatusForPeersRequest{}
-	mi := &file_api_v1_network_baseline_service_proto_msgTypes[5]
+	mi := &file_api_v1_network_baseline_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -372,7 +509,7 @@ func (x *ModifyBaselineStatusForPeersRequest) String() string {
 func (*ModifyBaselineStatusForPeersRequest) ProtoMessage() {}
 
 func (x *ModifyBaselineStatusForPeersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_network_baseline_service_proto_msgTypes[5]
+	mi := &file_api_v1_network_baseline_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -385,7 +522,7 @@ func (x *ModifyBaselineStatusForPeersRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ModifyBaselineStatusForPeersRequest.ProtoReflect.Descriptor instead.
 func (*ModifyBaselineStatusForPeersRequest) Descriptor() ([]byte, []int) {
-	return file_api_v1_network_baseline_service_proto_rawDescGZIP(), []int{5}
+	return file_api_v1_network_baseline_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ModifyBaselineStatusForPeersRequest) GetDeploymentId() string {
@@ -406,7 +543,7 @@ var File_api_v1_network_baseline_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_network_baseline_service_proto_rawDesc = "" +
 	"\n" +
-	"%api/v1/network_baseline_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1estorage/network_baseline.proto\x1a\x1astorage/network_flow.proto\"`\n" +
+	"%api/v1/network_baseline_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x17api/v1/pagination.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1estorage/network_baseline.proto\x1a\x1astorage/network_flow.proto\"`\n" +
 	"\x19NetworkBaselinePeerEntity\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x123\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x1f.storage.NetworkEntityInfo.TypeR\x04type\"\xb1\x01\n" +
@@ -425,17 +562,30 @@ const file_api_v1_network_baseline_service_proto_rawDesc = "" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x123\n" +
 	"\x05peers\x18\x02 \x03(\v2\x1d.v1.NetworkBaselineStatusPeerR\x05peers\"Z\n" +
 	"\x1dNetworkBaselineStatusResponse\x129\n" +
-	"\bstatuses\x18\x01 \x03(\v2\x1d.v1.NetworkBaselinePeerStatusR\bstatuses\"\x7f\n" +
+	"\bstatuses\x18\x01 \x03(\v2\x1d.v1.NetworkBaselinePeerStatusR\bstatuses\"\xc3\x01\n" +
+	"$NetworkBaselineExternalStatusRequest\x12#\n" +
+	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12\x14\n" +
+	"\x05query\x18\x02 \x01(\tR\x05query\x120\n" +
+	"\x05since\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x05since\x12.\n" +
+	"\n" +
+	"pagination\x18\x04 \x01(\v2\x0e.v1.PaginationR\n" +
+	"pagination\"\xef\x01\n" +
+	"%NetworkBaselineExternalStatusResponse\x12;\n" +
+	"\tanomalous\x18\x01 \x03(\v2\x1d.v1.NetworkBaselinePeerStatusR\tanomalous\x12'\n" +
+	"\x0ftotal_anomalous\x18\x02 \x01(\x05R\x0etotalAnomalous\x129\n" +
+	"\bbaseline\x18\x03 \x03(\v2\x1d.v1.NetworkBaselinePeerStatusR\bbaseline\x12%\n" +
+	"\x0etotal_baseline\x18\x04 \x01(\x05R\rtotalBaseline\"\x7f\n" +
 	"#ModifyBaselineStatusForPeersRequest\x12#\n" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x123\n" +
-	"\x05peers\x18\x02 \x03(\v2\x1d.v1.NetworkBaselinePeerStatusR\x05peers2\xe8\x04\n" +
+	"\x05peers\x18\x02 \x03(\v2\x1d.v1.NetworkBaselinePeerStatusR\x05peers2\xa7\x06\n" +
 	"\x16NetworkBaselineService\x12\x9e\x01\n" +
-	" GetNetworkBaselineStatusForFlows\x12 .v1.NetworkBaselineStatusRequest\x1a!.v1.NetworkBaselineStatusResponse\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/networkbaseline/{deployment_id}/status\x12b\n" +
+	" GetNetworkBaselineStatusForFlows\x12 .v1.NetworkBaselineStatusRequest\x1a!.v1.NetworkBaselineStatusResponse\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/networkbaseline/{deployment_id}/status\x12\xbc\x01\n" +
+	"(GetNetworkBaselineStatusForExternalFlows\x12(.v1.NetworkBaselineExternalStatusRequest\x1a).v1.NetworkBaselineExternalStatusResponse\";\x82\xd3\xe4\x93\x025\x123/v1/networkbaseline/{deployment_id}/status/external\x12b\n" +
 	"\x12GetNetworkBaseline\x12\x10.v1.ResourceByID\x1a\x18.storage.NetworkBaseline\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/networkbaseline/{id}\x12\x88\x01\n" +
 	"\x1cModifyBaselineStatusForPeers\x12'.v1.ModifyBaselineStatusForPeersRequest\x1a\t.v1.Empty\"4\x82\xd3\xe4\x93\x02.:\x01*2)/v1/networkbaseline/{deployment_id}/peers\x12\\\n" +
 	"\x13LockNetworkBaseline\x12\x10.v1.ResourceByID\x1a\t.v1.Empty\"(\x82\xd3\xe4\x93\x02\":\x01*2\x1d/v1/networkbaseline/{id}/lock\x12`\n" +
 	"\x15UnlockNetworkBaseline\x12\x10.v1.ResourceByID\x1a\t.v1.Empty\"*\x82\xd3\xe4\x93\x02$:\x01*2\x1f/v1/networkbaseline/{id}/unlockB'\n" +
-	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x02b\x06proto3"
+	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x03b\x06proto3"
 
 var (
 	file_api_v1_network_baseline_service_proto_rawDescOnce sync.Once
@@ -450,45 +600,55 @@ func file_api_v1_network_baseline_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v1_network_baseline_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_v1_network_baseline_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_api_v1_network_baseline_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_api_v1_network_baseline_service_proto_goTypes = []any{
-	(NetworkBaselinePeerStatus_Status)(0),       // 0: v1.NetworkBaselinePeerStatus.Status
-	(*NetworkBaselinePeerEntity)(nil),           // 1: v1.NetworkBaselinePeerEntity
-	(*NetworkBaselineStatusPeer)(nil),           // 2: v1.NetworkBaselineStatusPeer
-	(*NetworkBaselinePeerStatus)(nil),           // 3: v1.NetworkBaselinePeerStatus
-	(*NetworkBaselineStatusRequest)(nil),        // 4: v1.NetworkBaselineStatusRequest
-	(*NetworkBaselineStatusResponse)(nil),       // 5: v1.NetworkBaselineStatusResponse
-	(*ModifyBaselineStatusForPeersRequest)(nil), // 6: v1.ModifyBaselineStatusForPeersRequest
-	(storage.NetworkEntityInfo_Type)(0),         // 7: storage.NetworkEntityInfo.Type
-	(storage.L4Protocol)(0),                     // 8: storage.L4Protocol
-	(*ResourceByID)(nil),                        // 9: v1.ResourceByID
-	(*storage.NetworkBaseline)(nil),             // 10: storage.NetworkBaseline
-	(*Empty)(nil),                               // 11: v1.Empty
+	(NetworkBaselinePeerStatus_Status)(0),         // 0: v1.NetworkBaselinePeerStatus.Status
+	(*NetworkBaselinePeerEntity)(nil),             // 1: v1.NetworkBaselinePeerEntity
+	(*NetworkBaselineStatusPeer)(nil),             // 2: v1.NetworkBaselineStatusPeer
+	(*NetworkBaselinePeerStatus)(nil),             // 3: v1.NetworkBaselinePeerStatus
+	(*NetworkBaselineStatusRequest)(nil),          // 4: v1.NetworkBaselineStatusRequest
+	(*NetworkBaselineStatusResponse)(nil),         // 5: v1.NetworkBaselineStatusResponse
+	(*NetworkBaselineExternalStatusRequest)(nil),  // 6: v1.NetworkBaselineExternalStatusRequest
+	(*NetworkBaselineExternalStatusResponse)(nil), // 7: v1.NetworkBaselineExternalStatusResponse
+	(*ModifyBaselineStatusForPeersRequest)(nil),   // 8: v1.ModifyBaselineStatusForPeersRequest
+	(storage.NetworkEntityInfo_Type)(0),           // 9: storage.NetworkEntityInfo.Type
+	(storage.L4Protocol)(0),                       // 10: storage.L4Protocol
+	(*timestamppb.Timestamp)(nil),                 // 11: google.protobuf.Timestamp
+	(*Pagination)(nil),                            // 12: v1.Pagination
+	(*ResourceByID)(nil),                          // 13: v1.ResourceByID
+	(*storage.NetworkBaseline)(nil),               // 14: storage.NetworkBaseline
+	(*Empty)(nil),                                 // 15: v1.Empty
 }
 var file_api_v1_network_baseline_service_proto_depIdxs = []int32{
-	7,  // 0: v1.NetworkBaselinePeerEntity.type:type_name -> storage.NetworkEntityInfo.Type
+	9,  // 0: v1.NetworkBaselinePeerEntity.type:type_name -> storage.NetworkEntityInfo.Type
 	1,  // 1: v1.NetworkBaselineStatusPeer.entity:type_name -> v1.NetworkBaselinePeerEntity
-	8,  // 2: v1.NetworkBaselineStatusPeer.protocol:type_name -> storage.L4Protocol
+	10, // 2: v1.NetworkBaselineStatusPeer.protocol:type_name -> storage.L4Protocol
 	2,  // 3: v1.NetworkBaselinePeerStatus.peer:type_name -> v1.NetworkBaselineStatusPeer
 	0,  // 4: v1.NetworkBaselinePeerStatus.status:type_name -> v1.NetworkBaselinePeerStatus.Status
 	2,  // 5: v1.NetworkBaselineStatusRequest.peers:type_name -> v1.NetworkBaselineStatusPeer
 	3,  // 6: v1.NetworkBaselineStatusResponse.statuses:type_name -> v1.NetworkBaselinePeerStatus
-	3,  // 7: v1.ModifyBaselineStatusForPeersRequest.peers:type_name -> v1.NetworkBaselinePeerStatus
-	4,  // 8: v1.NetworkBaselineService.GetNetworkBaselineStatusForFlows:input_type -> v1.NetworkBaselineStatusRequest
-	9,  // 9: v1.NetworkBaselineService.GetNetworkBaseline:input_type -> v1.ResourceByID
-	6,  // 10: v1.NetworkBaselineService.ModifyBaselineStatusForPeers:input_type -> v1.ModifyBaselineStatusForPeersRequest
-	9,  // 11: v1.NetworkBaselineService.LockNetworkBaseline:input_type -> v1.ResourceByID
-	9,  // 12: v1.NetworkBaselineService.UnlockNetworkBaseline:input_type -> v1.ResourceByID
-	5,  // 13: v1.NetworkBaselineService.GetNetworkBaselineStatusForFlows:output_type -> v1.NetworkBaselineStatusResponse
-	10, // 14: v1.NetworkBaselineService.GetNetworkBaseline:output_type -> storage.NetworkBaseline
-	11, // 15: v1.NetworkBaselineService.ModifyBaselineStatusForPeers:output_type -> v1.Empty
-	11, // 16: v1.NetworkBaselineService.LockNetworkBaseline:output_type -> v1.Empty
-	11, // 17: v1.NetworkBaselineService.UnlockNetworkBaseline:output_type -> v1.Empty
-	13, // [13:18] is the sub-list for method output_type
-	8,  // [8:13] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	11, // 7: v1.NetworkBaselineExternalStatusRequest.since:type_name -> google.protobuf.Timestamp
+	12, // 8: v1.NetworkBaselineExternalStatusRequest.pagination:type_name -> v1.Pagination
+	3,  // 9: v1.NetworkBaselineExternalStatusResponse.anomalous:type_name -> v1.NetworkBaselinePeerStatus
+	3,  // 10: v1.NetworkBaselineExternalStatusResponse.baseline:type_name -> v1.NetworkBaselinePeerStatus
+	3,  // 11: v1.ModifyBaselineStatusForPeersRequest.peers:type_name -> v1.NetworkBaselinePeerStatus
+	4,  // 12: v1.NetworkBaselineService.GetNetworkBaselineStatusForFlows:input_type -> v1.NetworkBaselineStatusRequest
+	6,  // 13: v1.NetworkBaselineService.GetNetworkBaselineStatusForExternalFlows:input_type -> v1.NetworkBaselineExternalStatusRequest
+	13, // 14: v1.NetworkBaselineService.GetNetworkBaseline:input_type -> v1.ResourceByID
+	8,  // 15: v1.NetworkBaselineService.ModifyBaselineStatusForPeers:input_type -> v1.ModifyBaselineStatusForPeersRequest
+	13, // 16: v1.NetworkBaselineService.LockNetworkBaseline:input_type -> v1.ResourceByID
+	13, // 17: v1.NetworkBaselineService.UnlockNetworkBaseline:input_type -> v1.ResourceByID
+	5,  // 18: v1.NetworkBaselineService.GetNetworkBaselineStatusForFlows:output_type -> v1.NetworkBaselineStatusResponse
+	7,  // 19: v1.NetworkBaselineService.GetNetworkBaselineStatusForExternalFlows:output_type -> v1.NetworkBaselineExternalStatusResponse
+	14, // 20: v1.NetworkBaselineService.GetNetworkBaseline:output_type -> storage.NetworkBaseline
+	15, // 21: v1.NetworkBaselineService.ModifyBaselineStatusForPeers:output_type -> v1.Empty
+	15, // 22: v1.NetworkBaselineService.LockNetworkBaseline:output_type -> v1.Empty
+	15, // 23: v1.NetworkBaselineService.UnlockNetworkBaseline:output_type -> v1.Empty
+	18, // [18:24] is the sub-list for method output_type
+	12, // [12:18] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_network_baseline_service_proto_init() }
@@ -498,13 +658,14 @@ func file_api_v1_network_baseline_service_proto_init() {
 	}
 	file_api_v1_common_proto_init()
 	file_api_v1_empty_proto_init()
+	file_api_v1_pagination_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v1_network_baseline_service_proto_rawDesc), len(file_api_v1_network_baseline_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/api/v1/network_baseline_service.pb.go
+++ b/generated/api/v1/network_baseline_service.pb.go
@@ -78,7 +78,7 @@ type NetworkBaselinePeerEntity struct {
 	Id            string                         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Type          storage.NetworkEntityInfo_Type `protobuf:"varint,2,opt,name=type,proto3,enum=storage.NetworkEntityInfo_Type" json:"type,omitempty"`
 	Name          string                         `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
-	Cidr          string                         `protobuf:"bytes,4,opt,name=cidr,proto3" json:"cidr,omitempty"`
+	Discovered    bool                           `protobuf:"varint,4,opt,name=discovered,proto3" json:"discovered,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -134,11 +134,11 @@ func (x *NetworkBaselinePeerEntity) GetName() string {
 	return ""
 }
 
-func (x *NetworkBaselinePeerEntity) GetCidr() string {
+func (x *NetworkBaselinePeerEntity) GetDiscovered() bool {
 	if x != nil {
-		return x.Cidr
+		return x.Discovered
 	}
-	return ""
+	return false
 }
 
 type NetworkBaselineStatusPeer struct {
@@ -559,12 +559,14 @@ var File_api_v1_network_baseline_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_network_baseline_service_proto_rawDesc = "" +
 	"\n" +
-	"%api/v1/network_baseline_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x17api/v1/pagination.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1estorage/network_baseline.proto\x1a\x1astorage/network_flow.proto\"\x88\x01\n" +
+	"%api/v1/network_baseline_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x17api/v1/pagination.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1estorage/network_baseline.proto\x1a\x1astorage/network_flow.proto\"\x94\x01\n" +
 	"\x19NetworkBaselinePeerEntity\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x123\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x1f.storage.NetworkEntityInfo.TypeR\x04type\x12\x12\n" +
-	"\x04name\x18\x03 \x01(\tR\x04name\x12\x12\n" +
-	"\x04cidr\x18\x04 \x01(\tR\x04cidr\"\xb1\x01\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x1e\n" +
+	"\n" +
+	"discovered\x18\x04 \x01(\bR\n" +
+	"discovered\"\xb1\x01\n" +
 	"\x19NetworkBaselineStatusPeer\x125\n" +
 	"\x06entity\x18\x01 \x01(\v2\x1d.v1.NetworkBaselinePeerEntityR\x06entity\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\rR\x04port\x12/\n" +

--- a/generated/api/v1/network_baseline_service.pb.go
+++ b/generated/api/v1/network_baseline_service.pb.go
@@ -77,6 +77,8 @@ type NetworkBaselinePeerEntity struct {
 	state         protoimpl.MessageState         `protogen:"open.v1"`
 	Id            string                         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Type          storage.NetworkEntityInfo_Type `protobuf:"varint,2,opt,name=type,proto3,enum=storage.NetworkEntityInfo_Type" json:"type,omitempty"`
+	Name          string                         `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	Cidr          string                         `protobuf:"bytes,4,opt,name=cidr,proto3" json:"cidr,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -123,6 +125,20 @@ func (x *NetworkBaselinePeerEntity) GetType() storage.NetworkEntityInfo_Type {
 		return x.Type
 	}
 	return storage.NetworkEntityInfo_Type(0)
+}
+
+func (x *NetworkBaselinePeerEntity) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *NetworkBaselinePeerEntity) GetCidr() string {
+	if x != nil {
+		return x.Cidr
+	}
+	return ""
 }
 
 type NetworkBaselineStatusPeer struct {
@@ -543,10 +559,12 @@ var File_api_v1_network_baseline_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_network_baseline_service_proto_rawDesc = "" +
 	"\n" +
-	"%api/v1/network_baseline_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x17api/v1/pagination.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1estorage/network_baseline.proto\x1a\x1astorage/network_flow.proto\"`\n" +
+	"%api/v1/network_baseline_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x17api/v1/pagination.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1estorage/network_baseline.proto\x1a\x1astorage/network_flow.proto\"\x88\x01\n" +
 	"\x19NetworkBaselinePeerEntity\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x123\n" +
-	"\x04type\x18\x02 \x01(\x0e2\x1f.storage.NetworkEntityInfo.TypeR\x04type\"\xb1\x01\n" +
+	"\x04type\x18\x02 \x01(\x0e2\x1f.storage.NetworkEntityInfo.TypeR\x04type\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12\x12\n" +
+	"\x04cidr\x18\x04 \x01(\tR\x04cidr\"\xb1\x01\n" +
 	"\x19NetworkBaselineStatusPeer\x125\n" +
 	"\x06entity\x18\x01 \x01(\v2\x1d.v1.NetworkBaselinePeerEntityR\x06entity\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\rR\x04port\x12/\n" +

--- a/generated/api/v1/network_baseline_service.pb.gw.go
+++ b/generated/api/v1/network_baseline_service.pb.gw.go
@@ -77,6 +77,57 @@ func local_request_NetworkBaselineService_GetNetworkBaselineStatusForFlows_0(ctx
 	return msg, metadata, err
 }
 
+var filter_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0 = &utilities.DoubleArray{Encoding: map[string]int{"deployment_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+
+func request_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0(ctx context.Context, marshaler runtime.Marshaler, client NetworkBaselineServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq NetworkBaselineExternalStatusRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	io.Copy(io.Discard, req.Body)
+	val, ok := pathParams["deployment_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "deployment_id")
+	}
+	protoReq.DeploymentId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "deployment_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetNetworkBaselineStatusForExternalFlows(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0(ctx context.Context, marshaler runtime.Marshaler, server NetworkBaselineServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq NetworkBaselineExternalStatusRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["deployment_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "deployment_id")
+	}
+	protoReq.DeploymentId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "deployment_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetNetworkBaselineStatusForExternalFlows(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_NetworkBaselineService_GetNetworkBaseline_0(ctx context.Context, marshaler runtime.Marshaler, client NetworkBaselineServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ResourceByID
@@ -266,6 +317,26 @@ func RegisterNetworkBaselineServiceHandlerServer(ctx context.Context, mux *runti
 		}
 		forward_NetworkBaselineService_GetNetworkBaselineStatusForFlows_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v1.NetworkBaselineService/GetNetworkBaselineStatusForExternalFlows", runtime.WithHTTPPathPattern("/v1/networkbaseline/{deployment_id}/status/external"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_NetworkBaselineService_GetNetworkBaseline_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -403,6 +474,23 @@ func RegisterNetworkBaselineServiceHandlerClient(ctx context.Context, mux *runti
 		}
 		forward_NetworkBaselineService_GetNetworkBaselineStatusForFlows_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v1.NetworkBaselineService/GetNetworkBaselineStatusForExternalFlows", runtime.WithHTTPPathPattern("/v1/networkbaseline/{deployment_id}/status/external"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_NetworkBaselineService_GetNetworkBaseline_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -475,17 +563,19 @@ func RegisterNetworkBaselineServiceHandlerClient(ctx context.Context, mux *runti
 }
 
 var (
-	pattern_NetworkBaselineService_GetNetworkBaselineStatusForFlows_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "deployment_id", "status"}, ""))
-	pattern_NetworkBaselineService_GetNetworkBaseline_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "networkbaseline", "id"}, ""))
-	pattern_NetworkBaselineService_ModifyBaselineStatusForPeers_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "deployment_id", "peers"}, ""))
-	pattern_NetworkBaselineService_LockNetworkBaseline_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "id", "lock"}, ""))
-	pattern_NetworkBaselineService_UnlockNetworkBaseline_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "id", "unlock"}, ""))
+	pattern_NetworkBaselineService_GetNetworkBaselineStatusForFlows_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "deployment_id", "status"}, ""))
+	pattern_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 2, 4}, []string{"v1", "networkbaseline", "deployment_id", "status", "external"}, ""))
+	pattern_NetworkBaselineService_GetNetworkBaseline_0                       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "networkbaseline", "id"}, ""))
+	pattern_NetworkBaselineService_ModifyBaselineStatusForPeers_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "deployment_id", "peers"}, ""))
+	pattern_NetworkBaselineService_LockNetworkBaseline_0                      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "id", "lock"}, ""))
+	pattern_NetworkBaselineService_UnlockNetworkBaseline_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "networkbaseline", "id", "unlock"}, ""))
 )
 
 var (
-	forward_NetworkBaselineService_GetNetworkBaselineStatusForFlows_0 = runtime.ForwardResponseMessage
-	forward_NetworkBaselineService_GetNetworkBaseline_0               = runtime.ForwardResponseMessage
-	forward_NetworkBaselineService_ModifyBaselineStatusForPeers_0     = runtime.ForwardResponseMessage
-	forward_NetworkBaselineService_LockNetworkBaseline_0              = runtime.ForwardResponseMessage
-	forward_NetworkBaselineService_UnlockNetworkBaseline_0            = runtime.ForwardResponseMessage
+	forward_NetworkBaselineService_GetNetworkBaselineStatusForFlows_0         = runtime.ForwardResponseMessage
+	forward_NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_0 = runtime.ForwardResponseMessage
+	forward_NetworkBaselineService_GetNetworkBaseline_0                       = runtime.ForwardResponseMessage
+	forward_NetworkBaselineService_ModifyBaselineStatusForPeers_0             = runtime.ForwardResponseMessage
+	forward_NetworkBaselineService_LockNetworkBaseline_0                      = runtime.ForwardResponseMessage
+	forward_NetworkBaselineService_UnlockNetworkBaseline_0                    = runtime.ForwardResponseMessage
 )

--- a/generated/api/v1/network_baseline_service.swagger.json
+++ b/generated/api/v1/network_baseline_service.swagger.json
@@ -92,6 +92,94 @@
         ]
       }
     },
+    "/v1/networkbaseline/{deploymentId}/status/external": {
+      "get": {
+        "operationId": "NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1NetworkBaselineExternalStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "deploymentId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "pagination.limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pagination.offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pagination.sortOption.field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pagination.sortOption.reversed",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "pagination.sortOption.aggregateBy.aggrFunc",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "UNSET",
+              "COUNT",
+              "MIN",
+              "MAX"
+            ],
+            "default": "UNSET"
+          },
+          {
+            "name": "pagination.sortOption.aggregateBy.distinct",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "NetworkBaselineService"
+        ]
+      }
+    },
     "/v1/networkbaseline/{id}": {
       "get": {
         "operationId": "NetworkBaselineService_GetNetworkBaseline",
@@ -453,8 +541,56 @@
         }
       }
     },
+    "v1AggregateBy": {
+      "type": "object",
+      "properties": {
+        "aggrFunc": {
+          "$ref": "#/definitions/v1Aggregation"
+        },
+        "distinct": {
+          "type": "boolean"
+        }
+      }
+    },
+    "v1Aggregation": {
+      "type": "string",
+      "enum": [
+        "UNSET",
+        "COUNT",
+        "MIN",
+        "MAX"
+      ],
+      "default": "UNSET"
+    },
     "v1Empty": {
       "type": "object"
+    },
+    "v1NetworkBaselineExternalStatusResponse": {
+      "type": "object",
+      "properties": {
+        "anomalous": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1NetworkBaselinePeerStatus"
+          }
+        },
+        "totalAnomalous": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "baseline": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1NetworkBaselinePeerStatus"
+          }
+        },
+        "totalBaseline": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
     },
     "v1NetworkBaselinePeerEntity": {
       "type": "object",
@@ -517,6 +653,45 @@
             "type": "object",
             "$ref": "#/definitions/v1NetworkBaselinePeerStatus"
           }
+        }
+      }
+    },
+    "v1Pagination": {
+      "type": "object",
+      "properties": {
+        "limit": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sortOption": {
+          "$ref": "#/definitions/v1SortOption"
+        },
+        "sortOptions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SortOption"
+          },
+          "description": "This field is under development. It is not supported on any REST APIs."
+        }
+      }
+    },
+    "v1SortOption": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "reversed": {
+          "type": "boolean"
+        },
+        "aggregateBy": {
+          "$ref": "#/definitions/v1AggregateBy",
+          "description": "This field is under development. It is not supported on any REST APIs."
         }
       }
     }

--- a/generated/api/v1/network_baseline_service.swagger.json
+++ b/generated/api/v1/network_baseline_service.swagger.json
@@ -600,6 +600,12 @@
         },
         "type": {
           "$ref": "#/definitions/storageNetworkEntityInfoType"
+        },
+        "name": {
+          "type": "string"
+        },
+        "cidr": {
+          "type": "string"
         }
       }
     },

--- a/generated/api/v1/network_baseline_service.swagger.json
+++ b/generated/api/v1/network_baseline_service.swagger.json
@@ -604,8 +604,8 @@
         "name": {
           "type": "string"
         },
-        "cidr": {
-          "type": "string"
+        "discovered": {
+          "type": "boolean"
         }
       }
     },

--- a/generated/api/v1/network_baseline_service_grpc.pb.go
+++ b/generated/api/v1/network_baseline_service_grpc.pb.go
@@ -20,11 +20,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	NetworkBaselineService_GetNetworkBaselineStatusForFlows_FullMethodName = "/v1.NetworkBaselineService/GetNetworkBaselineStatusForFlows"
-	NetworkBaselineService_GetNetworkBaseline_FullMethodName               = "/v1.NetworkBaselineService/GetNetworkBaseline"
-	NetworkBaselineService_ModifyBaselineStatusForPeers_FullMethodName     = "/v1.NetworkBaselineService/ModifyBaselineStatusForPeers"
-	NetworkBaselineService_LockNetworkBaseline_FullMethodName              = "/v1.NetworkBaselineService/LockNetworkBaseline"
-	NetworkBaselineService_UnlockNetworkBaseline_FullMethodName            = "/v1.NetworkBaselineService/UnlockNetworkBaseline"
+	NetworkBaselineService_GetNetworkBaselineStatusForFlows_FullMethodName         = "/v1.NetworkBaselineService/GetNetworkBaselineStatusForFlows"
+	NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_FullMethodName = "/v1.NetworkBaselineService/GetNetworkBaselineStatusForExternalFlows"
+	NetworkBaselineService_GetNetworkBaseline_FullMethodName                       = "/v1.NetworkBaselineService/GetNetworkBaseline"
+	NetworkBaselineService_ModifyBaselineStatusForPeers_FullMethodName             = "/v1.NetworkBaselineService/ModifyBaselineStatusForPeers"
+	NetworkBaselineService_LockNetworkBaseline_FullMethodName                      = "/v1.NetworkBaselineService/LockNetworkBaseline"
+	NetworkBaselineService_UnlockNetworkBaseline_FullMethodName                    = "/v1.NetworkBaselineService/UnlockNetworkBaseline"
 )
 
 // NetworkBaselineServiceClient is the client API for NetworkBaselineService service.
@@ -32,6 +33,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type NetworkBaselineServiceClient interface {
 	GetNetworkBaselineStatusForFlows(ctx context.Context, in *NetworkBaselineStatusRequest, opts ...grpc.CallOption) (*NetworkBaselineStatusResponse, error)
+	GetNetworkBaselineStatusForExternalFlows(ctx context.Context, in *NetworkBaselineExternalStatusRequest, opts ...grpc.CallOption) (*NetworkBaselineExternalStatusResponse, error)
 	GetNetworkBaseline(ctx context.Context, in *ResourceByID, opts ...grpc.CallOption) (*storage.NetworkBaseline, error)
 	ModifyBaselineStatusForPeers(ctx context.Context, in *ModifyBaselineStatusForPeersRequest, opts ...grpc.CallOption) (*Empty, error)
 	LockNetworkBaseline(ctx context.Context, in *ResourceByID, opts ...grpc.CallOption) (*Empty, error)
@@ -50,6 +52,16 @@ func (c *networkBaselineServiceClient) GetNetworkBaselineStatusForFlows(ctx cont
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NetworkBaselineStatusResponse)
 	err := c.cc.Invoke(ctx, NetworkBaselineService_GetNetworkBaselineStatusForFlows_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *networkBaselineServiceClient) GetNetworkBaselineStatusForExternalFlows(ctx context.Context, in *NetworkBaselineExternalStatusRequest, opts ...grpc.CallOption) (*NetworkBaselineExternalStatusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(NetworkBaselineExternalStatusResponse)
+	err := c.cc.Invoke(ctx, NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,6 +113,7 @@ func (c *networkBaselineServiceClient) UnlockNetworkBaseline(ctx context.Context
 // for forward compatibility.
 type NetworkBaselineServiceServer interface {
 	GetNetworkBaselineStatusForFlows(context.Context, *NetworkBaselineStatusRequest) (*NetworkBaselineStatusResponse, error)
+	GetNetworkBaselineStatusForExternalFlows(context.Context, *NetworkBaselineExternalStatusRequest) (*NetworkBaselineExternalStatusResponse, error)
 	GetNetworkBaseline(context.Context, *ResourceByID) (*storage.NetworkBaseline, error)
 	ModifyBaselineStatusForPeers(context.Context, *ModifyBaselineStatusForPeersRequest) (*Empty, error)
 	LockNetworkBaseline(context.Context, *ResourceByID) (*Empty, error)
@@ -116,6 +129,9 @@ type UnimplementedNetworkBaselineServiceServer struct{}
 
 func (UnimplementedNetworkBaselineServiceServer) GetNetworkBaselineStatusForFlows(context.Context, *NetworkBaselineStatusRequest) (*NetworkBaselineStatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetNetworkBaselineStatusForFlows not implemented")
+}
+func (UnimplementedNetworkBaselineServiceServer) GetNetworkBaselineStatusForExternalFlows(context.Context, *NetworkBaselineExternalStatusRequest) (*NetworkBaselineExternalStatusResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNetworkBaselineStatusForExternalFlows not implemented")
 }
 func (UnimplementedNetworkBaselineServiceServer) GetNetworkBaseline(context.Context, *ResourceByID) (*storage.NetworkBaseline, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetNetworkBaseline not implemented")
@@ -163,6 +179,24 @@ func _NetworkBaselineService_GetNetworkBaselineStatusForFlows_Handler(srv interf
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(NetworkBaselineServiceServer).GetNetworkBaselineStatusForFlows(ctx, req.(*NetworkBaselineStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NetworkBaselineExternalStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NetworkBaselineServiceServer).GetNetworkBaselineStatusForExternalFlows(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NetworkBaselineServiceServer).GetNetworkBaselineStatusForExternalFlows(ctx, req.(*NetworkBaselineExternalStatusRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -249,6 +283,10 @@ var NetworkBaselineService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetNetworkBaselineStatusForFlows",
 			Handler:    _NetworkBaselineService_GetNetworkBaselineStatusForFlows_Handler,
+		},
+		{
+			MethodName: "GetNetworkBaselineStatusForExternalFlows",
+			Handler:    _NetworkBaselineService_GetNetworkBaselineStatusForExternalFlows_Handler,
 		},
 		{
 			MethodName: "GetNetworkBaseline",

--- a/generated/api/v1/network_baseline_service_vtproto.pb.go
+++ b/generated/api/v1/network_baseline_service_vtproto.pb.go
@@ -7,9 +7,11 @@ package v1
 import (
 	fmt "fmt"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
+	timestamppb1 "github.com/planetscale/vtprotobuf/types/known/timestamppb"
 	storage "github.com/stackrox/rox/generated/storage"
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	io "io"
 	unsafe "unsafe"
 )
@@ -121,6 +123,58 @@ func (m *NetworkBaselineStatusResponse) CloneVT() *NetworkBaselineStatusResponse
 }
 
 func (m *NetworkBaselineStatusResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *NetworkBaselineExternalStatusRequest) CloneVT() *NetworkBaselineExternalStatusRequest {
+	if m == nil {
+		return (*NetworkBaselineExternalStatusRequest)(nil)
+	}
+	r := new(NetworkBaselineExternalStatusRequest)
+	r.DeploymentId = m.DeploymentId
+	r.Query = m.Query
+	r.Since = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.Since).CloneVT())
+	r.Pagination = m.Pagination.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *NetworkBaselineExternalStatusRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *NetworkBaselineExternalStatusResponse) CloneVT() *NetworkBaselineExternalStatusResponse {
+	if m == nil {
+		return (*NetworkBaselineExternalStatusResponse)(nil)
+	}
+	r := new(NetworkBaselineExternalStatusResponse)
+	r.TotalAnomalous = m.TotalAnomalous
+	r.TotalBaseline = m.TotalBaseline
+	if rhs := m.Anomalous; rhs != nil {
+		tmpContainer := make([]*NetworkBaselinePeerStatus, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Anomalous = tmpContainer
+	}
+	if rhs := m.Baseline; rhs != nil {
+		tmpContainer := make([]*NetworkBaselinePeerStatus, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Baseline = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *NetworkBaselineExternalStatusResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -284,6 +338,90 @@ func (this *NetworkBaselineStatusResponse) EqualVT(that *NetworkBaselineStatusRe
 
 func (this *NetworkBaselineStatusResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*NetworkBaselineStatusResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *NetworkBaselineExternalStatusRequest) EqualVT(that *NetworkBaselineExternalStatusRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.DeploymentId != that.DeploymentId {
+		return false
+	}
+	if this.Query != that.Query {
+		return false
+	}
+	if !(*timestamppb1.Timestamp)(this.Since).EqualVT((*timestamppb1.Timestamp)(that.Since)) {
+		return false
+	}
+	if !this.Pagination.EqualVT(that.Pagination) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *NetworkBaselineExternalStatusRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*NetworkBaselineExternalStatusRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *NetworkBaselineExternalStatusResponse) EqualVT(that *NetworkBaselineExternalStatusResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if len(this.Anomalous) != len(that.Anomalous) {
+		return false
+	}
+	for i, vx := range this.Anomalous {
+		vy := that.Anomalous[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &NetworkBaselinePeerStatus{}
+			}
+			if q == nil {
+				q = &NetworkBaselinePeerStatus{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if this.TotalAnomalous != that.TotalAnomalous {
+		return false
+	}
+	if len(this.Baseline) != len(that.Baseline) {
+		return false
+	}
+	for i, vx := range this.Baseline {
+		vy := that.Baseline[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &NetworkBaselinePeerStatus{}
+			}
+			if q == nil {
+				q = &NetworkBaselinePeerStatus{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if this.TotalBaseline != that.TotalBaseline {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *NetworkBaselineExternalStatusResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*NetworkBaselineExternalStatusResponse)
 	if !ok {
 		return false
 	}
@@ -578,6 +716,140 @@ func (m *NetworkBaselineStatusResponse) MarshalToSizedBufferVT(dAtA []byte) (int
 	return len(dAtA) - i, nil
 }
 
+func (m *NetworkBaselineExternalStatusRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NetworkBaselineExternalStatusRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *NetworkBaselineExternalStatusRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Pagination != nil {
+		size, err := m.Pagination.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Since != nil {
+		size, err := (*timestamppb1.Timestamp)(m.Since).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Query) > 0 {
+		i -= len(m.Query)
+		copy(dAtA[i:], m.Query)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Query)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.DeploymentId) > 0 {
+		i -= len(m.DeploymentId)
+		copy(dAtA[i:], m.DeploymentId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DeploymentId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *NetworkBaselineExternalStatusResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NetworkBaselineExternalStatusResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *NetworkBaselineExternalStatusResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.TotalBaseline != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TotalBaseline))
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.Baseline) > 0 {
+		for iNdEx := len(m.Baseline) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Baseline[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if m.TotalAnomalous != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TotalAnomalous))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Anomalous) > 0 {
+		for iNdEx := len(m.Anomalous) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Anomalous[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ModifyBaselineStatusForPeersRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -718,6 +990,60 @@ func (m *NetworkBaselineStatusResponse) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *NetworkBaselineExternalStatusRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DeploymentId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Query)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Since != nil {
+		l = (*timestamppb1.Timestamp)(m.Since).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *NetworkBaselineExternalStatusResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Anomalous) > 0 {
+		for _, e := range m.Anomalous {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.TotalAnomalous != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.TotalAnomalous))
+	}
+	if len(m.Baseline) > 0 {
+		for _, e := range m.Baseline {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.TotalBaseline != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.TotalBaseline))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1276,6 +1602,350 @@ func (m *NetworkBaselineStatusResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NetworkBaselineExternalStatusRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeploymentId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DeploymentId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Query = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Since", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Since == nil {
+				m.Since = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.Since).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &Pagination{}
+			}
+			if err := m.Pagination.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NetworkBaselineExternalStatusResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Anomalous", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Anomalous = append(m.Anomalous, &NetworkBaselinePeerStatus{})
+			if err := m.Anomalous[len(m.Anomalous)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalAnomalous", wireType)
+			}
+			m.TotalAnomalous = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalAnomalous |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Baseline", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Baseline = append(m.Baseline, &NetworkBaselinePeerStatus{})
+			if err := m.Baseline[len(m.Baseline)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalBaseline", wireType)
+			}
+			m.TotalBaseline = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalBaseline |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -1956,6 +2626,358 @@ func (m *NetworkBaselineStatusResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NetworkBaselineExternalStatusRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeploymentId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DeploymentId = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Query = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Since", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Since == nil {
+				m.Since = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.Since).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &Pagination{}
+			}
+			if err := m.Pagination.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NetworkBaselineExternalStatusResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NetworkBaselineExternalStatusResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Anomalous", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Anomalous = append(m.Anomalous, &NetworkBaselinePeerStatus{})
+			if err := m.Anomalous[len(m.Anomalous)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalAnomalous", wireType)
+			}
+			m.TotalAnomalous = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalAnomalous |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Baseline", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Baseline = append(m.Baseline, &NetworkBaselinePeerStatus{})
+			if err := m.Baseline[len(m.Baseline)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalBaseline", wireType)
+			}
+			m.TotalBaseline = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalBaseline |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/api/v1/network_baseline_service_vtproto.pb.go
+++ b/generated/api/v1/network_baseline_service_vtproto.pb.go
@@ -31,7 +31,7 @@ func (m *NetworkBaselinePeerEntity) CloneVT() *NetworkBaselinePeerEntity {
 	r.Id = m.Id
 	r.Type = m.Type
 	r.Name = m.Name
-	r.Cidr = m.Cidr
+	r.Discovered = m.Discovered
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -219,7 +219,7 @@ func (this *NetworkBaselinePeerEntity) EqualVT(that *NetworkBaselinePeerEntity) 
 	if this.Name != that.Name {
 		return false
 	}
-	if this.Cidr != that.Cidr {
+	if this.Discovered != that.Discovered {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -501,12 +501,15 @@ func (m *NetworkBaselinePeerEntity) MarshalToSizedBufferVT(dAtA []byte) (int, er
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.Cidr) > 0 {
-		i -= len(m.Cidr)
-		copy(dAtA[i:], m.Cidr)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Cidr)))
+	if m.Discovered {
 		i--
-		dAtA[i] = 0x22
+		if m.Discovered {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
 	}
 	if len(m.Name) > 0 {
 		i -= len(m.Name)
@@ -941,9 +944,8 @@ func (m *NetworkBaselinePeerEntity) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	l = len(m.Cidr)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	if m.Discovered {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1212,10 +1214,10 @@ func (m *NetworkBaselinePeerEntity) UnmarshalVT(dAtA []byte) error {
 			m.Name = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 4:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Cidr", wireType)
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Discovered", wireType)
 			}
-			var stringLen uint64
+			var v int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -1225,24 +1227,12 @@ func (m *NetworkBaselinePeerEntity) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Cidr = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
+			m.Discovered = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2300,10 +2290,10 @@ func (m *NetworkBaselinePeerEntity) UnmarshalVTUnsafe(dAtA []byte) error {
 			m.Name = stringValue
 			iNdEx = postIndex
 		case 4:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Cidr", wireType)
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Discovered", wireType)
 			}
-			var stringLen uint64
+			var v int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -2313,28 +2303,12 @@ func (m *NetworkBaselinePeerEntity) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			var stringValue string
-			if intStringLen > 0 {
-				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
-			}
-			m.Cidr = stringValue
-			iNdEx = postIndex
+			m.Discovered = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/api/v1/network_baseline_service_vtproto.pb.go
+++ b/generated/api/v1/network_baseline_service_vtproto.pb.go
@@ -30,6 +30,8 @@ func (m *NetworkBaselinePeerEntity) CloneVT() *NetworkBaselinePeerEntity {
 	r := new(NetworkBaselinePeerEntity)
 	r.Id = m.Id
 	r.Type = m.Type
+	r.Name = m.Name
+	r.Cidr = m.Cidr
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -212,6 +214,12 @@ func (this *NetworkBaselinePeerEntity) EqualVT(that *NetworkBaselinePeerEntity) 
 		return false
 	}
 	if this.Type != that.Type {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if this.Cidr != that.Cidr {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -492,6 +500,20 @@ func (m *NetworkBaselinePeerEntity) MarshalToSizedBufferVT(dAtA []byte) (int, er
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Cidr) > 0 {
+		i -= len(m.Cidr)
+		copy(dAtA[i:], m.Cidr)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Cidr)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if m.Type != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Type))
@@ -915,6 +937,14 @@ func (m *NetworkBaselinePeerEntity) SizeVT() (n int) {
 	if m.Type != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Type))
 	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Cidr)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1149,6 +1179,70 @@ func (m *NetworkBaselinePeerEntity) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Cidr", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Cidr = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2169,6 +2263,78 @@ func (m *NetworkBaselinePeerEntity) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Name = stringValue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Cidr", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Cidr = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/api/v1/network_policy_service.swagger.json
+++ b/generated/api/v1/network_policy_service.swagger.json
@@ -1183,8 +1183,8 @@
         "name": {
           "type": "string"
         },
-        "cidr": {
-          "type": "string"
+        "discovered": {
+          "type": "boolean"
         }
       }
     },

--- a/generated/api/v1/network_policy_service.swagger.json
+++ b/generated/api/v1/network_policy_service.swagger.json
@@ -1179,6 +1179,12 @@
         },
         "type": {
           "$ref": "#/definitions/storageNetworkEntityInfoType"
+        },
+        "name": {
+          "type": "string"
+        },
+        "cidr": {
+          "type": "string"
         }
       }
     },

--- a/proto/api/v1/network_baseline_service.proto
+++ b/proto/api/v1/network_baseline_service.proto
@@ -4,7 +4,9 @@ package v1;
 
 import "api/v1/common.proto";
 import "api/v1/empty.proto";
+import "api/v1/pagination.proto";
 import weak "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
 import "storage/network_baseline.proto";
 import "storage/network_flow.proto";
 
@@ -56,6 +58,20 @@ message NetworkBaselineStatusResponse {
   repeated NetworkBaselinePeerStatus statuses = 1;
 }
 
+message NetworkBaselineExternalStatusRequest {
+  string deployment_id = 1;
+  string query = 2;
+  google.protobuf.Timestamp since = 3;
+  Pagination pagination = 4;
+}
+
+message NetworkBaselineExternalStatusResponse {
+  repeated NetworkBaselinePeerStatus anomalous = 1;
+  int32 total_anomalous = 2;
+  repeated NetworkBaselinePeerStatus baseline = 3;
+  int32 total_baseline = 4;
+}
+
 message ModifyBaselineStatusForPeersRequest {
   string deployment_id = 1;
   repeated NetworkBaselinePeerStatus peers = 2;
@@ -66,6 +82,12 @@ service NetworkBaselineService {
     option (google.api.http) = {
       post: "/v1/networkbaseline/{deployment_id}/status"
       body: "*"
+    };
+  }
+
+  rpc GetNetworkBaselineStatusForExternalFlows(NetworkBaselineExternalStatusRequest) returns (NetworkBaselineExternalStatusResponse) {
+    option (google.api.http) = {
+      get: "/v1/networkbaseline/{deployment_id}/status/external",
     };
   }
 

--- a/proto/api/v1/network_baseline_service.proto
+++ b/proto/api/v1/network_baseline_service.proto
@@ -16,6 +16,8 @@ option java_package = "io.stackrox.proto.api.v1";
 message NetworkBaselinePeerEntity {
   string id = 1;
   storage.NetworkEntityInfo.Type type = 2;
+  string name = 3;
+  string cidr = 4;
 }
 
 message NetworkBaselineStatusPeer {

--- a/proto/api/v1/network_baseline_service.proto
+++ b/proto/api/v1/network_baseline_service.proto
@@ -88,9 +88,7 @@ service NetworkBaselineService {
   }
 
   rpc GetNetworkBaselineStatusForExternalFlows(NetworkBaselineExternalStatusRequest) returns (NetworkBaselineExternalStatusResponse) {
-    option (google.api.http) = {
-      get: "/v1/networkbaseline/{deployment_id}/status/external",
-    };
+    option (google.api.http) = {get: "/v1/networkbaseline/{deployment_id}/status/external"};
   }
 
   rpc GetNetworkBaseline(ResourceByID) returns (storage.NetworkBaseline) {

--- a/proto/api/v1/network_baseline_service.proto
+++ b/proto/api/v1/network_baseline_service.proto
@@ -17,7 +17,7 @@ message NetworkBaselinePeerEntity {
   string id = 1;
   storage.NetworkEntityInfo.Type type = 2;
   string name = 3;
-  string cidr = 4;
+  bool discovered = 4;
 }
 
 message NetworkBaselineStatusPeer {


### PR DESCRIPTION
### Description

This extension to the network baseline API is to support the possible high-volume of external IP flows. The existing mechanism expects the caller to know about all of the flows up front, and will return status for only those flows, but the UI will not have this information for external IPs.

The new API endpoint will lookup the external flows and calculate the status all in the backend, returning a paginated list of anomalous and baseline peers back to the UI.

This is directly in support of https://issues.redhat.com/browse/ROX-28881 

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
~- [ ] added e2e tests~
~- [ ] added regression tests~
~- [ ] added compatibility tests~
~- [ ] modified existing tests~

#### How I validated my change

Locally I've spun this up on an openshift 4 cluster, using Berserker to generate external traffic, manually querying the endpoint with various queries to verify the functionality. 

Furthermore, additional unit tests have been written to verify these changes.
