### PR TITLE
fix(violations): network baseline violations with ext IPs

### DIFF
--- a/pkg/networkgraph/networkbaseline/peer.go
+++ b/pkg/networkgraph/networkbaseline/peer.go
@@ -201,15 +201,27 @@ func PeerFromNetworkEntityInfo(
 	protocol storage.L4Protocol,
 	isIngressToBaselineEntity bool,
 ) Peer {
+	entity := networkgraph.Entity{
+		Type: info.GetType(),
+		ID:   info.GetId(),
+	}
+	return PeerFromNetworkEntity(entity, peerName, dstPort, protocol, isIngressToBaselineEntity)
+}
+
+// PeerFromNetworkEntity converts peer from networkgraph.Entity
+func PeerFromNetworkEntity(
+	entity networkgraph.Entity,
+	peerName string,
+	dstPort uint32,
+	protocol storage.L4Protocol,
+	isIngressToBaselineEntity bool,
+) Peer {
 	return Peer{
 		IsIngress: isIngressToBaselineEntity,
-		Entity: networkgraph.Entity{
-			Type: info.GetType(),
-			ID:   info.GetId(),
-		},
-		Name:     peerName,
-		DstPort:  dstPort,
-		Protocol: protocol,
+		Entity:    entity,
+		Name:      peerName,
+		DstPort:   dstPort,
+		Protocol:  protocol,
 	}
 }
 

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -665,6 +665,15 @@ func (d *detectorImpl) getNetworkFlowEntityDetails(info *storage.NetworkEntityIn
 	case storage.NetworkEntityInfo_EXTERNAL_SOURCE:
 		extsrc := d.extSrcsStore.LookupByID(info.GetId())
 		if extsrc == nil {
+			if info.GetExternalSource().GetDiscovered() {
+				// extSrcStore will contain entities provided by Central
+				// but for discovered entities, they may not exist in this store
+				// yet. In this case, we can still perform detection, but using
+				// the live data from the flow
+				return networkEntityDetails{
+					name: info.GetExternalSource().GetName(),
+				}, nil
+			}
 			return networkEntityDetails{}, errors.Wrapf(externalEntityNotFoundErr, "External source with ID: %q not found while trying to run network flow policy", info.GetId())
 		}
 		return networkEntityDetails{

--- a/sensor/common/detector/networkbaseline/network_baseline.go
+++ b/sensor/common/detector/networkbaseline/network_baseline.go
@@ -78,13 +78,13 @@ func (e *networkBaselineEvaluator) checkPeerInBaselineForEntity(
 		// If a peer is a discovered external entity, we must anonymize it
 		// to the Internet, as the baselines do not currently store or monitor IP
 		// information.
-		peer = networkbaseline.Peer{
-			IsIngress: isIngressToBaselineEntity,
-			DstPort:   dstPort,
-			Protocol:  protocol,
-			Name:      networkgraph.InternetExternalSourceName,
-			Entity:    networkgraph.InternetEntity(),
-		}
+		peer = networkbaseline.PeerFromNetworkEntity(
+			networkgraph.InternetEntity(),
+			networkgraph.InternetExternalSourceName,
+			dstPort,
+			protocol,
+			isIngressToBaselineEntity,
+		)
 	} else {
 		peer = networkbaseline.PeerFromNetworkEntityInfo(peerEntity, peerEntityName, dstPort, protocol, isIngressToBaselineEntity)
 	}

--- a/sensor/common/detector/networkbaseline/network_baseline.go
+++ b/sensor/common/detector/networkbaseline/network_baseline.go
@@ -71,14 +71,18 @@ func (e *networkBaselineEvaluator) checkPeerInBaselineForEntity(
 		// If no baseline exists then we do not mark it as anomalous
 		return true
 	}
+
 	var peer networkbaseline.Peer
 	if peerEntity.GetType() == storage.NetworkEntityInfo_EXTERNAL_SOURCE &&
 		peerEntity.GetExternalSource().GetDiscovered() {
+		// If a peer is a discovered external entity, we must anonymize it
+		// to the Internet, as the baselines do not currently store or monitor IP
+		// information.
 		peer = networkbaseline.Peer{
 			IsIngress: isIngressToBaselineEntity,
 			DstPort:   dstPort,
 			Protocol:  protocol,
-			Name:      networkgraph.InternalEntitiesName,
+			Name:      networkgraph.InternetExternalSourceName,
 			Entity:    networkgraph.InternetEntity(),
 		}
 	} else {

--- a/sensor/common/detector/networkbaseline/network_baseline_test.go
+++ b/sensor/common/detector/networkbaseline/network_baseline_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -92,4 +93,103 @@ func TestNetworkBaselineEvaluator(t *testing.T) {
 	evaluator.RemoveBaselineByDeploymentID(baseline.GetDeploymentId())
 	assert.False(t, evaluator.IsOutsideLockedBaseline(inBaselineFlow, "dp1", "dp2"))
 	assert.False(t, evaluator.IsOutsideLockedBaseline(anomalousFlow, "dp1", "dp3"))
+
+}
+
+func TestDiscoveredExternalInBaseline(t *testing.T) {
+	baseline := &storage.NetworkBaseline{
+		DeploymentId: "dp1",
+		ClusterId:    "cluster1",
+		Namespace:    "namespace1",
+		Peers: []*storage.NetworkBaselinePeer{
+			{
+				Entity: &storage.NetworkEntity{
+					Info: &storage.NetworkEntityInfo{
+						Type: storage.NetworkEntityInfo_INTERNET,
+						Id:   networkgraph.InternetExternalSourceID,
+						Desc: &storage.NetworkEntityInfo_ExternalSource_{
+							ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+								Name: networkgraph.InternetExternalSourceName,
+							},
+						},
+					},
+				},
+				Properties: []*storage.NetworkBaselineConnectionProperties{
+					{
+						Ingress:  false,
+						Port:     80,
+						Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+					},
+				},
+			},
+		},
+		ForbiddenPeers:       nil,
+		ObservationPeriodEnd: nil,
+		Locked:               false,
+		DeploymentName:       "dp1",
+	}
+
+	inBaselineDiscoveredFlow := &storage.NetworkFlow{
+		Props: &storage.NetworkFlowProperties{
+			SrcEntity: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_DEPLOYMENT,
+				Id:   "dp1",
+			},
+			DstEntity: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+				Id:   "ip1",
+				Desc: &storage.NetworkEntityInfo_ExternalSource_{
+					ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+						Discovered: true,
+						Name:       "1.1.1.1",
+					},
+				},
+			},
+			DstPort:    80,
+			L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+	}
+
+	anomalousDiscoveredFlow := &storage.NetworkFlow{
+		Props: &storage.NetworkFlowProperties{
+			SrcEntity: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_DEPLOYMENT,
+				Id:   "dp1",
+			},
+			DstEntity: &storage.NetworkEntityInfo{
+				Type: storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+				Id:   "ip1",
+				Desc: &storage.NetworkEntityInfo_ExternalSource_{
+					ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
+						Discovered: true,
+						Name:       "1.1.1.1",
+					},
+				},
+			},
+			DstPort:    1337,
+			L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+	}
+
+	evaluator := NewNetworkBaselineEvaluator()
+
+	// No baseline yet. No flow should be outside of baseline
+	assert.False(t, evaluator.IsOutsideLockedBaseline(inBaselineDiscoveredFlow, "dp1", "ip1"))
+	assert.False(t, evaluator.IsOutsideLockedBaseline(anomalousDiscoveredFlow, "dp1", "ip1"))
+
+	// Add an unlocked baseline, should have no effect
+	assert.Nil(t, evaluator.AddBaseline(baseline))
+	assert.False(t, evaluator.IsOutsideLockedBaseline(inBaselineDiscoveredFlow, "dp1", "ip1"))
+	assert.False(t, evaluator.IsOutsideLockedBaseline(anomalousDiscoveredFlow, "dp1", "ip1"))
+
+	// Add a locked baseline and check flow statuses
+	baseline.Locked = true
+	assert.Nil(t, evaluator.AddBaseline(baseline))
+	assert.False(t, evaluator.IsOutsideLockedBaseline(inBaselineDiscoveredFlow, "dp1", "ip1"))
+	assert.True(t, evaluator.IsOutsideLockedBaseline(anomalousDiscoveredFlow, "dp1", "ip1"))
+
+	// Remove the baseline should silent the above difference in flow statuses
+	evaluator.RemoveBaselineByDeploymentID(baseline.GetDeploymentId())
+	assert.False(t, evaluator.IsOutsideLockedBaseline(inBaselineDiscoveredFlow, "dp1", "ip1"))
+	assert.False(t, evaluator.IsOutsideLockedBaseline(anomalousDiscoveredFlow, "dp1", "ip1"))
 }


