### PR TITLE
ROX-28877: Add Tech Preview alerts in CRS pages

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretTechPreviewAlert.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretTechPreviewAlert.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Alert } from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import { getVersionedDocs } from 'utils/versioning';
+import useMetadata from 'hooks/useMetadata';
+
+export default function ClusterRegistrationSecretTechPreviewAlert() {
+    const { version } = useMetadata();
+    return (
+        <Alert
+            isInline
+            component="p"
+            variant="info"
+            title="Cluster registration secrets are a Technology Preview feature"
+        >
+            Cluster registration secrets (or &ldquo;CRS&rdquo; for short) are a modern alternative
+            to init bundles and will at some point replace init bundles entirely. Cluster
+            registration secrets and init bundles differ in their specific usage semantics &mdash;
+            please consult the{' '}
+            <ExternalLink>
+                <a
+                    href={getVersionedDocs(
+                        version,
+                        'installing/installing-rhacs-on-red-hat-openshift#init-bundle-ocp'
+                    )}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                >
+                    RHACS documentation
+                </a>
+            </ExternalLink>{' '}
+            for details. In any case, you only need an init bundle or a CRS to secure a new cluster,
+            not both.
+        </Alert>
+    );
+}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
@@ -58,6 +58,7 @@ function ClusterRegistrationSecretsPage({
         }
     }
 
+    /* eslint-disable no-nested-ternary */
     return (
         <>
             <ClusterRegistrationSecretsHeader
@@ -105,6 +106,7 @@ function ClusterRegistrationSecretsPage({
             </PageSection>
         </>
     );
+    /* eslint-enable no-nested-ternary */
 }
 
 export default ClusterRegistrationSecretsPage;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
+import { Alert, Bullseye, Button, Divider, PageSection, Spinner } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useAnalytics, { CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED } from 'hooks/useAnalytics';
@@ -16,6 +16,7 @@ import ClusterRegistrationSecretsHeader, {
 } from './ClusterRegistrationSecretsHeader';
 import ClusterRegistrationSecretsTable from './ClusterRegistrationSecretsTable';
 import RevokeClusterRegistrationSecretModal from './RevokeClusterRegistrationSecretModal';
+import ClusterRegistrationSecretTechPreviewAlert from './ClusterRegistrationSecretTechPreviewAlert';
 
 export type ClusterRegistrationSecretsPageProps = {
     hasWriteAccessForClusterRegistrationSecrets: boolean;
@@ -57,13 +58,17 @@ function ClusterRegistrationSecretsPage({
         }
     }
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <ClusterRegistrationSecretsHeader
                 headerActions={headerActions}
                 title={titleClusterRegistrationSecrets}
             />
+
+            <Divider component="div" />
+            <PageSection component="div" variant="light">
+                <ClusterRegistrationSecretTechPreviewAlert />
+            </PageSection>
             <PageSection component="div">
                 {isFetching ? (
                     <Bullseye>
@@ -100,7 +105,6 @@ function ClusterRegistrationSecretsPage({
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default ClusterRegistrationSecretsPage;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -21,6 +21,7 @@ import {
     clustersSecureClusterCrsPath,
 } from 'routePaths';
 
+import ClusterRegistrationSecretTechPreviewAlert from './ClusterRegistrationSecretTechPreviewAlert';
 import SecureClusterUsingHelmChart from './SecureClusterUsingHelmChart';
 import SecureClusterUsingOperator from './SecureClusterUsingOperator';
 
@@ -51,7 +52,10 @@ function SecureClusterPage(): ReactElement {
             <PageSection component="div" variant="light">
                 <PageTitle title="Secure a cluster" />
                 <Flex direction={{ default: 'column' }}>
-                    <Flex direction={{ default: 'column' }}>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsMd' }}
+                    >
                         <Breadcrumb>
                             <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
                             <BreadcrumbItemLink to={clustersClusterRegistrationSecretsPath}>
@@ -62,6 +66,7 @@ function SecureClusterPage(): ReactElement {
                         <Title headingLevel="h1">
                             Secure a cluster with a cluster registration secret
                         </Title>
+                        <ClusterRegistrationSecretTechPreviewAlert />
                     </Flex>
                     <FlexItem>
                         <TabNav


### PR DESCRIPTION
### Description

Adds a Tech Preview banner to the CRS table page and "Secure a cluster" page.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit the CRS table and instructions pages:
![image](https://github.com/user-attachments/assets/bc7c682a-0ef5-455a-8be9-6e80b8428af5)
![image](https://github.com/user-attachments/assets/043c0c08-fea2-437a-ac01-859899486ced)

