### PR TITLE
chore(roxctl): wrap sensor errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -164,7 +164,7 @@ linters:
     rules:
       - linters:
           - wrapcheck
-        path: (central|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale)/
+        path: ^(central|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale)/
       - linters:
           - forbidigo
         path: (central/graphql/schema/print|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale|govulncheck)/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -164,7 +164,7 @@ linters:
     rules:
       - linters:
           - wrapcheck
-        path: ^(central|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale)/
+        path: ^(central|compliance|integration-tests|local|migrator|operator|pkg|roxctl/scanner|roxctl/central|scanner|sensor|tests|tools|scale)/
       - linters:
           - forbidigo
         path: (central/graphql/schema/print|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale|govulncheck)/

--- a/config-controller/pkg/client/client.go
+++ b/config-controller/pkg/client/client.go
@@ -385,7 +385,7 @@ func (c *client) FlushCache(ctx context.Context) error {
 func (c *client) EnsureFresh(ctx context.Context) error {
 	// Make sure token isn't expired before flushing cache
 	if err := c.centralSvc.TokenExchange(ctx); err != nil {
-		return err
+		return errors.Wrap(err, "could not exchange token")
 	}
 
 	if time.Since(c.lastUpdated).Minutes() > 5.0 {

--- a/config-controller/pkg/client/client.go
+++ b/config-controller/pkg/client/client.go
@@ -133,7 +133,7 @@ func (gc *grpcClient) ListNotifiers(ctx context.Context) ([]*storage.Notifier, e
 		return []*storage.Notifier{}, errors.Wrap(err, "Failed to list notifiers from grpc client")
 	}
 
-	return allNotifiers.Notifiers, err
+	return allNotifiers.Notifiers, nil
 }
 
 func (gc *grpcClient) ListClusters(ctx context.Context) ([]*storage.Cluster, error) {
@@ -142,7 +142,7 @@ func (gc *grpcClient) ListClusters(ctx context.Context) ([]*storage.Cluster, err
 		return []*storage.Cluster{}, errors.Wrap(err, "Failed to list clusters from grpc client")
 	}
 
-	return allClusters.Clusters, err
+	return allClusters.Clusters, nil
 }
 
 func (gc *grpcClient) ListPolicies(ctx context.Context) ([]*storage.ListPolicy, error) {
@@ -151,7 +151,7 @@ func (gc *grpcClient) ListPolicies(ctx context.Context) ([]*storage.ListPolicy, 
 		return []*storage.ListPolicy{}, errors.Wrap(err, "Failed to list policies from grpc client")
 	}
 
-	return allPolicies.Policies, err
+	return allPolicies.Policies, nil
 }
 
 func (gc *grpcClient) GetPolicy(ctx context.Context, id string) (*storage.Policy, error) {

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -116,7 +116,7 @@ func (s *sensorGenerateCommand) setClusterDefaults(envDefaults *util.CentralEnv)
 func (s *sensorGenerateCommand) fullClusterCreation() error {
 	conn, err := s.env.GRPCConnection()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create GRPC connection")
 	}
 	service := v1.NewClustersServiceClient(conn)
 
@@ -191,7 +191,7 @@ func (s *sensorGenerateCommand) createCluster(ctx context.Context, svc v1.Cluste
 
 	response, err := svc.PostCluster(ctx, s.cluster)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "error creating cluster")
 	}
 	return response.GetCluster().GetId(), nil
 }

--- a/roxctl/sensor/generate/openshift.go
+++ b/roxctl/sensor/generate/openshift.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/generated/storage"
 	clusterValidation "github.com/stackrox/rox/pkg/cluster"
@@ -68,7 +69,7 @@ func openshift(generateCmd *sensorGenerateCommand) *cobra.Command {
 			}
 
 			if err := clusterValidation.ValidatePartial(openshiftCommand.cluster).ToError(); err != nil {
-				return err
+				return errors.Wrap(err, "cluster validation failed")
 			}
 			return openshiftCommand.fullClusterCreation()
 		}),

--- a/roxctl/sensor/generatecerts/gen_certs.go
+++ b/roxctl/sensor/generatecerts/gen_certs.go
@@ -26,21 +26,21 @@ func downloadCerts(env environment.Environment, outputDir, clusterIDOrName strin
 ) error {
 	clusterID, err := util.ResolveClusterID(clusterIDOrName, timeout, retryTimeout, env)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not resolve cluster ID")
 	}
 
 	body, err := json.Marshal(&apiparams.ClusterCertGen{ID: clusterID})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not marshal cluster cert gen params")
 	}
 
 	client, err := env.HTTPClient(timeout)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not create HTTP client")
 	}
 	resp, err := client.DoReqAndVerifyStatusCode("/api/extensions/certgen/cluster", http.MethodPost, http.StatusOK, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not download certgen cluster")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 

--- a/roxctl/sensor/getbundle/get_bundle.go
+++ b/roxctl/sensor/getbundle/get_bundle.go
@@ -30,7 +30,7 @@ func downloadBundle(outputDir, clusterIDOrName string, timeout time.Duration,
 ) error {
 	conn, err := env.GRPCConnection()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not create GRPC connection")
 	}
 	service := v1.NewClustersServiceClient(conn)
 

--- a/roxctl/sensor/util/get_bundle.go
+++ b/roxctl/sensor/util/get_bundle.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/zipdownload"
@@ -29,9 +30,9 @@ func GetBundle(params apiparams.ClusterZip, outputDir string, timeout time.Durat
 	path := "/api/extensions/clusters/zip"
 	body, err := json.Marshal(&params)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not marshal zip params")
 	}
-	return zipdownload.GetZip(zipdownload.GetZipOptions{
+	err = zipdownload.GetZip(zipdownload.GetZipOptions{
 		Path:       path,
 		Method:     http.MethodPost,
 		Body:       body,
@@ -40,4 +41,5 @@ func GetBundle(params apiparams.ClusterZip, outputDir string, timeout time.Durat
 		ExpandZip:  true,
 		OutputDir:  outputDir,
 	}, env)
+	return errors.Wrap(err, "could not download zip")
 }

--- a/roxctl/sensor/util/resolve_id_or_name.go
+++ b/roxctl/sensor/util/resolve_id_or_name.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/errox"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
@@ -23,7 +24,7 @@ func ResolveClusterID(idOrName string, timeout time.Duration, retryTimeout time.
 
 	conn, err := env.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "could not create GRPC connection")
 	}
 
 	service := v1.NewClustersServiceClient(conn)
@@ -35,7 +36,7 @@ func ResolveClusterID(idOrName string, timeout time.Duration, retryTimeout time.
 		Query: fmt.Sprintf("%s:%s", search.Cluster, idOrName),
 	})
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "could not get cluster: %q", idOrName)
 	}
 
 	for _, cluster := range clusters.GetClusters() {


### PR DESCRIPTION
### Description

We have enabled wrapchedk in roxctl by disabling it everywhere else but our config is not 100% correct. It disables `sensor` and that catches `roxctl/sensor` too. This PR fixes wrapping in this package.

https://github.com/stackrox/stackrox/blob/23b101484b9ef4666bc20ba24ddf7ea1629eea83/.golangci.yml#L164-L167

See:
- https://github.com/stackrox/stackrox/pull/15045

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
