### PR TITLE
ROX-28690: stop hardcoding Central and Sensor endpoints

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         {{- if ._rox.env.centralServices }}
         - name: ROX_CENTRAL_ENDPOINT
-          value: {{ ._rox.centralEndpoint }}
+          value: central.{{ .Release.Namespace }}.svc
         {{- else }}
         - name: ROX_SENSOR_ENDPOINT
           value: {{ ._rox.sensor.endpoint }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -70,10 +70,10 @@ spec:
               fieldPath: metadata.namespace
         {{- if ._rox.env.centralServices }}
         - name: ROX_CENTRAL_ENDPOINT
-          value: central.{{ .Release.Namespace }}.svc
+          value: "{{ ._rox.central.endpoint }}"
         {{- else }}
         - name: ROX_SENSOR_ENDPOINT
-          value: {{ ._rox.sensor.endpoint }}
+          value: "{{ ._rox.sensor.endpoint }}"
         {{- end }}
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -68,6 +68,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if ._rox.env.centralServices }}
+        - name: ROX_CENTRAL_ENDPOINT
+          value: {{ ._rox.centralEndpoint }}
+        {{- else }}
+        - name: ROX_SENSOR_ENDPOINT
+          value: {{ ._rox.sensor.endpoint }}
+        {{- end }}
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -65,6 +65,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: ROX_CENTRAL_ENDPOINT
+          value: { { ._rox.centralEndpoint } }
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROX_CENTRAL_ENDPOINT
-          value: {{ ._rox.centralEndpoint }}
+          value: central.{{ .Release.Namespace }}.svc
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROX_CENTRAL_ENDPOINT
-          value: {{ ._rox.central.endpoint }}
+          value: central.{{ .Release.Namespace }}.svc
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROX_CENTRAL_ENDPOINT
-          value: { { ._rox.centralEndpoint } }
+          value: {{ ._rox.centralEndpoint }}
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROX_CENTRAL_ENDPOINT
-          value: central.{{ .Release.Namespace }}.svc
+          value: {{ ._rox.central.endpoint }}
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROX_CENTRAL_ENDPOINT
-          value: central.{{ .Release.Namespace }}.svc
+          value: "{{ ._rox.central.endpoint }}"
         {{- if ._rox.env.openshift }}
         - name: ROX_OPENSHIFT_API
           value: "true"

--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -33,7 +33,6 @@ central:
   config: null # string | dict
   dbConfig: null # string | dict
   endpointsConfig: null # string | dict
-  endpoint: null # string
   nodeSelector: null # string | dict
   tolerations: null # [dict]
   hostAliases: null # [dict]

--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -33,6 +33,7 @@ central:
   config: null # string | dict
   dbConfig: null # string | dict
   endpointsConfig: null # string | dict
+  endpoint: null # string
   nodeSelector: null # string | dict
   tolerations: null # [dict]
   hostAliases: null # [dict]

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -14,6 +14,7 @@ defaults:
   central:
     config: "@config/central/config.yaml|config/central/config.yaml.default"
     endpointsConfig: "@config/central/endpoints.yaml|config/central/endpoints.yaml.default"
+    endpoint: "central.{{ required "unknown namespace" .Release.Namespace }}.svc:443"
 
     exposeMonitoring: false
 

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -15,8 +15,6 @@ defaults:
     config: "@config/central/config.yaml|config/central/config.yaml.default"
     endpointsConfig: "@config/central/endpoints.yaml|config/central/endpoints.yaml.default"
 
-    endpoint: "central.{{ .Release.Namespace }}.svc:443"
-
     exposeMonitoring: false
 
     affinity:

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -15,6 +15,8 @@ defaults:
     config: "@config/central/config.yaml|config/central/config.yaml.default"
     endpointsConfig: "@config/central/endpoints.yaml|config/central/endpoints.yaml.default"
 
+    endpoint: "central.{{ .Release.Namespace }}.svc:443"
+
     exposeMonitoring: false
 
     affinity:

--- a/image/templates/helm/stackrox-central/internal/expandables.yaml
+++ b/image/templates/helm/stackrox-central/internal/expandables.yaml
@@ -10,7 +10,6 @@ ca:
 central:
   config: true
   endpointsConfig: true
-  endpoint: true
   nodeSelector: true
   jwtSigner:
     key: true

