### PR TITLE
chore(deps): Bump claircore to v1.5.37

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.63.0
-	github.com/quay/claircore v1.5.36-0.20250408161451-f5a19a457713
+	github.com/quay/claircore v1.5.37
 	github.com/quay/claircore/toolkit v1.2.5-0.20250120211107-bea8a6c197b2
 	github.com/quay/zlog v1.1.8
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319

--- a/go.sum
+++ b/go.sum
@@ -1302,8 +1302,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20241112170944-20d2c9ebc01d h1:HWfigq7lB31IeJL8iy7jkUmU/PG1Sr8jVGhS749dbUA=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20241112170944-20d2c9ebc01d/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
-github.com/quay/claircore v1.5.36-0.20250408161451-f5a19a457713 h1:44S04TJrIApnjEc65q9Tsl5ZGILmrXkN2BHIKO9xZg4=
-github.com/quay/claircore v1.5.36-0.20250408161451-f5a19a457713/go.mod h1:asvp3596/N5m1eZbDC/20N/45d1MvsNOTy0U1JQM+aE=
+github.com/quay/claircore v1.5.37 h1:98ncka8WqIAM04l62nwu96iFV7mf0z0BLKqNxQL3Iwo=
+github.com/quay/claircore v1.5.37/go.mod h1:3yfkeVOtu1BW54yyNrC4hWKxQQkPRbcH6AvQVInBeIU=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.2.5-0.20250120211107-bea8a6c197b2 h1:v4MBdtms7OhJgipiFSYNgfQ0nr7O+VPVESYwpS2Wb4M=
 github.com/quay/claircore/toolkit v1.2.5-0.20250120211107-bea8a6c197b2/go.mod h1:7CB7Q7tUGC0GwprVcq354sLRPRzmKJiLMgqJ1BzIwYc=


### PR DESCRIPTION
### Description

Use Claircore v1.5.37. This updates the package scanner versions for language package scanners to ensure we re-index to ignore RPM-installed language packages. This also optimizes the check for RPM-installed files.

### User-facing documentation

- [x] CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

no

#### How I validated my change

CI
