### PR TITLE
ROX-28878: Fix incorrect violations count in ConfigMgmt

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/deployments.test.js
@@ -21,6 +21,10 @@ describe('Configuration Management Deployments', () => {
 
     it('should render the deployments list and open the side panel when a row is clicked', () => {
         visitConfigurationManagementEntityInSidePanel(entitiesKey);
+        // Expect the list of failed policies to be displayed in the side panel
+        cy.get(
+            'header:contains("Deployment Findings") + div:contains("policies failed across this deployment")'
+        );
     });
 
     it('should go from table link to images table in side panel', () => {

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import FailedPoliciesAcrossDeployment from 'Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment';
 import ViolationsAcrossThisDeployment from 'Containers/Workflow/widgets/ViolationsAcrossThisDeployment';
 import entityTypes from 'constants/entityTypes';
@@ -9,7 +8,7 @@ export type DeploymentFindingsProps = {
     entityContext?: Record<string, any>;
 };
 
-const DeploymentFindings = ({ entityContext = {}, deploymentID }: DeploymentFindingsProps) => {
+function DeploymentFindings({ entityContext = {}, deploymentID }: DeploymentFindingsProps) {
     if (entityContext[entityTypes.POLICY]) {
         return (
             <ViolationsAcrossThisDeployment
@@ -24,12 +23,6 @@ const DeploymentFindings = ({ entityContext = {}, deploymentID }: DeploymentFind
             <FailedPoliciesAcrossDeployment deploymentID={deploymentID} />
         </div>
     );
-};
-
-DeploymentFindings.propTypes = {};
-
-DeploymentFindings.defaultProps = {
-    entityContext: {},
-};
+}
 
 export default DeploymentFindings;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
@@ -4,7 +4,12 @@ import FailedPoliciesAcrossDeployment from 'Containers/ConfigManagement/Entity/w
 import ViolationsAcrossThisDeployment from 'Containers/Workflow/widgets/ViolationsAcrossThisDeployment';
 import entityTypes from 'constants/entityTypes';
 
-const DeploymentFindings = ({ entityContext = {}, deploymentID }) => {
+export type DeploymentFindingsProps = {
+    deploymentID: string;
+    entityContext?: Record<string, any>;
+};
+
+const DeploymentFindings = ({ entityContext = {}, deploymentID }: DeploymentFindingsProps) => {
     if (entityContext[entityTypes.POLICY]) {
         return (
             <ViolationsAcrossThisDeployment
@@ -21,10 +26,7 @@ const DeploymentFindings = ({ entityContext = {}, deploymentID }) => {
     );
 };
 
-DeploymentFindings.propTypes = {
-    entityContext: PropTypes.shape({}),
-    deploymentID: PropTypes.string.isRequired,
-};
+DeploymentFindings.propTypes = {};
 
 DeploymentFindings.defaultProps = {
     entityContext: {},

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
@@ -5,7 +5,7 @@ import entityTypes from 'constants/entityTypes';
 
 export type DeploymentFindingsProps = {
     deploymentID: string;
-    entityContext?: Record<string, any>;
+    entityContext?: Partial<Record<string, string>>;
 };
 
 function DeploymentFindings({ entityContext = {}, deploymentID }: DeploymentFindingsProps) {

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import entityTypes from 'constants/entityTypes';
-import { useParams } from 'react-router-dom';
 import { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';
@@ -14,6 +13,7 @@ import Loader from 'Components/Loader';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
 import { formatLifecycleStages } from 'Containers/Policies/policies.utils';
 import TableWidget from './TableWidget';
+import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
 const QUERY = gql`
     query failedPolicies($query: String) {
@@ -43,8 +43,19 @@ const createTableRows = (data) => {
     return failedPolicies;
 };
 
-const FailedPoliciesAcrossDeployment = () => {
-    const { deploymentID } = useParams();
+export type FailedPoliciesAcrossDeploymentProps = {
+    deploymentID: string;
+};
+
+function FailedPoliciesAcrossDeployment({ deploymentID }: FailedPoliciesAcrossDeploymentProps) {
+    if (!deploymentID) {
+        return (
+            <TableErrorComponent
+                error={new Error('Unable to show failed policies for this deployment.')}
+                message="A required ID for this deployment was not provided!"
+            ></TableErrorComponent>
+        );
+    }
 
     return (
         <Query
@@ -150,6 +161,6 @@ const FailedPoliciesAcrossDeployment = () => {
             }}
         </Query>
     );
-};
+}
 
 export default FailedPoliciesAcrossDeployment;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
@@ -11,9 +11,9 @@ import NoResultsMessage from 'Components/NoResultsMessage';
 import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
+import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import { formatLifecycleStages } from 'Containers/Policies/policies.utils';
 import TableWidget from './TableWidget';
-import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
 const QUERY = gql`
     query failedPolicies($query: String) {

--- a/ui/apps/platform/src/Containers/Workflow/widgets/ViolationsAcrossThisDeployment.jsx
+++ b/ui/apps/platform/src/Containers/Workflow/widgets/ViolationsAcrossThisDeployment.jsx
@@ -48,7 +48,7 @@ const ViolationsAcrossThisDeployment = ({ deploymentID, policyID, message }) => 
 
 ViolationsAcrossThisDeployment.propTypes = {
     deploymentID: PropTypes.string.isRequired,
-    policyID: PropTypes.string.isRequired,
+    policyID: PropTypes.string,
     message: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
### Description

Fixes a missing `deploymentID` parameter in an API query, which was inadvertently dropped during a React Router refactor.

---

### Could this regression have been automatically prevented?

#### 1. **Prop-types?** — [**No**]  
The component was originally a JavaScript file using `prop-types`, which were removed during the refactor in favor of extracting `deploymentID` from the `useParams()` hook. Since the runtime prop validation was eliminated, and the change was consistent with the scope of the router refactor, it would not have been flagged automatically—only manual testing or data validation would have caught it.

#### 2. **Conversion to TypeScript?** — [**No** (mostly)]  
Although the component was later converted to TypeScript, this alone did not catch the issue. The function responsible for executing the query still accepted an untyped (`any`) argument, and the GraphQL query did not use generic types, so `deploymentID: undefined` was not flagged. Without strict typing throughout the call chain, the bug remained undetected.

#### 3. **Automated tests?** — [**No**]  
The issue would not be reliably detectable via automated tests without asserting internal implementation details (e.g., inspecting the actual network request payload). The data returned by the query could validly include zero, many, or all policies, so no clear assertion on the result set was possible. As such, this failure mode would pass through typical happy-path tests undetected.

---

### Suggested Improvements

The most reliable way to prevent regressions like this would be full TypeScript coverage across related code:

- **GraphQL queries** should use properly typed generics to enforce non-optional inputs like `deploymentID`.  
- **Typed utility functions** would fail to compile when passed an `undefined` ID, surfacing the issue early.  
- **Handling `string | undefined`** at runtime (e.g., rendering an error UI when `deploymentID` is missing) ensures graceful failure and testability.

In the updated implementation (as part of this PR), a fallback UI is shown when `deploymentID` is missing, and tests assert that the expected UI renders when valid input is provided. However, enforcing this proactively requires broader TypeScript adoption to make these guarantees statically.


### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit ConfigMgmt->Deployment and click a deployment. The list of failed policies in the sidebar should _not_ be a list of all policies in the system.
![image](https://github.com/user-attachments/assets/51c7d349-b050-4f85-992a-57ac479b17ca)