--- a/image/templates/helm/stackrox-central/internal/expandables.yaml
+++ b/image/templates/helm/stackrox-central/internal/expandables.yaml
@@ -10,6 +10,7 @@ ca:
 central:
   config: true
   endpointsConfig: true
+  endpoint: true
   nodeSelector: true
   jwtSigner:
     key: true

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -158,7 +158,7 @@
 {{ if not $platformCfgFile.found }}
   {{ include "srox.fail" (printf "Invalid platform %q. Please select a valid platform, or leave this field unset." $env.platform) }}
 {{ end }}
-{{ $_ = include "srox.mergeInto" (list $defaultsCfg (fromYaml $platformCfgFile.contents) ($.Files.Get "internal/defaults.yaml" | fromYaml)) }}
+{{ $_ = include "srox.mergeInto" (list $defaultsCfg (fromYaml $platformCfgFile.contents) (tpl ($.Files.Get "internal/defaults.yaml") . | fromYaml)) }}
 {{ $_ = set $rox "_defaults" $defaultsCfg }}
 {{ $_ = include "srox.mergeInto" (list $rox $defaultsCfg.defaults) }}
 

--- a/pkg/env/central_endpoint.go
+++ b/pkg/env/central_endpoint.go
@@ -1,5 +1,7 @@
 package env
 
+// These environment variables are used in deployment files.
+// Please check the files before deleting and check their usage in the code before editing.
 var (
 	// CentralEndpoint is used to provide Central's reachable endpoint to other StackRox services.
 	CentralEndpoint = RegisterSetting("ROX_CENTRAL_ENDPOINT", WithDefault("central.stackrox.svc:443"),

--- a/pkg/env/central_endpoint.go
+++ b/pkg/env/central_endpoint.go
@@ -1,0 +1,7 @@
+package env
+
+var (
+	// CentralEndpoint is used to provide Central's reachable endpoint to other StackRox services.
+	CentralEndpoint = RegisterSetting("ROX_CENTRAL_ENDPOINT", WithDefault("central.stackrox.svc:443"),
+		StripAnyPrefix("https://", "http://"))
+)

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -5,10 +5,6 @@ import "time"
 // These environment variables are used in the deployment file.
 // Please check the files before deleting.
 var (
-	// CentralEndpoint is used to provide Central's reachable endpoint to a sensor.
-	CentralEndpoint = RegisterSetting("ROX_CENTRAL_ENDPOINT", WithDefault("central.stackrox.svc:443"),
-		StripAnyPrefix("https://", "http://"))
-
 	// AdvertisedEndpoint is used to provide the Sensor with the endpoint it
 	// should advertise to services that need to contact it, within its own cluster.
 	AdvertisedEndpoint = RegisterSetting("ROX_ADVERTISED_ENDPOINT", WithDefault("sensor.stackrox.svc:443"),

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -63,13 +63,16 @@ tests:
     .objects | map(select(.kind == "StorageClass" and .metadata.name == "stackrox-gke-ssd")) | assertThat(length == 1)
 
 - name: "Scanner V4 Indexer and Matcher can find Central"
+  release:
+    namespace: "rhacs-test"
   set:
     scannerV4.disable: false
+    allowNonstandardNamespace: true
   expect: |
     .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
-          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc")
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.rhacs-test.svc")
     .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].env[] |
-          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc")
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.rhacs-test.svc")
 
 - name: "scanner V4 indexer and matcher skip gRPC health probes on Kubernetes < 1.24.0"
   set:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -67,9 +67,9 @@ tests:
     scannerV4.disable: false
   expect: |
     .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
-          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc:443")
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc")
     .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].env[] |
-          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc:443")
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc")
 
 - name: "scanner V4 indexer and matcher skip gRPC health probes on Kubernetes < 1.24.0"
   set:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -62,6 +62,15 @@ tests:
   expect: |
     .objects | map(select(.kind == "StorageClass" and .metadata.name == "stackrox-gke-ssd")) | assertThat(length == 1)
 
+- name: "Scanner V4 Indexer and Matcher can find Central"
+  set:
+    scannerV4.disable: false
+  expect: |
+    .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc:443")
+    .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.stackrox.svc:443")
+
 - name: "scanner V4 indexer and matcher skip gRPC health probes on Kubernetes < 1.24.0"
   set:
     scannerV4.disable: false

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -70,9 +70,9 @@ tests:
     allowNonstandardNamespace: true
   expect: |
     .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
-          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.rhacs-test.svc")
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.rhacs-test.svc:443")
     .deployments["scanner-v4-matcher"].spec.template.spec.containers[0].env[] |
-          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.rhacs-test.svc")
+          select(.name == "ROX_CENTRAL_ENDPOINT") | assertThat(.value == "central.rhacs-test.svc:443")
 
 - name: "scanner V4 indexer and matcher skip gRPC health probes on Kubernetes < 1.24.0"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -78,12 +78,15 @@ tests:
     .deployments["scanner-v4-db"] | assertThat(. != null)
 
 - name: "Scanner V4 Indexer can find Sensor"
+  release:
+    namespace: "other"
   set:
     scannerV4.disable: false
     imagePullSecrets.allowNone: true
+    allowNonstandardNamespace: true
   expect: |
     .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
-          select(.name == "ROX_SENSOR_ENDPOINT") | assertThat(.value == "sensor.stackrox.svc:443")
+          select(.name == "ROX_SENSOR_ENDPOINT") | assertThat(.value == "sensor.other.svc:443")
 
 - name: "no matcher resources should exist"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -77,6 +77,14 @@ tests:
     .deployments["scanner-v4-matcher"] | assertThat(. == null)
     .deployments["scanner-v4-db"] | assertThat(. != null)
 
+- name: "Scanner V4 Indexer can find Sensor"
+  set:
+    scannerV4.disable: false
+    imagePullSecrets.allowNone: true
+  expect: |
+    .deployments["scanner-v4-indexer"].spec.template.spec.containers[0].env[] |
+          select(.name == "ROX_SENSOR_ENDPOINT") | assertThat(.value == "sensor.stackrox.svc:443")
+
 - name: "no matcher resources should exist"
   set:
     scannerV4.disable: false

--- a/scanner/internal/httputil/transport_mux_test.go
+++ b/scanner/internal/httputil/transport_mux_test.go
@@ -13,21 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testTransports(t *testing.T) (http.RoundTripper, http.RoundTripper, http.RoundTripper) {
+func testTransports() (http.RoundTripper, http.RoundTripper, http.RoundTripper) {
 	defaultTransport := httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		assert.Equal(t, "quay.io", req.URL.Host)
 		return &http.Response{
 			Body: io.NopCloser(strings.NewReader("Default")),
 		}, nil
 	})
 	centralTransport := httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		assert.Equal(t, "central.rhacs.svc", req.URL.Host)
 		return &http.Response{
 			Body: io.NopCloser(strings.NewReader("Central")),
 		}, nil
 	})
 	sensorTransport := httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		assert.Equal(t, "sensor.rhacs.svc", req.URL.Host)
 		return &http.Response{
 			Body: io.NopCloser(strings.NewReader("Sensor")),
 		}, nil
