### PR TITLE
fix(ci): allow trigger if missed event

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -5,6 +5,8 @@ on:
     - 'release-*'
     tags-ignore:
     - '*-nightly-*'
+  repository_dispatch:
+    types: [trigger-missed-push]
 
 jobs:
   run-parameters:


### PR DESCRIPTION
### Description

Allow manually running release-ci (without exposing as a workflow_dispatch).
Why? github did not run release-ci on the push events for 4.6.5. We could move the tag onto a new commit now that the github outage is over, but it would be better to run the workflow on the original commit+tag.

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### How I validated my change


