### PR TITLE
ROX-28939: Create GetByQueryFn

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -32,7 +32,10 @@ var (
 	targetResource = resources.Deployment
 )
 
-type storeType = storage.ActiveComponent
+type (
+	storeType = storage.ActiveComponent
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ActiveComponent
 type Store interface {
@@ -48,12 +51,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/administration/events/datastore/internal/store/postgres/store.go
+++ b/central/administration/events/datastore/internal/store/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Administration
 )
 
-type storeType = storage.AdministrationEvent
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.AdministrationEvent
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.AdministrationEvent
 type Store interface {

--- a/central/administration/events/datastore/internal/store/postgres/store.go
+++ b/central/administration/events/datastore/internal/store/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.AdministrationEvent
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.AdministrationEvent
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/administration/events/datastore/internal/store/store.go
+++ b/central/administration/events/datastore/internal/store/store.go
@@ -11,7 +11,9 @@ import (
 type Store interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Get(ctx context.Context, id string) (*storage.AdministrationEvent, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.AdministrationEvent, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.AdministrationEvent) error) error
 	UpsertMany(ctx context.Context, objs []*storage.AdministrationEvent) error
 	DeleteMany(ctx context.Context, identifiers []string) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storage.AdministrationEvent, []int, error)

--- a/central/administration/usage/store/postgres/store.go
+++ b/central/administration/usage/store/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.SecuredUnits
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.SecuredUnits
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/administration/usage/store/postgres/store.go
+++ b/central/administration/usage/store/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Administration
 )
 
-type storeType = storage.SecuredUnits
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.SecuredUnits
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.SecuredUnits
 type Store interface {

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -117,6 +117,20 @@ func (mr *MockStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.Alert) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // GetIDs mocks base method.
 func (m *MockStore) GetIDs(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.Alert
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Alert
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Alert
 )
 
-type storeType = storage.Alert
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Alert
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Alert
 type Store interface {

--- a/central/alert/datastore/internal/store/postgres/store_test.go
+++ b/central/alert/datastore/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *AlertsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *AlertsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.Alert) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *AlertsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -19,7 +19,9 @@ type Store interface {
 	GetIDs(ctx context.Context) ([]string, error)
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Alert, []int, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.Alert) error) error
 	Upsert(ctx context.Context, alert *storage.Alert) error
 	UpsertMany(ctx context.Context, alerts []*storage.Alert) error
 	Delete(ctx context.Context, id string) error

--- a/central/apitoken/datastore/internal/store/mocks/store.go
+++ b/central/apitoken/datastore/internal/store/mocks/store.go
@@ -89,6 +89,20 @@ func (mr *MockStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.TokenMetadata) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // Search mocks base method.
 func (m *MockStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.TokenMetadata
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TokenMetadata
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TokenMetadata
 type Store interface {

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.TokenMetadata
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TokenMetadata
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/apitoken/datastore/internal/store/store.go
+++ b/central/apitoken/datastore/internal/store/store.go
@@ -18,7 +18,9 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storage.TokenMetadata, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.TokenMetadata, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.TokenMetadata) error) error
 	Walk(context.Context, func(*storage.TokenMetadata) error) error
 	Upsert(context.Context, *storage.TokenMetadata) error
 }

--- a/central/auth/store/postgres/store.go
+++ b/central/auth/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.AuthMachineToMachineConfig
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.AuthMachineToMachineConfig
 type Store interface {
@@ -51,8 +52,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/auth/store/postgres/store.go
+++ b/central/auth/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Access
 )
 
-type storeType = storage.AuthMachineToMachineConfig
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.AuthMachineToMachineConfig
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.AuthMachineToMachineConfig
 type Store interface {

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Access
 )
 
-type storeType = storage.AuthProvider
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.AuthProvider
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.AuthProvider
 type Store interface {

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.AuthProvider
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.AuthProvider
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Administration
 )
 
-type storeType = storage.Blob
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Blob
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Blob
 type Store interface {

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.Blob
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Blob
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, name string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cloudsources/datastore/internal/store/mocks/store.go
+++ b/central/cloudsources/datastore/internal/store/mocks/store.go
@@ -103,6 +103,20 @@ func (mr *MockStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.CloudSource) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // Search mocks base method.
 func (m *MockStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.CloudSource
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.CloudSource
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.CloudSource
 type Store interface {

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.CloudSource
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.CloudSource
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cloudsources/datastore/internal/store/store.go
+++ b/central/cloudsources/datastore/internal/store/store.go
@@ -16,7 +16,9 @@ type Store interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Get(ctx context.Context, id string) (*storage.CloudSource, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.CloudSource, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.CloudSource) error) error
 	Upsert(ctx context.Context, obj *storage.CloudSource) error
 	Delete(ctx context.Context, id string) error
 }

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.Cluster
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Cluster
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Cluster
 )
 
-type storeType = storage.Cluster
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Cluster
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Cluster
 type Store interface {

--- a/central/cluster/store/cluster/postgres/store_test.go
+++ b/central/cluster/store/cluster/postgres/store_test.go
@@ -277,6 +277,25 @@ func (s *ClustersStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ClustersStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.Cluster) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ClustersStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.ClusterHealthStatus
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ClusterHealthStatus
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Cluster
 )
 
