### PR TITLE
ROX-29191: Include `Unknown` severity at highest level in VM pages

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVESummaryData.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVESummaryData.json
@@ -30,6 +30,10 @@
                     "total": 0,
                     "__typename": "ResourceCountByFixability"
                 },
+                "unknown": {
+                    "total": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
                 "__typename": "ResourceCountByCVESeverity"
             },
             "__typename": "NodeCVECore"

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVEs.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeCVEs.json
@@ -20,6 +20,10 @@
                         "total": 0,
                         "__typename": "ResourceCountByFixability"
                     },
+                    "unknown": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
                     "__typename": "ResourceCountByCVESeverity"
                 },
                 "topCVSS": 7.099999904632568,
@@ -55,6 +59,10 @@
                         "total": 0,
                         "__typename": "ResourceCountByFixability"
                     },
+                    "unknown": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
                     "__typename": "ResourceCountByCVESeverity"
                 },
                 "topCVSS": 8.600000381469727,
@@ -87,6 +95,10 @@
                         "__typename": "ResourceCountByFixability"
                     },
                     "low": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "unknown": {
                         "total": 0,
                         "__typename": "ResourceCountByFixability"
                     },

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeVulnSummary.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodeVulnSummary.json
@@ -3,6 +3,11 @@
         "node": {
             "id": "1",
             "nodeCVECountBySeverity": {
+                "unknown": {
+                    "total": 2,
+                    "fixable": 2,
+                    "__typename": "ResourceCountByFixability"
+                },
                 "low": {
                     "total": 15,
                     "fixable": 0,

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodes.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/nodeCves/getNodes.json
@@ -21,6 +21,10 @@
                         "total": 15,
                         "__typename": "ResourceCountByFixability"
                     },
+                    "unknown": {
+                        "total": 2,
+                        "__typename": "ResourceCountByFixability"
+                    },
                     "__typename": "ResourceCountByCVESeverity"
                 },
                 "cluster": {
@@ -49,6 +53,10 @@
                     },
                     "low": {
                         "total": 15,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "unknown": {
+                        "total": 2,
                         "__typename": "ResourceCountByFixability"
                     },
                     "__typename": "ResourceCountByCVESeverity"

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCVEList.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCVEList.json
@@ -20,6 +20,10 @@
                         "total": 0,
                         "__typename": "ResourceCountByFixability"
                     },
+                    "unknown": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
                     "__typename": "ResourceCountByCVESeverity"
                 },
                 "topCVSS": 9.800000190734863,
