### PR TITLE
ROX-26178: Initial clusters page table migration

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -180,7 +180,7 @@ export_test_environment() {
     ci_export ROX_CVE_ADVISORY_SEPARATION "${ROX_CVE_ADVISORY_SEPARATION:-true}"
     ci_export ROX_EPSS_SCORE "${ROX_EPSS_SCORE:-true}"
     ci_export ROX_SBOM_GENERATION "${ROX_SBOM_GENERATION:-true}"
-    ci_export ROX_CLUSTERS_PAGE_MIGRATION_UI "${ROX_CLUSTERS_PAGE_MIGRATION_UI:-true}"
+    ci_export ROX_CLUSTERS_PAGE_MIGRATION_UI "${ROX_CLUSTERS_PAGE_MIGRATION_UI:-false}"
     ci_export ROX_EXTERNAL_IPS "${ROX_EXTERNAL_IPS:-true}"
     ci_export ROX_NETWORK_GRAPH_EXTERNAL_IPS "${ROX_NETWORK_GRAPH_EXTERNAL_IPS:-false}"
     ci_export ROX_FLATTEN_CVE_DATA "${ROX_FLATTEN_CVE_DATA:-false}"
@@ -319,7 +319,7 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n      - name: ROX_EPSS_SCORE'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_CLUSTERS_PAGE_MIGRATION_UI'
-    customize_envVars+=$'\n        value: "true"'
+    customize_envVars+=$'\n        value: "false"'
     customize_envVars+=$'\n      - name: ROX_EXTERNAL_IPS'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_NETWORK_GRAPH_EXTERNAL_IPS'

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -64,7 +64,7 @@ function ClustersTable({
         }));
     }
 
