### PR TITLE
chore(pg): get limit or default when unlimited

### DIFF
--- a/pkg/search/paginated/paginated.go
+++ b/pkg/search/paginated/paginated.go
@@ -2,6 +2,7 @@ package paginated
 
 import (
 	"context"
+	"math"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	v2 "github.com/stackrox/rox/generated/api/v2"
@@ -189,4 +190,12 @@ func PaginateSlice[T any](offset, limit int, slice []T) []T {
 	// if we pass nil, then there can be no error
 	result, _ := paginate(offset, limit, slice, nil)
 	return result
+}
+
+// GetLimit returns pagination limit or a value if it's unlimited
+func GetLimit(paginationLimit int32, whenUnlimited int32) int32 {
+	if paginationLimit == 0 || paginationLimit == math.MaxInt32 {
+		return whenUnlimited
+	}
+	return paginationLimit
 }

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -222,8 +223,7 @@ func (s *genericStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, err
 func (s *genericStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
 
-	limit := max(batchAfter, min(batchAfter, query.GetPagination().GetLimit()))
-	rows := make([]*T, 0, limit)
+	rows := make([]*T, 0, paginated.GetLimit(query.GetPagination().GetLimit(), batchAfter))
 	err := RunQueryForSchemaFn(ctx, s.schema, query, s.db, func(obj PT) error {
 		rows = append(rows, obj)
 		return nil


### PR DESCRIPTION
This PR create a handy function to use for preallocation when query is unlimited.