### PR DESCRIPTION
### Description

With discovered external entities, Sensor was failing to detect network baseline violations because the discovered entity did not exist in Sensor's external src store at the time of detection:

1. Sensor updates its external entities store with entities from Central
2. A flow to a new discovered entity is received from Collector
3. Sensor looks up the entity ID and finds that it does not exist
4. Detection fails
5. Some time later, Central updates Sensor's external entities with the new discovered entity.

The changes here make it so that discovered entities are detected based on the live network flow rather than via the store, at stage (4) above.

Further changes in this PR anonymize discovered entities for the purposes of baseline anomaly detection by converting them to the Internet entity. This is inline with changes from #14656 which prevents network baselines from containing IP information.

### User-facing documentation

- [ ] CHANGELOG is updated **OR** update is not needed
~- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [ ] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
~- [ ] added e2e tests~
~- [ ] added regression tests~
~- [ ] added compatibility tests~
- [x] modified existing tests

#### How I validated my change

Beyond the unit tests my process of validating this change is as follows:

On a new cluster:
- enable external IPs in Collector
- enable external IPs in Central
- Set a low baseline observation period
- run a debian deployment: `kubectl run --rm -it --restart=Never --image=debian:12 debian-test`
- Wait for observeration period to end and then enable baseline violation alerting for the deployment (this will mean any network traffic will raise a violation)
- run `apt update` on the debian-test deployment and await the violation.

Result:
![screenshot-08-05-2025-14-30-00](https://github.com/user-attachments/assets/4dc22394-034a-41b5-aac7-3bf375422b43)

