### PR TITLE
ROX-28934: Avoid sensor restarts on central upgrade

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -167,6 +167,10 @@ test_upgrade_paths() {
 
     touch "${UPGRADE_PROGRESS_POSTGRES_CENTRAL_DB_BOUNCE}"
 
+    # Since central gets upgraded, connection with sensor will be terminated several times.
+    # To avoid sensor restarts we will scale it down.
+    kubectl -n stackrox patch deploy/sensor -p '{ "spec": { "replicas": 0 } }';
+
     ########################################################################################
     # Upgrade back to latest to run the smoke tests by first walking previous releases     #
     ########################################################################################


### PR DESCRIPTION
### Description

In upgrade tests, we are bumping central versions, but sensor keeps running on the oldest version. The problem is that sensor 4.1 still restarts if a connection is broken.

This change enables sensor flag that stops sensor from restarting, and it should fix the problem encountered in the test failure.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] let CI run. Upgrade tests should be enabled by default.
- [x] check that workload is properly created by sensor

**UPDATE**
I didn't find a good way to identify if workload is properly created. There are a few indicators that we can use as confirmation, but still not 100% sure.
- Logs in GKE are showing that sensor is connected and not restarting for 13-14 mins. After that, we start bouncing central bouncing, and we can see sensor restarts.
- Log in central in "final" step:
```
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:43.957927 perform.go:24: Info: Deleting 284 deployments as a part of reconciliation
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:49.388124 perform.go:24: Info: Deleting 378 pods as a part of reconciliation
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:51.326984 perform.go:24: Info: Deleting 7 network policies as a part of reconciliation
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:51.343704 perform.go:24: Info: Deleting 27 namespaces as a part of reconciliation
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:51.390023 perform.go:24: Info: Deleting 14 secrets as a part of reconciliation
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:51.414568 perform.go:24: Info: Deleting 10 nodes as a part of reconciliation
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:51.499665 perform.go:24: Info: Deleting 75 service accounts as a part of reconciliation
sensor/service/pipeline/reconciliation: 2025/04/24 19:14:51.638051 perform.go:24: Info: Deleting 123 k8sroles as a part of reconciliation
```
After testing we are removing cluster with roxctl -> that will also remove data from DB. Because of that, we can see only ~80 deployments in DB (based on metrics dumps done at the end of the test). But here we can see that it was a bigger number at some point. 🤷 