### PR TITLE
ROX-28941: Use GetByQueryFn in alerts

### DIFF
--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -38,7 +38,6 @@ func BenchmarkAlertDatabaseOps(b *testing.B) {
 		sevToCount[a.Policy.Severity]++
 		require.NoError(b, datastore.UpsertAlert(ctx, a))
 	}
-	log.Info("Successfully loaded the DB")
 
 	var expected []*violationsBySeverity
 	for sev, count := range sevToCount {

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -30,7 +30,6 @@ type DataStore interface {
 	SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error)
 	SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error)
 
-	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
 	WalkByQuery(ctx context.Context, q *v1.Query, db func(d *storage.Alert) error) error
 	WalkAll(ctx context.Context, fn func(alert *storage.ListAlert) error) error
 	GetAlert(ctx context.Context, id string) (*storage.Alert, bool, error)

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -283,12 +283,8 @@ func hasSameScope(o1, o2 sac.NamespaceScopedObject) bool {
 	return o1 != nil && o2 != nil && o1.GetClusterId() == o2.GetClusterId() && o1.GetNamespace() == o2.GetNamespace()
 }
 
-func (ds *datastoreImpl) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
-	return ds.storage.GetByQuery(ctx, q)
-}
-
 func (ds *datastoreImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(alert *storage.Alert) error) error {
-	return ds.storage.WalkByQuery(ctx, q, fn)
+	return ds.storage.GetByQueryFn(ctx, q, fn)
 }
 
 func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert) error) error {

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -239,7 +239,7 @@ func (s *alertDataStoreTestSuite) TestGetByQuery() {
 		DoAndReturn(func(ctx context.Context, query *v1.Query, fn func(*storage.Alert) error) error {
 			return fn(fakeAlert)
 		}).Times(1)
-	err := s.dataStore.WalkByQuery(s.hasWriteCtx, search.EmptyQuery(), func(a *storage.Alert) error {
+	err := s.dataStore.WalkByQuery(s.hasReadCtx, search.EmptyQuery(), func(a *storage.Alert) error {
 		protoassert.Equal(s.T(), fakeAlert, a)
 		return nil
 	})

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -11,7 +11,10 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/alert/convert"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 )
+
+const whenUnlimited = 100
 
 type AlertSearcher interface {
 	Search(ctx context.Context, q *v1.Query, excludeResolved bool) ([]search.Result, error)
@@ -42,7 +45,7 @@ func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query, exclu
 	if excludeResolved {
 		q = applyDefaultState(q)
 	}
-	listAlerts := make([]*storage.ListAlert, 0, q.GetPagination().GetLimit())
+	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(q.GetPagination().GetLimit(), whenUnlimited))
 	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
 		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
 		return nil
@@ -59,7 +62,7 @@ func (ds *searcherImpl) SearchRawAlerts(ctx context.Context, q *v1.Query, exclud
 	if excludeResolved {
 		q = applyDefaultState(q)
 	}
-	alerts := make([]*storage.Alert, 0, q.GetPagination().GetLimit())
+	alerts := make([]*storage.Alert, 0, paginated.GetLimit(q.GetPagination().GetLimit(), whenUnlimited))
 	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
 		alerts = append(alerts, alert)
 		return nil

--- a/central/alert/datastore/internal/search/searcher_impl.go
+++ b/central/alert/datastore/internal/search/searcher_impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/alert/datastore/internal/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -41,13 +42,13 @@ func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query, exclu
 	if excludeResolved {
 		q = applyDefaultState(q)
 	}
-	alerts, err := ds.storage.GetByQuery(ctx, q)
+	listAlerts := make([]*storage.ListAlert, 0, q.GetPagination().GetLimit())
+	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
+		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	listAlerts := make([]*storage.ListAlert, 0, len(alerts))
-	for _, alert := range alerts {
-		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
 	}
 	return listAlerts, nil
 
@@ -55,8 +56,18 @@ func (ds *searcherImpl) SearchListAlerts(ctx context.Context, q *v1.Query, exclu
 
 // SearchRawAlerts retrieves Alerts from the storage
 func (ds *searcherImpl) SearchRawAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error) {
-	alerts, err := ds.searchAlerts(ctx, q, excludeResolved)
-	return alerts, err
+	if excludeResolved {
+		q = applyDefaultState(q)
+	}
+	alerts := make([]*storage.Alert, 0, q.GetPagination().GetLimit())
+	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
+		alerts = append(alerts, alert)
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to search alerts")
+	}
+	return alerts, nil
 }
 
 func (ds *searcherImpl) searchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, []search.Result, error) {
@@ -74,13 +85,6 @@ func (ds *searcherImpl) searchListAlerts(ctx context.Context, q *v1.Query) ([]*s
 	}
 	results = search.RemoveMissingResults(results, missingIndices)
 	return listAlerts, results, nil
-}
-
-func (ds *searcherImpl) searchAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.Alert, error) {
-	if excludeResolved {
-		q = applyDefaultState(q)
-	}
-	return ds.storage.GetByQuery(ctx, q)
 }
 
 // Search takes a SearchRequest and finds any matches

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -116,20 +116,6 @@ func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
 }
 
-// GetByQueryFn mocks base method.
-func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.Alert) error) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GetByQueryFn indicates an expected call of GetByQueryFn.
-func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
-}
-
 // GetIDs mocks base method.
 func (m *MockStore) GetIDs(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -102,19 +102,18 @@ func (mr *MockStoreMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
-// GetByQuery mocks base method.
-func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error) {
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.Alert) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
-	ret0, _ := ret[0].([]*storage.Alert)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetByQuery indicates an expected call of GetByQuery.
-func (mr *MockStoreMockRecorder) GetByQuery(ctx, query any) *gomock.Call {
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
 }
 
 // GetByQueryFn mocks base method.

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -19,8 +19,6 @@ type Store interface {
 	GetIDs(ctx context.Context) ([]string, error)
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Alert, []int, error)
-	// Deprecated: use GetByQueryFn instead
-	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error)
 	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.Alert) error) error
 	Upsert(ctx context.Context, alert *storage.Alert) error
 	UpsertMany(ctx context.Context, alerts []*storage.Alert) error

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -108,21 +108,6 @@ func (mr *MockDataStoreMockRecorder) GetAlert(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAlert", reflect.TypeOf((*MockDataStore)(nil).GetAlert), ctx, id)
 }
 
