### PR TITLE
doc: Align commands and descriptions in manual helm install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
   --set central.persistence.none="true"
 ```
 
-If you're installing on a single node cluster, or the default installation results in pending resources, use the following command instead to reduce stackrox-central-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
+If you're installing on a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-central-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
@@ -167,7 +167,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-s
   --set centralEndpoint="central.stackrox.svc:443"
 ```
 
-If you're installing on a single node cluster, or the default installation results in pending resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
+If you're installing on a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-services \

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To perform the installation, choose one of the following commands depending on y
 
 #### Default Central Installation
 
-If you're installing on a reasonably sized cluster, use the default installation command:
+If you're installing in a reasonably sized cluster, use the default installation command:
 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
@@ -121,7 +121,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
 
 #### Central Installation in Clusters With Limited Resources
 
-If you're installing on a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-central-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
+If you're installing in a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-central-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
@@ -174,7 +174,7 @@ To perform the installation, choose one of the following commands depending on y
 
 #### Default Secured Cluster Services Installation
 
-If you're installing on a reasonably sized cluster, use the default installation command:
+If you're installing in a reasonably sized cluster, use the default installation command:
 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-services \
@@ -186,7 +186,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-s
 
 #### Secured Cluster Services Installation in Clusters With Limited Resources
 
-If you're installing on a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
+If you're installing in a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-services \

--- a/README.md
+++ b/README.md
@@ -143,12 +143,6 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
 
 Next, the secured cluster component will need to be deployed to collect information on from the Kubernetes nodes.
 
-Generate an init bundle containing initialization secrets. The init bundle will be saved in `stackrox-init-bundle.yaml`, and you will use it to provision secured clusters as shown below.
-```sh
-echo "$ROX_ADMIN_PASSWORD" | \
-kubectl -n stackrox exec -i deploy/central -- bash -c 'ROX_ADMIN_PASSWORD=$(cat) roxctl --insecure-skip-tls-verify \
-  central init-bundles generate stackrox-init-bundle --output -' > stackrox-init-bundle.yaml
-```
 Set a meaningful cluster name for your secured cluster in the `CLUSTER_NAME` shell variable. The cluster will be identified by this name in the clusters list of the StackRox UI.
 ```sh
 CLUSTER_NAME="my-secured-cluster"
@@ -160,7 +154,14 @@ Set the endpoint of Central the Secured Cluster Services should communicate to. 
 CENTRAL_ENDPOINT="central.stackrox.svc:443"
 ```
 
-Then install stackrox-secured-cluster-services (with the init bundle you generated earlier).
+Generate an init bundle containing initialization secrets. The init bundle will be saved in `stackrox-init-bundle.yaml`, and you will use it to provision secured clusters as shown below.
+```sh
+echo "$ROX_ADMIN_PASSWORD" | \
+kubectl -n stackrox exec -i deploy/central -- bash -c 'ROX_ADMIN_PASSWORD=$(cat) roxctl --insecure-skip-tls-verify \
+  central init-bundles generate stackrox-init-bundle --output -' > stackrox-init-bundle.yaml
+```
+
+Then install stackrox-secured-cluster-services (with the init bundle you just generated).
 
 If you're installing on a reasonably sized cluster, use the default installation command:
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ CLUSTER_NAME="my-secured-cluster"
 ```
 Then install stackrox-secured-cluster-services (with the init bundle you generated earlier).
 
-When deploying stackrox-secured-cluster-services on a different cluster than the one where stackrox-central-services is deployed, you will also need to specify the endpoint (address and port number) of Central via `--set centralEndpoint=<endpoint_of_central_service>` command-line argument.
+**Note:** When deploying stackrox-secured-cluster-services on a different cluster than the one where stackrox-central-services is deployed, you will also need to specify the endpoint (address and port number) of Central via `--set centralEndpoint=<endpoint_of_central_service>` command-line argument.
 
 If you're installing on a reasonably sized cluster, use the default installation command:
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-s
 If you're installing on a single node cluster, or the default installation results in pending resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
-helm install -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
+helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
   --set centralEndpoint="central.stackrox.svc:443" \

--- a/README.md
+++ b/README.md
@@ -153,9 +153,14 @@ Set a meaningful cluster name for your secured cluster in the `CLUSTER_NAME` she
 ```sh
 CLUSTER_NAME="my-secured-cluster"
 ```
-Then install stackrox-secured-cluster-services (with the init bundle you generated earlier).
 
-**Note:** When deploying stackrox-secured-cluster-services on a different cluster than the one where stackrox-central-services is deployed, you will also need to specify the endpoint (address and port number) of Central via `--set centralEndpoint=<endpoint_of_central_service>` command-line argument.
+Set the endpoint of Central the Secured Cluster Services should communicate to. If you're deploying stackrox-secured-cluster-services on the same cluster as stackrox-central-services, leave it as shown, otherwise change the value to the endpoint through which Central is accessible.
+
+```sh
+CENTRAL_ENDPOINT="central.stackrox.svc:443"
+```
+
+Then install stackrox-secured-cluster-services (with the init bundle you generated earlier).
 
 If you're installing on a reasonably sized cluster, use the default installation command:
 
@@ -164,7 +169,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-s
   stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
-  --set centralEndpoint="central.stackrox.svc:443"
+  --set centralEndpoint="$CENTRAL_ENDPOINT"
 ```
 
 If you're installing on a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
