### PR TITLE
ROX-29073: include advisory link

### DIFF
--- a/central/cve/converter/utils/convert_utils_v2.go
+++ b/central/cve/converter/utils/convert_utils_v2.go
@@ -32,12 +32,18 @@ func ImageCVEV2ToEmbeddedVulnerability(vuln *storage.ImageCVEV2) *storage.Embedd
 		VulnerabilityType:     storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
 		VulnerabilityTypes:    []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
 		State:                 vuln.GetState(),
-		Advisory:              vuln.GetAdvisory(),
 	}
 
 	if vuln.IsFixable {
 		ret.SetFixedBy = &storage.EmbeddedVulnerability_FixedBy{
 			FixedBy: vuln.GetFixedBy(),
+		}
+	}
+
+	if vuln.GetAdvisory() != "" {
+		ret.Advisory = &storage.Advisory{
+			Name: vuln.GetAdvisory(),
+			Link: vuln.GetAdvisoryLink(),
 		}
 	}
 
@@ -110,7 +116,8 @@ func EmbeddedVulnerabilityToImageCVEV2(imageID string, componentID string, from 
 		State:                from.GetState(),
 		IsFixable:            from.GetFixedBy() != "",
 		ImpactScore:          impactScore,
-		Advisory:             from.GetAdvisory(),
+		Advisory:             from.GetAdvisory().GetName(),
+		AdvisoryLink:         from.GetAdvisory().GetLink(),
 	}
 
 	if from.GetFixedBy() != "" {

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -44,6 +44,10 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"scanInline: Boolean!",
 		"timeoutSeconds: Int!",
 	}))
+	utils.Must(builder.AddType("Advisory", []string{
+		"link: String!",
+		"name: String!",
+	}))
 	utils.Must(builder.AddInput("AggregateBy", []string{
 		"aggregateFunc: String",
 		"distinct: Boolean",
@@ -1858,6 +1862,58 @@ func (resolver *admissionControllerConfigResolver) ScanInline(ctx context.Contex
 
 func (resolver *admissionControllerConfigResolver) TimeoutSeconds(ctx context.Context) int32 {
 	value := resolver.data.GetTimeoutSeconds()
+	return value
+}
+
+type advisoryResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data *storage.Advisory
+}
+
+func (resolver *Resolver) wrapAdvisory(value *storage.Advisory, ok bool, err error) (*advisoryResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &advisoryResolver{root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapAdvisories(values []*storage.Advisory, err error) ([]*advisoryResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*advisoryResolver, len(values))
+	for i, v := range values {
+		output[i] = &advisoryResolver{root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *Resolver) wrapAdvisoryWithContext(ctx context.Context, value *storage.Advisory, ok bool, err error) (*advisoryResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &advisoryResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapAdvisoriesWithContext(ctx context.Context, values []*storage.Advisory, err error) ([]*advisoryResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*advisoryResolver, len(values))
+	for i, v := range values {
+		output[i] = &advisoryResolver{ctx: ctx, root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *advisoryResolver) Link(ctx context.Context) string {
+	value := resolver.data.GetLink()
+	return value
+}
+
+func (resolver *advisoryResolver) Name(ctx context.Context) string {
+	value := resolver.data.GetName()
 	return value
 }
 

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -1184,7 +1184,7 @@ func (resolver *imageCVEV2Resolver) Advisory(ctx context.Context) (string, error
 
 	// Short path. Full image is embedded when image scan resolver is called.
 	if embeddedVuln := embeddedobjs.VulnFromContext(resolver.ctx); embeddedVuln != nil {
-		return embeddedVuln.GetAdvisory(), nil
+		return embeddedVuln.GetAdvisory().GetName(), nil
 	}
 
 	scope, hasScope := scoped.GetScope(resolver.ctx)

--- a/central/image/datastore/store/postgres/store_test.go
+++ b/central/image/datastore/store/postgres/store_test.go
@@ -75,7 +75,6 @@ func (s *ImagesStoreSuite) TestStore() {
 			vuln.FirstSystemOccurrence = foundImage.GetLastUpdated()
 			vuln.FirstImageOccurrence = foundImage.GetLastUpdated()
 			vuln.Epss = nil
-			// TODO(ROX-27402) remove this
 			vuln.Advisory = nil
 		}
 	}

--- a/central/image/datastore/store/postgres/store_test.go
+++ b/central/image/datastore/store/postgres/store_test.go
@@ -76,7 +76,7 @@ func (s *ImagesStoreSuite) TestStore() {
 			vuln.FirstImageOccurrence = foundImage.GetLastUpdated()
 			vuln.Epss = nil
 			// TODO(ROX-27402) remove this
-			vuln.Advisory = ""
+			vuln.Advisory = nil
 		}
 	}
 

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -87,7 +87,6 @@ func (s *ImagesStoreSuite) TestStore() {
 			vuln.Suppressed = false
 			vuln.SuppressActivation = nil
 			vuln.SuppressExpiry = nil
-			// TODO(ROX-27402) remove this
 			vuln.Advisory = nil
 		}
 		comp.License = nil

--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -88,7 +88,7 @@ func (s *ImagesStoreSuite) TestStore() {
 			vuln.SuppressActivation = nil
 			vuln.SuppressExpiry = nil
 			// TODO(ROX-27402) remove this
-			vuln.Advisory = ""
+			vuln.Advisory = nil
 		}
 		comp.License = nil
 	}

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -802,6 +802,17 @@
       ],
       "default": "UNSET_SOURCE_TYPE"
     },
+    "storageAdvisory": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "link": {
+          "type": "string"
+        }
+      }
+    },
     "storageCVSSScore": {
       "type": "object",
       "properties": {
@@ -1125,7 +1136,7 @@
           "type": "string"
         },
         "advisory": {
-          "type": "string"
+          "$ref": "#/definitions/storageAdvisory"
         },
         "cvss": {
           "type": "number",

--- a/generated/api/v1/node_service.swagger.json
+++ b/generated/api/v1/node_service.swagger.json
@@ -223,6 +223,17 @@
       "additionalProperties": {},
       "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := &pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
+    "storageAdvisory": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "link": {
+          "type": "string"
+        }
+      }
+    },
     "storageCVEInfo": {
       "type": "object",
       "properties": {
@@ -554,7 +565,7 @@
           "type": "string"
         },
         "advisory": {
-          "type": "string"
+          "$ref": "#/definitions/storageAdvisory"
         },
         "cvss": {
           "type": "number",

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -280,6 +280,17 @@
       "additionalProperties": {},
       "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := &pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
+    "storageAdvisory": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "link": {
+          "type": "string"
+        }
+      }
+    },
     "storageCVSSScore": {
       "type": "object",
       "properties": {
@@ -832,7 +843,7 @@
           "type": "string"
         },
         "advisory": {
-          "type": "string"
+          "$ref": "#/definitions/storageAdvisory"
         },
         "cvss": {
           "type": "number",

--- a/generated/internalapi/scanner/v4/vulnerability_report.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report.pb.go
@@ -127,7 +127,7 @@ func (x VulnerabilityReport_Vulnerability_Severity) Number() protoreflect.EnumNu
 
 // Deprecated: Use VulnerabilityReport_Vulnerability_Severity.Descriptor instead.
 func (VulnerabilityReport_Vulnerability_Severity) EnumDescriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0, 0}
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 0}
 }
 
 type VulnerabilityReport_Vulnerability_CVSS_Source int32
@@ -179,7 +179,7 @@ func (x VulnerabilityReport_Vulnerability_CVSS_Source) Number() protoreflect.Enu
 
 // Deprecated: Use VulnerabilityReport_Vulnerability_CVSS_Source.Descriptor instead.
 func (VulnerabilityReport_Vulnerability_CVSS_Source) EnumDescriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0, 0, 0}
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 0, 0}
 }
 
 // Next tag: 16
