### PR TITLE
chore(scanner): more Scanner V4 DB logging

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4-db/postgresql.conf.default
+++ b/image/templates/helm/shared/config-templates/scanner-v4-db/postgresql.conf.default
@@ -50,8 +50,19 @@ min_wal_size = 80MB
 # REPORTING AND LOGGING
 #------------------------------------------------------------------------------
 
+# - When to Log -
+
+log_min_duration_statement = 500
+
 # - What to Log -
 
+log_autovacuum_min_duration = 500
+log_checkpoints = 'on'
+log_connections = 'on'
+log_disconnections = 'on'
+log_lock_waits = 'on'
+log_parameter_max_length = 0
+log_temp_files = 1024
 log_timezone = 'Etc/UTC'
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

This updates the postgresql.conf to add more logs to Scanner V4 DB. These values are based on Central DB's.

### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

no

#### How I validated my change

Installed this version of StackRox onto a cluster and found more DB logs were present:

```
PostgreSQL Database directory appears to contain a database; Skipping initialization

Waiting for child process 9 to exit
2025-04-24 16:35:30.097 UTC [10] LOG:  starting PostgreSQL 15.12 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-23), 64-bit
2025-04-24 16:35:30.097 UTC [10] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2025-04-24 16:35:30.097 UTC [10] LOG:  listening on IPv6 address "::", port 5432
2025-04-24 16:35:30.134 UTC [10] LOG:  listening on Unix socket "/run/postgresql/.s.PGSQL.5432"
2025-04-24 16:35:30.219 UTC [10] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2025-04-24 16:35:30.258 UTC [13] LOG:  database system was shut down at 2025-04-24 16:35:27 UTC
2025-04-24 16:35:30.371 UTC [10] LOG:  database system is ready to accept connections
2025-04-24 16:37:35.499 UTC [11] LOG:  checkpoint starting: wal
2025-04-24 16:38:51.195 UTC [11] LOG:  checkpoint complete: wrote 55625 buffers (57.9%); 0 WAL file(s) added, 1 removed, 100 recycled; write=75.190 s, sync=0.131 s, total=75.696 s; sync files=291, longest=0.033 s, average=0.001 s; distance=1647544 kB, estimate=1647544 kB
2025-04-24 16:39:01.201 UTC [11] LOG:  checkpoint starting: wal
2025-04-24 16:40:32.932 UTC [11] LOG:  checkpoint complete: wrote 72280 buffers (75.3%); 0 WAL file(s) added, 1 removed, 100 recycled; write=90.383 s, sync=0.970 s, total=91.731 s; sync files=67, longest=0.760 s, average=0.015 s; distance=1654823 kB, estimate=1654823 kB
2025-04-24 16:40:37.107 UTC [11] LOG:  checkpoint starting: wal
2025-04-24 16:41:20.304 UTC [11] LOG:  checkpoint complete: wrote 87737 buffers (91.4%); 0 WAL file(s) added, 2 removed, 99 recycled; write=42.093 s, sync=0.735 s, total=43.197 s; sync files=42, longest=0.419 s, average=0.018 s; distance=1654611 kB, estimate=1654802 kB
2025-04-24 16:41:26.985 UTC [11] LOG:  checkpoint starting: wal
2025-04-24 16:42:58.239 UTC [11] LOG:  checkpoint complete: wrote 64148 buffers (66.8%); 0 WAL file(s) added, 1 removed, 100 recycled; write=89.903 s, sync=1.008 s, total=91.255 s; sync files=29, longest=0.720 s, average=0.035 s; distance=1656336 kB, estimate=1656336 kB
2025-04-24 16:43:07.399 UTC [11] LOG:  checkpoint starting: wal
2025-04-24 16:43:59.458 UTC [11] LOG:  checkpoint complete: wrote 84512 buffers (88.0%); 0 WAL file(s) added, 1 removed, 100 recycled; write=51.030 s, sync=0.682 s, total=52.059 s; sync files=38, longest=0.347 s, average=0.018 s; distance=1655350 kB, estimate=1656238 kB
2025-04-24 16:44:03.167 UTC [11] LOG:  checkpoint starting: wal
2025-04-24 16:44:42.554 UTC [11] LOG:  checkpoint complete: wrote 73369 buffers (76.4%); 0 WAL file(s) added, 3 removed, 98 recycled; write=37.426 s, sync=1.461 s, total=39.388 s; sync files=50, longest=0.719 s, average=0.030 s; distance=1652796 kB, estimate=1655893 kB
2025-04-24 16:44:45.880 UTC [11] LOG:  checkpoint starting: wal
```
