### PR TITLE
ROX-27962: CA rotation mechanism in Operator

### DIFF
--- a/operator/internal/central/carotation/rotation.go
+++ b/operator/internal/central/carotation/rotation.go
@@ -37,7 +37,9 @@ func DetermineAction(primary, secondary *x509.Certificate, current time.Time) Ac
 		return AddSecondary
 	}
 
-	// Promote secondary to primary in final year
+	// Promote secondary to primary in the final year
+	// If we're in the final year and no secondary CA exists, the rotation will be done in two steps
+	// (first reconcile - AddSecondary, subsequent reconcile - PromoteSecondary)
 	promoteSecondaryCATime := startTime.Add(4 * fifthOfValidityDuration)
 	if current.After(promoteSecondaryCATime) {
 		return PromoteSecondary

--- a/operator/internal/central/carotation/rotation.go
+++ b/operator/internal/central/carotation/rotation.go
@@ -25,7 +25,8 @@ const (
 	DeleteSecondary
 )
 
-// DetermineAction selects a rotation action based on the current time and the validity of the primary CA certificate
+// DetermineAction selects a rotation action based on the current time, and the validity of the primary CA certificate
+// Important: The function assumes that input certificates have valid time ranges
 func DetermineAction(primary, secondary *x509.Certificate, current time.Time) Action {
 	startTime := primary.NotBefore
 	validityDuration := primary.NotAfter.Sub(primary.NotBefore)

--- a/operator/internal/central/carotation/rotation.go
+++ b/operator/internal/central/carotation/rotation.go
@@ -29,7 +29,7 @@ const (
 func DetermineAction(primary, secondary *x509.Certificate, current time.Time) Action {
 	startTime := primary.NotBefore
 	validityDuration := primary.NotAfter.Sub(primary.NotBefore)
-	fifthOfValidityDuration := time.Duration(validityDuration.Nanoseconds()/5) * time.Nanosecond
+	fifthOfValidityDuration := validityDuration / 5
 
 	// Add secondary CA after 3/5 of validity
 	addSecondaryCATime := startTime.Add(3 * fifthOfValidityDuration)

--- a/operator/internal/central/carotation/rotation.go
+++ b/operator/internal/central/carotation/rotation.go
@@ -1,0 +1,72 @@
+package carotation
+
+import (
+	"crypto/x509"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/operator/internal/types"
+	"github.com/stackrox/rox/pkg/certgen"
+)
+
+// Action represents the possible actions to take during CA rotation.
+type Action int
+
+const (
+	// NoAction indicates that no action needs to be taken at this time
+	NoAction Action = iota
+	// AddSecondary indicates that the CA has passed a threshold (e.g., 3/5 of its validity)
+	// and a secondary CA should be generated and added.
+	AddSecondary
+	// PromoteSecondary indicates that the secondary CA should become the new primary CA,
+	// typically when the primary is nearing the end of its validity (e.g., last year).
+	PromoteSecondary
+	// DeleteSecondary indicates that the secondary CA has expired and should be removed.
+	DeleteSecondary
+)
+
+// DetermineAction selects a rotation action based on the current time and the validity of the primary CA certificate
+func DetermineAction(primary, secondary *x509.Certificate, current time.Time) Action {
+	startTime := primary.NotBefore
+	validityDuration := primary.NotAfter.Sub(primary.NotBefore)
+	fifthOfValidityDuration := time.Duration(validityDuration.Nanoseconds()/5) * time.Nanosecond
+
+	// Add secondary CA after 3/5 of validity
+	addSecondaryCATime := startTime.Add(3 * fifthOfValidityDuration)
+	if current.After(addSecondaryCATime) && secondary == nil {
+		return AddSecondary
+	}
+
+	// Promote secondary to primary in final year
+	promoteSecondaryCATime := startTime.Add(4 * fifthOfValidityDuration)
+	if current.After(promoteSecondaryCATime) {
+		return PromoteSecondary
+	}
+
+	// Delete expired secondary
+	if secondary != nil && current.After(secondary.NotAfter) {
+		return DeleteSecondary
+	}
+
+	return NoAction
+}
+
+// Handle applies the rotation action to the given file map.
+func Handle(action Action, fileMap types.SecretDataMap) error {
+	switch action {
+	case AddSecondary:
+		ca, err := certgen.GenerateCA()
+		if err != nil {
+			return errors.Wrap(err, "creating secondary CA failed")
+		}
+		certgen.AddSecondaryCAToFileMap(fileMap, ca)
+
+	case DeleteSecondary:
+		certgen.RemoveSecondaryCA(fileMap)
+
+	case PromoteSecondary:
+		certgen.PromoteSecondaryCA(fileMap)
+	}
+
+	return nil
+}

--- a/operator/internal/central/carotation/rotation.go
+++ b/operator/internal/central/carotation/rotation.go
@@ -13,7 +13,7 @@ import (
 type Action int
 
 const (
-	// NoAction indicates that no action needs to be taken at this time
+	// NoAction indicates that no action needs to be taken at this time.
 	NoAction Action = iota
 	// AddSecondary indicates that the CA has passed a threshold (e.g., 3/5 of its validity)
 	// and a secondary CA should be generated and added.
@@ -25,8 +25,8 @@ const (
 	DeleteSecondary
 )
 
-// DetermineAction selects a rotation action based on the current time, and the validity of the primary CA certificate
-// Important: The function assumes that input certificates have valid time ranges
+// DetermineAction selects a rotation action based on the current time, and the validity of the primary CA certificate.
+// Important: The function assumes that input certificates have valid time ranges.
 func DetermineAction(primary, secondary *x509.Certificate, current time.Time) Action {
 	startTime := primary.NotBefore
 	validityDuration := primary.NotAfter.Sub(primary.NotBefore)
@@ -38,9 +38,9 @@ func DetermineAction(primary, secondary *x509.Certificate, current time.Time) Ac
 		return AddSecondary
 	}
 
-	// Promote secondary to primary in the final year
-	// If we're in the final year and no secondary CA exists, the rotation will be done in two steps
-	// (first reconcile - AddSecondary, subsequent reconcile - PromoteSecondary)
+	// Promote secondary to primary after 4/5 of the primary's validity period has elapsed.
+	// If no secondary CA exists at this point, the rotation will be done in two steps:
+	// first reconcile - AddSecondary, subsequent reconcile - PromoteSecondary
 	promoteSecondaryCATime := startTime.Add(4 * fifthOfValidityDuration)
 	if current.After(promoteSecondaryCATime) {
 		return PromoteSecondary

--- a/operator/internal/central/carotation/rotation_test.go
+++ b/operator/internal/central/carotation/rotation_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/operator/internal/types"
+	"github.com/stackrox/rox/pkg/certgen"
+	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,6 +69,114 @@ func Test_DetermineAction(t *testing.T) {
 
 			action := DetermineAction(primary, secondary, now)
 			assert.Equal(t, c.wantAction, action)
+		})
+	}
+}
+
+func TestGenerateCentralTLSData_Rotation(t *testing.T) {
+	type testCase struct {
+		name            string
+		action          Action
+		additionalSetup func(t *testing.T, old types.SecretDataMap)
+		assert          func(t *testing.T, old, new types.SecretDataMap)
+	}
+
+	cases := []testCase{
+		{
+			name:   "add secondary CA",
+			action: AddSecondary,
+			assert: func(t *testing.T, old, new types.SecretDataMap) {
+				require.Contains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
+				require.Contains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
+				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA should be unchanged")
+			},
+		},
+		{
+			name:   "promote secondary CA",
+			action: PromoteSecondary,
+			additionalSetup: func(t *testing.T, old types.SecretDataMap) {
+				secondary, err := certgen.GenerateCA()
+				require.NoError(t, err)
+				certgen.AddSecondaryCAToFileMap(old, secondary)
+			},
+			assert: func(t *testing.T, old, new types.SecretDataMap) {
+				require.Contains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
+				require.Contains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
+				require.NotEqual(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA should have changed")
+				require.Equal(t, new[mtls.SecondaryCACertFileName], old[mtls.CACertFileName],
+					"secondary CA cert should be the old primary CA cert")
+				require.Equal(t, new[mtls.SecondaryCAKeyFileName], old[mtls.CAKeyFileName],
+					"secondary CA key should be the old primary CA key")
+				require.Equal(t, new[mtls.CACertFileName], old[mtls.SecondaryCACertFileName],
+					"primary CA cert should be the old secondary CA cert")
+				require.Equal(t, new[mtls.CAKeyFileName], old[mtls.SecondaryCAKeyFileName],
+					"primary CA key should be the old secondary CA key")
+				require.Contains(t, new, mtls.ServiceCertFileName, "central cert should be present")
+				require.Contains(t, new, mtls.ServiceKeyFileName, "central cert should be present")
+			},
+		},
+		{
+			name:   "delete secondary CA",
+			action: DeleteSecondary,
+			additionalSetup: func(t *testing.T, old types.SecretDataMap) {
+				secondary, err := certgen.GenerateCA()
+				require.NoError(t, err)
+				certgen.AddSecondaryCAToFileMap(old, secondary)
+			},
+			assert: func(t *testing.T, old, new types.SecretDataMap) {
+				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
+				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
+				require.NotContains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be removed")
+				require.NotContains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be removed")
+			},
+		},
+		{
+			name:   "no rotation action, secondary CA not present",
+			action: NoAction,
+			assert: func(t *testing.T, old, new types.SecretDataMap) {
+				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
+				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
+				require.NotContains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
+				require.NotContains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
+			},
+		},
+		{
+			name:   "no rotation action, secondary CA present",
+			action: NoAction,
+			additionalSetup: func(t *testing.T, old types.SecretDataMap) {
+				secondary, err := certgen.GenerateCA()
+				require.NoError(t, err)
+				certgen.AddSecondaryCAToFileMap(old, secondary)
+			},
+			assert: func(t *testing.T, old, new types.SecretDataMap) {
+				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
+				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
+				require.Equal(t, old[mtls.SecondaryCACertFileName], new[mtls.SecondaryCACertFileName], "secondary CA cert should be unchanged")
+				require.Equal(t, old[mtls.SecondaryCAKeyFileName], new[mtls.SecondaryCAKeyFileName], "secondary CA key should be unchanged")
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			primary, err := certgen.GenerateCA()
+			require.NoError(t, err)
+			fileMap := make(types.SecretDataMap)
+			certgen.AddCAToFileMap(fileMap, primary)
+			err = certgen.IssueCentralCert(fileMap, primary, mtls.WithNamespace("stackrox"))
+			require.NoError(t, err)
+
+			if tt.additionalSetup != nil {
+				tt.additionalSetup(t, fileMap)
+			}
+
+			oldFileMap := maputil.ShallowClone(fileMap)
+			err = Handle(tt.action, fileMap)
+			require.NoError(t, err)
+
+			tt.assert(t, oldFileMap, fileMap)
 		})
 	}
 }

--- a/operator/internal/central/carotation/rotation_test.go
+++ b/operator/internal/central/carotation/rotation_test.go
@@ -1,11 +1,11 @@
 package carotation
 
 import (
-	"crypto/x509"
 	"testing"
 	"time"
 
 	"github.com/stackrox/rox/operator/internal/types"
+	"github.com/stackrox/rox/operator/internal/utils/testutils"
 	"github.com/stackrox/rox/pkg/certgen"
 	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/mtls"
@@ -70,8 +70,8 @@ func Test_DetermineAction(t *testing.T) {
 			now, err := time.Parse(time.RFC3339, c.now)
 			require.NoError(t, err)
 
-			primary := generateTestCertWithValidity(t, c.primaryNotBefore, c.primaryNotAfter)
-			secondary := generateTestCertWithValidity(t, c.secondaryNotBefore, c.secondaryNotAfter)
+			primary := testutils.GenerateTestCertWithValidity(t, c.primaryNotBefore, c.primaryNotAfter)
+			secondary := testutils.GenerateTestCertWithValidity(t, c.secondaryNotBefore, c.secondaryNotAfter)
 
 			action := DetermineAction(primary, secondary, now)
 			assert.Equal(t, c.wantAction, action)
@@ -184,20 +184,5 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 
 			tt.assert(t, oldFileMap, fileMap)
 		})
-	}
-}
-
-func generateTestCertWithValidity(t *testing.T, notBeforeStr, notAfterStr string) *x509.Certificate {
-	t.Helper()
-	if notBeforeStr == "" && notAfterStr == "" {
-		return nil
-	}
-	notBefore, err := time.Parse(time.RFC3339, notBeforeStr)
-	require.NoError(t, err)
-	notAfter, err := time.Parse(time.RFC3339, notAfterStr)
-	require.NoError(t, err)
-	return &x509.Certificate{
-		NotBefore: notBefore,
-		NotAfter:  notAfter,
 	}
 }

--- a/operator/internal/central/carotation/rotation_test.go
+++ b/operator/internal/central/carotation/rotation_test.go
@@ -4,11 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackrox/rox/operator/internal/types"
 	"github.com/stackrox/rox/operator/internal/utils/testutils"
-	"github.com/stackrox/rox/pkg/certgen"
-	"github.com/stackrox/rox/pkg/maputil"
-	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,114 +71,6 @@ func Test_DetermineAction(t *testing.T) {
 
 			action := DetermineAction(primary, secondary, now)
 			assert.Equal(t, c.wantAction, action)
-		})
-	}
-}
-
-func TestGenerateCentralTLSData_Rotation(t *testing.T) {
-	type testCase struct {
-		name            string
-		action          Action
-		additionalSetup func(t *testing.T, old types.SecretDataMap)
-		assert          func(t *testing.T, old, new types.SecretDataMap)
-	}
-
-	cases := []testCase{
-		{
-			name:   "add secondary CA",
-			action: AddSecondary,
-			assert: func(t *testing.T, old, new types.SecretDataMap) {
-				require.Contains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
-				require.Contains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
-				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA should be unchanged")
-			},
-		},
-		{
-			name:   "promote secondary CA",
-			action: PromoteSecondary,
-			additionalSetup: func(t *testing.T, old types.SecretDataMap) {
-				secondary, err := certgen.GenerateCA()
-				require.NoError(t, err)
-				certgen.AddSecondaryCAToFileMap(old, secondary)
-			},
-			assert: func(t *testing.T, old, new types.SecretDataMap) {
-				require.Contains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
-				require.Contains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
-				require.NotEqual(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA should have changed")
-				require.Equal(t, new[mtls.SecondaryCACertFileName], old[mtls.CACertFileName],
-					"secondary CA cert should be the old primary CA cert")
-				require.Equal(t, new[mtls.SecondaryCAKeyFileName], old[mtls.CAKeyFileName],
-					"secondary CA key should be the old primary CA key")
-				require.Equal(t, new[mtls.CACertFileName], old[mtls.SecondaryCACertFileName],
-					"primary CA cert should be the old secondary CA cert")
-				require.Equal(t, new[mtls.CAKeyFileName], old[mtls.SecondaryCAKeyFileName],
-					"primary CA key should be the old secondary CA key")
-				require.Contains(t, new, mtls.ServiceCertFileName, "central cert should be present")
-				require.Contains(t, new, mtls.ServiceKeyFileName, "central cert should be present")
-			},
-		},
-		{
-			name:   "delete secondary CA",
-			action: DeleteSecondary,
-			additionalSetup: func(t *testing.T, old types.SecretDataMap) {
-				secondary, err := certgen.GenerateCA()
-				require.NoError(t, err)
-				certgen.AddSecondaryCAToFileMap(old, secondary)
-			},
-			assert: func(t *testing.T, old, new types.SecretDataMap) {
-				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
-				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
-				require.NotContains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be removed")
-				require.NotContains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be removed")
-			},
-		},
-		{
-			name:   "no rotation action, secondary CA not present",
-			action: NoAction,
-			assert: func(t *testing.T, old, new types.SecretDataMap) {
-				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
-				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
-				require.NotContains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be absent")
-				require.NotContains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be absent")
-			},
-		},
-		{
-			name:   "no rotation action, secondary CA present",
-			action: NoAction,
-			additionalSetup: func(t *testing.T, old types.SecretDataMap) {
-				secondary, err := certgen.GenerateCA()
-				require.NoError(t, err)
-				certgen.AddSecondaryCAToFileMap(old, secondary)
-			},
-			assert: func(t *testing.T, old, new types.SecretDataMap) {
-				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
-				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
-				require.Equal(t, old[mtls.SecondaryCACertFileName], new[mtls.SecondaryCACertFileName], "secondary CA cert should be unchanged")
-				require.Equal(t, old[mtls.SecondaryCAKeyFileName], new[mtls.SecondaryCAKeyFileName], "secondary CA key should be unchanged")
-			},
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			primary, err := certgen.GenerateCA()
-			require.NoError(t, err)
-			fileMap := make(types.SecretDataMap)
-			certgen.AddCAToFileMap(fileMap, primary)
-			err = certgen.IssueCentralCert(fileMap, primary, mtls.WithNamespace("stackrox"))
-			require.NoError(t, err)
-
-			if tt.additionalSetup != nil {
-				tt.additionalSetup(t, fileMap)
-			}
-
-			oldFileMap := maputil.ShallowClone(fileMap)
-			err = Handle(tt.action, fileMap)
-			require.NoError(t, err)
-
-			tt.assert(t, oldFileMap, fileMap)
 		})
 	}
 }