@@ -60,6 +64,10 @@
                         "__typename": "ResourceCountByFixability"
                     },
                     "low": {
+                        "total": 0,
+                        "__typename": "ResourceCountByFixability"
+                    },
+                    "unknown": {
                         "total": 0,
                         "__typename": "ResourceCountByFixability"
                     },

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/multipleCvesForImage.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/multipleCvesForImage.json
@@ -24,6 +24,11 @@
             "__typename": "Image",
             "imageVulnerabilityCount": 2,
             "imageCVECountBySeverity": {
+                "unknown": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
                 "low": {
                     "total": 0,
                     "fixable": 0,

--- a/ui/apps/platform/cypress/helpers/sort.js
+++ b/ui/apps/platform/cypress/helpers/sort.js
@@ -119,7 +119,7 @@ export const callbackForPairOfDescendingPolicySeverityValuesFromElements =
         isPairOfDescendingPolicySeverityValues
     );
 
-const vulnerabilitySeverityValues = ['Low', 'Moderate', 'Important', 'Critical'];
+const vulnerabilitySeverityValues = ['Unknown', 'Low', 'Moderate', 'Important', 'Critical'];
 
 export function isValidVulnerabilitySeverityValue(value) {
     return typeof value === 'string' && vulnerabilitySeverityValues.includes(value);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
@@ -95,7 +95,7 @@ describe('Workload CVE Image Single page', () => {
         // Check that no severities are hidden by default
         cy.get(vulnSelectors.summaryCard('CVEs by severity'))
             .find('p')
-            .contains(new RegExp('(Critical|Important|Moderate|Low) hidden'))
+            .contains(new RegExp('(Critical|Important|Moderate|Low|Unknown) hidden'))
             .should('not.exist');
 
         const severityFilter = 'Critical';
@@ -107,6 +107,7 @@ describe('Workload CVE Image Single page', () => {
         cy.get(`*:contains("Important hidden")`);
         cy.get(`*:contains("Moderate hidden")`);
         cy.get(`*:contains("Low hidden")`);
+        cy.get(`*:contains("Unknown hidden")`);
 
         // Check that table rows are filtered
         cy.get(selectors.filteredViewLabel);
@@ -177,6 +178,11 @@ describe('Workload CVE Image Single page', () => {
                     },
                     __typename: 'Image',
                     imageCVECountBySeverity: {
+                        unknown: {
+                            total: 0,
+                            fixable: 0,
+                            __typename: 'ResourceCountByFixability',
+                        },
                         low: {
                             total: 0,
                             fixable: 0,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -166,11 +166,13 @@ function RequestCVEsTable({
                                 const importantCount = affectedImageCountBySeverity.important.total;
                                 const moderateCount = affectedImageCountBySeverity.moderate.total;
                                 const lowCount = affectedImageCountBySeverity.low.total;
+                                const unknownCount = affectedImageCountBySeverity.unknown.total;
                                 const filteredSeverities: VulnerabilitySeverityLabel[] = [
                                     'Critical',
                                     'Important',
                                     'Moderate',
                                     'Low',
+                                    'Unknown',
                                 ];
                                 const prioritizedDistros = sortCveDistroList(distroTuples);
                                 const scoreVersions = getScoreVersionsForTopCVSS(
@@ -214,6 +216,7 @@ function RequestCVEsTable({
                                                     importantCount={importantCount}
                                                     moderateCount={moderateCount}
                                                     lowCount={lowCount}
+                                                    unknownCount={unknownCount}
                                                     filteredSeverities={filteredSeverities}
                                                 />
                                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesSummaryCard.tsx
@@ -13,7 +13,7 @@ function AffectedNodesSummaryCard({
     operatingSystemCount,
 }: AffectedNodesSummaryCardProps) {
     return (
-        <Card isCompact isFlat>
+        <Card isCompact isFlat isFullHeight>
             <CardTitle>Affected nodes</CardTitle>
             <CardBody>
                 <Grid>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -149,12 +149,16 @@ describe(Cypress.spec.relative, () => {
                     'IMPORTANT_VULNERABILITY_SEVERITY',
                 ],
             ]);
+            const unknownSeverityNode = createNodeWithComponentSeverities([
+                ['UNKNOWN_VULNERABILITY_SEVERITY'],
+            ]);
 
             const nodes = [
                 lowSeverityNode,
                 moderateSeverityNode,
                 importantSeverityNode,
                 criticalSeverityNode,
+                unknownSeverityNode,
             ];
 
             setup({ type: 'COMPLETE', data: nodes });
@@ -166,6 +170,7 @@ describe(Cypress.spec.relative, () => {
                 { rowIndex: 2, expectedSeverity: 'Moderate' },
                 { rowIndex: 3, expectedSeverity: 'Important' },
                 { rowIndex: 4, expectedSeverity: 'Critical' },
+                { rowIndex: 5, expectedSeverity: 'Unknown' },
             ].forEach(({ rowIndex, expectedSeverity }) => {
                 cy.findAllByRole('row')
                     .eq(rowIndex)

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -64,6 +64,7 @@ const defaultNodeCveSummary = {
         important: { total: 0 },
         moderate: { total: 0 },
         low: { total: 0 },
+        unknown: { total: 0 },
     },
     distroTuples: [],
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveSummaryData.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveSummaryData.ts
@@ -23,6 +23,9 @@ const summaryDataQuery = gql`
                 low {
                     total
                 }
+                unknown {
+                    total
+                }
             }
         }
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -158,7 +158,13 @@ function CVEsTable({
                     data.map((nodeCve, rowIndex) => {
                         const {
                             cve,
-                            affectedNodeCountBySeverity: { critical, important, moderate, low },
+                            affectedNodeCountBySeverity: {
+                                critical,
+                                important,
+                                moderate,
+                                low,
+                                unknown,
+                            },
                             distroTuples,
                             topCVSS,
                             affectedNodeCount,
@@ -197,6 +203,7 @@ function CVEsTable({
                                             importantCount={important.total}
                                             moderateCount={moderate.total}
                                             lowCount={low.total}
+                                            unknownCount={unknown.total}
                                             filteredSeverities={filteredSeverities}
                                             entity={'node'}
                                         />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -100,7 +100,8 @@ function NodesTable({
                         {data.map((node) => {
                             const { id, name, nodeCVECountBySeverity, cluster, osImage, scanTime } =
                                 node;
-                            const { critical, important, moderate, low } = nodeCVECountBySeverity;
+                            const { critical, important, moderate, low, unknown } =
+                                nodeCVECountBySeverity;
                             return (
                                 <Tr key={id}>
                                     <Td dataLabel="Node" modifier="nowrap">
@@ -114,6 +115,7 @@ function NodesTable({
                                             importantCount={important.total}
                                             moderateCount={moderate.total}
                                             lowCount={low.total}
+                                            unknownCount={unknown.total}
                                             filteredSeverities={filteredSeverities}
                                             entity={'node'}
                                         />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -21,6 +21,9 @@ const cvesListQuery = gql`
                 low {
                     total
                 }
+                unknown {
+                    total
+                }
             }
             topCVSS
             affectedNodeCount
@@ -42,6 +45,7 @@ export type NodeCVE = {
         important: { total: number };
         moderate: { total: number };
         low: { total: number };
+        unknown: { total: number };
     };
     topCVSS: number;
     affectedNodeCount: number;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -22,6 +22,9 @@ const nodeListQuery = gql`
                 low {
                     total
                 }
+                unknown {
+                    total
+                }
             }
             cluster {
                 name
@@ -46,6 +49,9 @@ type Node = {
             total: number;
         };
         low: {
+            total: number;
+        };
+        unknown: {
             total: number;
         };
     };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -139,6 +139,7 @@ export const imageCveAffectedDeploymentsQuery = gql`
     query getDeploymentsForCVE(
         $query: String
         $pagination: Pagination
+        $unknownImageCountQuery: String
         $lowImageCountQuery: String
         $moderateImageCountQuery: String
         $importantImageCountQuery: String
@@ -173,6 +174,7 @@ const defaultSeveritySummary = {
         important: { total: 0 },
         moderate: { total: 0 },
         low: { total: 0 },
+        unknown: { total: 0 },
     },
     affectedImageCount: 0,
     topCVSS: 0,
@@ -269,6 +271,7 @@ function ImageCvePage() {
         { deploymentCount: number; deployments: DeploymentForCve[] },
         {
             query: string;
+            unknownImageCountQuery: string;
             lowImageCountQuery: string;
             moderateImageCountQuery: string;
             importantImageCountQuery: string;
@@ -279,6 +282,7 @@ function ImageCvePage() {
     >(imageCveAffectedDeploymentsQuery, {
         variables: {
             query: getDeploymentSearchQuery(),
+            unknownImageCountQuery: getDeploymentSearchQuery('UNKNOWN_VULNERABILITY_SEVERITY'),
             lowImageCountQuery: getDeploymentSearchQuery('LOW_VULNERABILITY_SEVERITY'),
             moderateImageCountQuery: getDeploymentSearchQuery('MODERATE_VULNERABILITY_SEVERITY'),
             importantImageCountQuery: getDeploymentSearchQuery('IMPORTANT_VULNERABILITY_SEVERITY'),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -58,6 +58,7 @@ export type DeploymentForCve = {
     namespace: string;
     clusterName: string;
     created: string | null;
+    unknownImageCount: number;
     lowImageCount: number;
     moderateImageCount: number;
     importantImageCount: number;
@@ -74,6 +75,7 @@ export const deploymentsForCveFragment = gql`
         namespace
         clusterName
         created
+        unknownImageCount: imageCount(query: $unknownImageCountQuery)
         lowImageCount: imageCount(query: $lowImageCountQuery)
         moderateImageCount: imageCount(query: $moderateImageCountQuery)
         importantImageCount: imageCount(query: $importantImageCountQuery)
@@ -152,6 +154,7 @@ function AffectedDeploymentsTable({
                             name,
                             namespace,
                             clusterName,
+                            unknownImageCount,
                             lowImageCount,
                             moderateImageCount,
                             importantImageCount,
@@ -204,6 +207,7 @@ function AffectedDeploymentsTable({
                                             importantCount={importantImageCount}
                                             moderateCount={moderateImageCount}
                                             lowCount={lowImageCount}
+                                            unknownCount={unknownImageCount}
                                             filteredSeverities={filteredSeverities}
                                         />
                                     </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -65,6 +65,9 @@ export const deploymentListQuery = gql`
                 low {
                     total
                 }
+                unknown {
+                    total
+                }
             }
             clusterName
             namespace
@@ -82,6 +85,7 @@ export type Deployment = {
         important: { total: number };
         moderate: { total: number };
         low: { total: number };
+        unknown: { total: number };
     };
     clusterName: string;
     namespace: string;
@@ -169,6 +173,7 @@ function DeploymentOverviewTable({
                         const importantCount = imageCVECountBySeverity.important.total;
                         const moderateCount = imageCVECountBySeverity.moderate.total;
                         const lowCount = imageCVECountBySeverity.low.total;
+                        const unknownCount = imageCVECountBySeverity.unknown.total;
                         return (
                             <Tbody
                                 key={id}
@@ -200,6 +205,7 @@ function DeploymentOverviewTable({
                                                 importantCount={importantCount}
                                                 moderateCount={moderateCount}
                                                 lowCount={lowCount}
+                                                unknownCount={unknownCount}
                                                 entity="deployment"
                                                 filteredSeverities={filteredSeverities}
                                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -78,6 +78,9 @@ export const imageListQuery = gql`
                 low {
                     total
                 }
+                unknown {
+                    total
+                }
             }
             operatingSystem
             deploymentCount(query: $query)
@@ -107,6 +110,7 @@ export type Image = {
         important: { total: number };
         moderate: { total: number };
         low: { total: number };
+        unknown: { total: number };
     };
     operatingSystem: string;
     deploymentCount: number;
@@ -225,6 +229,7 @@ function ImageOverviewTable({
                         const importantCount = imageCVECountBySeverity.important.total;
                         const moderateCount = imageCVECountBySeverity.moderate.total;
                         const lowCount = imageCVECountBySeverity.low.total;
+                        const unknownCount = imageCVECountBySeverity.unknown.total;
 
                         const isWatchedImage = watchStatus === 'WATCHED';
                         const watchImageMenuText = isWatchedImage ? 'Unwatch image' : 'Watch image';
@@ -304,6 +309,7 @@ function ImageOverviewTable({
                                                 importantCount={importantCount}
                                                 moderateCount={moderateCount}
                                                 lowCount={lowCount}
+                                                unknownCount={unknownCount}
                                                 entity="image"
                                                 filteredSeverities={filteredSeverities}
                                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -109,6 +109,9 @@ export const cveListQuery = gql`
                 low {
                     total
                 }
+                unknown {
+                    total
+                }
             }
             topCVSS
             affectedImageCount
@@ -151,6 +154,7 @@ export type ImageCVE = {
         important: { total: number };
         moderate: { total: number };
         low: { total: number };
+        unknown: { total: number };
     };
     topCVSS: number;
     affectedImageCount: number;
@@ -321,6 +325,7 @@ function WorkloadCVEOverviewTable({
                             const importantCount = affectedImageCountBySeverity.important.total;
                             const moderateCount = affectedImageCountBySeverity.moderate.total;
                             const lowCount = affectedImageCountBySeverity.low.total;
+                            const unknownCount = affectedImageCountBySeverity.unknown.total;
 
                             const prioritizedDistros = sortCveDistroList(distroTuples);
                             const scoreVersions = getScoreVersionsForTopCVSS(topCVSS, distroTuples);
@@ -388,6 +393,7 @@ function WorkloadCVEOverviewTable({
                                                 importantCount={importantCount}
                                                 moderateCount={moderateCount}
                                                 lowCount={lowCount}
+                                                unknownCount={unknownCount}
                                                 filteredSeverities={filteredSeverities}
                                             />
                                         </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -18,6 +18,7 @@ function analyticsTrackDefaultFilters(
             SEVERITY_IMPORTANT: filters.SEVERITY.includes('Important') ? 1 : 0,
             SEVERITY_MODERATE: filters.SEVERITY.includes('Moderate') ? 1 : 0,
             SEVERITY_LOW: filters.SEVERITY.includes('Low') ? 1 : 0,
+            SEVERITY_UNKNOWN: filters.SEVERITY.includes('Unknown') ? 1 : 0,
             CVE_STATUS_FIXABLE: filters.FIXABLE.includes('Fixable') ? 1 : 0,
             CVE_STATUS_NOT_FIXABLE: filters.FIXABLE.includes('Not fixable') ? 1 : 0,
         },
@@ -137,6 +138,14 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
                                 isChecked={severityValues.includes('Low')}
                                 onChange={(_event, isChecked) => {
                                     handleSeverityChange('Low', isChecked);
+                                }}
+                            />
+                            <Checkbox
+                                label="Unknown"
+                                id="unknown-severity"
+                                isChecked={severityValues.includes('Unknown')}
+                                onChange={(_event, isChecked) => {
+                                    handleSeverityChange('Unknown', isChecked);
                                 }}
                             />
                         </FormGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
@@ -6,11 +6,12 @@ import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 
-const severitiesCriticalToLow = [
+const severitiesDescendingCriticality = [
     'CRITICAL_VULNERABILITY_SEVERITY',
     'IMPORTANT_VULNERABILITY_SEVERITY',
     'MODERATE_VULNERABILITY_SEVERITY',
     'LOW_VULNERABILITY_SEVERITY',
+    'UNKNOWN_VULNERABILITY_SEVERITY',
 ] as const;
 
 const severityToQuerySeverityKeys = {
@@ -18,6 +19,7 @@ const severityToQuerySeverityKeys = {
     IMPORTANT_VULNERABILITY_SEVERITY: 'important',
     MODERATE_VULNERABILITY_SEVERITY: 'moderate',
     LOW_VULNERABILITY_SEVERITY: 'low',
+    UNKNOWN_VULNERABILITY_SEVERITY: 'unknown',
 } as const;
 
 const severityToHiddenText = {
@@ -25,6 +27,7 @@ const severityToHiddenText = {
     IMPORTANT_VULNERABILITY_SEVERITY: 'Important hidden',
     MODERATE_VULNERABILITY_SEVERITY: 'Moderate hidden',
     LOW_VULNERABILITY_SEVERITY: 'Low hidden',
+    UNKNOWN_VULNERABILITY_SEVERITY: 'Unknown hidden',
 } as const;
 
 const fadedTextColor = 'var(--pf-v5-global--Color--200)';
@@ -34,6 +37,7 @@ export type ResourceCountsByCveSeverity = {
     important: { total: number };
     moderate: { total: number };
     low: { total: number };
+    unknown: { total: number };
 };
 
 export type BySeveritySummaryCardProps = {
@@ -50,11 +54,11 @@ function BySeveritySummaryCard({
     hiddenSeverities,
 }: BySeveritySummaryCardProps) {
     return (
-        <Card className={className} isCompact isFlat>
+        <Card className={className} isCompact isFlat isFullHeight>
             <CardTitle>{title}</CardTitle>
             <CardBody>
                 <Grid className="pf-v5-u-pl-sm">
-                    {severitiesCriticalToLow.map((severity) => {
+                    {severitiesDescendingCriticality.map((severity) => {
                         const querySeverityKey = severityToQuerySeverityKeys[severity];
                         const count = severityCounts[querySeverityKey];
                         const isHidden = hiddenSeverities.has(severity);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESeverityDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESeverityDropdown.tsx
@@ -35,6 +35,7 @@ function CVESeverityDropdown({ searchFilter, onSelect }: CVESeverityDropdownProp
             <SelectOption key="Important" value="Important" />
             <SelectOption key="Moderate" value="Moderate" />
             <SelectOption key="Low" value="Low" />
+            <SelectOption key="Unknown" value="Unknown" />
         </Select>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
@@ -14,6 +14,7 @@ type SeverityCountLabelsProps = {
     importantCount: number;
     moderateCount: number;
     lowCount: number;
+    unknownCount: number;
     entity?: string;
     filteredSeverities?: VulnerabilitySeverityLabel[];
 };
@@ -38,6 +39,7 @@ function SeverityCountLabels({
     importantCount,
     moderateCount,
     lowCount,
+    unknownCount,
     entity,
     filteredSeverities,
 }: SeverityCountLabelsProps) {
@@ -45,16 +47,19 @@ function SeverityCountLabels({
     const ImportantIcon = SeverityIcons.IMPORTANT_VULNERABILITY_SEVERITY;
     const ModerateIcon = SeverityIcons.MODERATE_VULNERABILITY_SEVERITY;
     const LowIcon = SeverityIcons.LOW_VULNERABILITY_SEVERITY;
+    const UnknownIcon = SeverityIcons.UNKNOWN_VULNERABILITY_SEVERITY;
 
     const isCriticalHidden = !!filteredSeverities && !filteredSeverities.includes('Critical');
     const isImportantHidden = !!filteredSeverities && !filteredSeverities.includes('Important');
     const isModerateHidden = !!filteredSeverities && !filteredSeverities.includes('Moderate');
     const isLowHidden = !!filteredSeverities && !filteredSeverities.includes('Low');
+    const isUnknownHidden = !!filteredSeverities && !filteredSeverities.includes('Unknown');
 
     const critical = isCriticalHidden ? undefined : criticalCount;
     const important = isImportantHidden ? undefined : importantCount;
     const moderate = isModerateHidden ? undefined : moderateCount;
     const low = isLowHidden ? undefined : lowCount;
+    const unknown = isUnknownHidden ? undefined : unknownCount;
 
     return (
         <Flex
@@ -103,6 +108,17 @@ function SeverityCountLabels({
                 >
                     <span className={getClassNameForCount(low)}>
                         {!low && low !== 0 ? <EllipsisHIcon /> : low}
+                    </span>
+                </Label>
+            </Tooltip>
+            <Tooltip content={getTooltipContent('unknown', unknown, entity)}>
+                <Label
+                    aria-label={getTooltipContent('unknown', unknown, entity)}
+                    variant="outline"
+                    icon={<UnknownIcon color={unknown ? undefined : noViolationsColor} />}
+                >
+                    <span className={getClassNameForCount(unknown)}>
+                        {!unknown && unknown !== 0 ? <EllipsisHIcon /> : unknown}
                     </span>
                 </Label>
             </Tooltip>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
@@ -2,7 +2,13 @@ import * as yup from 'yup';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
 
-export const vulnerabilitySeverityLabels = ['Critical', 'Important', 'Moderate', 'Low'] as const;
+export const vulnerabilitySeverityLabels = [
+    'Critical',
+    'Important',
+    'Moderate',
+    'Low',
+    'Unknown',
+] as const;
 export type VulnerabilitySeverityLabel = (typeof vulnerabilitySeverityLabels)[number];
 export function isVulnerabilitySeverityLabel(value: unknown): value is VulnerabilitySeverityLabel {
     return vulnerabilitySeverityLabels.some((severity) => severity === value);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -127,6 +127,8 @@ export function severityLabelToSeverity(label: VulnerabilitySeverityLabel): Vuln
             return 'MODERATE_VULNERABILITY_SEVERITY';
         case 'Low':
             return 'LOW_VULNERABILITY_SEVERITY';
+        case 'Unknown':
+            return 'UNKNOWN_VULNERABILITY_SEVERITY';
         default:
             return ensureExhaustive(label);
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.test.ts
@@ -141,11 +141,14 @@ describe('getSeveritySortOptions', () => {
     });
 
     it('should return all severity sort options when all severity filters are applied', () => {
-        expect(getSeveritySortOptions(['Critical', 'Important', 'Moderate', 'Low'])).toEqual([
+        expect(
+            getSeveritySortOptions(['Critical', 'Important', 'Moderate', 'Low', 'Unknown'])
+        ).toEqual([
             { field: 'Critical Severity Count' },
             { field: 'Important Severity Count' },
             { field: 'Moderate Severity Count' },
             { field: 'Low Severity Count' },
+            { field: 'Unknown Severity Count' },
         ]);
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.test.ts
@@ -126,6 +126,7 @@ describe('getSeveritySortOptions', () => {
             { field: 'Important Severity Count' },
             { field: 'Moderate Severity Count' },
             { field: 'Low Severity Count' },
+            { field: 'Unknown Severity Count' },
         ]);
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -48,6 +48,7 @@ export function getWorkloadCveOverviewSortFields(
                     'Important Severity Count',
                     'Moderate Severity Count',
                     'Low Severity Count',
+                    'Unknown Severity Count',
                 ],
                 'CVSS',
                 'Image Sha',
@@ -61,6 +62,7 @@ export function getWorkloadCveOverviewSortFields(
                     'Important Severity Count',
                     'Moderate Severity Count',
                     'Low Severity Count',
+                    'Unknown Severity Count',
                 ],
                 'Image OS',
                 'Image Created Time',
@@ -175,6 +177,7 @@ export const severitySortMap = {
     Important: 'Important Severity Count',
     Moderate: 'Moderate Severity Count',
     Low: 'Low Severity Count',
+    Unknown: 'Unknown Severity Count',
 } as const;
 
 /**
@@ -200,6 +203,7 @@ export function getSeveritySortOptions(
         { field: 'Important Severity Count' },
         { field: 'Moderate Severity Count' },
         { field: 'Low Severity Count' },
+        { field: 'Unknown Severity Count' },
     ];
 }
 

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -201,6 +201,7 @@ export type AnalyticsEvent =
               SEVERITY_IMPORTANT: AnalyticsBoolean;
               SEVERITY_MODERATE: AnalyticsBoolean;
               SEVERITY_LOW: AnalyticsBoolean;
+              SEVERITY_UNKNOWN: AnalyticsBoolean;
               CVE_STATUS_FIXABLE: AnalyticsBoolean;
               CVE_STATUS_NOT_FIXABLE: AnalyticsBoolean;
           };


### PR DESCRIPTION
### Description

Adds 'Unknown' severity as a UI item with equal weight to Critical, Important, Moderate, and Low severities.

Prior to this change, the number of unknown severity CVEs was omitted in several locations: cards, summary counts, filters. This caused inconsistent or missing information throughout the VM UI.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Images by severity counts:
![image](https://github.com/user-attachments/assets/d507da6e-894e-47d0-8be4-e38e656bc541)

Cves by severity counts:
![image](https://github.com/user-attachments/assets/c5c1d0f8-884f-467d-9aa5-083e58fc124f)

Filtering:
![image](https://github.com/user-attachments/assets/bfe71e51-d51b-4276-ab00-1e7af7b0fd88)

CVEs by severity on deployments:
![image](https://github.com/user-attachments/assets/689a745e-1862-4e6c-be3b-9806e514164b)

Application of default filters:
![image](https://github.com/user-attachments/assets/62fb7ab3-ba18-4730-bb15-ba2156aa19d5)
![image](https://github.com/user-attachments/assets/d511aa9c-d624-41a1-9084-c776b3b7d464)

Within Exception Management:
![image](https://github.com/user-attachments/assets/46e025b5-d0e9-4f38-984f-b2a09ce5d68a)

CVE single page + summary card:
![image](https://github.com/user-attachments/assets/38786179-9dca-4785-a571-89f471ae3d79)

Image single page + summary cards:
![image](https://github.com/user-attachments/assets/01966f69-63c0-4b76-9411-b6254c58aae8)

Deployment single page + summary cards:
![image](https://github.com/user-attachments/assets/e8ce79ca-69b3-4e7a-89dd-6576a7af5cea)

Nodes by severity:
![image](https://github.com/user-attachments/assets/3598ec25-4a30-485a-971b-08964c66da26)

Node CVEs by severity:
![image](https://github.com/user-attachments/assets/821ae184-7927-44bd-95df-860bb5a2b454)

Node filtering:
![image](https://github.com/user-attachments/assets/c75dedeb-1742-4da3-a4aa-38d37d706db6)

Node single page + summary cards:
![image](https://github.com/user-attachments/assets/d323942c-a427-4d97-b5dc-1ff39aa28d6a)

Node CVE single page + summary cards:
![image](https://github.com/user-attachments/assets/b19536b8-0e11-4445-ad0a-2a73adf5d71c)