-// GetByQuery mocks base method.
-func (m *MockDataStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.Alert, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
-	ret0, _ := ret[0].([]*storage.Alert)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetByQuery indicates an expected call of GetByQuery.
-func (mr *MockDataStoreMockRecorder) GetByQuery(ctx, q any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockDataStore)(nil).GetByQuery), ctx, q)
-}
-
 // MarkAlertsResolvedBatch mocks base method.
 func (m *MockDataStore) MarkAlertsResolvedBatch(ctx context.Context, id ...string) ([]*storage.Alert, error) {
 	m.ctrl.T.Helper()

--- a/central/platform/reprocessor/reprocessor_impl.go
+++ b/central/platform/reprocessor/reprocessor_impl.go
@@ -110,6 +110,7 @@ func (pr *platformReprocessorImpl) reprocessAlerts() error {
 		if err != nil {
 			return err
 		}
+		alerts = alerts[:0]
 	}
 	log.Info("Done reprocessing alerts with platform rules")
 	return nil


### PR DESCRIPTION
This PR uses a feature created in #15010  to improve alerts service performance and present how to use `GetByQueryFn` in other places.


```
                                          │   old.txt   │              new.txt               │
                                          │   sec/op    │   sec/op     vs base               │
AlertDatabaseOps/searchWithRawListAlert-8   9.708m ± 1%   9.448m ± 1%  -2.68% (p=0.000 n=20)

                                          │   old.txt    │               new.txt               │
                                          │     B/op     │     B/op      vs base               │
AlertDatabaseOps/searchWithRawListAlert-8   8.334Mi ± 0%   8.327Mi ± 0%  -0.09% (p=0.000 n=20)

                                          │   old.txt   │              new.txt               │
                                          │  allocs/op  │  allocs/op   vs base               │
AlertDatabaseOps/searchWithRawListAlert-8   109.2k ± 0%   109.2k ± 0%  +0.00% (p=0.000 n=20)
```

More bench tests are in:
- https://github.com/stackrox/stackrox/pull/14636