### PR TITLE
doc: Unify helm flags in limited resource install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
 If you're deploying StackRox on nodes with limited resources such as a local development cluster, run the following command to reduce StackRox resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
-helm upgrade -n stackrox stackrox-central-services stackrox/stackrox-central-services \
+helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
+  stackrox/stackrox-central-services \
   --set central.resources.requests.memory=1Gi \
   --set central.resources.requests.cpu=1 \
   --set central.resources.limits.memory=4Gi \


### PR DESCRIPTION
### Description

The default `helm upgrade` command already contained `--install` and `--create-namespace`, which are handy when installing in a fresh cluster.

Now these flags are also present in the instructions for deploying in a cluster with limited resources.

### User-facing documentation

- [X] ~CHANGELOG is updated **OR** update is not needed~
- [X] ~[documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [X] ~the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag~
- [X] ~CI results are inspected~

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X] ~added unit tests~
- [X] ~added e2e tests~
- [X] ~added regression tests~
- [X] ~added compatibility tests~
- [X] ~modified existing tests~

#### How I validated my change

I copy-pasted the modified helm command in my terminal to verify it works.