-    function isExpanded(clusterId: string, col: ColId) {
+    function isCellExpanded(clusterId: string, col: ColId) {
         return expanded[clusterId] === col;
     }
 
@@ -148,7 +148,7 @@ function ClustersTable({
                                         <Td
                                             dataLabel="Status"
                                             compoundExpand={{
-                                                isExpanded: isExpanded(clusterId, COL.STATUS),
+                                                isExpanded: isCellExpanded(clusterId, COL.STATUS),
                                                 onToggle: () => toggle(clusterId, COL.STATUS),
                                                 rowIndex,
                                                 columnIndex: 3,
@@ -164,7 +164,7 @@ function ClustersTable({
                                         <Td
                                             dataLabel="Sensor upgrade status"
                                             compoundExpand={{
-                                                isExpanded: isExpanded(clusterId, COL.SENSOR),
+                                                isExpanded: isCellExpanded(clusterId, COL.SENSOR),
                                                 onToggle: () => toggle(clusterId, COL.SENSOR),
                                                 rowIndex,
                                                 columnIndex: 4,
@@ -211,7 +211,7 @@ function ClustersTable({
                                             />
                                         </Td>
                                     </Tr>
-                                    {isExpanded(clusterId, COL.STATUS) && (
+                                    {isCellExpanded(clusterId, COL.STATUS) && (
                                         <Tr isExpanded>
                                             <Td colSpan={colSpan}>
                                                 <ExpandableRowContent>
@@ -222,7 +222,7 @@ function ClustersTable({
                                             </Td>
                                         </Tr>
                                     )}
-                                    {isExpanded(clusterId, COL.SENSOR) && (
+                                    {isCellExpanded(clusterId, COL.SENSOR) && (
                                         <Tr isExpanded>
                                             <Td colSpan={colSpan}>
                                                 <ExpandableRowContent>

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -1,0 +1,246 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Flex } from '@patternfly/react-core';
+import {
+    ActionsColumn,
+    ExpandableRowContent,
+    Table,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
+
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import useMetadata from 'hooks/useMetadata';
+import { Cluster } from 'types/cluster.proto';
+import { ClusterIdToRetentionInfo } from 'types/clusterService.proto';
+import { TableUIState } from 'utils/getTableUIState';
+
+import { formatCloudProvider } from './cluster.helpers';
+import { CertExpiryStatus, ClusterHealthStatus } from './clusterTypes';
+import ClusterDeletion from './Components/ClusterDeletion';
+import ClusterStatus from './Components/ClusterStatus';
+import CredentialExpiration from './Components/CredentialExpiration';
+import HelmIndicator from './Components/HelmIndicator';
+import OperatorIndicator from './Components/OperatorIndicator';
+import SensorUpgrade from './Components/SensorUpgrade';
+
+export type ClustersTableProps = {
+    clusterIdToRetentionInfo: ClusterIdToRetentionInfo;
+    tableState: TableUIState<Cluster>;
+    selectedClusterIds: string[];
+    onClearFilters: () => void;
+    onDeleteCluster: (cluster: Cluster) => (event: React.MouseEvent) => void;
+    toggleAllClusters: () => void;
+    toggleCluster: (clusterId) => void;
+};
+
+export const COL = {
+    STATUS: 'status',
+    SENSOR: 'sensor',
+} as const;
+type ColId = (typeof COL)[keyof typeof COL];
+
+type ExpansionMap = Record<string, ColId | null>;
+
+function ClustersTable({
+    clusterIdToRetentionInfo,
+    tableState,
+    selectedClusterIds,
+    onClearFilters,
+    onDeleteCluster,
+    toggleAllClusters,
+    toggleCluster,
+}: ClustersTableProps) {
+    const metadata = useMetadata();
+    const [expanded, setExpanded] = useState<ExpansionMap>({});
+
+    function toggle(clusterId: string, col: ColId) {
+        setExpanded((prev) => ({
+            ...prev,
+            [clusterId]: prev[clusterId] === col ? null : col,
+        }));
+    }
+
+    function isExpanded(clusterId: string, col: ColId) {
+        return expanded[clusterId] === col;
+    }
+
+    function isRowExpanded(clusterId: string) {
+        return expanded[clusterId] != null;
+    }
+
+    function isHelmManaged(cluster: Cluster) {
+        return (
+            cluster.managedBy === 'MANAGER_TYPE_HELM_CHART' ||
+            (cluster.managedBy === 'MANAGER_TYPE_UNKNOWN' && !!cluster.helmConfig)
+        );
+    }
+
+    function isOperatorManaged(cluster: Cluster) {
+        return cluster.managedBy === 'MANAGER_TYPE_KUBERNETES_OPERATOR';
+    }
+
+    const colSpan = 9;
+
+    return (
+        <Table>
+            <Thead>
+                <Tr>
+                    <Th
+                        select={{
+                            onSelect: () => toggleAllClusters(),
+                            isSelected:
+                                tableState.type === 'COMPLETE' &&
+                                tableState.data.length === selectedClusterIds.length,
+                        }}
+                    />
+                    <Th>Cluster</Th>
+                    <Th>Provider (Region)</Th>
+                    <Th>Status</Th>
+                    <Th>Sensor upgrade status</Th>
+                    <Th>Credential expiration</Th>
+                    <Th>Cluster deletion</Th>
+                </Tr>
+            </Thead>
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={colSpan}
+                errorProps={{
+                    title: 'There was an error loading cluster information',
+                }}
+                filteredEmptyProps={{ onClearFilters }}
+                renderer={({ data }) => (
+                    <>
+                        {data.map((clusterInfo, rowIndex) => {
+                            const provider = formatCloudProvider(
+                                clusterInfo.status?.providerMetadata
+                            );
+                            const clusterId = clusterInfo.id;
+                            return (
+                                <Tbody isExpanded={isRowExpanded(clusterId)} key={clusterInfo.id}>
+                                    <Tr key={clusterInfo.id}>
+                                        <Td
+                                            select={{
+                                                rowIndex,
+                                                onSelect: () => toggleCluster(clusterId),
+                                                isSelected: selectedClusterIds.includes(clusterId),
+                                            }}
+                                        />
+                                        <Td dataLabel="Cluster">
+                                            <Flex
+                                                alignItems={{ default: 'alignItemsCenter' }}
+                                                columnGap={{ default: 'columnGapXs' }}
+                                                flexWrap={{ default: 'nowrap' }}
+                                            >
+                                                <Link to={clusterId} className="">
+                                                    {clusterInfo.name}
+                                                </Link>
+                                                {isHelmManaged(clusterInfo) && <HelmIndicator />}
+                                                {isOperatorManaged(clusterInfo) && (
+                                                    <OperatorIndicator />
+                                                )}
+                                            </Flex>
+                                        </Td>
+                                        <Td dataLabel="Provider (Region)">{provider}</Td>
+                                        <Td
+                                            dataLabel="Status"
+                                            compoundExpand={{
+                                                isExpanded: isExpanded(clusterId, COL.STATUS),
+                                                onToggle: () => toggle(clusterId, COL.STATUS),
+                                                rowIndex,
+                                                columnIndex: 3,
+                                            }}
+                                        >
+                                            {/* TODO: needs update for upgrade */}
+                                            <ClusterStatus
+                                                healthStatus={
+                                                    clusterInfo?.healthStatus as ClusterHealthStatus
+                                                }
+                                            />
+                                        </Td>
+                                        <Td
+                                            dataLabel="Sensor upgrade status"
+                                            compoundExpand={{
+                                                isExpanded: isExpanded(clusterId, COL.SENSOR),
+                                                onToggle: () => toggle(clusterId, COL.SENSOR),
+                                                rowIndex,
+                                                columnIndex: 4,
+                                            }}
+                                        >
+                                            {/* TODO: needs update for upgrade */}
+                                            <SensorUpgrade
+                                                upgradeStatus={clusterInfo.status?.upgradeStatus}
+                                                centralVersion={metadata.version}
+                                                sensorVersion={clusterInfo.status?.sensorVersion}
+                                                isList
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Credential expiration">
+                                            {/* TODO: needs update for upgrade */}
+                                            <CredentialExpiration
+                                                certExpiryStatus={
+                                                    clusterInfo.status
+                                                        ?.certExpiryStatus as CertExpiryStatus
+                                                }
+                                                autoRefreshEnabled={clusterInfo.sensorCapabilities?.includes(
+                                                    'SecuredClusterCertificatesRefresh'
+                                                )}
+                                                isList
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Cluster deletion">
+                                            <ClusterDeletion
+                                                clusterRetentionInfo={
+                                                    clusterIdToRetentionInfo[clusterId] ?? null
+                                                }
+                                            />
+                                        </Td>
+                                        <Td isActionCell>
+                                            <ActionsColumn
+                                                items={[
+                                                    {
+                                                        title: 'Delete cluster',
+                                                        onClick: (event) => {
+                                                            onDeleteCluster(clusterInfo)(event);
+                                                        },
+                                                    },
+                                                ]}
+                                            />
+                                        </Td>
+                                    </Tr>
+                                    {isExpanded(clusterId, COL.STATUS) && (
+                                        <Tr isExpanded>
+                                            <Td colSpan={colSpan}>
+                                                <ExpandableRowContent>
+                                                    <div className="pf-v5-u-text-align-center">
+                                                        *status details*
+                                                    </div>
+                                                </ExpandableRowContent>
+                                            </Td>
+                                        </Tr>
+                                    )}
+                                    {isExpanded(clusterId, COL.SENSOR) && (
+                                        <Tr isExpanded>
+                                            <Td colSpan={colSpan}>
+                                                <ExpandableRowContent>
+                                                    <div className="pf-v5-u-text-align-center">
+                                                        *sensor details*
+                                                    </div>
+                                                </ExpandableRowContent>
+                                            </Td>
+                                        </Tr>
+                                    )}
+                                </Tbody>
+                            );
+                        })}
+                    </>
+                )}
+            />
+        </Table>
+    );
+}
+
+export default ClustersTable;

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -33,6 +33,7 @@ import useAnalytics, {
     CRS_SECURE_A_CLUSTER_LINK_CLICKED,
 } from 'hooks/useAnalytics';
 import useAuthStatus from 'hooks/useAuthStatus';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
 import usePermissions from 'hooks/usePermissions';
@@ -48,6 +49,7 @@ import { RestSearchOption } from 'services/searchOptionsToQuery';
 import { Cluster } from 'types/cluster.proto';
 import { ClusterIdToRetentionInfo } from 'types/clusterService.proto';
 import { toggleRow, toggleSelectAll } from 'utils/checkboxUtils';
+import { getTableUIState } from 'utils/getTableUIState';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
 import {
@@ -60,6 +62,7 @@ import {
     clustersClusterRegistrationSecretsPath,
 } from 'routePaths';
 
+import ClustersTable from './ClustersTable';
 import AutoUpgradeToggle from './Components/AutoUpgradeToggle';
 import SecureClusterModal from './InitBundles/SecureClusterModal';
 import { clusterTablePollingInterval, getUpgradeableClusters } from './cluster.helpers';
@@ -77,6 +80,9 @@ function ClustersTablePanel({
 }: ClustersTablePanelProps): ReactElement {
     const { analyticsTrack } = useAnalytics();
     const navigate = useNavigate();
+
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isClustersPageMigrationEnabled = isFeatureFlagEnabled('ROX_CLUSTERS_PAGE_MIGRATION_UI');
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForAdministration = hasReadAccess('Administration');
@@ -216,6 +222,13 @@ function ClustersTablePanel({
     }
 
     const restSearch = convertToRestSearch(searchFilter || {});
+
+    const tableState = getTableUIState({
+        isLoading: false,
+        data: currentClusters,
+        error: errorMessage ? new Error(errorMessage) : undefined,
+        searchFilter,
+    });
 
     useDeepCompareEffect(() => {
         refreshClusterList(restSearch);
@@ -513,21 +526,33 @@ function ClustersTablePanel({
                         {messages}
                     </div>
                 )}
-                <CheckboxTable
-                    ref={(table) => {
-                        setTableRef(table);
-                    }}
-                    rows={currentClusters}
-                    columns={clusterColumns}
-                    onRowClick={setSelectedClusterId}
-                    toggleRow={toggleCluster}
-                    toggleSelectAll={toggleAllClusters}
-                    selection={checkedClusterIds}
-                    selectedRowId={selectedClusterId}
-                    noDataText="No clusters to show."
-                    minRows={20}
-                    pageSize={pageSize}
-                />
+                {isClustersPageMigrationEnabled ? (
+                    <ClustersTable
+                        clusterIdToRetentionInfo={clusterIdToRetentionInfo}
+                        tableState={tableState}
+                        selectedClusterIds={checkedClusterIds}
+                        onClearFilters={() => setSearchFilter({})}
+                        onDeleteCluster={onDeleteHandler}
+                        toggleAllClusters={toggleAllClusters}
+                        toggleCluster={toggleCluster}
+                    />
+                ) : (
+                    <CheckboxTable
+                        ref={(table) => {
+                            setTableRef(table);
+                        }}
+                        rows={currentClusters}
+                        columns={clusterColumns}
+                        onRowClick={setSelectedClusterId}
+                        toggleRow={toggleCluster}
+                        toggleSelectAll={toggleAllClusters}
+                        selection={checkedClusterIds}
+                        selectedRowId={selectedClusterId}
+                        noDataText="No clusters to show."
+                        minRows={20}
+                        pageSize={pageSize}
+                    />
+                )}
             </PageSection>
             <Dialog
                 className="w-1/3"

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -528,6 +528,7 @@ function ClustersTablePanel({
                 )}
                 {isClustersPageMigrationEnabled ? (
                     <ClustersTable
+                        centralVersion={metadata.version}
                         clusterIdToRetentionInfo={clusterIdToRetentionInfo}
                         tableState={tableState}
                         selectedClusterIds={checkedClusterIds}

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Flex } from '@patternfly/react-core';
+import { Cluster } from 'types/cluster.proto';
+import HelmIndicator from './HelmIndicator';
+import OperatorIndicator from './OperatorIndicator';
+
+type ClusterNameWithTypeIconProps = {
+    cluster: Cluster;
+};
+
+function ClusterNameWithTypeIcon({ cluster }: ClusterNameWithTypeIconProps) {
+    function isHelmManaged(cluster: Cluster) {
+        return (
+            cluster.managedBy === 'MANAGER_TYPE_HELM_CHART' ||
+            (cluster.managedBy === 'MANAGER_TYPE_UNKNOWN' && !!cluster.helmConfig)
+        );
+    }
+
+    function isOperatorManaged(cluster: Cluster) {
+        return cluster.managedBy === 'MANAGER_TYPE_KUBERNETES_OPERATOR';
+    }
+
+    return (
+        <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            columnGap={{ default: 'columnGapXs' }}
+            flexWrap={{ default: 'nowrap' }}
+            data-testid="cluster-name"
+        >
+            <Link to={cluster.id} className="">
+                {cluster.name}
+            </Link>
+            {isHelmManaged(cluster) && <HelmIndicator />}
+            {isOperatorManaged(cluster) && <OperatorIndicator />}
+        </Flex>
+    );
+}
+
+export default ClusterNameWithTypeIcon;

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
@@ -28,7 +28,7 @@ function ClusterNameWithTypeIcon({ cluster }: ClusterNameWithTypeIconProps) {
             flexWrap={{ default: 'nowrap' }}
             data-testid="cluster-name"
         >
-            <Link to={cluster.id} className="">
+            <Link to={cluster.id} className="pf-v5-u-text-break-word">
                 {cluster.name}
             </Link>
             {isHelmManaged(cluster) && <HelmIndicator />}

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
@@ -6,7 +6,7 @@ import helm from 'images/helm.svg';
 function HelmIndicator(): ReactElement {
     return (
         <Tooltip content="This cluster is managed by Helm.">
-            <span className="w-5 h-5 inline-block">
+            <span className="w-5 h-5 inline-block pf-v5-u-flex-shrink-0">
                 <img className="w-5 h-5" src={helm} alt="Managed by Helm" />
             </span>
         </Tooltip>

--- a/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
@@ -6,7 +6,7 @@ import operatorLogo from 'images/operator-logo.png';
 function OperatorIndicator(): ReactElement {
     return (
         <Tooltip content="This cluster is managed by a Kubernetes Operator.">
-            <span className="w-5 h-5 inline-block">
+            <span className="w-5 h-5 inline-block pf-v5-u-flex-shrink-0">
                 <img
                     className="w-5 h-5"
                     src={operatorLogo}

--- a/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Trash2 } from 'react-feather';
-import { Link } from 'react-router-dom';
 
 import RowActionButton from 'Components/RowActionButton';
 import {
@@ -9,15 +8,13 @@ import {
     wrapClassName,
     rtTrActionsClassName,
 } from 'Components/Table';
-import { clustersBasePath } from 'routePaths';
 
 import { formatCloudProvider } from './cluster.helpers';
 import ClusterDeletion from './Components/ClusterDeletion';
+import ClusterNameWithTypeIcon from './Components/ClusterNameWithTypeIcon';
 import ClusterStatus from './Components/ClusterStatus';
 import CredentialExpiration from './Components/CredentialExpiration';
 import SensorUpgrade from './Components/SensorUpgrade';
-import HelmIndicator from './Components/HelmIndicator';
-import OperatorIndicator from './Components/OperatorIndicator';
 
 export function getColumnsForClusters({
     clusterIdToRetentionInfo,
@@ -46,23 +43,7 @@ export function getColumnsForClusters({
             Header: 'Name',
             headerClassName: `w-1/7 ${defaultHeaderClassName}`,
             className: `w-1/7 ${wrapClassName} ${defaultColumnClassName}`,
-            Cell: ({ original }) => (
-                <span className="flex items-center" data-testid="cluster-name">
-                    <Link to={`${clustersBasePath}/${original.id}`}>{original.name}</Link>
-                    {(original.managedBy === 'MANAGER_TYPE_HELM_CHART' ||
-                        (original.managedBy === 'MANAGER_TYPE_UNKNOWN' &&
-                            !!original.helmConfig)) && (
-                        <span className="pl-2">
-                            <HelmIndicator />
-                        </span>
-                    )}
-                    {original.managedBy === 'MANAGER_TYPE_KUBERNETES_OPERATOR' && (
-                        <span className="pl-2">
-                            <OperatorIndicator />
-                        </span>
-                    )}
-                </span>
-            ),
+            Cell: ({ original }) => <ClusterNameWithTypeIcon cluster={original} />,
         },
         {
             Header: 'Cloud Provider',


### PR DESCRIPTION
### Description

Implements the initial migration of the clusters table to use PatternFly components and `TbodyUnified`

Note: Status, Sensor upgrade status, and Credential expiration columns will all be updated in a later PR


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Default view:
![Screenshot 2025-04-14 at 2 47 31 PM](https://github.com/user-attachments/assets/24093541-ca1f-477f-a59f-e29e04fe1169)

Expandable sections:
![Screenshot 2025-04-14 at 2 48 03 PM](https://github.com/user-attachments/assets/cd156375-dc02-4a57-9114-1578447242ea)