@@ -36,38 +33,79 @@ func testTransports(t *testing.T) (http.RoundTripper, http.RoundTripper, http.Ro
 }
 
 func TestTransportMux(t *testing.T) {
-	t.Setenv(env.Namespace.EnvVar(), "rhacs")
+	// This is currently not utilized in tests, but it will help us catch any changes to
+	// both ROX_CENTRAL_ENDPOINT and ROX_SENSOR_ENDPOINT, as it'll change the default endpoints.
+	t.Setenv(env.Namespace.EnvVar(), "something-else")
 
-	defaultTransport, centralTransport, sensorTransport := testTransports(t)
-
-	tr, err := transportMux(defaultTransport, options{
-		centralTransport: centralTransport,
-		sensorTransport:  sensorTransport,
-	})
-	require.NoError(t, err)
-
-	c := &http.Client{
-		Transport: tr,
-	}
+	defaultTransport, centralTransport, sensorTransport := testTransports()
 
 	for _, testcase := range []struct {
 		name string
+		msg  string
 		url  string
+		envs map[string]string
 	}{
 		{
-			name: "Central",
-			url:  "https://central.rhacs.svc/api/extensions/scannerdefinitions?file=repo2cpe",
+			// ROX_CENTRAL_ENDPOINT is not allowed to be empty, so we'll use the default value of
+			// central.stackrox.svc:443 for this test.
+			// This test will hopefully catch any changes and trigger the author of the change
+			// to notify us to ensure we are all on the same page.
+			name: "Central (default)",
+			msg:  "Central",
+			url:  "https://central.stackrox.svc/api/extensions/scannerdefinitions?file=repo2cpe",
+			envs: map[string]string{
+				env.CentralEndpoint.EnvVar(): "",
+			},
 		},
 		{
-			name: "Sensor",
-			url:  "https://sensor.rhacs.svc/api/extensions/scannerdefinitions?file=repo2cpe",
+			name: "Central (configured)",
+			msg:  "Central",
+			url:  "https://central.stackrox/api/extensions/scannerdefinitions?file=repo2cpe",
+			envs: map[string]string{
+				env.CentralEndpoint.EnvVar(): "central.stackrox",
+			},
+		},
+		{
+			// ROX_SENSOR_ENDPOINT is not allowed to be empty, so we'll use the default value of
+			// sensor.stackrox.svc:443 for this test.
+			// This test will hopefully catch any changes and trigger the author of the change
+			// to notify us to ensure we are all on the same page.
+			name: "Sensor (default)",
+			msg:  "Sensor",
+			url:  "https://sensor.stackrox.svc/api/extensions/scannerdefinitions?file=repo2cpe",
+			envs: map[string]string{
+				env.SensorEndpoint.EnvVar(): "",
+			},
+		},
+		{
+			name: "Sensor (configured)",
+			msg:  "Sensor",
+			url:  "https://sensor.rhacs/api/extensions/scannerdefinitions?file=repo2cpe",
+			envs: map[string]string{
+				env.SensorEndpoint.EnvVar(): "sensor.rhacs",
+			},
 		},
 		{
 			name: "Default",
+			msg:  "Default",
 			url:  "https://quay.io/image_layer_query_here",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
+			for k, v := range testcase.envs {
+				t.Setenv(k, v)
+			}
+
+			tr, err := transportMux(defaultTransport, options{
+				centralTransport: centralTransport,
+				sensorTransport:  sensorTransport,
+			})
+			require.NoError(t, err)
+
+			c := &http.Client{
+				Transport: tr,
+			}
+
 			resp, err := c.Get(testcase.url)
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -75,15 +113,19 @@ func TestTransportMux(t *testing.T) {
 			})
 			msg, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			assert.Equal(t, testcase.name, string(msg))
+			assert.Equal(t, testcase.msg, string(msg))
 		})
 	}
 }
 
 func TestTransportMux_deny(t *testing.T) {
-	t.Setenv(env.Namespace.EnvVar(), "rhacs")
+	// These are currently not utilized in tests, but it will help us catch any changes to
+	// both ROX_CENTRAL_ENDPOINT and ROX_SENSOR_ENDPOINT, as it'll change the default endpoints.
+	t.Setenv(env.Namespace.EnvVar(), "something-else")
+	t.Setenv(env.CentralEndpoint.EnvVar(), "")
+	t.Setenv(env.SensorEndpoint.EnvVar(), "")
 
-	defaultTransport, _, _ := testTransports(t)
+	defaultTransport, _, _ := testTransports()
 
 	tr, err := TransportMux(defaultTransport, WithDenyStackRoxServices(true))
 	require.NoError(t, err)
@@ -99,12 +141,12 @@ func TestTransportMux_deny(t *testing.T) {
 	}{
 		{
 			name:      "Central",
-			url:       "https://central.rhacs.svc/api/extensions/scannerdefinitions?file=repo2cpe",
+			url:       "https://central.stackrox.svc/api/extensions/scannerdefinitions?file=repo2cpe",
 			wantPanic: true,
 		},
 		{
 			name:      "Sensor",
-			url:       "https://sensor.rhacs.svc/api/extensions/scannerdefinitions?file=repo2cpe",
+			url:       "https://sensor.stackrox.svc/api/extensions/scannerdefinitions?file=repo2cpe",
 			wantPanic: true,
 		},
 		{


### PR DESCRIPTION
### Description

Not everyone uses `central.<namespace>.svc` nor `sensor.<namespace>.svc` as the Central and Sensor endpoints. Scanner V4 did not consider other possibilities, so it did not properly use mTLS between itself and Central (and Sensor) in these situations.

This PR allows users to customize the Central and Sensor endpoints via `ROX_CENTRAL_ENDPOINT` and `ROX_SENSOR_ENDPOINT` in Scanner V4 Indexer and Scanner V4 Matcher. These environment variables already exist and have been in-use elsewhere, but now Scanner V4 is adopting them.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI
