### PR TITLE
chore: Add vulnerability version to scanner startup log

### DIFF
--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -87,11 +87,7 @@ func main() {
 	}
 
 	ctx = zlog.ContextWithValues(ctx, "component", "main")
-	zlog.Info(ctx).
-		Str("version", version.Version).
-		Str("vulnerability_version", version.VulnerabilityVersion).
-		Str("build_flavor", buildinfo.BuildFlavor).
-		Msg("starting scanner")
+	zlog.Info(ctx).Str("version", version.Version).Str("build_flavor", buildinfo.BuildFlavor).Msg("starting scanner")
 
 	// If certs was specified, configure the identity environment.
 	if p := cfg.MTLS.CertsDir; p != "" {

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -87,7 +87,11 @@ func main() {
 	}
 
 	ctx = zlog.ContextWithValues(ctx, "component", "main")
-	zlog.Info(ctx).Str("version", version.Version).Str("build_flavor", buildinfo.BuildFlavor).Msg("starting scanner")
+	zlog.Info(ctx).
+		Str("version", version.Version).
+		Str("vulnerability_version", version.VulnerabilityVersion).
+		Str("build_flavor", buildinfo.BuildFlavor).
+		Msg("starting scanner")
 
 	// If certs was specified, configure the identity environment.
 	if p := cfg.MTLS.CertsDir; p != "" {

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/mitchellh/mapstructure"
+	"github.com/quay/zlog"
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 	"github.com/stackrox/rox/pkg/buildinfo"
@@ -249,6 +251,14 @@ func (c *MatcherConfig) validate() error {
 	default:
 		return fmt.Errorf("readiness: invalid readiness type %q", c.Readiness)
 	}
+
+	zlog.Info(context.Background()).
+		Str("embedded_vulnerability_version", version.VulnerabilityVersion).
+		Str("config_vulnerability_version", c.VulnerabilityVersion).
+		Str("ROX_VERSION", roxVer).
+		Str("ROX_VULNERABILITY_VERSION", vulnVer).
+		Str("url", c.VulnerabilitiesURL).
+		Msg("Built vulnerability URL")
 
 	return nil
 }


### PR DESCRIPTION
### Description

To assist in future troubleshooting.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

No automated testing

#### How I validated my change

Deployed new image and verified log contains vulnerability version:

PR build (`quay.io/rhacs-eng/scanner-v4:4.8.x-505-g5e271796c8`):
```
{"level":"info","embedded_vulnerability_version":"v2","config_vulnerability_version":"","ROX_VERSION":"dev","ROX_VULNERABILITY_VERSION":"dev","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=dev","time":"2025-04-16T23:04:22Z","message":"Built vulnerability URL"}
```

Local build - forcing release flag:
```
{"level":"info","embedded_vulnerability_version":"v2","config_vulnerability_version":"","ROX_VERSION":"4.8.x-498-g1e8aeaea1b-dirty","ROX_VULNERABILITY_VERSION":"v2","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=v2","time":"2025-04-16T22:28:13Z","message":"Built vulnerability URL"}
```

After setting `vulnerability_version: V2` in matcher config map:
```
{"level":"info","embedded_vulnerability_version":"v2","config_vulnerability_version":"V2","ROX_VERSION":"V2","ROX_VULNERABILITY_VERSION":"V2","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=V2","time":"2025-04-16T22:26:05Z","message":"Built vulnerability URL"}
```