@@ -303,13 +303,65 @@ func (x *StringList) GetValues() []string {
 	return nil
 }
 
+type VulnerabilityReport_Advisory struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Link          string                 `protobuf:"bytes,2,opt,name=link,proto3" json:"link,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VulnerabilityReport_Advisory) Reset() {
+	*x = VulnerabilityReport_Advisory{}
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VulnerabilityReport_Advisory) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VulnerabilityReport_Advisory) ProtoMessage() {}
+
+func (x *VulnerabilityReport_Advisory) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VulnerabilityReport_Advisory.ProtoReflect.Descriptor instead.
+func (*VulnerabilityReport_Advisory) Descriptor() ([]byte, []int) {
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0}
+}
+
+func (x *VulnerabilityReport_Advisory) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Advisory) GetLink() string {
+	if x != nil {
+		return x.Link
+	}
+	return ""
+}
+
 type VulnerabilityReport_Vulnerability struct {
-	state       protoimpl.MessageState `protogen:"open.v1"`
-	Id          string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name        string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Advisory    string                 `protobuf:"bytes,15,opt,name=advisory,proto3" json:"advisory,omitempty"`
-	Description string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
-	Issued      *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=issued,proto3" json:"issued,omitempty"`
+	state       protoimpl.MessageState        `protogen:"open.v1"`
+	Id          string                        `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name        string                        `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Advisory    *VulnerabilityReport_Advisory `protobuf:"bytes,15,opt,name=advisory,proto3" json:"advisory,omitempty"`
+	Description string                        `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	Issued      *timestamppb.Timestamp        `protobuf:"bytes,4,opt,name=issued,proto3" json:"issued,omitempty"`
 	// Deprecated: Marked as deprecated in internalapi/scanner/v4/vulnerability_report.proto.
 	Link               string                                     `protobuf:"bytes,5,opt,name=link,proto3" json:"link,omitempty"` // link is duplicated with CVSS URL field, the exact deprecation date is undecided
 	Severity           string                                     `protobuf:"bytes,6,opt,name=severity,proto3" json:"severity,omitempty"`
@@ -328,7 +380,7 @@ type VulnerabilityReport_Vulnerability struct {
 
 func (x *VulnerabilityReport_Vulnerability) Reset() {
 	*x = VulnerabilityReport_Vulnerability{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[2]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -340,7 +392,7 @@ func (x *VulnerabilityReport_Vulnerability) String() string {
 func (*VulnerabilityReport_Vulnerability) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[2]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -353,7 +405,7 @@ func (x *VulnerabilityReport_Vulnerability) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use VulnerabilityReport_Vulnerability.ProtoReflect.Descriptor instead.
 func (*VulnerabilityReport_Vulnerability) Descriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0}
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1}
 }
 
 func (x *VulnerabilityReport_Vulnerability) GetId() string {
@@ -370,11 +422,11 @@ func (x *VulnerabilityReport_Vulnerability) GetName() string {
 	return ""
 }
 
-func (x *VulnerabilityReport_Vulnerability) GetAdvisory() string {
+func (x *VulnerabilityReport_Vulnerability) GetAdvisory() *VulnerabilityReport_Advisory {
 	if x != nil {
 		return x.Advisory
 	}
-	return ""
+	return nil
 }
 
 func (x *VulnerabilityReport_Vulnerability) GetDescription() string {
@@ -475,7 +527,7 @@ type VulnerabilityReport_Vulnerability_CVSS struct {
 
 func (x *VulnerabilityReport_Vulnerability_CVSS) Reset() {
 	*x = VulnerabilityReport_Vulnerability_CVSS{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[5]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -487,7 +539,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS) String() string {
 func (*VulnerabilityReport_Vulnerability_CVSS) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_CVSS) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[5]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -500,7 +552,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use VulnerabilityReport_Vulnerability_CVSS.ProtoReflect.Descriptor instead.
 func (*VulnerabilityReport_Vulnerability_CVSS) Descriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0, 0}
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 0}
 }
 
 func (x *VulnerabilityReport_Vulnerability_CVSS) GetV2() *VulnerabilityReport_Vulnerability_CVSS_V2 {
@@ -543,7 +595,7 @@ type VulnerabilityReport_Vulnerability_EPSS struct {
 
 func (x *VulnerabilityReport_Vulnerability_EPSS) Reset() {
 	*x = VulnerabilityReport_Vulnerability_EPSS{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[6]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -555,7 +607,7 @@ func (x *VulnerabilityReport_Vulnerability_EPSS) String() string {
 func (*VulnerabilityReport_Vulnerability_EPSS) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_EPSS) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[6]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -568,7 +620,7 @@ func (x *VulnerabilityReport_Vulnerability_EPSS) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use VulnerabilityReport_Vulnerability_EPSS.ProtoReflect.Descriptor instead.
 func (*VulnerabilityReport_Vulnerability_EPSS) Descriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0, 1}
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 1}
 }
 
 func (x *VulnerabilityReport_Vulnerability_EPSS) GetDate() string {
@@ -609,7 +661,7 @@ type VulnerabilityReport_Vulnerability_CVSS_V2 struct {
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V2) Reset() {
 	*x = VulnerabilityReport_Vulnerability_CVSS_V2{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[7]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -621,7 +673,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V2) String() string {
 func (*VulnerabilityReport_Vulnerability_CVSS_V2) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V2) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[7]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -634,7 +686,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V2) ProtoReflect() protoreflect.
 
 // Deprecated: Use VulnerabilityReport_Vulnerability_CVSS_V2.ProtoReflect.Descriptor instead.
 func (*VulnerabilityReport_Vulnerability_CVSS_V2) Descriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0, 0, 0}
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 0, 0}
 }
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V2) GetBaseScore() float32 {
@@ -661,7 +713,7 @@ type VulnerabilityReport_Vulnerability_CVSS_V3 struct {
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V3) Reset() {
 	*x = VulnerabilityReport_Vulnerability_CVSS_V3{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -673,7 +725,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V3) String() string {
 func (*VulnerabilityReport_Vulnerability_CVSS_V3) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V3) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -686,7 +738,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V3) ProtoReflect() protoreflect.
 
 // Deprecated: Use VulnerabilityReport_Vulnerability_CVSS_V3.ProtoReflect.Descriptor instead.
 func (*VulnerabilityReport_Vulnerability_CVSS_V3) Descriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 0, 0, 1}
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 0, 1}
 }
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V3) GetBaseScore() float32 {
@@ -708,17 +760,20 @@ var File_internalapi_scanner_v4_vulnerability_report_proto protoreflect.FileDesc
 const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\n" +
 	"1internalapi/scanner/v4/vulnerability_report.proto\x12\n" +
-	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\xb4\x10\n" +
+	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\x92\x11\n" +
 	"\x13VulnerabilityReport\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12^\n" +
 	"\x0fvulnerabilities\x18\x02 \x03(\v24.scanner.v4.VulnerabilityReport.VulnerabilitiesEntryR\x0fvulnerabilities\x12t\n" +
 	"\x17package_vulnerabilities\x18\x03 \x03(\v2;.scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntryR\x16packageVulnerabilities\x120\n" +
 	"\bcontents\x18\x04 \x01(\v2\x14.scanner.v4.ContentsR\bcontents\x12:\n" +
-	"\x05notes\x18\x05 \x03(\x0e2$.scanner.v4.VulnerabilityReport.NoteR\x05notes\x1a\x9d\v\n" +
+	"\x05notes\x18\x05 \x03(\x0e2$.scanner.v4.VulnerabilityReport.NoteR\x05notes\x1a2\n" +
+	"\bAdvisory\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04link\x18\x02 \x01(\tR\x04link\x1a\xc7\v\n" +
 	"\rVulnerability\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1a\n" +
-	"\badvisory\x18\x0f \x01(\tR\badvisory\x12 \n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12D\n" +
+	"\badvisory\x18\x0f \x01(\v2(.scanner.v4.VulnerabilityReport.AdvisoryR\badvisory\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x122\n" +
 	"\x06issued\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x06issued\x12\x16\n" +
 	"\x04link\x18\x05 \x01(\tB\x02\x18\x01R\x04link\x12\x1a\n" +
@@ -793,43 +848,45 @@ func file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP() []byte
 }
 
 var file_internalapi_scanner_v4_vulnerability_report_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_internalapi_scanner_v4_vulnerability_report_proto_goTypes = []any{
 	(VulnerabilityReport_Note)(0),                      // 0: scanner.v4.VulnerabilityReport.Note
 	(VulnerabilityReport_Vulnerability_Severity)(0),    // 1: scanner.v4.VulnerabilityReport.Vulnerability.Severity
 	(VulnerabilityReport_Vulnerability_CVSS_Source)(0), // 2: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.Source
 	(*VulnerabilityReport)(nil),                        // 3: scanner.v4.VulnerabilityReport
 	(*StringList)(nil),                                 // 4: scanner.v4.StringList
-	(*VulnerabilityReport_Vulnerability)(nil),          // 5: scanner.v4.VulnerabilityReport.Vulnerability
-	nil, // 6: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
-	nil, // 7: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
-	(*VulnerabilityReport_Vulnerability_CVSS)(nil),    // 8: scanner.v4.VulnerabilityReport.Vulnerability.CVSS
-	(*VulnerabilityReport_Vulnerability_EPSS)(nil),    // 9: scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil), // 10: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
-	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil), // 11: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
-	(*Contents)(nil),              // 12: scanner.v4.Contents
-	(*timestamppb.Timestamp)(nil), // 13: google.protobuf.Timestamp
+	(*VulnerabilityReport_Advisory)(nil),               // 5: scanner.v4.VulnerabilityReport.Advisory
+	(*VulnerabilityReport_Vulnerability)(nil),          // 6: scanner.v4.VulnerabilityReport.Vulnerability
+	nil, // 7: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
+	nil, // 8: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
+	(*VulnerabilityReport_Vulnerability_CVSS)(nil),    // 9: scanner.v4.VulnerabilityReport.Vulnerability.CVSS
+	(*VulnerabilityReport_Vulnerability_EPSS)(nil),    // 10: scanner.v4.VulnerabilityReport.Vulnerability.EPSS
+	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil), // 11: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
+	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil), // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
+	(*Contents)(nil),              // 13: scanner.v4.Contents
+	(*timestamppb.Timestamp)(nil), // 14: google.protobuf.Timestamp
 }
 var file_internalapi_scanner_v4_vulnerability_report_proto_depIdxs = []int32{
-	6,  // 0: scanner.v4.VulnerabilityReport.vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
-	7,  // 1: scanner.v4.VulnerabilityReport.package_vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
-	12, // 2: scanner.v4.VulnerabilityReport.contents:type_name -> scanner.v4.Contents
+	7,  // 0: scanner.v4.VulnerabilityReport.vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
+	8,  // 1: scanner.v4.VulnerabilityReport.package_vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
+	13, // 2: scanner.v4.VulnerabilityReport.contents:type_name -> scanner.v4.Contents
 	0,  // 3: scanner.v4.VulnerabilityReport.notes:type_name -> scanner.v4.VulnerabilityReport.Note
-	13, // 4: scanner.v4.VulnerabilityReport.Vulnerability.issued:type_name -> google.protobuf.Timestamp
-	1,  // 5: scanner.v4.VulnerabilityReport.Vulnerability.normalized_severity:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.Severity
-	8,  // 6: scanner.v4.VulnerabilityReport.Vulnerability.cvss:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
-	8,  // 7: scanner.v4.VulnerabilityReport.Vulnerability.cvss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
-	9,  // 8: scanner.v4.VulnerabilityReport.Vulnerability.epss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	5,  // 9: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry.value:type_name -> scanner.v4.VulnerabilityReport.Vulnerability
-	4,  // 10: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry.value:type_name -> scanner.v4.StringList
-	10, // 11: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v2:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
-	11, // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v3:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
-	2,  // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.source:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.Source
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	5,  // 4: scanner.v4.VulnerabilityReport.Vulnerability.advisory:type_name -> scanner.v4.VulnerabilityReport.Advisory
+	14, // 5: scanner.v4.VulnerabilityReport.Vulnerability.issued:type_name -> google.protobuf.Timestamp
+	1,  // 6: scanner.v4.VulnerabilityReport.Vulnerability.normalized_severity:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.Severity
+	9,  // 7: scanner.v4.VulnerabilityReport.Vulnerability.cvss:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
+	9,  // 8: scanner.v4.VulnerabilityReport.Vulnerability.cvss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
+	10, // 9: scanner.v4.VulnerabilityReport.Vulnerability.epss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.EPSS
+	6,  // 10: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry.value:type_name -> scanner.v4.VulnerabilityReport.Vulnerability
+	4,  // 11: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry.value:type_name -> scanner.v4.StringList
+	11, // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v2:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
+	12, // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v3:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
+	2,  // 14: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.source:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.Source
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_scanner_v4_vulnerability_report_proto_init() }
@@ -844,7 +901,7 @@ func file_internalapi_scanner_v4_vulnerability_report_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc), len(file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   9,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
@@ -24,6 +24,24 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+func (m *VulnerabilityReport_Advisory) CloneVT() *VulnerabilityReport_Advisory {
+	if m == nil {
+		return (*VulnerabilityReport_Advisory)(nil)
+	}
+	r := new(VulnerabilityReport_Advisory)
+	r.Name = m.Name
+	r.Link = m.Link
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *VulnerabilityReport_Advisory) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *VulnerabilityReport_Vulnerability_CVSS_V2) CloneVT() *VulnerabilityReport_Vulnerability_CVSS_V2 {
 	if m == nil {
 		return (*VulnerabilityReport_Vulnerability_CVSS_V2)(nil)
@@ -107,7 +125,7 @@ func (m *VulnerabilityReport_Vulnerability) CloneVT() *VulnerabilityReport_Vulne
 	r := new(VulnerabilityReport_Vulnerability)
 	r.Id = m.Id
 	r.Name = m.Name
-	r.Advisory = m.Advisory
+	r.Advisory = m.Advisory.CloneVT()
 	r.Description = m.Description
 	r.Issued = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.Issued).CloneVT())
 	r.Link = m.Link
@@ -195,6 +213,28 @@ func (m *StringList) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (this *VulnerabilityReport_Advisory) EqualVT(that *VulnerabilityReport_Advisory) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if this.Link != that.Link {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *VulnerabilityReport_Advisory) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*VulnerabilityReport_Advisory)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *VulnerabilityReport_Vulnerability_CVSS_V2) EqualVT(that *VulnerabilityReport_Vulnerability_CVSS_V2) bool {
 	if this == that {
 		return true
@@ -357,7 +397,7 @@ func (this *VulnerabilityReport_Vulnerability) EqualVT(that *VulnerabilityReport
 	if !this.EpssMetrics.EqualVT(that.EpssMetrics) {
 		return false
 	}
-	if this.Advisory != that.Advisory {
+	if !this.Advisory.EqualVT(that.Advisory) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -466,6 +506,53 @@ func (this *StringList) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (m *VulnerabilityReport_Advisory) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VulnerabilityReport_Advisory) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *VulnerabilityReport_Advisory) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Link) > 0 {
+		i -= len(m.Link)
+		copy(dAtA[i:], m.Link)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Link)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *VulnerabilityReport_Vulnerability_CVSS_V2) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -712,10 +799,13 @@ func (m *VulnerabilityReport_Vulnerability) MarshalToSizedBufferVT(dAtA []byte) 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.Advisory) > 0 {
-		i -= len(m.Advisory)
-		copy(dAtA[i:], m.Advisory)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Advisory)))
+	if m.Advisory != nil {
+		size, err := m.Advisory.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0x7a
 	}
@@ -989,6 +1079,24 @@ func (m *StringList) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *VulnerabilityReport_Advisory) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Link)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *VulnerabilityReport_Vulnerability_CVSS_V2) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1135,8 +1243,8 @@ func (m *VulnerabilityReport_Vulnerability) SizeVT() (n int) {
 		l = m.EpssMetrics.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	l = len(m.Advisory)
-	if l > 0 {
+	if m.Advisory != nil {
+		l = m.Advisory.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -1210,6 +1318,121 @@ func (m *StringList) SizeVT() (n int) {
 	return n
 }
 
+func (m *VulnerabilityReport_Advisory) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VulnerabilityReport_Advisory: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VulnerabilityReport_Advisory: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Link", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Link = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *VulnerabilityReport_Vulnerability_CVSS_V2) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2191,7 +2414,7 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVT(dAtA []byte) error {
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Advisory", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -2201,23 +2424,27 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return protohelpers.ErrInvalidLength
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return protohelpers.ErrInvalidLength
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Advisory = string(dAtA[iNdEx:postIndex])
+			if m.Advisory == nil {
+				m.Advisory = &VulnerabilityReport_Advisory{}
+			}
+			if err := m.Advisory.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2747,6 +2974,129 @@ func (m *StringList) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Values = append(m.Values, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VulnerabilityReport_Advisory) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VulnerabilityReport_Advisory: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VulnerabilityReport_Advisory: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Name = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Link", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Link = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3807,7 +4157,7 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVTUnsafe(dAtA []byte) error
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Advisory", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -3817,27 +4167,27 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVTUnsafe(dAtA []byte) error
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return protohelpers.ErrInvalidLength
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return protohelpers.ErrInvalidLength
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var stringValue string
-			if intStringLen > 0 {
-				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			if m.Advisory == nil {
+				m.Advisory = &VulnerabilityReport_Advisory{}
 			}
-			m.Advisory = stringValue
+			if err := m.Advisory.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/storage/cve.pb.go
+++ b/generated/storage/cve.pb.go
@@ -1533,6 +1533,7 @@ type ImageCVEV2 struct {
 	HasFixedBy    isImageCVEV2_HasFixedBy `protobuf_oneof:"has_fixed_by"`
 	ComponentId   string                  `protobuf:"bytes,13,opt,name=component_id,json=componentId,proto3" json:"component_id,omitempty" sql:"fk(ImageComponentV2:id),index=btree"` // @gotags: sql:"fk(ImageComponentV2:id),index=btree"
 	Advisory      string                  `protobuf:"bytes,14,opt,name=advisory,proto3" json:"advisory,omitempty" search:"Advisory"`                          // @gotags: search:"Advisory"
+	AdvisoryLink  string                  `protobuf:"bytes,15,opt,name=advisory_link,json=advisoryLink,proto3" json:"advisory_link,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1670,6 +1671,13 @@ func (x *ImageCVEV2) GetComponentId() string {
 func (x *ImageCVEV2) GetAdvisory() string {
 	if x != nil {
 		return x.Advisory
+	}
+	return ""
+}
+
+func (x *ImageCVEV2) GetAdvisoryLink() string {
+	if x != nil {
+		return x.AdvisoryLink
 	}
 	return ""
 }