@@ -174,7 +179,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-s
   stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
-  --set centralEndpoint="central.stackrox.svc:443" \
+  --set centralEndpoint="$CENTRAL_ENDPOINT" \
   --set sensor.resources.requests.memory=500Mi \
   --set sensor.resources.requests.cpu=500m \
   --set sensor.resources.limits.memory=500Mi \

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Deploying using Helm consists of 4 steps
 
 <details><summary>Install StackRox Central Services</summary>
 
-#### Default Central Installation
 First, the StackRox Central Services will be added to your Kubernetes cluster. This includes the UI and Scanner. To start, add the [stackrox/helm-charts/opensource](https://github.com/stackrox/helm-charts/tree/main/opensource) repository to Helm.
 
 ```sh
@@ -105,6 +104,9 @@ To install stackrox-central-services, you will need a secure password. This pass
 ROX_ADMIN_PASSWORD="$(openssl rand -base64 20 | tr -d '/=+')"
 ```
 From here, you can install stackrox-central-services to get Central and Scanner components deployed on your cluster. Note that you need only one deployed instance of stackrox-central-services even if you plan to secure multiple clusters.
+
+If you're installing on a reasonably sized cluster, use the default installation command:
+
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
   stackrox/stackrox-central-services \
@@ -112,9 +114,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
   --set central.persistence.none="true"
 ```
 
-#### Install Central in Clusters With Limited Resources
-
-If you're deploying StackRox on nodes with limited resources such as a local development cluster, run the following command to reduce StackRox resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
+If you're installing on a single node cluster, or the default installation results in pending resources, use the following command instead to reduce stackrox-central-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
@@ -141,7 +141,6 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
 
 <details><summary>Install StackRox Secured Cluster Services</summary>
 
-#### Default Secured Cluster Installation
 Next, the secured cluster component will need to be deployed to collect information on from the Kubernetes nodes.
 
 Generate an init bundle containing initialization secrets. The init bundle will be saved in `stackrox-init-bundle.yaml`, and you will use it to provision secured clusters as shown below.
@@ -154,17 +153,20 @@ Set a meaningful cluster name for your secured cluster in the `CLUSTER_NAME` she
 ```sh
 CLUSTER_NAME="my-secured-cluster"
 ```
-Then install stackrox-secured-cluster-services (with the init bundle you generated earlier) using this command:
+Then install stackrox-secured-cluster-services (with the init bundle you generated earlier).
+
+When deploying stackrox-secured-cluster-services on a different cluster than the one where stackrox-central-services is deployed, you will also need to specify the endpoint (address and port number) of Central via `--set centralEndpoint=<endpoint_of_central_service>` command-line argument.
+
+If you're installing on a reasonably sized cluster, use the default installation command:
+
 ```sh
 helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
   --set centralEndpoint="central.stackrox.svc:443"
 ```
-When deploying stackrox-secured-cluster-services on a different cluster than the one where stackrox-central-services is deployed, you will also need to specify the endpoint (address and port number) of Central via `--set centralEndpoint=<endpoint_of_central_service>` command-line argument.
 
-#### Install Secured Cluster with Limited Resources
-When deploying StackRox Secured Cluster Services on a small node, you can install with additional options. This should reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not recommended for a production setup.
+If you're installing on a single node cluster, or the default installation results in pending resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
 helm install -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \

--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ To install stackrox-central-services, you will need a secure password. This pass
 ```sh
 ROX_ADMIN_PASSWORD="$(openssl rand -base64 20 | tr -d '/=+')"
 ```
+
 From here, you can install stackrox-central-services to get Central and Scanner components deployed on your cluster. Note that you need only one deployed instance of stackrox-central-services even if you plan to secure multiple clusters.
+
+To perform the installation, choose one of the following commands depending on your cluster size.
+
+#### Default Central Installation
 
 If you're installing on a reasonably sized cluster, use the default installation command:
 
@@ -113,6 +118,8 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
   --set central.adminPassword.value="${ROX_ADMIN_PASSWORD}" \
   --set central.persistence.none="true"
 ```
+
+#### Central Installation in Clusters With Limited Resources
 
 If you're installing on a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-central-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
@@ -163,6 +170,10 @@ kubectl -n stackrox exec -i deploy/central -- bash -c 'ROX_ADMIN_PASSWORD=$(cat)
 
 Then install stackrox-secured-cluster-services (with the init bundle you just generated).
 
+To perform the installation, choose one of the following commands depending on your cluster size.
+
+#### Default Secured Cluster Services Installation
+
 If you're installing on a reasonably sized cluster, use the default installation command:
 
 ```sh
@@ -172,6 +183,8 @@ helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-s
   --set clusterName="$CLUSTER_NAME" \
   --set centralEndpoint="$CENTRAL_ENDPOINT"
 ```
+
+#### Secured Cluster Services Installation in Clusters With Limited Resources
 
 If you're installing on a single node cluster, or the default installation results in pods stuck pending due to lack of resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
   --set scanner.resources.requests.cpu=500m \
   --set scanner.resources.limits.memory=2500Mi \
   --set scanner.resources.limits.cpu=2000m \
+  --set central.adminPassword.value="${ROX_ADMIN_PASSWORD}" \
   --set central.persistence.none="true"
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ If you're installing on a single node cluster, or the default installation resul
 ```sh
 helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
   stackrox/stackrox-central-services \
+  --set central.adminPassword.value="${ROX_ADMIN_PASSWORD}" \
+  --set central.persistence.none="true" \
   --set central.resources.requests.memory=1Gi \
   --set central.resources.requests.cpu=1 \
   --set central.resources.limits.memory=4Gi \
@@ -132,9 +134,7 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
   --set scanner.resources.requests.memory=500Mi \
   --set scanner.resources.requests.cpu=500m \
   --set scanner.resources.limits.memory=2500Mi \
-  --set scanner.resources.limits.cpu=2000m \
-  --set central.adminPassword.value="${ROX_ADMIN_PASSWORD}" \
-  --set central.persistence.none="true"
+  --set scanner.resources.limits.cpu=2000m
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Finally, the script will automatically open the browser and log you into StackRo
 
 ### Manual Installation using Helm
 
-StackRox offers quick installation via Helm Charts. Follow the [Helm Installation Guide](https://helm.sh/docs/intro/install/) to get the `helm` CLI on your system.
+Follow the [Helm Installation Guide](https://helm.sh/docs/intro/install/) to get the `helm` CLI on your system.
 
 Deploying using Helm consists of 4 steps
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ helm upgrade --install -n stackrox --create-namespace stackrox-central-services 
 If you're deploying StackRox on nodes with limited resources such as a local development cluster, run the following command to reduce StackRox resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
-helm upgrade -n stackrox stackrox-central-services stackrox/stackrox-central-services \
+helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
+  stackrox/stackrox-central-services \
   --set central.resources.requests.memory=1Gi \
   --set central.resources.requests.cpu=1 \
   --set central.resources.limits.memory=4Gi \

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ When deploying stackrox-secured-cluster-services on a different cluster than the
 If you're installing on a reasonably sized cluster, use the default installation command:
 
 ```sh
-helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
+helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services \
+  stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
   --set centralEndpoint="central.stackrox.svc:443"
@@ -169,7 +170,8 @@ helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-s
 If you're installing on a single node cluster, or the default installation results in pending resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
-helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services stackrox/stackrox-secured-cluster-services \
+helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services \
+  stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
   --set centralEndpoint="central.stackrox.svc:443" \

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Then install stackrox-secured-cluster-services (with the init bundle you generat
 If you're installing on a reasonably sized cluster, use the default installation command:
 
 ```sh
-helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services \
+helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-services \
   stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \
@@ -170,7 +170,7 @@ helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-s
 If you're installing on a single node cluster, or the default installation results in pending resources, use the following command instead to reduce stackrox-secured-cluster-services resource requirements. Keep in mind that these reduced resource settings are not suited for a production setup.
 
 ```sh
-helm upgrade --install --create-namespace -n stackrox stackrox-secured-cluster-services \
+helm upgrade --install -n stackrox --create-namespace stackrox-secured-cluster-services \
   stackrox/stackrox-secured-cluster-services \
   -f stackrox-init-bundle.yaml \
   --set clusterName="$CLUSTER_NAME" \


### PR DESCRIPTION
### Description

This improves the manual helm installation section as follows:

- The `--install` and `--create-namespace` flags were added to the commands for deploying on clusters with limited resources, so that those also work when ran in a fresh cluster.
- The sections for central and secured cluster services were aligned, when it comes to structure, helm command flags, and instructions.
- Other minor cosmetic fixes.

### User-facing documentation

- [X] ~CHANGELOG is updated **OR** update is not needed~
- [X] ~[documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [X] ~the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag~
- [X] ~CI results are inspected~

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X] ~added unit tests~
- [X] ~added e2e tests~
- [X] ~added regression tests~
- [X] ~added compatibility tests~
- [X] ~modified existing tests~

#### How I validated my change

I have verified that the results are unchanged when compared with the previous commands, for both central and secured cluster services.

I also checked that the commands for installing in limited-resources clusters work both standalone and when ran after the default installation commands.
