### PR TITLE
chore(roxctl): ensure --format json is not removed until replaced

### DIFF
--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -133,9 +133,9 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.Flags().BoolVarP(&imageScanCmd.failOnFinding, "fail", "", false, "Fail if vulnerabilities have been found.")
 
 	// Deprecated flag
-	// TODO(ROX-8303): Remove this once we have fully deprecated the old output format and are sure we do not break existing customer scripts
-	// The error message will be prefixed by "command <command-name> has been deprecated,"
-	// Fully deprecated "pretty" format, since we can assume no customer has built scripting around its loose format
+	// The error message will be prefixed by "command <command-name> has been deprecated".
+	//
+	// TODO(ROX-29120): This may NOT be removed until we find another place to put this or we replace this with another equivalent format.
 	c.Flags().StringVarP(&imageScanCmd.format, "format", "", "json", "Format of the output. Choose output format from json and csv.")
 	utils.Must(c.Flags().MarkDeprecated("format", deprecationNote))
 


### PR DESCRIPTION
### Description

This has come up a few times over the years, so I want to add this to make it clear it may not be removed until a replacement is found. See https://issues.redhat.com/browse/ROX-29120 for more information.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

no

#### How I validated my change

I didn't