@@ -2552,7 +2560,7 @@ const file_storage_cve_proto_rawDesc = "" +
 	"\anvdcvss\x18\n" +
 	" \x01(\x02R\anvdcvss\x125\n" +
 	"\fcvss_metrics\x18\v \x03(\v2\x12.storage.CVSSScoreR\vcvssMetrics\x12E\n" +
-	"\x11nvd_score_version\x18\f \x01(\x0e2\x19.storage.CvssScoreVersionR\x0fnvdScoreVersion:\x02\x18\x01\"\xd1\x04\n" +
+	"\x11nvd_score_version\x18\f \x01(\x0e2\x19.storage.CvssScoreVersionR\x0fnvdScoreVersion:\x02\x18\x01\"\xf6\x04\n" +
 	"\n" +
 	"ImageCVEV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
@@ -2570,7 +2578,8 @@ const file_storage_cve_proto_rawDesc = "" +
 	"is_fixable\x18\v \x01(\bR\tisFixable\x12\x1b\n" +
 	"\bfixed_by\x18\f \x01(\tH\x00R\afixedBy\x12!\n" +
 	"\fcomponent_id\x18\r \x01(\tR\vcomponentId\x12\x1a\n" +
-	"\badvisory\x18\x0e \x01(\tR\badvisoryB\x0e\n" +
+	"\badvisory\x18\x0e \x01(\tR\badvisory\x12#\n" +
+	"\radvisory_link\x18\x0f \x01(\tR\fadvisoryLinkB\x0e\n" +
 	"\fhas_fixed_by\"\xe4\x03\n" +
 	"\aNodeCVE\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x124\n" +

