### PR TITLE
chore: Delegated scanning remove duplicate log

### DIFF
--- a/sensor/common/scan/scan.go
+++ b/sensor/common/scan/scan.go
@@ -247,7 +247,6 @@ func (s *LocalScan) getImageWithMetadata(ctx context.Context, errorList *errorhe
 	for _, pullSource := range pullSources {
 		reg, pullSourceImage, err := s.enrichImageForPullSource(ctx, pullSource, req)
 		if err != nil {
-			log.Warnf("Error getting registries for pull source %q, skipping: %v", pullSource.GetName().GetFullName(), err)
 			allErrs.AddError(err)
 			continue
 		}


### PR DESCRIPTION
### Description

The duplicate log line was mistakenly kept after a refactor - the line removed was not accurate where it was positioned.

Good location:

https://github.com/stackrox/stackrox/blob/701c3c07a18df8d75aeef6edd8e04c389a26728f/sensor/common/scan/scan.go#L206-L211

Bad location

https://github.com/stackrox/stackrox/blob/701c3c07a18df8d75aeef6edd8e04c389a26728f/sensor/common/scan/scan.go#L248-L253


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

Existing tests are OK

#### How I validated my change

CI