### PR TITLE
fix(release-ci): allow build scans to fail

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -19,11 +19,13 @@ jobs:
     name: Build
     uses: ./.github/workflows/build.yaml
     secrets: inherit
+    continue-on-error: true
 
   build-scanner-v4:
     name: Build Scanner v4
     uses: ./.github/workflows/scanner-build.yaml
     secrets: inherit
+    continue-on-error: true
 
   check-is-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
re-used build workflows include steps that should not block a release but are required (scans).

Follow-up: find an alternative way to allow failure of scans (conditionals if running on a release tag?), or move the scans out of the build workflows.