--- a/generated/storage/cve_vtproto.pb.go
+++ b/generated/storage/cve_vtproto.pb.go
@@ -250,6 +250,7 @@ func (m *ImageCVEV2) CloneVT() *ImageCVEV2 {
 	r.IsFixable = m.IsFixable
 	r.ComponentId = m.ComponentId
 	r.Advisory = m.Advisory
+	r.AdvisoryLink = m.AdvisoryLink
 	if m.HasFixedBy != nil {
 		r.HasFixedBy = m.HasFixedBy.(interface {
 			CloneVT() isImageCVEV2_HasFixedBy
@@ -842,6 +843,9 @@ func (this *ImageCVEV2) EqualVT(that *ImageCVEV2) bool {
 		return false
 	}
 	if this.Advisory != that.Advisory {
+		return false
+	}
+	if this.AdvisoryLink != that.AdvisoryLink {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1898,6 +1902,13 @@ func (m *ImageCVEV2) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i -= size
 	}
+	if len(m.AdvisoryLink) > 0 {
+		i -= len(m.AdvisoryLink)
+		copy(dAtA[i:], m.AdvisoryLink)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.AdvisoryLink)))
+		i--
+		dAtA[i] = 0x7a
+	}
 	if len(m.Advisory) > 0 {
 		i -= len(m.Advisory)
 		copy(dAtA[i:], m.Advisory)
@@ -2871,6 +2882,10 @@ func (m *ImageCVEV2) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.Advisory)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.AdvisoryLink)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -5493,6 +5508,38 @@ func (m *ImageCVEV2) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Advisory = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdvisoryLink", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AdvisoryLink = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -9292,6 +9339,42 @@ func (m *ImageCVEV2) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.Advisory = stringValue
+			iNdEx = postIndex
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdvisoryLink", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.AdvisoryLink = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/storage/vulnerability.pb.go
+++ b/generated/storage/vulnerability.pb.go
@@ -131,7 +131,7 @@ func (EmbeddedVulnerability_VulnerabilityType) EnumDescriptor() ([]byte, []int) 
 type EmbeddedVulnerability struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Cve      string                 `protobuf:"bytes,1,opt,name=cve,proto3" json:"cve,omitempty" search:"CVE,store"` // @gotags: search:"CVE,store"