-type storeType = storage.ClusterHealthStatus
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ClusterHealthStatus
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ClusterHealthStatus
 type Store interface {

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -30,8 +30,10 @@ var (
 	targetResource = resources.Cluster
 )
 
-type storeType = storage.ClusterCVEEdge
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ClusterCVEEdge
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ClusterCVEEdge
 type Store interface {

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -31,6 +31,7 @@ var (
 )
 
 type storeType = storage.ClusterCVEEdge
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ClusterCVEEdge
 type Store interface {
@@ -39,12 +40,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	schema = pkgSchema.ClusterInitBundlesSchema
 )
 
-type storeType = storage.InitBundleMeta
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.InitBundleMeta
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.InitBundleMeta
 type Store interface {

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.InitBundleMeta
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.InitBundleMeta
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceConfig
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceConfig
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceConfig
 type Store interface {

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceConfig
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceConfig
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceDomain
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceDomain
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceDomain
 type Store interface {

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceDomain
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceDomain
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.ComplianceRunMetadata
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceRunMetadata
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, runID string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceRunMetadata
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceRunMetadata
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceRunMetadata
 type Store interface {

--- a/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store_test.go
@@ -277,6 +277,25 @@ func (s *ComplianceRunMetadataStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceRunMetadataStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceRunMetadata) error {
+				identifiers = append(identifiers, obj.GetRunId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceRunMetadataStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.ComplianceRunResults
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceRunResults
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, runMetadataRunID string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceRunResults
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceRunResults
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceRunResults
 type Store interface {

--- a/central/compliance/datastore/internal/store/postgres/results/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store_test.go
@@ -277,6 +277,25 @@ func (s *ComplianceRunResultsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceRunResultsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceRunResults) error {
+				identifiers = append(identifiers, obj.GetRunMetadata().GetRunId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceRunResultsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceStrings
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceStrings
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceStrings
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceStrings
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceStrings
 type Store interface {

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.ComplianceOperator
 )
 
-type storeType = storage.ComplianceOperatorCheckResult
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorCheckResult
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorCheckResult
 type Store interface {

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorCheckResult
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorCheckResult
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorProfile
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorProfile
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.ComplianceOperator
 )
 
-type storeType = storage.ComplianceOperatorProfile
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorProfile
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorProfile
 type Store interface {

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorRule
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorRule
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.ComplianceOperator
 )
 
-type storeType = storage.ComplianceOperatorRule
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorRule
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorRule
 type Store interface {

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.ComplianceOperator
 )
 
-type storeType = storage.ComplianceOperatorScan
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorScan
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScan
 type Store interface {

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorScan
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScan
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorScanSettingBinding
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanSettingBinding
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.ComplianceOperator
 )
 
-type storeType = storage.ComplianceOperatorScanSettingBinding
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorScanSettingBinding
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanSettingBinding
 type Store interface {

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorBenchmarkV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorBenchmarkV2
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorBenchmarkV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorBenchmarkV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorBenchmarkV2
 type Store interface {

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorCheckResultV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorCheckResultV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorCheckResultV2
 type Store interface {

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorCheckResultV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorCheckResultV2
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorCheckResultV2StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorCheckResultV2StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorCheckResultV2) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorCheckResultV2StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/integration/store/postgres/store.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ComplianceIntegration
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceIntegration
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/integration/store/postgres/store.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceIntegration
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceIntegration
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceIntegration
 type Store interface {

--- a/central/complianceoperator/v2/integration/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store_test.go
@@ -277,6 +277,25 @@ func (s *ComplianceIntegrationsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceIntegrationsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceIntegration) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceIntegrationsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorProfileV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorProfileV2
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorProfileV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorProfileV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorProfileV2
 type Store interface {

--- a/central/complianceoperator/v2/profiles/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorProfileV2StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorProfileV2StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorProfileV2) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorProfileV2StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/remediations/store/postgres/store.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorRemediationV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorRemediationV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorRemediationV2
 type Store interface {

--- a/central/complianceoperator/v2/remediations/store/postgres/store.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorRemediationV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorRemediationV2
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/remediations/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorRemediationV2StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorRemediationV2StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorRemediationV2) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorRemediationV2StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/report/store/postgres/store.go
+++ b/central/complianceoperator/v2/report/store/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorReportSnapshotV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorReportSnapshotV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorReportSnapshotV2
 type Store interface {

--- a/central/complianceoperator/v2/report/store/postgres/store.go
+++ b/central/complianceoperator/v2/report/store/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorReportSnapshotV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorReportSnapshotV2
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, reportID string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/rules/store/postgres/store.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorRuleV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorRuleV2
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/rules/store/postgres/store.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorRuleV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorRuleV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorRuleV2
 type Store interface {

--- a/central/complianceoperator/v2/rules/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorRuleV2StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorRuleV2StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorRuleV2) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorRuleV2StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorClusterScanConfigStatus
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorClusterScanConfigStatus
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorClusterScanConfigStatus
 type Store interface {

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorClusterScanConfigStatus
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorClusterScanConfigStatus
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorClusterScanConfigStatus) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorClusterScanConfigStatusesStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorScanConfigurationV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanConfigurationV2
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorScanConfigurationV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorScanConfigurationV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanConfigurationV2
 type Store interface {

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorScanV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorScanV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanV2
 type Store interface {

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorScanV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanV2
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/scans/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorScanV2StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorScanV2StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorScanV2) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorScanV2StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorScanSettingBindingV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanSettingBindingV2
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorScanSettingBindingV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorScanSettingBindingV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorScanSettingBindingV2
 type Store interface {

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorScanSettingBindingV2) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorScanSettingBindingV2StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/complianceoperator/v2/suites/store/postgres/store.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ComplianceOperatorSuiteV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorSuiteV2
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/complianceoperator/v2/suites/store/postgres/store.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Compliance
 )
 
-type storeType = storage.ComplianceOperatorSuiteV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComplianceOperatorSuiteV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComplianceOperatorSuiteV2
 type Store interface {

--- a/central/complianceoperator/v2/suites/store/postgres/store_test.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store_test.go
@@ -284,6 +284,25 @@ func (s *ComplianceOperatorSuiteV2StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ComplianceOperatorSuiteV2StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ComplianceOperatorSuiteV2) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ComplianceOperatorSuiteV2StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -30,8 +30,10 @@ var (
 	targetResource = resources.Image
 )
 
-type storeType = storage.ComponentCVEEdge
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ComponentCVEEdge
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ComponentCVEEdge
 type Store interface {

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -31,6 +31,7 @@ var (
 )
 
 type storeType = storage.ComponentCVEEdge
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ComponentCVEEdge
 type Store interface {
@@ -39,12 +40,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Cluster
 )
 
-type storeType = storage.ClusterCVE
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ClusterCVE
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ClusterCVE
 type Store interface {

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.ClusterCVE
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ClusterCVE
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Image
 )
 
-type storeType = storage.ImageCVE
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ImageCVE
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ImageCVE
 type Store interface {

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.ImageCVE
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ImageCVE
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Image
 )
 
-type storeType = storage.ImageCVEV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ImageCVEV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ImageCVEV2
 type Store interface {

--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.ImageCVEV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ImageCVEV2
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Node
 )
 
-type storeType = storage.NodeCVE
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NodeCVE
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NodeCVE
 type Store interface {

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.NodeCVE
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NodeCVE
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.DeclarativeConfigHealth
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.DeclarativeConfigHealth
 type Store interface {
@@ -51,8 +52,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.DeclarativeConfigHealth
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.DeclarativeConfigHealth
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.DeclarativeConfigHealth
 type Store interface {

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Deployment
 )
 
-type storeType = storage.Deployment
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Deployment
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Deployment
 type Store interface {

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.Deployment
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Deployment
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/deployment/datastore/internal/store/postgres/store_test.go
+++ b/central/deployment/datastore/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *DeploymentsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *DeploymentsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.Deployment) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *DeploymentsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/discoveredclusters/datastore/internal/store/mocks/store.go
+++ b/central/discoveredclusters/datastore/internal/store/mocks/store.go
@@ -104,6 +104,20 @@ func (mr *MockStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.DiscoveredCluster) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // Search mocks base method.
 func (m *MockStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/discoveredclusters/datastore/internal/store/postgres/store.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.DiscoveredCluster
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.DiscoveredCluster
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/discoveredclusters/datastore/internal/store/postgres/store.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Administration
 )
 
-type storeType = storage.DiscoveredCluster
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.DiscoveredCluster
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.DiscoveredCluster
 type Store interface {

--- a/central/discoveredclusters/datastore/internal/store/store.go
+++ b/central/discoveredclusters/datastore/internal/store/store.go
@@ -16,7 +16,9 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storage.DiscoveredCluster, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.DiscoveredCluster, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.DiscoveredCluster) error) error
 	UpsertMany(ctx context.Context, objs []*storage.DiscoveredCluster) error
 	DeleteByQuery(ctx context.Context, query *v1.Query) ([]string, error)
 }

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ExternalBackup
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ExternalBackup
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.ExternalBackup
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ExternalBackup
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ExternalBackup
 type Store interface {

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Access
 )
 
-type storeType = storage.Group
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Group
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Group
 type Store interface {

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.Group
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Group
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.Hash
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Hash
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Hash
 )
 
-type storeType = storage.Hash
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Hash
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Hash
 type Store interface {

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Image
 )
 
-type storeType = storage.ImageComponent
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ImageComponent
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ImageComponent
 type Store interface {

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ImageComponent
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ImageComponent
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imagecomponent/v2/datastore/store/postgres/store.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ImageComponentV2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ImageComponentV2
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imagecomponent/v2/datastore/store/postgres/store.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Image
 )
 
-type storeType = storage.ImageComponentV2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ImageComponentV2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ImageComponentV2
 type Store interface {

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -30,8 +30,10 @@ var (
 	targetResource = resources.Image
 )
 
-type storeType = storage.ImageComponentEdge
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ImageComponentEdge
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ImageComponentEdge
 type Store interface {

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -31,6 +31,7 @@ var (
 )
 
 type storeType = storage.ImageComponentEdge
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ImageComponentEdge
 type Store interface {
@@ -39,12 +40,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -31,6 +31,7 @@ var (
 )
 
 type storeType = storage.ImageCVEEdge
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ImageCVEEdge
 type Store interface {
@@ -39,12 +40,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -30,8 +30,10 @@ var (
 	targetResource = resources.Image
 )
 
-type storeType = storage.ImageCVEEdge
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ImageCVEEdge
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ImageCVEEdge
 type Store interface {

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.ImageIntegration
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ImageIntegration
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.ImageIntegration
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ImageIntegration
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ImageIntegration
 type Store interface {

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.IntegrationHealth
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.IntegrationHealth
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.IntegrationHealth
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.IntegrationHealth
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.IntegrationHealth
 type Store interface {

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Administration
 )
 
-type storeType = storage.LogImbue
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.LogImbue
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.LogImbue
 type Store interface {

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.LogImbue
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.LogImbue
 type Store interface {
@@ -51,8 +52,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/namespace/datastore/internal/store/postgres/store.go
+++ b/central/namespace/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.NamespaceMetadata
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NamespaceMetadata
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/namespace/datastore/internal/store/postgres/store.go
+++ b/central/namespace/datastore/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.NamespaceMetadata
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NamespaceMetadata
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NamespaceMetadata
 type Store interface {

--- a/central/namespace/datastore/internal/store/postgres/store_test.go
+++ b/central/namespace/datastore/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *NamespacesStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *NamespacesStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.NamespaceMetadata) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *NamespacesStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.NetworkBaseline
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NetworkBaseline
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, deploymentID string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.DeploymentExtension
 )
 
-type storeType = storage.NetworkBaseline
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NetworkBaseline
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NetworkBaseline
 type Store interface {

--- a/central/networkbaseline/store/postgres/store_test.go
+++ b/central/networkbaseline/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *NetworkBaselinesStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *NetworkBaselinesStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.NetworkBaseline) error {
+				identifiers = append(identifiers, obj.GetDeploymentId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *NetworkBaselinesStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Administration
 )
 
-type storeType = storage.NetworkGraphConfig
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NetworkGraphConfig
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NetworkGraphConfig
 type Store interface {

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.NetworkGraphConfig
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NetworkGraphConfig
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/networkgraph/entity/datastore/internal/store/mocks/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/mocks/store.go
@@ -116,6 +116,20 @@ func (mr *MockEntityStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockEntityStore)(nil).GetByQuery), ctx, query)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockEntityStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.NetworkEntity) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockEntityStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockEntityStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // GetIDs mocks base method.
 func (m *MockEntityStore) GetIDs(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	schema = pkgSchema.NetworkEntitiesSchema
 )
 
-type storeType = storage.NetworkEntity
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NetworkEntity
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NetworkEntity
 type Store interface {

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.NetworkEntity
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NetworkEntity
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, infoID string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/networkgraph/entity/datastore/internal/store/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/store.go
@@ -24,5 +24,7 @@ type EntityStore interface {
 	Walk(ctx context.Context, fn func(obj *storage.NetworkEntity) error) error
 	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storage.NetworkEntity) error) error
 
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkEntity, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.NetworkEntity) error) error
 }

--- a/central/networkpolicies/datastore/internal/store/mocks/store.go
+++ b/central/networkpolicies/datastore/internal/store/mocks/store.go
@@ -103,6 +103,20 @@ func (mr *MockStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.NetworkPolicy) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // Search mocks base method.
 func (m *MockStore) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	m.ctrl.T.Helper()

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.NetworkPolicy
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NetworkPolicy
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.NetworkPolicy
 )
 
-type storeType = storage.NetworkPolicy
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NetworkPolicy
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NetworkPolicy
 type Store interface {

--- a/central/networkpolicies/datastore/internal/store/postgres/store_test.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *NetworkpoliciesStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *NetworkpoliciesStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.NetworkPolicy) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *NetworkpoliciesStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/networkpolicies/datastore/internal/store/store.go
+++ b/central/networkpolicies/datastore/internal/store/store.go
@@ -15,7 +15,9 @@ type Store interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 	Get(ctx context.Context, id string) (*storage.NetworkPolicy, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkPolicy, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.NetworkPolicy) error) error
 	Upsert(ctx context.Context, obj *storage.NetworkPolicy) error
 	Delete(ctx context.Context, id string) error
 

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.NetworkPolicy
 )
 
-type storeType = storage.NetworkPolicyApplicationUndoDeploymentRecord
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NetworkPolicyApplicationUndoDeploymentRecord
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NetworkPolicyApplicationUndoDeploymentRecord
 type Store interface {

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.NetworkPolicyApplicationUndoDeploymentRecord
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NetworkPolicyApplicationUndoDeploymentRecord
 type Store interface {
@@ -51,8 +52,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.NetworkPolicy
 )
 
-type storeType = storage.NetworkPolicyApplicationUndoRecord
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NetworkPolicyApplicationUndoRecord
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NetworkPolicyApplicationUndoRecord
 type Store interface {

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.NetworkPolicyApplicationUndoRecord
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NetworkPolicyApplicationUndoRecord
 type Store interface {
@@ -51,8 +52,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Node
 )
 
-type storeType = storage.NodeComponent
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NodeComponent
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NodeComponent
 type Store interface {

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.NodeComponent
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NodeComponent
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -30,8 +30,10 @@ var (
 	targetResource = resources.Node
 )
 
-type storeType = storage.NodeComponentCVEEdge
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NodeComponentCVEEdge
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NodeComponentCVEEdge
 type Store interface {

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -31,6 +31,7 @@ var (
 )
 
 type storeType = storage.NodeComponentCVEEdge
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NodeComponentCVEEdge
 type Store interface {
@@ -39,12 +40,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -31,6 +31,7 @@ var (
 )
 
 type storeType = storage.NodeComponentEdge
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.NodeComponentEdge
 type Store interface {
@@ -39,12 +40,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -30,8 +30,10 @@ var (
 	targetResource = resources.Node
 )
 
-type storeType = storage.NodeComponentEdge
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.NodeComponentEdge
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.NodeComponentEdge
 type Store interface {

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.Notifier
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Notifier
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.Notifier
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Notifier
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Notifier
 type Store interface {

--- a/central/pod/datastore/internal/store/postgres/store.go
+++ b/central/pod/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.Pod
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Pod
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/pod/datastore/internal/store/postgres/store.go
+++ b/central/pod/datastore/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.Deployment
 )
 
-type storeType = storage.Pod
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Pod
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Pod
 type Store interface {

--- a/central/pod/datastore/internal/store/postgres/store_test.go
+++ b/central/pod/datastore/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *PodsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *PodsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.Pod) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *PodsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.WorkflowAdministration
 )
 
-type storeType = storage.Policy
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Policy
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Policy
 type Store interface {

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.Policy
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Policy
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.PolicyCategory
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.PolicyCategory
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.WorkflowAdministration
 )
 
-type storeType = storage.PolicyCategory
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.PolicyCategory
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.PolicyCategory
 type Store interface {

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.WorkflowAdministration
 )
 
-type storeType = storage.PolicyCategoryEdge
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.PolicyCategoryEdge
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.PolicyCategoryEdge
 type Store interface {

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.PolicyCategoryEdge
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.PolicyCategoryEdge
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/policycategoryedge/store/store.go
+++ b/central/policycategoryedge/store/store.go
@@ -20,7 +20,9 @@ type Store interface {
 	GetIDs(ctx context.Context) ([]string, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.PolicyCategoryEdge, []int, error)
 	DeleteMany(ctx context.Context, ids []string) error
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategoryEdge, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.PolicyCategoryEdge) error) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) ([]string, error)
 
 	Walk(ctx context.Context, fn func(obj *storage.PolicyCategoryEdge) error) error

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ProcessBaseline
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ProcessBaseline
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.DeploymentExtension
 )
 
-type storeType = storage.ProcessBaseline
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ProcessBaseline
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ProcessBaseline
 type Store interface {

--- a/central/processbaseline/store/postgres/store_test.go
+++ b/central/processbaseline/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *ProcessBaselinesStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ProcessBaselinesStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ProcessBaseline) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ProcessBaselinesStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.DeploymentExtension
 )
 
-type storeType = storage.ProcessBaselineResults
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ProcessBaselineResults
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ProcessBaselineResults
 type Store interface {

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ProcessBaselineResults
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ProcessBaselineResults
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, deploymentID string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *ProcessBaselineResultsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ProcessBaselineResultsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ProcessBaselineResults) error {
+				identifiers = append(identifiers, obj.GetDeploymentId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ProcessBaselineResultsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.ProcessIndicator
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ProcessIndicator
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.DeploymentExtension
 )
 
-type storeType = storage.ProcessIndicator
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ProcessIndicator
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ProcessIndicator
 type Store interface {

--- a/central/processindicator/store/postgres/store_test.go
+++ b/central/processindicator/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *ProcessIndicatorsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ProcessIndicatorsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ProcessIndicator) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ProcessIndicatorsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/processlisteningonport/store/mocks/store.go
+++ b/central/processlisteningonport/store/mocks/store.go
@@ -147,6 +147,20 @@ func (mr *MockStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.ProcessListeningOnPortStorage) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // GetIDs mocks base method.
 func (m *MockStore) GetIDs(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.ProcessListeningOnPortStorage
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ProcessListeningOnPortStorage
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.DeploymentExtension
 )
 
-type storeType = storage.ProcessListeningOnPortStorage
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ProcessListeningOnPortStorage
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ProcessListeningOnPortStorage
 type Store interface {

--- a/central/processlisteningonport/store/postgres/store_test.go
+++ b/central/processlisteningonport/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *ListeningEndpointsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ListeningEndpointsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ProcessListeningOnPortStorage) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ListeningEndpointsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/processlisteningonport/store/store.go
+++ b/central/processlisteningonport/store/store.go
@@ -24,7 +24,9 @@ type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)
 
 	Get(ctx context.Context, id string) (*storage.ProcessListeningOnPortStorage, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.ProcessListeningOnPortStorage, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.ProcessListeningOnPortStorage) error) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storage.ProcessListeningOnPortStorage, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.K8SRole
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.K8SRole
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.K8sRole
 )
 
-type storeType = storage.K8SRole
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.K8SRole
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.K8SRole
 type Store interface {

--- a/central/rbac/k8srole/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srole/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *K8sRolesStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *K8sRolesStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.K8SRole) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *K8sRolesStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.K8sRoleBinding
 )
 
-type storeType = storage.K8SRoleBinding
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.K8SRoleBinding
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.K8SRoleBinding
 type Store interface {

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.K8SRoleBinding
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.K8SRoleBinding
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *RoleBindingsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *RoleBindingsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.K8SRoleBinding) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *RoleBindingsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/reports/config/store/postgres/store.go
+++ b/central/reports/config/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.WorkflowAdministration
 )
 
-type storeType = storage.ReportConfiguration
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ReportConfiguration
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ReportConfiguration
 type Store interface {

--- a/central/reports/config/store/postgres/store.go
+++ b/central/reports/config/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ReportConfiguration
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ReportConfiguration
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.ReportSnapshot
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ReportSnapshot
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, reportID string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.WorkflowAdministration
 )
 
-type storeType = storage.ReportSnapshot
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ReportSnapshot
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ReportSnapshot
 type Store interface {

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.WorkflowAdministration
 )
 
-type storeType = storage.ResourceCollection
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ResourceCollection
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ResourceCollection
 type Store interface {

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ResourceCollection
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ResourceCollection
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.Risk
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Risk
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.DeploymentExtension
 )
 
-type storeType = storage.Risk
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Risk
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Risk
 type Store interface {

--- a/central/risk/datastore/internal/store/postgres/store_test.go
+++ b/central/risk/datastore/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *RisksStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *RisksStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.Risk) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *RisksStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Access
 )
 
-type storeType = storage.PermissionSet
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.PermissionSet
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.PermissionSet
 type Store interface {

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.PermissionSet
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.PermissionSet
 type Store interface {
@@ -51,8 +52,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Access
 )
 
-type storeType = storage.Role
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Role
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Role
 type Store interface {

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.Role
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Role
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Access
 )
 
-type storeType = storage.SimpleAccessScope
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.SimpleAccessScope
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.SimpleAccessScope
 type Store interface {

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.SimpleAccessScope
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.SimpleAccessScope
 type Store interface {
@@ -51,8 +52,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -36,8 +36,10 @@ var (
 	targetResource = resources.Secret
 )
 
-type storeType = storage.Secret
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.Secret
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.Secret
 type Store interface {

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -37,6 +37,7 @@ var (
 )
 
 type storeType = storage.Secret
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.Secret
 type Store interface {
@@ -52,12 +53,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/secret/internal/store/postgres/store_test.go
+++ b/central/secret/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *SecretsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *SecretsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.Secret) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *SecretsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -36,6 +36,7 @@ var (
 )
 
 type storeType = storage.ServiceAccount
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ServiceAccount
 type Store interface {
@@ -51,12 +52,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -35,8 +35,10 @@ var (
 	targetResource = resources.ServiceAccount
 )
 
-type storeType = storage.ServiceAccount
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ServiceAccount
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ServiceAccount
 type Store interface {

--- a/central/serviceaccount/internal/store/postgres/store_test.go
+++ b/central/serviceaccount/internal/store/postgres/store_test.go
@@ -278,6 +278,25 @@ func (s *ServiceAccountsStoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *ServiceAccountsStoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *storage.ServiceAccount) error {
+				identifiers = append(identifiers, obj.GetId())
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *ServiceAccountsStoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.ServiceIdentity
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.ServiceIdentity
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Administration
 )
 
-type storeType = storage.ServiceIdentity
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.ServiceIdentity
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.ServiceIdentity
 type Store interface {

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.SignatureIntegration
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.SignatureIntegration
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Integration
 )
 
-type storeType = storage.SignatureIntegration
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.SignatureIntegration
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.SignatureIntegration
 type Store interface {

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -32,8 +32,10 @@ var (
 	schema = pkgSchema.VulnerabilityRequestsSchema
 )
 
-type storeType = storage.VulnerabilityRequest
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.VulnerabilityRequest
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.VulnerabilityRequest
 type Store interface {

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.VulnerabilityRequest
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.VulnerabilityRequest
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.WatchedImage
 )
 
-type storeType = storage.WatchedImage
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.WatchedImage
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.WatchedImage
 type Store interface {

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.WatchedImage
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.WatchedImage
 type Store interface {
@@ -50,8 +51,8 @@ type Store interface {
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -222,7 +222,7 @@ func (s *genericStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, err
 
 // GetByQueryFn iterates over all the objects scoped by the query and applies the closure.
 // The main difference between GetByQueryFn and WalkByQuery or Walk is cursor usage. Prefer GetByQueryFn when
-// results set is limited or tables is small.
+// results set is limited or tables are small.
 // TODO(ROX-28999): merge with WalkByQuery if cursor is removed
 func (s *genericStore[T, PT]) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -306,37 +306,7 @@ func (c *cachedStore[T, PT]) GetMany(ctx context.Context, identifiers []string) 
 
 // WalkByQuery iterates over all the objects scoped by the query applies the closure.
 func (c *cachedStore[T, PT]) WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
-	if query == nil || query.EqualVT(search.EmptyQuery()) {
-		c.cacheLock.RLock()
-		defer c.cacheLock.RUnlock()
-		return c.walkCacheNoLock(ctx, fn)
-	}
-
-	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
-	// Fallback to the underlying store on error.
-	if err != nil {
-		log.Errorf("Failed to get identifiers by query, falling back to walk results by query: %v", err)
-		return c.underlyingStore.WalkByQuery(ctx, query, fn)
-	}
-	c.cacheLock.RLock()
-	defer c.cacheLock.RUnlock()
-	for _, id := range identifiers {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		obj, found := c.cache[id]
-		if !found {
-			log.Warnf("Object %q not found in store cache", id)
-			continue
-		}
-		if !c.isReadAllowed(ctx, obj) {
-			continue
-		}
-		if err := fn(obj); err != nil {
-			return err
-		}
-	}
-	return nil
+	return c.getByQueryFn(ctx, query, fn)
 }
 
 // Walk iterates over all the objects in the store and applies the closure.
@@ -349,54 +319,18 @@ func (c *cachedStore[T, PT]) Walk(ctx context.Context, fn func(obj PT) error) er
 // GetByQueryFn iterates over the objects from the store matching the query.
 func (c *cachedStore[T, PT]) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
 	defer c.setCacheOperationDurationTime(time.Now(), ops.GetByQuery)
-	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
-	// Fallback to the underlying store on error.
-	if err != nil {
-		log.Errorf("Failed to get identifiers by query, falling back to get results by query: %v", err)
-		return c.underlyingStore.GetByQueryFn(ctx, query, fn)
-	}
-	c.cacheLock.RLock()
-	defer c.cacheLock.RUnlock()
-	for _, id := range identifiers {
-		obj, found := c.cache[id]
-		if !found {
-			log.Warnf("Object %q not found in store cache", id)
-			continue
-		}
-		if !c.isReadAllowed(ctx, obj) {
-			continue
-		}
-		if err := fn(obj); err != nil {
-			return err
-		}
-	}
-	return nil
+	return c.getByQueryFn(ctx, query, fn)
 }
 
 // GetByQuery returns the objects from the store matching the query.
 func (c *cachedStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
 	defer c.setCacheOperationDurationTime(time.Now(), ops.GetByQuery)
-	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
-	// Fallback to the underlying store on error.
-	if err != nil {
-		log.Errorf("Failed to get identifiers by query, falling back to get results by query: %v", err)
-		return c.underlyingStore.GetByQuery(ctx, query)
-	}
-	results := make([]*T, 0, len(identifiers))
-	c.cacheLock.RLock()
-	defer c.cacheLock.RUnlock()
-	for _, id := range identifiers {
-		obj, found := c.cache[id]
-		if !found {
-			log.Warnf("Object %q not found in store cache", id)
-			continue
-		}
-		if !c.isReadAllowed(ctx, obj) {
-			continue
-		}
-		results = append(results, obj.CloneVT())
-	}
-	return results, nil
+	results := make([]*T, 0, query.GetPagination().GetLimit())
+	err := c.getByQueryFn(ctx, query, func(obj PT) error {
+		results = append(results, obj)
+		return nil
+	})
+	return results, err
 }
 
 // DeleteByQuery removes the objects from the store based on the passed query.
@@ -433,6 +367,37 @@ func (c *cachedStore[T, PT]) GetIDs(ctx context.Context) ([]string, error) {
 // GetIDsByQuery returns the IDs for the store matching the query.
 func (c *cachedStore[T, PT]) GetIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error) {
 	return c.underlyingStore.GetIDsByQuery(ctx, query)
+}
+
+func (c *cachedStore[T, PT]) getByQueryFn(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
+	if query == nil || query.EqualVT(search.EmptyQuery()) {
+		c.cacheLock.RLock()
+		defer c.cacheLock.RUnlock()
+		return c.walkCacheNoLock(ctx, fn)
+	}
+
+	identifiers, err := c.underlyingStore.GetIDsByQuery(ctx, query)
+	// Fallback to the underlying store on error.
+	if err != nil {
+		log.Errorf("Failed to get identifiers by query, falling back to get results by query: %v", err)
+		return c.underlyingStore.GetByQueryFn(ctx, query, fn)
+	}
+	c.cacheLock.RLock()
+	defer c.cacheLock.RUnlock()
+	for _, id := range identifiers {
+		obj, found := c.cache[id]
+		if !found {
+			log.Warnf("Object %q not found in store cache", id)
+			continue
+		}
+		if !c.isReadAllowed(ctx, obj) {
+			continue
+		}
+		if err := fn(obj); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *cachedStore[T, PT]) walkCacheNoLock(ctx context.Context, fn func(obj PT) error) error {

--- a/pkg/search/postgres/store_cache_test.go
+++ b/pkg/search/postgres/store_cache_test.go
@@ -268,6 +268,40 @@ func TestCachedWalkContextCancelation(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+func TestCachedGetByQueryDoesNotModifyTheObject(t *testing.T) {
+	testDB := pgtest.ForT(t)
+	store := newCachedStore(testDB)
+	require.NotNil(t, store)
+
+	testObjects := sampleCachedTestSingleKeyStructArray("WalkByQuery")
+	err := store.UpsertMany(cachedStoreCtx, testObjects)
+	require.NoError(t, err)
+
+	query2 := getCachedMatchFieldQuery("Test Name", "Test WalkByQuery 2")
+	query4 := getCachedMatchFieldQuery("Test Key", "TestWalkByQuery4")
+	query := getCachedDisjunctionQuery(query2, query4)
+
+	walkedNames := make([]string, 0, len(testObjects))
+	walkFn := func(obj *storage.TestSingleKeyStruct) error {
+		walkedNames = append(walkedNames, obj.Name)
+		obj.Name = "changed"
+		return nil
+	}
+	err = store.GetByQueryFn(cachedStoreCtx, query, walkFn)
+	require.NoError(t, err)
+
+	expectedNames := []string{
+		"Test WalkByQuery 2",
+		"Test WalkByQuery 4",
+	}
+	assert.ElementsMatch(t, expectedNames, walkedNames)
+
+	walkedNames = make([]string, 0, len(testObjects))
+	err = store.GetByQueryFn(cachedStoreCtx, nil, walkFn)
+	assert.NoError(t, err)
+	assert.Subset(t, walkedNames, expectedNames)
+}
+
 func TestCachedWalkByQuery(t *testing.T) {
 	testDB := pgtest.ForT(t)
 	store := newCachedStore(testDB)
@@ -318,6 +352,11 @@ func TestCachedWalkByQueryContextCancelation(t *testing.T) {
 		return nil
 	}
 	err = store.WalkByQuery(ctx, nil, walkFn)
+
+	assert.ErrorIs(t, err, context.Canceled)
+
+	q := getCachedMatchFieldQuery("Test Name", "Test WalkByQuery 2")
+	err = store.WalkByQuery(ctx, q, walkFn)
 
 	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/search/postgres/store_test.go
+++ b/pkg/search/postgres/store_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -385,6 +386,13 @@ func TestGetByQueryFn(t *testing.T) {
 	}
 	protoassert.ElementsMatch(t, objects, expectedObjectsAfter)
 
+	count := 0
+	err := store.GetByQueryFn(ctx, query, func(*storage.TestSingleKeyStruct) error {
+		count++
+		return errors.New("some error")
+	})
+	assert.EqualError(t, err, "processing rows: some error")
+	assert.Equal(t, 1, count)
 }
 
 func TestDeleteByQuery(t *testing.T) {

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.TestStruct
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestStruct
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, key1 string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestStruct
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestStruct
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestStruct
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -49,7 +49,10 @@ var (
     {{- end }}
 )
 
-type storeType = {{ .Type }}
+type (
+    storeType = {{ .Type }}
+    callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for {{ .Type }}
 type Store interface {
@@ -68,13 +71,15 @@ type Store interface {
 
     Get(ctx context.Context, {{$primaryKeyName}} {{$primaryKeyType}}) (*storeType, bool, error)
 {{- if .SearchCategory }}
+    // Deprecated: use GetByQueryFn instead
     GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+    GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 {{- end }}
     GetMany(ctx context.Context, identifiers []{{$primaryKeyType}}) ([]*storeType, []int, error)
     GetIDs(ctx context.Context) ([]{{$primaryKeyType}}, error)
 
-    Walk(ctx context.Context, fn func(obj *storeType) error) error
-    WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+    Walk(ctx context.Context, fn callback) error
+    WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 {{ define "defineScopeChecker" }}scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_{{ . }}_ACCESS).Resource(targetResource){{ end }}

--- a/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store_test.go.tpl
@@ -323,6 +323,25 @@ func (s *{{$namePrefix}}StoreSuite) TestSACWalk() {
 	}
 }
 
+func (s *{{$namePrefix}}StoreSuite) TestSACGetByQueryFn() {
+	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))
+	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objB))
+
+	for name, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
+			identifiers := []string{}
+			getIDs := func(obj *{{.Type}}) error {
+				identifiers = append(identifiers, {{ (index .Schema.PrimaryKeys 0).Getter "obj" }} )
+				return nil
+			}
+			err := s.store.GetByQueryFn(testCase.context, nil, getIDs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedIdentifiers, identifiers)
+		})
+	}
+}
+
 func (s *{{$namePrefix}}StoreSuite) TestSACGetIDs() {
 	objA, objB, testCases := s.getTestData(storage.Access_READ_ACCESS)
 	s.Require().NoError(s.store.Upsert(withAllAccessCtx, objA))

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestSingleKeyStruct
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestSingleKeyStruct
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestSingleKeyStruct
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.TestSingleKeyStruct
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestSingleKeyStruct
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, key string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestChild1
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestChild1
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestChild1
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestChild1
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestChild1
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestChild1P4
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestChild1P4
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestChild1P4
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.TestChild1P4
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestChild1P4
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestChild2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestChild2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestChild2
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.TestChild2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestChild2
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestG2GrandChild1
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestG2GrandChild1
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestG2GrandChild1
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestG2GrandChild1
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestG2GrandChild1
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestG3GrandChild1
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestG3GrandChild1
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestG3GrandChild1
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestG3GrandChild1
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestG3GrandChild1
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestGGrandChild1
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestGGrandChild1
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestGGrandChild1
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestGGrandChild1
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestGGrandChild1
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestGrandChild1
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestGrandChild1
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestGrandChild1
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestGrandChild1
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestGrandChild1
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestGrandparent
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestGrandparent
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestGrandparent
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestGrandparent
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestGrandparent
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestParent1
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestParent1
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestParent1
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestParent1
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestParent1
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestParent2
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestParent2
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestParent2
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.TestParent2
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestParent2
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestParent3
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestParent3
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestParent3
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestParent3
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestParent3
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -33,6 +33,7 @@ var (
 )
 
 type storeType = storage.TestParent4
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestParent4
 type Store interface {
@@ -48,12 +49,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -32,8 +32,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestParent4
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestParent4
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestParent4
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -31,8 +31,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestShortCircuit
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestShortCircuit
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestShortCircuit
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -32,6 +32,7 @@ var (
 )
 
 type storeType = storage.TestShortCircuit
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestShortCircuit
 type Store interface {
@@ -47,12 +48,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -33,8 +33,10 @@ var (
 	targetResource = resources.Namespace
 )
 
-type storeType = storage.TestSingleUUIDKeyStruct
-type callback = func(obj *storeType) error
+type (
+	storeType = storage.TestSingleUUIDKeyStruct
+	callback  = func(obj *storeType) error
+)
 
 // Store is the interface to interact with the storage for storage.TestSingleUUIDKeyStruct
 type Store interface {

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -34,6 +34,7 @@ var (
 )
 
 type storeType = storage.TestSingleUUIDKeyStruct
+type callback = func(obj *storeType) error
 
 // Store is the interface to interact with the storage for storage.TestSingleUUIDKeyStruct
 type Store interface {
@@ -49,12 +50,14 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, key string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
-	Walk(ctx context.Context, fn func(obj *storeType) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storeType) error) error
+	Walk(ctx context.Context, fn callback) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn callback) error
 }
 
 // New returns a new Store instance using the provided sql instance.


### PR DESCRIPTION
### Description

The `GetByQuery` function retrieves a slice of objects from the database, which we often process item-by-item afterward. To improve performance, this update introduces support for a callback that is invoked during row iteration. This approach is similar to `WalkByQuery`, but it operates without using a database cursor.

Refs:
- #14758 
- https://github.com/stackrox/stackrox/pull/14636
- https://github.com/stackrox/stackrox/pull/14216

---

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