--- a/operator/internal/central/carotation/rotation_test.go
+++ b/operator/internal/central/carotation/rotation_test.go
@@ -28,8 +28,20 @@ func Test_DetermineAction(t *testing.T) {
 			primaryNotAfter:  "2030-01-01T00:00:00Z",
 			wantAction:       NoAction,
 		},
+		"should return no action just before 3/5 of validity": {
+			now:              "2027-12-31T23:59:59Z",
+			primaryNotBefore: "2025-01-01T00:00:00Z",
+			primaryNotAfter:  "2030-01-01T00:00:00Z",
+			wantAction:       NoAction,
+		},
 		"should add secondary after 3/5 of validity": {
 			now:              "2028-01-02T00:00:00Z",
+			primaryNotBefore: "2025-01-01T00:00:00Z",
+			primaryNotAfter:  "2030-01-01T00:00:00Z",
+			wantAction:       AddSecondary,
+		},
+		"should add secondary just before 4/5 of validity": {
+			now:              "2028-12-31T23:59:59Z",
 			primaryNotBefore: "2025-01-01T00:00:00Z",
 			primaryNotAfter:  "2030-01-01T00:00:00Z",
 			wantAction:       AddSecondary,

--- a/operator/internal/central/carotation/rotation_test.go
+++ b/operator/internal/central/carotation/rotation_test.go
@@ -1,0 +1,82 @@
+package carotation
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_DetermineAction(t *testing.T) {
+	cases := map[string]struct {
+		now                string
+		primaryNotBefore   string
+		primaryNotAfter    string
+		secondaryNotBefore string
+		secondaryNotAfter  string
+		wantAction         Action
+	}{
+		"should return no action in first 3/5 of validity": {
+			now:              "2026-06-01T00:00:00Z",
+			primaryNotBefore: "2025-01-01T00:00:00Z",
+			primaryNotAfter:  "2030-01-01T00:00:00Z",
+			wantAction:       NoAction,
+		},
+		"should add secondary after 3/5 of validity": {
+			now:              "2028-01-02T00:00:00Z",
+			primaryNotBefore: "2025-01-01T00:00:00Z",
+			primaryNotAfter:  "2030-01-01T00:00:00Z",
+			wantAction:       AddSecondary,
+		},
+		"should promote secondary after 4/5 of validity": {
+			now:                "2029-01-02T00:00:00Z",
+			primaryNotBefore:   "2025-01-01T00:00:00Z",
+			primaryNotAfter:    "2030-01-01T00:00:00Z",
+			secondaryNotBefore: "2028-01-01T00:00:00Z",
+			secondaryNotAfter:  "2033-01-01T00:00:00Z",
+			wantAction:         PromoteSecondary,
+		},
+		"should delete expired secondary": {
+			now:                "2031-01-02T00:00:00Z",
+			primaryNotBefore:   "2028-01-01T00:00:00Z",
+			primaryNotAfter:    "2033-01-01T00:00:00Z",
+			secondaryNotBefore: "2025-01-01T00:00:00Z",
+			secondaryNotAfter:  "2030-01-01T00:00:00Z",
+			wantAction:         DeleteSecondary,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, c.now)
+			require.NoError(t, err)
+
+			var primary *x509.Certificate
+			if c.primaryNotBefore != "" && c.primaryNotAfter != "" {
+				primary = generateTestCertWithValidity(t, c.primaryNotBefore, c.primaryNotAfter)
+			}
+
+			var secondary *x509.Certificate
+			if c.secondaryNotBefore != "" && c.secondaryNotAfter != "" {
+				secondary = generateTestCertWithValidity(t, c.secondaryNotBefore, c.secondaryNotAfter)
+			}
+
+			action := DetermineAction(primary, secondary, now)
+			assert.Equal(t, c.wantAction, action)
+		})
+	}
+}
+
+func generateTestCertWithValidity(t *testing.T, notBeforeStr, notAfterStr string) *x509.Certificate {
+	t.Helper()
+	notBefore, err := time.Parse(time.RFC3339, notBeforeStr)
+	require.NoError(t, err)
+	notAfter, err := time.Parse(time.RFC3339, notAfterStr)
+	require.NoError(t, err)
+	return &x509.Certificate{
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+	}
+}

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -1007,6 +1007,7 @@ func Test_createCentralTLSExtensionRun_validateAndConsumeCentralTLSData(t *testi
 			},
 			assert: func(t *testing.T, err error) {
 				assert.ErrorContains(t, err, "no CA key in file map")
+				assert.ErrorContains(t, err, "loading secondary CA failed")
 			},
 		},
 		"should fail when the secondary CA key is invalid": {
@@ -1020,6 +1021,7 @@ func Test_createCentralTLSExtensionRun_validateAndConsumeCentralTLSData(t *testi
 			},
 			assert: func(t *testing.T, err error) {
 				assert.ErrorContains(t, err, "failed to find any PEM data in key input")
+				assert.ErrorContains(t, err, "loading secondary CA failed")
 			},
 		},
 		"should fail when the secondary CA cert is invalid": {
@@ -1033,6 +1035,7 @@ func Test_createCentralTLSExtensionRun_validateAndConsumeCentralTLSData(t *testi
 			},
 			assert: func(t *testing.T, err error) {
 				assert.ErrorContains(t, err, "failed to find any PEM data in certificate input")
+				assert.ErrorContains(t, err, "loading secondary CA failed")
 			},
 		},
 		"should fail when the secondary CA has an invalid common name": {

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -705,8 +705,8 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 			assert: func(t *testing.T, old, new types.SecretDataMap) {
 				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
 				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
-				require.NotContains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
-				require.NotContains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
+				require.NotContains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be absent")
+				require.NotContains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be absent")
 				require.NotEqual(t, old[mtls.ServiceCertFileName], new[mtls.ServiceCertFileName], "central cert should be reissued")
 				require.NotEqual(t, old[mtls.ServiceKeyFileName], new[mtls.ServiceKeyFileName], "central key should be reissued")
 			},

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -717,8 +717,15 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 			assert: func(t *testing.T, old, new types.SecretDataMap) {
 				require.Contains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
 				require.Contains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
-
 				require.NotEqual(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA should have changed")
+				require.Equal(t, new[mtls.SecondaryCACertFileName], old[mtls.CACertFileName],
+					"secondary CA cert should be the old primary CA cert")
+				require.Equal(t, new[mtls.SecondaryCAKeyFileName], old[mtls.CAKeyFileName],
+					"secondary CA key should be the old primary CA key")
+				require.Equal(t, new[mtls.CACertFileName], old[mtls.SecondaryCACertFileName],
+					"primary CA cert should be the old secondary CA cert")
+				require.Equal(t, new[mtls.CAKeyFileName], old[mtls.SecondaryCAKeyFileName],
+					"primary CA key should be the old secondary CA key")
 				require.Contains(t, new, mtls.ServiceCertFileName, "central cert should be present")
 				require.Contains(t, new, mtls.ServiceKeyFileName, "central cert should be present")
 			},
@@ -732,10 +739,10 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 				certgen.AddSecondaryCAToFileMap(old, secondary)
 			},
 			assert: func(t *testing.T, old, new types.SecretDataMap) {
+				require.Equal(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA cert should be unchanged")
+				require.Equal(t, old[mtls.CAKeyFileName], new[mtls.CAKeyFileName], "primary CA key should be unchanged")
 				require.NotContains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be removed")
 				require.NotContains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be removed")
-				require.Equal(t, old[mtls.ServiceCertFileName], new[mtls.ServiceCertFileName], "central cert should be unchanged")
-				require.Equal(t, old[mtls.ServiceKeyFileName], new[mtls.ServiceKeyFileName], "central key should be unchanged")
 			},
 		},
 		{

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -2,7 +2,6 @@ package extensions
 
 import (
 	"context"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"strings"
@@ -72,18 +71,6 @@ func generateInvalidCA() (mtls.CA, error) {
 		return nil, pkgErrors.Wrap(err, "could not generate keypair")
 	}
 	return mtls.LoadCAForSigning(caCert, caKey)
-}
-
-func generateTestCertWithValidity(t *testing.T, notBeforeStr, notAfterStr string) *x509.Certificate {
-	t.Helper()
-	notBefore, err := time.Parse(time.RFC3339, notBeforeStr)
-	require.NoError(t, err)
-	notAfter, err := time.Parse(time.RFC3339, notAfterStr)
-	require.NoError(t, err)
-	return &x509.Certificate{
-		NotBefore: notBefore,
-		NotAfter:  notAfter,
-	}
 }
 
 func TestCreateCentralTLS(t *testing.T) {
@@ -577,7 +564,7 @@ func Test_checkCertRenewal(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			cert := generateTestCertWithValidity(t, c.notBefore, c.notAfter)
+			cert := testutils.GenerateTestCertWithValidity(t, c.notBefore, c.notAfter)
 			now, err := time.Parse(time.RFC3339, c.now)
 			require.NoError(t, err)
 			r := &createCentralTLSExtensionRun{currentTime: now}
@@ -624,7 +611,7 @@ func Test_checkCertificateTimeValidity(t *testing.T) {
 			now, err := time.Parse(time.RFC3339, c.now)
 			require.NoError(t, err)
 
-			cert := generateTestCertWithValidity(t, c.notBefore, c.notAfter)
+			cert := testutils.GenerateTestCertWithValidity(t, c.notBefore, c.notAfter)
 			r := &createCentralTLSExtensionRun{currentTime: now}
 
 			err = r.checkCertificateTimeValidity(cert)

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -752,9 +752,15 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 				ca:               primary,
 			}
 
+			oldFileMapCopy := make(types.SecretDataMap, len(oldFileMap))
+			for k, v := range oldFileMap {
+				oldFileMapCopy[k] = v
+			}
+
 			newFileMap, err := r.generateCentralTLSData(oldFileMap)
 			require.NoError(t, err)
 			require.NotNil(t, newFileMap)
+			require.Equal(t, oldFileMapCopy, oldFileMap)
 
 			tt.assert(t, oldFileMap, newFileMap)
 		})

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -680,6 +680,8 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 					"primary CA key should be the old secondary CA key")
 				require.Contains(t, new, mtls.ServiceCertFileName, "central cert should be present")
 				require.Contains(t, new, mtls.ServiceKeyFileName, "central cert should be present")
+				require.NotEqual(t, old[mtls.ServiceCertFileName], new[mtls.ServiceCertFileName], "central cert should be reissued")
+				require.NotEqual(t, old[mtls.ServiceKeyFileName], new[mtls.ServiceKeyFileName], "central key should be reissued")
 			},
 		},
 		{

--- a/operator/internal/utils/testutils/cert.go
+++ b/operator/internal/utils/testutils/cert.go
@@ -1,0 +1,24 @@
+package testutils
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func GenerateTestCertWithValidity(t *testing.T, notBeforeStr, notAfterStr string) *x509.Certificate {
+	t.Helper()
+	if notBeforeStr == "" && notAfterStr == "" {
+		return nil
+	}
+	notBefore, err := time.Parse(time.RFC3339, notBeforeStr)
+	require.NoError(t, err)
+	notAfter, err := time.Parse(time.RFC3339, notAfterStr)
+	require.NoError(t, err)
+	return &x509.Certificate{
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+	}
+}

--- a/pkg/certgen/ca_test.go
+++ b/pkg/certgen/ca_test.go
@@ -1,13 +1,27 @@
 package certgen
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/mtls/mocks"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
+
+func checkCertAndKey(t *testing.T, fileMap map[string][]byte, expectedCert, expectedKey []byte, certFileName, keyFileName string) {
+	t.Helper()
+	if !bytes.Equal(fileMap[certFileName], expectedCert) {
+		t.Errorf("Expected cert for %s to be %q, got %q", certFileName, expectedCert, fileMap[certFileName])
+	}
+	if !bytes.Equal(fileMap[keyFileName], expectedKey) {
+		t.Errorf("Expected key for %s to be %q, got %q", keyFileName, expectedKey, fileMap[keyFileName])
+	}
+}
 
 func TestGenerateCA(t *testing.T) {
 	ca, err := GenerateCA()
@@ -23,4 +37,39 @@ func TestGenerateCA(t *testing.T) {
 	const fiveYears = 5 * 365 * 24 * time.Hour
 	validity := cert.NotAfter.Sub(cert.NotBefore)
 	assert.InDelta(t, fiveYears, validity, float64(time.Hour), "cert validity should be ~5 years")
+}
+
+func TestPromoteSecondaryCA(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	primaryCert := []byte("primary-cert")
+	primaryKey := []byte("primary-key")
+	secondaryCert := []byte("secondary-cert")
+	secondaryKey := []byte("secondary-key")
+
+	primaryCA := mocks.NewMockCA(ctrl)
+	primaryCA.EXPECT().CertPEM().Return(primaryCert).AnyTimes()
+	primaryCA.EXPECT().KeyPEM().Return(primaryKey).AnyTimes()
+
+	secondaryCA := mocks.NewMockCA(ctrl)
+	secondaryCA.EXPECT().CertPEM().Return(secondaryCert).AnyTimes()
+	secondaryCA.EXPECT().KeyPEM().Return(secondaryKey).AnyTimes()
+
+	fileMap := make(map[string][]byte)
+	AddCAToFileMap(fileMap, primaryCA)
+	AddSecondaryCAToFileMap(fileMap, secondaryCA)
+
+	checkCertAndKey(t, fileMap, primaryCert, primaryKey, mtls.CACertFileName, mtls.CAKeyFileName)
+	checkCertAndKey(t, fileMap, secondaryCert, secondaryKey, mtls.SecondaryCACertFileName, mtls.SecondaryCAKeyFileName)
+
+	PromoteSecondaryCA(fileMap)
+
+	checkCertAndKey(t, fileMap, secondaryCert, secondaryKey, mtls.CACertFileName, mtls.CAKeyFileName)
+	checkCertAndKey(t, fileMap, primaryCert, primaryKey, mtls.SecondaryCACertFileName, mtls.SecondaryCAKeyFileName)
+
+	RemoveSecondaryCA(fileMap)
+
+	checkCertAndKey(t, fileMap, secondaryCert, secondaryKey, mtls.CACertFileName, mtls.CAKeyFileName)
+	checkCertAndKey(t, fileMap, nil, nil, mtls.SecondaryCACertFileName, mtls.SecondaryCAKeyFileName)
 }

--- a/pkg/mtls/crypto.go
+++ b/pkg/mtls/crypto.go
@@ -29,6 +29,13 @@ const (
 	// CAKeyFileName is the canonical file name (basename) of the file storing the CA certificate private key.
 	CAKeyFileName = "ca-key.pem"
 
+	// SecondaryCACertFileName is the file name of the secondary CA certificate.
+	// Operator installations use two CA certificates in parallel to enable CA certificate rotation.
+	SecondaryCACertFileName = "ca-secondary.pem"
+
+	// SecondaryCAKeyFileName is the file name of the secondary CA private key.
+	SecondaryCAKeyFileName = "ca-secondary-key.pem"
+
 	// ServiceCertFileName is the canonical file name (basename) of the file storing the public part of
 	// an internal service certificate. Note that if files for several services are stored in the same
 	// location (directory or file map), it is common to prefix the file name with the service name in


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Implements support for CA certification rotation in the Operator, based on [this design](https://docs.google.com/document/d/1I1r3bg3nwt96Q0dWs_mYdl5Wl4_xxVNz3NnB4UbHOCk/edit?usp=sharing).

The current implementation proposes 3 possible states of the CA:
1. only the primary CA is available (first 3 years of validity)
2. a secondary CA is created after 3 years, which is initially used to sign only Secured Cluster certificates (the idea being that a Sensor using exclusively the old (primary) CA doesn't know yet the new CA, and wouldn't be able to authenticate Central if the secondary CA was used also for Central at this point)
3. the secondary CA is promoted to primary CA after 4 years, and it's used to sign both Central and Secured Cluster certificates
(after 5 years the original CA is deleted, which brings us back to 1)

**The CA rotation is currently behind a feature flag and is disabled in production.**

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Only automated tests so far (but the feature is currently disabled in production). Further testing is coming in a future PR.