-	Advisory string                 `protobuf:"bytes,24,opt,name=advisory,proto3" json:"advisory,omitempty"`
+	Advisory *Advisory              `protobuf:"bytes,24,opt,name=advisory,proto3" json:"advisory,omitempty"`
 	Cvss     float32                `protobuf:"fixed32,2,opt,name=cvss,proto3" json:"cvss,omitempty" search:"CVSS,store"` // @gotags: search:"CVSS,store"
 	Summary  string                 `protobuf:"bytes,3,opt,name=summary,proto3" json:"summary,omitempty"`
 	Link     string                 `protobuf:"bytes,4,opt,name=link,proto3" json:"link,omitempty"`
@@ -202,11 +202,11 @@ func (x *EmbeddedVulnerability) GetCve() string {
 	return ""
 }
 
-func (x *EmbeddedVulnerability) GetAdvisory() string {
+func (x *EmbeddedVulnerability) GetAdvisory() *Advisory {
 	if x != nil {
 		return x.Advisory
 	}
-	return ""
+	return nil
 }
 
 func (x *EmbeddedVulnerability) GetCvss() float32 {
@@ -489,14 +489,66 @@ type NodeVulnerability_FixedBy struct {
 
 func (*NodeVulnerability_FixedBy) isNodeVulnerability_SetFixedBy() {}
 
+type Advisory struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Link          string                 `protobuf:"bytes,2,opt,name=link,proto3" json:"link,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Advisory) Reset() {
+	*x = Advisory{}
+	mi := &file_storage_vulnerability_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Advisory) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Advisory) ProtoMessage() {}
+
+func (x *Advisory) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_vulnerability_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Advisory.ProtoReflect.Descriptor instead.
+func (*Advisory) Descriptor() ([]byte, []int) {
+	return file_storage_vulnerability_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *Advisory) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Advisory) GetLink() string {
+	if x != nil {
+		return x.Link
+	}
+	return ""
+}
+
 var File_storage_vulnerability_proto protoreflect.FileDescriptor
 
 const file_storage_vulnerability_proto_rawDesc = "" +
 	"\n" +
-	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\xaf\v\n" +
+	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\xc2\v\n" +
 	"\x15EmbeddedVulnerability\x12\x10\n" +
-	"\x03cve\x18\x01 \x01(\tR\x03cve\x12\x1a\n" +
-	"\badvisory\x18\x18 \x01(\tR\badvisory\x12\x12\n" +
+	"\x03cve\x18\x01 \x01(\tR\x03cve\x12-\n" +
+	"\badvisory\x18\x18 \x01(\v2\x11.storage.AdvisoryR\badvisory\x12\x12\n" +
 	"\x04cvss\x18\x02 \x01(\x02R\x04cvss\x12\x18\n" +
 	"\asummary\x18\x03 \x01(\tR\asummary\x12\x12\n" +
 	"\x04link\x18\x04 \x01(\tR\x04link\x12\x1b\n" +
@@ -540,7 +592,10 @@ const file_storage_vulnerability_proto_rawDesc = "" +
 	"\asnoozed\x18\x05 \x01(\bR\asnoozed\x12=\n" +
 	"\fsnooze_start\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\vsnoozeStart\x12?\n" +
 	"\rsnooze_expiry\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\fsnoozeExpiryB\x0e\n" +
-	"\fset_fixed_byB.\n" +
+	"\fset_fixed_by\"2\n" +
+	"\bAdvisory\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04link\x18\x02 \x01(\tR\x04linkB.\n" +
 	"\x19io.stackrox.proto.storageZ\x11./storage;storageb\x06proto3"
 
 var (
@@ -556,46 +611,48 @@ func file_storage_vulnerability_proto_rawDescGZIP() []byte {
 }
 
 var file_storage_vulnerability_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_storage_vulnerability_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_storage_vulnerability_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_storage_vulnerability_proto_goTypes = []any{
 	(EmbeddedVulnerability_ScoreVersion)(0),      // 0: storage.EmbeddedVulnerability.ScoreVersion
 	(EmbeddedVulnerability_VulnerabilityType)(0), // 1: storage.EmbeddedVulnerability.VulnerabilityType
 	(*EmbeddedVulnerability)(nil),                // 2: storage.EmbeddedVulnerability
 	(*NodeVulnerability)(nil),                    // 3: storage.NodeVulnerability
-	(*CVSSV2)(nil),                               // 4: storage.CVSSV2
-	(*CVSSV3)(nil),                               // 5: storage.CVSSV3
-	(*timestamppb.Timestamp)(nil),                // 6: google.protobuf.Timestamp
-	(VulnerabilitySeverity)(0),                   // 7: storage.VulnerabilitySeverity
-	(VulnerabilityState)(0),                      // 8: storage.VulnerabilityState
-	(*CVSSScore)(nil),                            // 9: storage.CVSSScore
-	(*EPSS)(nil),                                 // 10: storage.EPSS
-	(*CVEInfo)(nil),                              // 11: storage.CVEInfo
+	(*Advisory)(nil),                             // 4: storage.Advisory
+	(*CVSSV2)(nil),                               // 5: storage.CVSSV2
+	(*CVSSV3)(nil),                               // 6: storage.CVSSV3
+	(*timestamppb.Timestamp)(nil),                // 7: google.protobuf.Timestamp
+	(VulnerabilitySeverity)(0),                   // 8: storage.VulnerabilitySeverity
+	(VulnerabilityState)(0),                      // 9: storage.VulnerabilityState
+	(*CVSSScore)(nil),                            // 10: storage.CVSSScore
+	(*EPSS)(nil),                                 // 11: storage.EPSS
+	(*CVEInfo)(nil),                              // 12: storage.CVEInfo
 }
 var file_storage_vulnerability_proto_depIdxs = []int32{
-	0,  // 0: storage.EmbeddedVulnerability.score_version:type_name -> storage.EmbeddedVulnerability.ScoreVersion
-	4,  // 1: storage.EmbeddedVulnerability.cvss_v2:type_name -> storage.CVSSV2
-	5,  // 2: storage.EmbeddedVulnerability.cvss_v3:type_name -> storage.CVSSV3
-	6,  // 3: storage.EmbeddedVulnerability.published_on:type_name -> google.protobuf.Timestamp
-	6,  // 4: storage.EmbeddedVulnerability.last_modified:type_name -> google.protobuf.Timestamp
-	1,  // 5: storage.EmbeddedVulnerability.vulnerability_type:type_name -> storage.EmbeddedVulnerability.VulnerabilityType
-	1,  // 6: storage.EmbeddedVulnerability.vulnerability_types:type_name -> storage.EmbeddedVulnerability.VulnerabilityType
-	6,  // 7: storage.EmbeddedVulnerability.suppress_activation:type_name -> google.protobuf.Timestamp
-	6,  // 8: storage.EmbeddedVulnerability.suppress_expiry:type_name -> google.protobuf.Timestamp
-	6,  // 9: storage.EmbeddedVulnerability.first_system_occurrence:type_name -> google.protobuf.Timestamp
-	6,  // 10: storage.EmbeddedVulnerability.first_image_occurrence:type_name -> google.protobuf.Timestamp
-	7,  // 11: storage.EmbeddedVulnerability.severity:type_name -> storage.VulnerabilitySeverity
-	8,  // 12: storage.EmbeddedVulnerability.state:type_name -> storage.VulnerabilityState
-	9,  // 13: storage.EmbeddedVulnerability.cvss_metrics:type_name -> storage.CVSSScore
-	10, // 14: storage.EmbeddedVulnerability.epss:type_name -> storage.EPSS
-	11, // 15: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
-	7,  // 16: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
-	6,  // 17: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
-	6,  // 18: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	4,  // 0: storage.EmbeddedVulnerability.advisory:type_name -> storage.Advisory
+	0,  // 1: storage.EmbeddedVulnerability.score_version:type_name -> storage.EmbeddedVulnerability.ScoreVersion
+	5,  // 2: storage.EmbeddedVulnerability.cvss_v2:type_name -> storage.CVSSV2
+	6,  // 3: storage.EmbeddedVulnerability.cvss_v3:type_name -> storage.CVSSV3
+	7,  // 4: storage.EmbeddedVulnerability.published_on:type_name -> google.protobuf.Timestamp
+	7,  // 5: storage.EmbeddedVulnerability.last_modified:type_name -> google.protobuf.Timestamp
+	1,  // 6: storage.EmbeddedVulnerability.vulnerability_type:type_name -> storage.EmbeddedVulnerability.VulnerabilityType
+	1,  // 7: storage.EmbeddedVulnerability.vulnerability_types:type_name -> storage.EmbeddedVulnerability.VulnerabilityType
+	7,  // 8: storage.EmbeddedVulnerability.suppress_activation:type_name -> google.protobuf.Timestamp
+	7,  // 9: storage.EmbeddedVulnerability.suppress_expiry:type_name -> google.protobuf.Timestamp
+	7,  // 10: storage.EmbeddedVulnerability.first_system_occurrence:type_name -> google.protobuf.Timestamp
+	7,  // 11: storage.EmbeddedVulnerability.first_image_occurrence:type_name -> google.protobuf.Timestamp
+	8,  // 12: storage.EmbeddedVulnerability.severity:type_name -> storage.VulnerabilitySeverity
+	9,  // 13: storage.EmbeddedVulnerability.state:type_name -> storage.VulnerabilityState
+	10, // 14: storage.EmbeddedVulnerability.cvss_metrics:type_name -> storage.CVSSScore
+	11, // 15: storage.EmbeddedVulnerability.epss:type_name -> storage.EPSS
+	12, // 16: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
+	8,  // 17: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
+	7,  // 18: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
+	7,  // 19: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_storage_vulnerability_proto_init() }
@@ -616,7 +673,7 @@ func file_storage_vulnerability_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_vulnerability_proto_rawDesc), len(file_storage_vulnerability_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/storage/vulnerability_vtproto.pb.go
+++ b/generated/storage/vulnerability_vtproto.pb.go
@@ -30,7 +30,7 @@ func (m *EmbeddedVulnerability) CloneVT() *EmbeddedVulnerability {
 	}
 	r := new(EmbeddedVulnerability)
 	r.Cve = m.Cve
-	r.Advisory = m.Advisory
+	r.Advisory = m.Advisory.CloneVT()
 	r.Cvss = m.Cvss
 	r.Summary = m.Summary
 	r.Link = m.Link
@@ -120,6 +120,24 @@ func (m *NodeVulnerability_FixedBy) CloneVT() isNodeVulnerability_SetFixedBy {
 	r := new(NodeVulnerability_FixedBy)
 	r.FixedBy = m.FixedBy
 	return r
+}
+
+func (m *Advisory) CloneVT() *Advisory {
+	if m == nil {
+		return (*Advisory)(nil)
+	}
+	r := new(Advisory)
+	r.Name = m.Name
+	r.Link = m.Link
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *Advisory) CloneMessageVT() proto.Message {
+	return m.CloneVT()
 }
 
 func (this *EmbeddedVulnerability) EqualVT(that *EmbeddedVulnerability) bool {
@@ -223,7 +241,7 @@ func (this *EmbeddedVulnerability) EqualVT(that *EmbeddedVulnerability) bool {
 	if !this.Epss.EqualVT(that.Epss) {
 		return false
 	}
-	if this.Advisory != that.Advisory {
+	if !this.Advisory.EqualVT(that.Advisory) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -316,6 +334,28 @@ func (this *NodeVulnerability_FixedBy) EqualVT(thatIface isNodeVulnerability_Set
 	return true
 }
 
+func (this *Advisory) EqualVT(that *Advisory) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if this.Link != that.Link {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *Advisory) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Advisory)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *EmbeddedVulnerability) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -355,10 +395,13 @@ func (m *EmbeddedVulnerability) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 		}
 		i -= size
 	}
-	if len(m.Advisory) > 0 {
-		i -= len(m.Advisory)
-		copy(dAtA[i:], m.Advisory)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Advisory)))
+	if m.Advisory != nil {
+		size, err := m.Advisory.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0x1
 		i--
@@ -688,6 +731,53 @@ func (m *NodeVulnerability_FixedBy) MarshalToSizedBufferVT(dAtA []byte) (int, er
 	dAtA[i] = 0x22
 	return len(dAtA) - i, nil
 }
+func (m *Advisory) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Advisory) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *Advisory) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Link) > 0 {
+		i -= len(m.Link)
+		copy(dAtA[i:], m.Link)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Link)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *EmbeddedVulnerability) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -779,8 +869,8 @@ func (m *EmbeddedVulnerability) SizeVT() (n int) {
 		l = m.Epss.SizeVT()
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	l = len(m.Advisory)
-	if l > 0 {
+	if m.Advisory != nil {
+		l = m.Advisory.SizeVT()
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -841,6 +931,24 @@ func (m *NodeVulnerability_FixedBy) SizeVT() (n int) {
 	n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	return n
 }
+func (m *Advisory) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Link)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *EmbeddedVulnerability) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1547,7 +1655,7 @@ func (m *EmbeddedVulnerability) UnmarshalVT(dAtA []byte) error {
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Advisory", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -1557,23 +1665,27 @@ func (m *EmbeddedVulnerability) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return protohelpers.ErrInvalidLength
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return protohelpers.ErrInvalidLength
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Advisory = string(dAtA[iNdEx:postIndex])
+			if m.Advisory == nil {
+				m.Advisory = &Advisory{}
+			}
+			if err := m.Advisory.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -1815,6 +1927,121 @@ func (m *NodeVulnerability) UnmarshalVT(dAtA []byte) error {
 			if err := (*timestamppb1.Timestamp)(m.SnoozeExpiry).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Advisory) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Advisory: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Advisory: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Link", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Link = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2560,7 +2787,7 @@ func (m *EmbeddedVulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Advisory", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -2570,27 +2797,27 @@ func (m *EmbeddedVulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return protohelpers.ErrInvalidLength
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return protohelpers.ErrInvalidLength
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			var stringValue string
-			if intStringLen > 0 {
-				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			if m.Advisory == nil {
+				m.Advisory = &Advisory{}
 			}
-			m.Advisory = stringValue
+			if err := m.Advisory.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2836,6 +3063,129 @@ func (m *NodeVulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 			if err := (*timestamppb1.Timestamp)(m.SnoozeExpiry).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Advisory) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Advisory: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Advisory: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Name = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Link", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Link = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -164,7 +164,7 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 		// TODO(ROX-20355): Populate last modified once the API is available.
 		vuln := &storage.EmbeddedVulnerability{
 			Cve:      ccVuln.GetName(),
-			Advisory: ccVuln.GetAdvisory(),
+			Advisory: advisory(ccVuln.GetAdvisory()),
 			Summary:  ccVuln.GetDescription(),
 			// TODO(ROX-26547)
 			// The link field will be overwritten if preferred CVSS source is available
@@ -189,6 +189,16 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 	}
 
 	return vulns
+}
+
+func advisory(advisory *v4.VulnerabilityReport_Advisory) *storage.Advisory {
+	if advisory == nil {
+		return nil
+	}
+	return &storage.Advisory{
+		Name: advisory.GetName(),
+		Link: advisory.GetLink(),
+	}
 }
 
 func epss(epssDetail *v4.VulnerabilityReport_Vulnerability_EPSS) *storage.EPSS {

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -2039,7 +2039,7 @@ func Test_advisory(t *testing.T) {
 	}
 	for name, testcase := range testcases {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, testcase.expected, advisory(testcase.vuln))
+			protoassert.Equal(t, testcase.expected, advisory(testcase.vuln))
 		})
 	}
 }

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -1731,9 +1731,12 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			enableRedHatCVEs: true,
 			want: map[string]*v4.VulnerabilityReport_Vulnerability{
 				"foo": {
-					Id:                 "foo",
-					Name:               "CVE-2021-44228",
-					Advisory:           "RHSA-2021:5132",
+					Id:   "foo",
+					Name: "CVE-2021-44228",
+					Advisory: &v4.VulnerabilityReport_Advisory{
+						Name: "RHSA-2021:5132",
+						Link: "https://access.redhat.com/errata/RHSA-2021:5132",
+					},
 					Link:               "https://access.redhat.com/security/cve/CVE-2021-44228 https://access.redhat.com/errata/RHSA-2021:5132",
 					Issued:             protoNow,
 					Severity:           "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
@@ -2007,28 +2010,31 @@ func Test_advisory(t *testing.T) {
 	testutils.MustUpdateFeature(t, features.ScannerV4RedHatCVEs, true)
 	testcases := map[string]struct {
 		vuln     *claircore.Vulnerability
-		expected string
+		expected *v4.VulnerabilityReport_Advisory
 	}{
 		"non-VEX": {
 			vuln: &claircore.Vulnerability{
 				Links:   "https://access.redhat.com/security/cve/CVE-2023-25761 https://access.redhat.com/errata/RHSA-2023:1866 https://access.redhat.com/security/cve/CVE-2023-25762",
 				Updater: "not-vex",
 			},
-			expected: "",
+			expected: nil,
 		},
 		"no RHSA": {
 			vuln: &claircore.Vulnerability{
 				Links:   "https://access.redhat.com/security/cve/CVE-2023-25761 https://access.redhat.com/security/cve/CVE-2023-25762",
 				Updater: "rhel-vex",
 			},
-			expected: "",
+			expected: nil,
 		},
 		"RHSA": {
 			vuln: &claircore.Vulnerability{
 				Links:   "https://access.redhat.com/security/cve/CVE-2023-25761 https://access.redhat.com/errata/RHSA-2023:1866 https://access.redhat.com/security/cve/CVE-2023-25762",
 				Updater: "rhel-vex",
 			},
-			expected: "RHSA-2023:1866",
+			expected: &v4.VulnerabilityReport_Advisory{
+				Name: "RHSA-2023:1866",
+				Link: "https://access.redhat.com/errata/RHSA-2023:1866",
+			},
 		},
 	}
 	for name, testcase := range testcases {

--- a/proto/internalapi/scanner/v4/vulnerability_report.proto
+++ b/proto/internalapi/scanner/v4/vulnerability_report.proto
@@ -13,6 +13,10 @@ option go_package = "./internalapi/scanner/v4;v4";
 
 // Next tag: 16
 message VulnerabilityReport {
+  message Advisory {
+    string name = 1;
+    string link = 2;
+  }
   message Vulnerability {
     enum Severity {
       SEVERITY_UNSPECIFIED = 0;
@@ -49,7 +53,7 @@ message VulnerabilityReport {
     }
     string id = 1;
     string name = 2;
-    string advisory = 15;
+    Advisory advisory = 15;
     string description = 3;
     google.protobuf.Timestamp issued = 4;
     string link = 5 [deprecated = true]; // link is duplicated with CVSS URL field, the exact deprecation date is undecided

--- a/proto/storage/cve.proto
+++ b/proto/storage/cve.proto
@@ -189,6 +189,7 @@ message ImageCVEV2 {
 
   string component_id = 13; // @gotags: sql:"fk(ImageComponentV2:id),index=btree"
   string advisory = 14; // @gotags: search:"Advisory"
+  string advisory_link = 15;
 }
 
 message NodeCVE {

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -6115,6 +6115,11 @@
                 "id": 14,
                 "name": "advisory",
                 "type": "string"
+              },
+              {
+                "id": 15,
+                "name": "advisory_link",
+                "type": "string"
               }
             ]
           },
@@ -18221,7 +18226,7 @@
               {
                 "id": 24,
                 "name": "advisory",
-                "type": "string"
+                "type": "Advisory"
               },
               {
                 "id": 2,
@@ -18374,6 +18379,21 @@
                 "id": 7,
                 "name": "snooze_expiry",
                 "type": "google.protobuf.Timestamp"
+              }
+            ]
+          },
+          {
+            "name": "Advisory",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "link",
+                "type": "string"
               }
             ]
           }

--- a/proto/storage/vulnerability.proto
+++ b/proto/storage/vulnerability.proto
@@ -26,7 +26,7 @@ message EmbeddedVulnerability {
   }
 
   string cve = 1; // @gotags: search:"CVE,store"
-  string advisory = 24;
+  Advisory advisory = 24;
   float cvss = 2; // @gotags: search:"CVSS,store"
   string summary = 3;
   string link = 4;
@@ -72,4 +72,9 @@ message NodeVulnerability {
   bool snoozed = 5; // @gotags: policy:"CVE Snoozed"
   google.protobuf.Timestamp snooze_start = 6;
   google.protobuf.Timestamp snooze_expiry = 7;
+}
+
+message Advisory {
+  string name = 1;
+  string link = 2;
 }


### PR DESCRIPTION
### Description

Red Hat Scanner Certification requires a link to the Red Hat Advisory, so this PR adds the link to the advisory output.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI
