### PR TITLE
chore(query): replace math.MaxInt32 with 0

### DIFF
--- a/central/alert/service/service_impl.go
+++ b/central/alert/service/service_impl.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -125,7 +124,7 @@ func listAlertsRequestToQuery(request *v1.ListAlertsRequest, sort bool) (*v1.Que
 		}
 	}
 
-	paginated.FillPagination(q, request.GetPagination(), math.MaxInt32)
+	paginated.FillPagination(q, request.GetPagination(), paginated.Unlimited)
 	if sort {
 		q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 	}
@@ -173,7 +172,7 @@ func ensureAllAlertsAreFetched(req *v1.ListAlertsRequest) *v1.ListAlertsRequest 
 		req.Pagination = &v1.Pagination{}
 	}
 	req.Pagination.Offset = 0
-	req.Pagination.Limit = math.MaxInt32
+	req.Pagination.Limit = paginated.Unlimited
 	return req
 }
 
@@ -417,7 +416,7 @@ func (s *serviceImpl) DeleteAlerts(ctx context.Context, request *v1.DeleteAlerts
 	if err != nil {
 		return nil, errors.Wrapf(errox.InvalidArgs, "error parsing query: %v", err)
 	}
-	paginated.FillPagination(query, request.GetQuery().GetPagination(), math.MaxInt32)
+	paginated.FillPagination(query, request.GetQuery().GetPagination(), paginated.Unlimited)
 
 	specified := false
 	search.ApplyFnToAllBaseQueries(query, func(bq *v1.BaseQuery) {

--- a/central/alert/service/service_test.go
+++ b/central/alert/service/service_test.go
@@ -346,7 +346,7 @@ func (s *getAlertsGroupsTests) testGetAlertsGroupFor(fakeListAlertSlice []*stora
 	fakeContext := context.Background()
 	protoQuery := search.NewQueryBuilder().ProtoQuery()
 	protoQuery.Pagination = &v1.QueryPagination{
-		Limit: math.MaxInt32,
+		Limit: paginated.Unlimited,
 	}
 	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(fakeListAlertSlice, nil)
 
@@ -362,7 +362,7 @@ func (s *getAlertsGroupsTests) TestGetAlertsGroupWhenTheDataAccessLayerFails() {
 	fakeContext := context.Background()
 	protoQuery := search.NewQueryBuilder().ProtoQuery()
 	protoQuery.Pagination = &v1.QueryPagination{
-		Limit: math.MaxInt32,
+		Limit: paginated.Unlimited,
 	}
 	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(nil, errFake)
 
@@ -863,7 +863,7 @@ func (s *getAlertTimeseriesTests) TestGetAlertTimeseries() {
 		},
 	}
 	fakeContext := context.Background()
-	protoQuery := search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+	protoQuery := search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery()
 	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(alerts, nil)
 
 	result, err := s.service.GetAlertTimeseries(fakeContext, &v1.ListAlertsRequest{
@@ -876,7 +876,7 @@ func (s *getAlertTimeseriesTests) TestGetAlertTimeseries() {
 
 func (s *getAlertTimeseriesTests) TestGetAlertTimeseriesWhenTheDataAccessLayerFails() {
 	fakeContext := context.Background()
-	protoQuery := search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+	protoQuery := search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery()
 	s.datastoreMock.EXPECT().SearchListAlerts(fakeContext, protoQuery, true).Return(nil, errFake)
 
 	result, err := s.service.GetAlertTimeseries(fakeContext, &v1.ListAlertsRequest{
@@ -971,7 +971,7 @@ func (s *baseSuite) TestDeleteAlerts() {
 		AddStrings(search.ViolationState, storage.ViolationState_RESOLVED.String())
 	expectedQuery := expectedQueryBuilder.ProtoQuery()
 	expectedQuery.Pagination = &v1.QueryPagination{
-		Limit: math.MaxInt32,
+		Limit: paginated.Unlimited,
 	}
 
 	s.datastoreMock.EXPECT().Search(context.Background(), expectedQuery, true).Return([]search.Result{}, nil)

--- a/central/compliance/data/repository.go
+++ b/central/compliance/data/repository.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"math"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/mailru/easyjson"
@@ -18,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -203,7 +203,7 @@ func (r *repository) init(ctx context.Context, domain framework.ComplianceDomain
 
 	clusterQuery := search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
 	infPagination := &v1.QueryPagination{
-		Limit: math.MaxInt32,
+		Limit: paginated.Unlimited,
 	}
 	clusterQuery.Pagination = infPagination
 

--- a/central/deployment/service/service_impl.go
+++ b/central/deployment/service/service_impl.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"math"
 	"slices"
 	"time"
 
@@ -209,7 +208,7 @@ func (s *serviceImpl) ListDeployments(ctx context.Context, request *v1.RawQuery)
 func queryForLabels() *v1.Query {
 	q := search.NewQueryBuilder().AddStringsHighlighted(search.DeploymentLabel, search.WildcardString).ProtoQuery()
 	q.Pagination = &v1.QueryPagination{
-		Limit: math.MaxInt32,
+		Limit: paginated.Unlimited,
 	}
 	return q
 }

--- a/central/graphql/handler/clusters_test.go
+++ b/central/graphql/handler/clusters_test.go
@@ -16,7 +16,7 @@ import (
 
 func emptyPaginatedQuery() *v1.Query {
 	q := search.EmptyQuery()
-	paginated.FillPagination(q, nil, math.MaxInt32)
+	paginated.FillPagination(q, nil, paginated.Unlimited)
 	return q
 }
 

--- a/central/graphql/resolvers/image_cve_core_test.go
+++ b/central/graphql/resolvers/image_cve_core_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
@@ -11,6 +10,7 @@ import (
 	imageCVEViewMock "github.com/stackrox/rox/central/views/imagecve/mocks"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -80,7 +80,7 @@ func (s *ImageCVECoreResolverTestSuite) TestGetImageCVEsWithQuery() {
 		Query: pointers.String("CVE:cve-2022-xyz"),
 	}
 	expectedQ := search.NewQueryBuilder().AddStrings(search.CVE, "cve-2022-xyz").
-		WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+		WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery()
 
 	expected := []imagecve.CveCore{
 		imageCVEViewMock.NewMockCveCore(s.mockCtrl),
@@ -108,7 +108,7 @@ func (s *ImageCVECoreResolverTestSuite) TestImageCVEsWithPaginatedQuery() {
 	expectedQ := search.NewQueryBuilder().WithPagination(
 		search.NewPagination().AddSortOption(
 			search.NewSortOption(search.CVSS).AggregateBy(aggregatefunc.Max, false),
-		).Limit(math.MaxInt32),
+		).Limit(paginated.Unlimited),
 	).ProtoQuery()
 
 	s.imageCVEView.EXPECT().Get(s.ctx, expectedQ, views.ReadOptions{}).Return(nil, nil)

--- a/central/graphql/resolvers/image_cve_v2_core_test.go
+++ b/central/graphql/resolvers/image_cve_v2_core_test.go
@@ -85,7 +85,7 @@ func (s *ImageCVEV2CoreResolverTestSuite) TestGetImageCVEsWithQuery() {
 		Query: pointers.String("CVE:cve-2022-xyz"),
 	}
 	expectedQ := search.NewQueryBuilder().AddStrings(search.CVE, "cve-2022-xyz").
-		WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+		WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery()
 
 	expected := []imagecve.CveCore{
 		imageCVEViewMock.NewMockCveCore(s.mockCtrl),
@@ -113,7 +113,7 @@ func (s *ImageCVEV2CoreResolverTestSuite) TestImageCVEsWithPaginatedQuery() {
 	expectedQ := search.NewQueryBuilder().WithPagination(
 		search.NewPagination().AddSortOption(
 			search.NewSortOption(search.CVSS).AggregateBy(aggregatefunc.Max, false),
-		).Limit(math.MaxInt32),
+		).Limit(paginated.Unlimited),
 	).ProtoQuery()
 
 	s.imageCVEView.EXPECT().Get(s.ctx, expectedQ, views.ReadOptions{}).Return(nil, nil)

--- a/central/graphql/resolvers/node_cve_core_test.go
+++ b/central/graphql/resolvers/node_cve_core_test.go
@@ -87,7 +87,7 @@ func (s *NodeCVECoreResolverTestSuite) TestNodeCVEsWithQuery() {
 		Query: pointers.String("CVE:cve-2022-xyz"),
 	}
 	expectedQ := search.NewQueryBuilder().AddStrings(search.CVE, "cve-2022-xyz").
-		WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+		WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery()
 	expectedQ = tryUnsuppressedQuery(expectedQ)
 	expectedQ = noOrphanedCVEsQuery(s.T(), expectedQ)
 
@@ -117,7 +117,7 @@ func (s *NodeCVECoreResolverTestSuite) TestNodeCVEsWithPaginatedQuery() {
 	expectedQ := search.NewQueryBuilder().WithPagination(
 		search.NewPagination().AddSortOption(
 			search.NewSortOption(search.NodeTopCVSS).AggregateBy(aggregatefunc.Max, false),
-		).Limit(math.MaxInt32),
+		).Limit(paginated.Unlimited),
 	).ProtoQuery()
 	expectedQ = tryUnsuppressedQuery(expectedQ)
 	expectedQ = noOrphanedCVEsQuery(s.T(), expectedQ)
@@ -450,7 +450,7 @@ func (s *NodeCVECoreResolverTestSuite) TestNodeCVESubResolvers() {
 	cveCoreMock.EXPECT().GetCVEIDs().Return(cveIDsToTest)
 	expectedQ = search.NewQueryBuilder().AddExactMatches(search.CVEID, cveIDsToTest...).
 		AddBools(search.CVESuppressed, true, false).
-		WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+		WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery()
 	expectedQ = noOrphanedCVEsQuery(s.T(), expectedQ)
 
 	s.nodeCVEDatastore.EXPECT().Search(s.ctx, expectedQ).Return(cveResults, nil)

--- a/central/graphql/resolvers/platform_cve_core_test.go
+++ b/central/graphql/resolvers/platform_cve_core_test.go
@@ -82,7 +82,7 @@ func (s *PlatformCVEResolverTestSuite) TestGetPlatformCVEsWithQuery() {
 		Query: pointers.String("CVE:cve-2022-xyz"),
 	}
 	expectedQ := search.NewQueryBuilder().AddStrings(search.CVE, "cve-2022-xyz").
-		WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery()
+		WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery()
 	expectedQ = tryUnsuppressedQuery(expectedQ)
 
 	expected := []platformcve.CveCore{
@@ -111,7 +111,7 @@ func (s *PlatformCVEResolverTestSuite) TestPlatformCVEsCVEsWithPaginatedQuery() 
 	expectedQ := search.NewQueryBuilder().WithPagination(
 		search.NewPagination().AddSortOption(
 			search.NewSortOption(search.CVSS).AggregateBy(aggregatefunc.Max, false),
-		).Limit(math.MaxInt32),
+		).Limit(paginated.Unlimited),
 	).ProtoQuery()
 	expectedQ = tryUnsuppressedQuery(expectedQ)
 

--- a/central/graphql/resolvers/search.go
+++ b/central/graphql/resolvers/search.go
@@ -41,14 +41,14 @@ func (r *PaginatedQuery) AsV1QueryOrEmpty() (*v1.Query, error) {
 	var q *v1.Query
 	if r == nil || r.Query == nil {
 		q := search.EmptyQuery()
-		paginated.FillPagination(q, r.Pagination.AsV1Pagination(), math.MaxInt32)
+		paginated.FillPagination(q, r.Pagination.AsV1Pagination(), paginated.Unlimited)
 		return q, nil
 	}
 	q, err := search.ParseQuery(*r.Query, search.MatchAllIfEmpty())
 	if err != nil {
 		return nil, err
 	}
-	paginated.FillPagination(q, r.Pagination.AsV1Pagination(), math.MaxInt32)
+	paginated.FillPagination(q, r.Pagination.AsV1Pagination(), paginated.Unlimited)
 	return q, nil
 }
 

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -114,7 +114,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 				Query: pointers.String("CVE:abc"),
 			},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.CVE, "abc").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "simple query w/ plus in value",
@@ -122,7 +122,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 				Query: pointers.String("CVE:ab+c"),
 			},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.CVE, "ab+c").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "exact query",
@@ -130,7 +130,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 				Query: pointers.String("CVE:\"abc\""),
 			},
 			expectedQ: search.NewQueryBuilder().AddExactMatches(search.CVE, "abc").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "exact query w/ plus in value",
@@ -138,7 +138,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 				Query: pointers.String("CVE:\"ab+c\""),
 			},
 			expectedQ: search.NewQueryBuilder().AddExactMatches(search.CVE, "ab+c").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "conjunction query",
@@ -147,7 +147,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 			},
 			expectedQ: search.NewQueryBuilder().
 				AddStrings(search.CVE, "abc").AddStrings(search.ImageName, "xyz").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "disjunction query",
@@ -155,7 +155,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 				Query: pointers.String("CVE:abc,xyz"),
 			},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.CVE, "abc", "xyz").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "conjunction & disjunctions",
@@ -164,7 +164,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 			},
 			expectedQ: search.NewQueryBuilder().
 				AddStrings(search.CVE, "abc", "xyz").AddStrings(search.ImageName, "img1", "img2").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "query + sort",
@@ -177,7 +177,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 				},
 			},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.CVE, "abc").WithPagination(
-				search.NewPagination().AddSortOption(search.NewSortOption(search.ImageName)).Limit(math.MaxInt32),
+				search.NewPagination().AddSortOption(search.NewSortOption(search.ImageName)).Limit(paginated.Unlimited),
 			).ProtoQuery(),
 		},
 		{
@@ -299,7 +299,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 				},
 			},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.CVE, "abc").
-				WithPagination(search.NewPagination().Limit(math.MaxInt32)).ProtoQuery(),
+				WithPagination(search.NewPagination().Limit(paginated.Unlimited)).ProtoQuery(),
 		},
 		{
 			desc: "query + empty sorts",
@@ -315,7 +315,7 @@ func TestAsV1QueryOrEmpty(t *testing.T) {
 			expectedQ: search.NewQueryBuilder().AddStrings(search.CVE, "abc").
 				WithPagination(search.NewPagination().
 					AddSortOption(search.NewSortOption("")).
-					AddSortOption(search.NewSortOption("")).Limit(math.MaxInt32),
+					AddSortOption(search.NewSortOption("")).Limit(paginated.Unlimited),
 				).ProtoQuery(),
 		},
 		{

--- a/central/graphql/resolvers/vulnerability_requests.go
+++ b/central/graphql/resolvers/vulnerability_requests.go
@@ -330,7 +330,7 @@ func (resolver *Resolver) VulnerabilityRequests(ctx context.Context,
 	}
 
 	// Fill in pagination.
-	paginated.FillPagination(parsedQuery, args.Pagination.AsV1Pagination(), math.MaxInt32)
+	paginated.FillPagination(parsedQuery, args.Pagination.AsV1Pagination(), paginated.Unlimited)
 
 	response, err := resolver.vulnReqStore.SearchRawRequests(
 		ctx,

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -732,7 +732,7 @@ func (s *serviceImpl) DeleteImages(ctx context.Context, request *v1.DeleteImages
 	if err != nil {
 		return nil, errors.Wrapf(errox.InvalidArgs, "error parsing query: %v", err)
 	}
-	paginated.FillPagination(query, request.GetQuery().GetPagination(), math.MaxInt32)
+	paginated.FillPagination(query, request.GetQuery().GetPagination(), paginated.Unlimited)
 
 	results, err := s.datastore.Search(ctx, query)
 	if err != nil {

--- a/central/namespace/service/service_impl.go
+++ b/central/namespace/service/service_impl.go
@@ -56,7 +56,7 @@ func (s *serviceImpl) GetNamespaces(ctx context.Context, req *v1.GetNamespaceReq
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	// Fill in pagination. MaxInt32 preserves previous functionality
-	paginated.FillPagination(parsedQuery, rawQuery.GetPagination(), math.MaxInt32)
+	paginated.FillPagination(parsedQuery, rawQuery.GetPagination(), paginated.Unlimited)
 
 	namespaces, err := namespace.ResolveAll(ctx, s.datastore, s.deployments, s.secrets, s.networkPolicies, parsedQuery)
 	if err != nil {

--- a/central/rbac/service/get_subject.go
+++ b/central/rbac/service/get_subject.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/k8srbac"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/set"
 )
 
@@ -28,7 +29,7 @@ func getSubjectFromStores(ctx context.Context, subjectName string, roleDS k8sRol
 			[]string{search.ExactMatchString(subjectName), search.ExactMatchString(storage.SubjectKind_GROUP.String())}).ProtoQuery(),
 	)
 	bindingsQuery.Pagination = &v1.QueryPagination{
-		Limit: math.MaxInt32,
+		Limit: paginated.Unlimited,
 	}
 	relevantBindings, err := bindingDS.SearchRawRoleBindings(ctx, bindingsQuery)
 	if err != nil || len(relevantBindings) == 0 {
@@ -65,7 +66,7 @@ func getSubjectFromStores(ctx context.Context, subjectName string, roleDS k8sRol
 
 	rolesQuery := search.NewQueryBuilder().AddExactMatches(search.RoleID, roleIDs.AsSlice()...).ProtoQuery()
 	rolesQuery.Pagination = &v1.QueryPagination{
-		Limit: math.MaxInt32,
+		Limit: paginated.Unlimited,
 	}
 	relevantRoles, err := roleDS.SearchRawRoles(ctx, rolesQuery)
 	if err != nil {

--- a/pkg/search/paginated/paginated.go
+++ b/pkg/search/paginated/paginated.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 )
 
+const Unlimited = 0
+
 // WithDefaultSortOption is a higher order function that makes sure results are sorted.
 func WithDefaultSortOption(searcher search.Searcher, defaultSortOption *v1.QuerySortOption) search.Searcher {
 	return search.FuncSearcher{
@@ -85,7 +87,7 @@ func FillPagination(query *v1.Query, pagination *v1.Pagination, maxLimit int32) 
 	queryPagination := &v1.QueryPagination{}
 
 	// Fill in limit, and check boundaries.
-	if pagination.GetLimit() == 0 || pagination.GetLimit() > maxLimit {
+	if pagination.GetLimit() == Unlimited || pagination.GetLimit() > maxLimit {
 		queryPagination.Limit = maxLimit
 	} else {
 		queryPagination.Limit = pagination.GetLimit()

--- a/pkg/search/parser/url_parser.go
+++ b/pkg/search/parser/url_parser.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"math"
 	"net/url"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -23,6 +22,6 @@ func ParseURLQuery(values url.Values) (*v1.Query, *v1.RawQuery, error) {
 		return nil, nil, err
 	}
 
-	paginated.FillPagination(query, rawQuery.GetPagination(), math.MaxInt32)
+	paginated.FillPagination(query, rawQuery.GetPagination(), paginated.Unlimited)
 	return query, &rawQuery, nil
 }


### PR DESCRIPTION
This PR unifies the way how unlimited query pagination looks like. Currently we have both `0` and `math.MaxInt32` but only `0` has a special treatment when generating a SQL query. Let's unify it and make unlimited query explicit by exposing `0` as well named const.

https://github.com/stackrox/stackrox/blob/9831caa88a5bb251000b013b10a1f987fe916537/pkg/search/postgres/common.go#L415