### PR TITLE
ROX-29007: Add lint rule for version of PatternFly utility class

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -147,6 +147,61 @@ const rules = {
             };
         },
     },
+    'version-utility-class': {
+        // Require version of PatternFly utility class.
+        // PatternFly 4 did not have version number.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Require version of PatternFly utility class',
+            },
+            schema: [],
+        },
+        create(context) {
+            const findErrorMessage = (value) => {
+                const pfRegExpArray = [
+                    /^pf-u-/, // utility class (at beginning of string)
+                    / pf-u-/, // utility class (in middle of string)
+                ];
+                for (let i = 0; i !== pfRegExpArray.length; i += 1) {
+                    const pfRegExp = pfRegExpArray[i];
+                    if (pfRegExp.test(value)) {
+                        return `PatternFly utility class ${value} lacks version number`;
+                    }
+                }
+                return undefined;
+            };
+
+            return {
+                Literal(node) {
+                    if (typeof node.value === 'string') {
+                        const message = findErrorMessage(node.value);
+                        if (typeof message === 'string') {
+                            context.report({
+                                node,
+                                message,
+                            });
+                        }
+                    }
+                },
+                TemplateLiteral(node) {
+                    if (Array.isArray(node.quasis)) {
+                        node.quasis.forEach((quasi) => {
+                            if (typeof quasi.value?.cooked === 'string') {
+                                const message = findErrorMessage(quasi.value.cooked);
+                                if (typeof message === 'string') {
+                                    context.report({
+                                        node,
+                                        message,
+                                    });
+                                }
+                            }
+                        });
+                    }
+                },
+            };
+        },
+    },
     'version-variable-class': {
         // Require consistent version of PatternFly variable or class.
         meta: {
@@ -160,15 +215,15 @@ const rules = {
             const findErrorMessage = (value) => {
                 const versionExpected = '5';
                 // Include capturing group for digits in each regular expression.
-                const variableRegExpArray = [
+                const pfRegExpArray = [
                     /^var\(--pf-v(\d+)-/, // variable inside var (at beginning of string)
                     /^--pf-v(\d+)-/, // variable outside var (at beginning of string)
                     /^pf-v(\d+)-/, // class (at beginning of string)
                     / pf-v(\d+)-/, // class (in middle of string)
                 ];
-                for (let i = 0; i !== variableRegExpArray.length; i += 1) {
-                    const variableRegExp = variableRegExpArray[i];
-                    const result = variableRegExp.exec(value);
+                for (let i = 0; i !== pfRegExpArray.length; i += 1) {
+                    const pfRegExp = pfRegExpArray[i];
+                    const result = pfRegExp.exec(value);
                     if (Array.isArray(result)) {
                         const [, versionReceived] = result;
                         if (versionReceived !== versionExpected) {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsHeader.tsx
@@ -72,11 +72,7 @@ function CheckDetailsHeader({
     }
 
     return (
-        <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsSm' }}
-            className="pf-u-w-50"
-        >
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
                 <Title headingLevel="h1" className="pf-v5-u-w-100">
                     {checkName}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -44,9 +44,7 @@ function NodePageHeader({ data }: NodePageHeaderProps) {
 
     return (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
-            <Title headingLevel="h1" className="pf-u-mb-sm">
-                {data.name}
-            </Title>
+            <Title headingLevel="h1">{data.name}</Title>
             <LabelGroup numLabels={numLabels}>
                 <Label>OS: {data.osImage}</Label>
                 <Label>Kubelet: {data.kubeletVersion}</Label>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
@@ -49,7 +49,7 @@ function ClusterPageDetails({ clusterId }: ClusterPageDetailsProps) {
 
     return (
         <>
-            <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-u-px-xl">
+            <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-v5-u-px-xl">
                 <Text>View details about this cluster</Text>
             </PageSection>
             <PageSection isFilled className="pf-v5-u-display-flex pf-v5-u-flex-direction-column">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
@@ -11,11 +11,7 @@ function HeaderLoadingSkeleton({
     metadataScreenreaderText,
 }: HeaderLoadingSkeletonProps) {
     return (
-        <Flex
-            direction={{ default: 'column' }}
-            spaceItems={{ default: 'spaceItemsXs' }}
-            className="pf-u-w-50"
-        >
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
             <Skeleton screenreaderText={nameScreenreaderText} fontSize="2xl" />
             <Skeleton screenreaderText={metadataScreenreaderText} height="100px" />
         </Flex>


### PR DESCRIPTION
### Description

Reduce the risk to have inconsistent (absence of) version number when we adapt examples.

Follow up recommendation in https://github.com/stackrox/stackrox/pull/14964#pullrequestreview-2760897263

### Errors

src/Containers/ComplianceEnhanced/Coverage/CheckDetailsHeader.tsx
78:23  error  PatternFly utility class pf-u-w-50 lacks version number

src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
47:48  error  PatternFly utility class pf-u-mb-sm lacks version number

src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
52:68  error  PatternFly utility class pf-v5-u-py-md pf-u-px-xl lacks version number

src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
17:23  error  PatternFly utility class pf-u-w-50 lacks version number

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform folder

#### Manual testing

1. Visit /main/compliance/coverage/profiles and then click a check link.

    Before change with `className="pf-u-w-50"` prop, see full width.
    **Brad Rogers** and I agreed that full with header looks intuitive.
    ![CheckDetailsHeader_with_utility_class](https://github.com/user-attachments/assets/3fbb53af-a5d2-4605-b0e1-fa409830c77c)

    After change without `className="pf-u-w-50"` prop, see ditto.

2. Visit /main/vulnerabilities/node-cves?entityTab=Node and then click a node link.

    Before change with `className="pf-u-mb-sm"` prop, see 8px margin bottom.
    ![NodePageHeader_with_utility_class](https://github.com/user-attachments/assets/4c0dd64a-2587-4045-9eec-7dcdc0b871a8)

    After change without `className="pf-u-mb-sm"` prop, see 8px margin bottom.
    ![NodePageHeader_without_utility_class](https://github.com/user-attachments/assets/1b15c563-0e38-4779-bb38-28494d165f7a)

3. Visit /main/vulnerabilities/platform-cves?entityTab=Cluster click a cluster link, and then click **Details** tab.

    Before change with `className="pf-v5-u-py-md pf-u-px-xl"` prop, see absence of padding, therefore paragraph does not align with tab text.
    ![ClusterPageDetails_without_version](https://github.com/user-attachments/assets/16fc20ed-95d7-4aea-967e-4f506f05a592)

    After change with `className="pf-v5-u-py-md pf-v5-u-px-xl"` prop, see presence of padding, therefore paragraph does align with tab text.
    ![ClusterPageDetails_with_version](https://github.com/user-attachments/assets/460d7d94-d378-432b-8983-655cf286a402)

4. Visit /main/vulnerabilities/node-cves?entityTab=Node and then click a node link.

    Temporarily edit code to render `HeaderLoadingSkeleton` element.

    Before change with `className="pf-u-w-50"` prop, see full width.
    **David Vail** and I agreed that full with skeleton looks intuitive.
    ![HeaderLoadingSkeleton_NodePageHeader_without_version](https://github.com/user-attachments/assets/d56fff6e-0225-4d4d-aab3-0af4e6ec7251)

    After change without `className="pf-u-w-50"` prop, see ditto.
