### PR TITLE
ROX-28954: Increase gql client timeout from 60s -> 180s

### DIFF
--- a/ui/apps/platform/src/configureApolloClient.js
+++ b/ui/apps/platform/src/configureApolloClient.js
@@ -17,8 +17,8 @@ const httpLink = new HttpLink({
         //   - testability: easier to mock and wait for the request in e2e tests
         const { operationName } = JSON.parse(config.data);
 
-        // set a long timeout for GraphQL requests, as an escape hatch for slow queries
-        const modifiedConfig = { ...config, timeout: 60000 };
+        // set a loooong timeout for GraphQL requests, as an escape hatch for slow queries
+        const modifiedConfig = { ...config, timeout: 180000 };
 
         return {
             ...modifiedConfig,


### PR DESCRIPTION
### Description

As titled.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manual testing with a very small value to verify that this setting takes effect.
