### PR TITLE
ROX-28953: create GetByIDs

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/administration/events/datastore/internal/store/postgres/store.go
+++ b/central/administration/events/datastore/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/administration/usage/store/postgres/store.go
+++ b/central/administration/usage/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *AlertsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *AlertsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *AlertsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/auth/store/postgres/store.go
+++ b/central/auth/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, name string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -406,3 +406,23 @@ func (s *ClustersStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ClustersStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -421,7 +421,7 @@ func (s *ClustersStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -41,6 +41,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, standardID string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, runID string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -406,3 +406,23 @@ func (s *ComplianceRunMetadataStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceRunMetadataStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetRunId(), objB.GetRunId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -421,7 +421,7 @@ func (s *ComplianceRunMetadataStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, runMetadataRunID string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -421,7 +421,7 @@ func (s *ComplianceRunResultsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -406,3 +406,23 @@ func (s *ComplianceRunResultsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceRunResultsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetRunMetadata().GetRunId(), objB.GetRunMetadata().GetRunId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorCheckResultV2StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorCheckResultV2StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorCheckResultV2StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/integration/store/postgres/store.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/integration/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store_test.go
@@ -421,7 +421,7 @@ func (s *ComplianceIntegrationsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/integration/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store_test.go
@@ -406,3 +406,23 @@ func (s *ComplianceIntegrationsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceIntegrationsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorProfileV2StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorProfileV2StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorProfileV2StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/remediations/store/postgres/store.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/remediations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorRemediationV2StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorRemediationV2StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/remediations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorRemediationV2StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/report/store/postgres/store.go
+++ b/central/complianceoperator/v2/report/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, reportID string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/rules/store/postgres/store.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorRuleV2StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorRuleV2StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorRuleV2StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestSACGetMany()
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestSACGetByIDs(
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorScanV2StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorScanV2StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorScanV2StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/suites/store/postgres/store.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/complianceoperator/v2/suites/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store_test.go
@@ -428,7 +428,7 @@ func (s *ComplianceOperatorSuiteV2StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/complianceoperator/v2/suites/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store_test.go
@@ -413,3 +413,23 @@ func (s *ComplianceOperatorSuiteV2StoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ComplianceOperatorSuiteV2StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -41,6 +41,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/deployment/datastore/internal/store/postgres/store_test.go
+++ b/central/deployment/datastore/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *DeploymentsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *DeploymentsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/deployment/datastore/internal/store/postgres/store_test.go
+++ b/central/deployment/datastore/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *DeploymentsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/discoveredclusters/datastore/internal/store/postgres/store.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, propsID string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, clusterID string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/imagecomponent/v2/datastore/store/postgres/store.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -41,6 +41,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -41,6 +41,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/namespace/datastore/internal/store/postgres/store.go
+++ b/central/namespace/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/namespace/datastore/internal/store/postgres/store_test.go
+++ b/central/namespace/datastore/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *NamespacesStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *NamespacesStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/namespace/datastore/internal/store/postgres/store_test.go
+++ b/central/namespace/datastore/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *NamespacesStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, deploymentID string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *NetworkBaselinesStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *NetworkBaselinesStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *NetworkBaselinesStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetDeploymentId(), objB.GetDeploymentId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, infoID string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *NetworkpoliciesStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *NetworkpoliciesStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *NetworkpoliciesStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 
 	Get(ctx context.Context, deploymentID string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 
 	Get(ctx context.Context, clusterID string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -41,6 +41,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -41,6 +41,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/pod/datastore/internal/store/postgres/store.go
+++ b/central/pod/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/pod/datastore/internal/store/postgres/store_test.go
+++ b/central/pod/datastore/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *PodsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/pod/datastore/internal/store/postgres/store_test.go
+++ b/central/pod/datastore/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *PodsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *PodsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *ProcessBaselinesStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ProcessBaselinesStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *ProcessBaselinesStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, deploymentID string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *ProcessBaselineResultsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *ProcessBaselineResultsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ProcessBaselineResultsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetDeploymentId(), objB.GetDeploymentId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -71,7 +71,7 @@ func (ds *datastoreImpl) GetProcessIndicator(ctx context.Context, id string) (*s
 }
 
 func (ds *datastoreImpl) GetProcessIndicators(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, bool, error) {
-	indicators, _, err := ds.storage.GetMany(ctx, ids)
+	indicators, err := ds.storage.GetByIDs(ctx, ids)
 	if err != nil || len(indicators) == 0 {
 		return nil, false, err
 	}

--- a/central/processindicator/store/mocks/store.go
+++ b/central/processindicator/store/mocks/store.go
@@ -103,6 +103,21 @@ func (mr *MockStoreMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
+// GetByIDs mocks base method.
+func (m *MockStore) GetByIDs(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByIDs", ctx, ids)
+	ret0, _ := ret[0].([]*storage.ProcessIndicator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByIDs indicates an expected call of GetByIDs.
+func (mr *MockStoreMockRecorder) GetByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByIDs", reflect.TypeOf((*MockStore)(nil).GetByIDs), ctx, ids)
+}
+
 // GetByQuery mocks base method.
 func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
 	m.ctrl.T.Helper()
@@ -116,22 +131,6 @@ func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Pro
 func (mr *MockStoreMockRecorder) GetByQuery(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
-}
-
-// GetMany mocks base method.
-func (m *MockStore) GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMany", ctx, ids)
-	ret0, _ := ret[0].([]*storage.ProcessIndicator)
-	ret1, _ := ret[1].([]int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetMany indicates an expected call of GetMany.
-func (mr *MockStoreMockRecorder) GetMany(ctx, ids any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMany", reflect.TypeOf((*MockStore)(nil).GetMany), ctx, ids)
 }
 
 // Search mocks base method.

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *ProcessIndicatorsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *ProcessIndicatorsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ProcessIndicatorsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -17,7 +17,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
-	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
+	GetByIDs(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, error)
 
 	UpsertMany(context.Context, []*storage.ProcessIndicator) error
 	DeleteMany(ctx context.Context, id []string) error

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/processlisteningonport/store/postgres/store_test.go
+++ b/central/processlisteningonport/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *ListeningEndpointsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/processlisteningonport/store/postgres/store_test.go
+++ b/central/processlisteningonport/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *ListeningEndpointsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ListeningEndpointsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *K8sRolesStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *K8sRolesStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *K8sRolesStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *RoleBindingsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *RoleBindingsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *RoleBindingsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/reports/config/store/postgres/store.go
+++ b/central/reports/config/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, reportID string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *RisksStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *RisksStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *RisksStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, name string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -49,6 +49,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -54,6 +54,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *SecretsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *SecretsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *SecretsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -53,6 +53,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -422,7 +422,7 @@ func (s *ServiceAccountsStoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -407,3 +407,23 @@ func (s *ServiceAccountsStoreSuite) TestSACGetMany() {
 		assert.Nil(t, missingIndices)
 	})
 }
+
+func (s *ServiceAccountsStoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{objA.GetId(), objB.GetId()})
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, serialStr string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ type Store interface {
 
 	Get(ctx context.Context, name string) (*storeType, bool, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -261,7 +261,7 @@ func (s *genericStore[T, PT]) GetIDsByQuery(ctx context.Context, query *v1.Query
 
 // GetByIDs returns the objects specified by the IDs from the store as well as the index in the missing indices slice.
 func (s *genericStore[T, PT]) GetByIDs(ctx context.Context, identifiers []string) ([]PT, error) {
-	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetMany)
 
 	if len(identifiers) == 0 {
 		return nil, nil

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, key1 string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -71,6 +71,7 @@ type Store interface {
     GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 {{- end }}
     GetMany(ctx context.Context, identifiers []{{$primaryKeyType}}) ([]*storeType, []int, error)
+    GetByIDs(ctx context.Context, identifiers []{{$primaryKeyType}}) ([]*storeType, error)
     GetIDs(ctx context.Context) ([]{{$primaryKeyType}}, error)
 
     Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -453,5 +453,25 @@ func (s *{{$namePrefix}}StoreSuite) TestSACGetMany() {
 	})
 }
 
+func (s *{{$namePrefix}}StoreSuite) TestSACGetByIDs() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			actual, err := s.store.GetByIDs(testCase.context, []string{ {{ "objA" | .Obj.GetID }}, {{ "objB" | .Obj.GetID }} })
+			assert.NoError(t, err)
+			protoassert.SlicesEqual(t, testCase.expectedObjects, actual)
+		})
+	}
+
+	s.T().Run("with no identifiers", func(t *testing.T) {
+		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		assert.Nil(t, err)
+		assert.Nil(t, actual)
+	})
+}
+
 {{end}}
 {{- end }}

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -467,7 +467,7 @@ func (s *{{$namePrefix}}StoreSuite) TestSACGetByIDs() {
 	}
 
 	s.T().Run("with no identifiers", func(t *testing.T) {
-		actual, missingIndices, err := s.store.GetByIDs(withAllAccessCtx, []string{})
+		actual, err := s.store.GetByIDs(withAllAccessCtx, []string{})
 		assert.Nil(t, err)
 		assert.Nil(t, actual)
 	})

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, key string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -51,6 +51,7 @@ type Store interface {
 	Get(ctx context.Context, key string) (*storeType, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
+	GetByIDs(ctx context.Context, identifiers []string) ([]*storeType, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storeType) error) error


### PR DESCRIPTION
### Description

This will create new method for stores `GetByIDs` that is similar to `GetMany` except it does not return missing ids and does not guarantee order of results.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
