### PR TITLE
Add scraped field to NetworkConnection

### DIFF
--- a/generated/internalapi/sensor/network_connection_info.pb.go
+++ b/generated/internalapi/sensor/network_connection_info.pb.go
@@ -99,8 +99,10 @@ type NetworkConnection struct {
 	// If this connection was closed, this gives the timestamp when it was closed. If this is unset, we treat it as an
 	// open connection.
 	CloseTimestamp *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=close_timestamp,json=closeTimestamp,proto3" json:"close_timestamp,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// NetworkConnection origin, either an inspector event or scraper
+	Scraped       bool `protobuf:"varint,12,opt,name=scraped,proto3" json:"scraped,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *NetworkConnection) Reset() {
@@ -180,6 +182,13 @@ func (x *NetworkConnection) GetCloseTimestamp() *timestamppb.Timestamp {
 		return x.CloseTimestamp
 	}
 	return nil
+}
+
+func (x *NetworkConnection) GetScraped() bool {
+	if x != nil {
+		return x.Scraped
+	}
+	return false
 }
 
 type NetworkEndpoint struct {
@@ -340,7 +349,7 @@ const file_internalapi_sensor_network_connection_info_proto_rawDesc = "" +
 	"\x15NetworkConnectionInfo\x12J\n" +
 	"\x13updated_connections\x18\x01 \x03(\v2\x19.sensor.NetworkConnectionR\x12updatedConnections\x12D\n" +
 	"\x11updated_endpoints\x18\x03 \x03(\v2\x17.sensor.NetworkEndpointR\x10updatedEndpoints\x12.\n" +
-	"\x04time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\"\x91\x03\n" +
+	"\x04time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\"\xab\x03\n" +
 	"\x11NetworkConnection\x129\n" +
 	"\rsocket_family\x18\x01 \x01(\x0e2\x14.sensor.SocketFamilyR\fsocketFamily\x12;\n" +
 	"\rlocal_address\x18\x02 \x01(\v2\x16.sensor.NetworkAddressR\flocalAddress\x12=\n" +
@@ -348,7 +357,8 @@ const file_internalapi_sensor_network_connection_info_proto_rawDesc = "" +
 	"\bprotocol\x18\x04 \x01(\x0e2\x13.storage.L4ProtocolR\bprotocol\x12,\n" +
 	"\x04role\x18\x05 \x01(\x0e2\x18.sensor.ClientServerRoleR\x04role\x12!\n" +
 	"\fcontainer_id\x18\x06 \x01(\tR\vcontainerId\x12C\n" +
-	"\x0fclose_timestamp\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\x0ecloseTimestamp\"\xe6\x02\n" +
+	"\x0fclose_timestamp\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\x0ecloseTimestamp\x12\x18\n" +
+	"\ascraped\x18\f \x01(\bR\ascraped\"\xe6\x02\n" +
 	"\x0fNetworkEndpoint\x129\n" +
 	"\rsocket_family\x18\x01 \x01(\x0e2\x14.sensor.SocketFamilyR\fsocketFamily\x12/\n" +
 	"\bprotocol\x18\x02 \x01(\x0e2\x13.storage.L4ProtocolR\bprotocol\x12=\n" +

--- a/generated/internalapi/sensor/network_connection_info_vtproto.pb.go
+++ b/generated/internalapi/sensor/network_connection_info_vtproto.pb.go
@@ -66,6 +66,7 @@ func (m *NetworkConnection) CloneVT() *NetworkConnection {
 	r.Role = m.Role
 	r.ContainerId = m.ContainerId
 	r.CloseTimestamp = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.CloseTimestamp).CloneVT())
+	r.Scraped = m.Scraped
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -212,6 +213,9 @@ func (this *NetworkConnection) EqualVT(that *NetworkConnection) bool {
 		return false
 	}
 	if !(*timestamppb1.Timestamp)(this.CloseTimestamp).EqualVT((*timestamppb1.Timestamp)(that.CloseTimestamp)) {
+		return false
+	}
+	if this.Scraped != that.Scraped {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -385,6 +389,16 @@ func (m *NetworkConnection) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Scraped {
+		i--
+		if m.Scraped {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x60
 	}
 	if m.CloseTimestamp != nil {
 		size, err := (*timestamppb1.Timestamp)(m.CloseTimestamp).MarshalToSizedBufferVT(dAtA[:i])
@@ -641,6 +655,9 @@ func (m *NetworkConnection) SizeVT() (n int) {
 	if m.CloseTimestamp != nil {
 		l = (*timestamppb1.Timestamp)(m.CloseTimestamp).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Scraped {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1086,6 +1103,26 @@ func (m *NetworkConnection) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Scraped", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Scraped = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -1868,6 +1905,26 @@ func (m *NetworkConnection) UnmarshalVTUnsafe(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Scraped", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Scraped = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/internalapi/sensor/network_connection_info.proto
+++ b/proto/internalapi/sensor/network_connection_info.proto
@@ -34,6 +34,9 @@ message NetworkConnection {
   // If this connection was closed, this gives the timestamp when it was closed. If this is unset, we treat it as an
   // open connection.
   google.protobuf.Timestamp close_timestamp = 11;
+
+  // NetworkConnection origin, either an inspector event or scraper
+  bool scraped = 12;
 }
 
 message NetworkEndpoint {


### PR DESCRIPTION
### Description

ProcessSignal contains an internal field "scraped" to indicate that this
information was acquired by the procfs scraper instead of an inspector event.
This field is intended for troubleshooting purposes and can be quite useful for
that. The NetworkConnection proto is missing this type of information for some
reason. Now that we have a need to get this for improving network tests, add
"scraped" to the networking information as well.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Not validated yet.