### PR TITLE
ROX-28665: Save metrics from long running clusters

### DIFF
--- a/deploy/charts/monitoring/templates/networkpolicy.yaml
+++ b/deploy/charts/monitoring/templates/networkpolicy.yaml
@@ -12,6 +12,8 @@ spec:
       protocol: TCP
     - port: 8443
       protocol: TCP
+    - port: 9090
+      protocol: TCP
   podSelector:
     matchLabels:
       app: monitoring

--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -3,10 +3,9 @@ global:
   gc: true
   indexerConfig:
     enabled: true
-    type: local
-    metricsDirectory: collected-metrics
-    createTarball: true
-    tarballName: collected-metrics.tar.gz
+    type: elastic
+    esServers: [ {{ env "ELASTICSEARCH_URL" }} ]
+    defaultIndex: kube-burner-long-running-test
   measurements: []
 jobs:
   - name: berserker-load

--- a/scripts/release-tools/kube-burner-configs/no-load-only-elasticsearch/config.yml
+++ b/scripts/release-tools/kube-burner-configs/no-load-only-elasticsearch/config.yml
@@ -1,0 +1,9 @@
+---
+global:
+  gc: true
+  indexerConfig:
+    enabled: true
+    type: elastic
+    esServers: [ {{ env "ELASTICSEARCH_URL" }} ]
+    defaultIndex: kube-burner-long-running-test
+  measurements: []

--- a/tests/performance/scale/config/metrics-full.yml
+++ b/tests/performance/scale/config/metrics-full.yml
@@ -142,37 +142,30 @@
 - query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Workers
   instant: true
-  captureStart: true
 
 - query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Masters
   instant: true
-  captureStart: true
 
 - query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Infra
   instant: true
-  captureStart: true
 
 - query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{ role = "worker",role != "infra" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Workers
   instant: true
-  captureStart: true
 
 - query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "master" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Masters
   instant: true
-  captureStart: true
 
 - query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "infra" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Infra
   instant: true
-  captureStart: true
 
 - query: sum( container_cpu_usage_seconds_total{container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
   metricName: cgroupCPUSeconds-namespaces
   instant: true
-  captureStart: true
 
 # File: metrics-acs-base.yml
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

See the companion PR here https://github.com/stackrox/actions/pull/60

This PR changes the main config file used by kube-burner such that it sends results to OpenSearch/Elasticsearch.

The PR changes the network policy for the monitoring pod, such that is allows for ingress to port 9090. This is needed so that the Prometheus metrics can be obtained from the pod.

It also creates a kube-burner config file with no load but settings for sending results to OpenSearch/Easticsearch.


### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

~~- [ ] added unit tests~~
~~- [ ] added e2e tests~~
~~- [ ] added regression tests~~
~~- [ ] added compatibility tests~~
~~- [ ] modified existing tests~~

This just changes some config files so that kube-burner can send metrics to OpenSearch. This does not have an impact on production.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Testing was done here https://github.com/stackrox/actions/pull/60
