### PR TITLE
ROX-29139: Add name for KUBE_SERVICE_ACCOUNT M2M config type

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -112,6 +112,9 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
                     if (type === 'GITHUB_ACTIONS') {
                         return 'GitHub action';
                     }
+                    if (type === 'KUBE_SERVICE_ACCOUNT') {
+                        return 'Kubernetes service account';
+                    }
                     return 'Unknown';
                 },
                 Header: 'Configuration',

--- a/ui/apps/platform/src/services/MachineAccessService.ts
+++ b/ui/apps/platform/src/services/MachineAccessService.ts
@@ -1,7 +1,7 @@
 import axios from './instance';
 import { Empty } from './types';
 
-export type MachineConfigType = 'GENERIC' | 'GITHUB_ACTIONS';
+export type MachineConfigType = 'GENERIC' | 'GITHUB_ACTIONS' | 'KUBE_SERVICE_ACCOUNT';
 
 export type MachineConfigMapping = {
     key: string;


### PR DESCRIPTION
For the PaC GA release, the M2M config for the Kube service account is now visible in the UI because it is now configurable. But because the "kube service account" type was added for the config-controller (before it was visible in the UI), it was not added to the UI. So the new M2M config type needs to be added.

#### How I validated my change

Built and deployed the UI locally and observed the new name successfully displayed.  The M2M config is added during Central bootstrap, so there is no additional setup needed to observe this specific M2M config.