### PR TITLE
refactor: better context naming consistency in VM datastore

### DIFF
--- a/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl.go
@@ -103,8 +103,8 @@ func (ds *datastoreImpl) AddRequest(ctx context.Context, request *storage.Vulner
 		return sac.ErrResourceAccessDenied
 	}
 
-	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
-	return ds.store.Upsert(storeWriteCtx, request)
+	storeReadWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	return ds.store.Upsert(storeReadWriteCtx, request)
 }
 
 func (ds *datastoreImpl) UpdateRequestStatus(ctx context.Context, id, message string, status storage.RequestStatus) (*storage.VulnerabilityRequest, error) {
@@ -271,8 +271,8 @@ func (ds *datastoreImpl) UpdateRequestExpiry(ctx context.Context, id, message st
 		req.Status = storage.RequestStatus_APPROVED_PENDING_UPDATE
 	}
 
-	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
-	if err := ds.store.Upsert(storeWriteCtx, req); err != nil {
+	storeReadWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.Upsert(storeReadWriteCtx, req); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -309,8 +309,8 @@ func (ds *datastoreImpl) UpdateRequest(ctx context.Context, id string, update *c
 		falsePositiveUpdate(req, update.FalsePositiveUpdate)
 	}
 
-	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
-	if err := ds.store.Upsert(storeWriteCtx, req); err != nil {
+	storeReadWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.Upsert(storeReadWriteCtx, req); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -402,8 +402,8 @@ func (ds *datastoreImpl) MarkRequestInactive(ctx context.Context, id, comment st
 	req.Comments = append(req.Comments, utils.CreateRequestCommentProto(ctx, comment))
 	req.Expired = true
 
-	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
-	if err := ds.store.Upsert(storeWriteCtx, req); err != nil {
+	storeReadWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.Upsert(storeReadWriteCtx, req); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -464,8 +464,8 @@ func (ds *datastoreImpl) RemoveRequestsInternal(ctx context.Context, ids []strin
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-	storeWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
-	if err := ds.store.DeleteMany(storeWriteCtx, ids); err != nil {
+	storeReadWriteCtx := getStoreAccessContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	if err := ds.store.DeleteMany(storeReadWriteCtx, ids); err != nil {
 		return err
 	}
 	ds.pendingReqCache.RemoveMany(ids...)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Address nit from #14384 

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->
Variable naming change. The existing CI should caught any unexpected issue.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI
