### PR TITLE
ci: post test log collection curl retry

### DIFF
--- a/scripts/ci/collect-infrastructure-logs.sh
+++ b/scripts/ci/collect-infrastructure-logs.sh
@@ -17,6 +17,10 @@ set -eu
 # - Logs are saved under /tmp/k8s-service-logs/ by default
 
 
+SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/lib.sh
+source "$SCRIPTS_ROOT/scripts/lib.sh"
+
 if [ $# -gt 0 ]; then
     log_dir="$1"
 else
@@ -34,10 +38,9 @@ proxy_pid=$!
 
 sleep 5 # Let kubectl proxy stabilize
 mkdir -p "${log_dir}"/infrastructure
-curl -v --retry 8 --retry-connrefused --retry-max-time 120 --continue-at - \
-  -s http://localhost:8001/logs/kube-apiserver.log \
-  -o "${log_dir}"/infrastructure/kube-apiserver.log \
-  || true
+retry 5 true curl -v --retry 2 --retry-all-errors --continue-at - \
+    -s http://localhost:8001/logs/kube-apiserver.log \
+    -o "${log_dir}"/infrastructure/kube-apiserver.log
 
 kill $proxy_pid
 


### PR DESCRIPTION
There have been many recent failures on the scripts/ci/collect-infrastructure-logs.sh failing to download the kubeserver api log.

Log:
```
2025/04/24 01:59:35 httputil: ReverseProxy read error during body copy: stream error: stream ID 3; INTERNAL_ERROR; received from peer
01:59:35: Exception raised in ['scripts/ci/collect-infrastructure-logs.sh', '/tmp/k8s-service-logs'], Command '['scripts/ci/collect-infrastructure-logs.sh', '/tmp/k8s-service-logs']' returned non-zero exit status 18.
```

In one failure, it looks like the download was cut-off and a retry was able to resume it (https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/stackrox_stackrox/15062/pull-ci-stackrox-stackrox-master-gke-upgrade-tests/1915200956656521216/artifacts/gke-upgrade-tests/stackrox-stackrox-e2e-test/build-log.txt).
