### PR TITLE
chore(ui): Use consistent helper function for date formatting

### DIFF
--- a/ui/apps/platform/src/Components/DateTimeField/DateTimeField.tsx
+++ b/ui/apps/platform/src/Components/DateTimeField/DateTimeField.tsx
@@ -1,27 +1,17 @@
 import React, { ReactElement } from 'react';
-import { isValid, parse, format } from 'date-fns';
+import { isValid, parse } from 'date-fns';
+import { getDateTime } from 'utils/dateUtils';
 
 type DateTimeFieldProps = {
     date?: string; // ISO 8601 formatted date
-    asString?: boolean;
 };
 
-function DateTimeField({ date = '', asString = false }: DateTimeFieldProps): ReactElement {
+function DateTimeField({ date = '' }: DateTimeFieldProps): ReactElement {
     if (!date || !isValid(parse(date))) {
         return <span>—</span>;
     }
 
-    const datePart = format(date, 'MM/DD/YYYY');
-    const timePart = format(date, 'h:mm:ssA');
-
-    return asString ? (
-        <span>{`${datePart} | ${timePart}`}</span>
-    ) : (
-        <div className="flex flex-col">
-            <span>{datePart}</span>
-            <span>{timePart}</span>
-        </div>
-    );
+    return <span>{getDateTime(date)}</span>;
 }
 
 export default DateTimeField;

--- a/ui/apps/platform/src/Components/WorkflowPDFExportButton.jsx
+++ b/ui/apps/platform/src/Components/WorkflowPDFExportButton.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import 'jspdf-autotable';
-import dateFns from 'date-fns';
 import computedStyleToInlineStyle from 'computed-style-to-inline-style';
 import { Button } from '@patternfly/react-core';
+
+import { getDate } from 'utils/dateUtils';
 import { enhanceWordBreak } from 'utils/pdfUtils';
 import { getProductBranding } from 'constants/productBranding';
 
@@ -65,7 +66,7 @@ class WorkflowPDFExportButton extends Component {
             <img alt="stackrox-logo" src=${getProductBranding().logoSvg} class="h-20 pl-2" />
             <div class="pr-4 text-right">
                 <div class="text-2xl">${this.props.pdfTitle}</div>
-                <div class="pt-2 text-xl">${dateFns.format(new Date(), 'MM/DD/YYYY')}</div>
+                <div class="pt-2 text-xl">${getDate(new Date())}</div>
             </div>
         </div>`;
         const header = document.createElement('header');

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState } from 'react';
-import { format } from 'date-fns';
 import pluralize from 'pluralize';
 
 import entityTypes from 'constants/entityTypes';
@@ -24,6 +23,7 @@ import PageNotFound from 'Components/PageNotFound';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import useCases from 'constants/useCaseTypes';
 import isGQLLoading from 'utils/gqlLoading';
+import { getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import searchContext from 'Containers/searchContext';
 
 import Header from './Header';
@@ -40,9 +40,6 @@ function processData(data) {
     const [ipAddress] = result.internalIpAddresses;
     result.ipAddress = ipAddress;
 
-    const joinedAt = new Date(result.joinedAt);
-    result.joinedAtDate = format(joinedAt, 'MM/DD/YYYY');
-    result.joinedAtTime = format(joinedAt, 'h:mm:ss:A');
     return result;
 }
 
@@ -81,8 +78,7 @@ const NodePage = ({
                     clusterName,
                     osImage,
                     ipAddress,
-                    joinedAtDate,
-                    joinedAtTime,
+                    joinedAt,
                     kernelVersion,
                     labels,
                 } = node;
@@ -172,8 +168,12 @@ const NodePage = ({
                                     <div className="md:pl-3 pb-3">
                                         <InfoWidget
                                             title="Node Join Time"
-                                            headline={joinedAtDate}
-                                            description={joinedAtTime}
+                                            headline={getDistanceStrictAsPhrase(
+                                                joinedAt,
+                                                new Date()
+                                            )}
+                                            description={getDateTime(joinedAt)}
+                                            textSizeClass="text-base"
                                             loading={loading}
                                         />
                                     </div>

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ClusterVersion.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ClusterVersion.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CLUSTER_VERSION_QUERY as QUERY } from 'queries/cluster';
 import { clusterVersionLabels } from 'messages/common';
-import { format as dateFormat } from 'date-fns';
+import { getDate } from 'utils/dateUtils';
 import NoResultsMessage from 'Components/NoResultsMessage';
 
 import Widget from 'Components/Widget';
@@ -42,7 +42,7 @@ const ClusterVersion = ({ clusterId }) => {
                                 </div>
                                 <div>
                                     Build date:&nbsp;
-                                    {dateFormat(orchestratorMetadata.buildDate, 'MMMM DD, YYYY')}
+                                    {getDate(orchestratorMetadata.buildDate)}
                                 </div>
                             </div>
                         );

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityImage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityImage.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { gql } from '@apollo/client';
-import { format } from 'date-fns';
 import cloneDeep from 'lodash/cloneDeep';
 
 import Query from 'Components/ThrowingQuery';
@@ -10,12 +9,12 @@ import PageNotFound from 'Components/PageNotFound';
 import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityToColumns } from 'constants/listColumns';
 import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
 import CVETable from 'Containers/Images/CVETable';
 import searchContext from 'Containers/searchContext';
 import { getConfigMgmtCountQuery } from 'Containers/ConfigManagement/ConfigMgmt.utils';
+import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';
 import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
@@ -137,7 +136,7 @@ const ConfigManagementEntityImage = ({
                 const metadataKeyValuePairs = [
                     {
                         key: 'Last Scanned',
-                        value: lastUpdated ? format(lastUpdated, dateTimeFormat) : 'N/A',
+                        value: lastUpdated ? getDateTime(lastUpdated) : 'N/A',
                     },
                 ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNamespace.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNamespace.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { format } from 'date-fns';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -9,11 +8,11 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import RelatedEntity from 'Components/RelatedEntity';
 import Metadata from 'Components/Metadata';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
 import DeploymentsWithFailedPolicies from 'Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies';
 import searchContext from 'Containers/searchContext';
 import { getConfigMgmtCountQuery } from 'Containers/ConfigManagement/ConfigMgmt.utils';
+import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';
 import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
@@ -128,7 +127,7 @@ const ConfigManagementEntityNamespace = ({
                 const metadataKeyValuePairs = [
                     {
                         key: 'Created',
-                        value: creationTime ? format(creationTime, dateTimeFormat) : 'N/A',
+                        value: creationTime ? getDateTime(creationTime) : 'N/A',
                     },
                 ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNode.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNode.jsx
@@ -1,8 +1,6 @@
 import React, { useContext } from 'react';
 import { gql } from '@apollo/client';
-import { format } from 'date-fns';
 
-import dateTimeFormat from 'constants/dateTimeFormat';
 import NoResultsMessage from 'Components/NoResultsMessage';
 import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
@@ -18,6 +16,7 @@ import searchContext from 'Containers/searchContext';
 import { standardLabels } from 'messages/standards';
 import { CONTROL_FRAGMENT } from 'queries/controls';
 import { sortVersion } from 'sorters/sorters';
+import { getDateTime } from 'utils/dateUtils';
 import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
 import getControlsWithStatus from '../List/utilities/getControlsWithStatus';
@@ -117,7 +116,7 @@ const ConfigManagementEntityNode = ({
                     },
                     {
                         key: 'Join time',
-                        value: joinedAt ? format(joinedAt, dateTimeFormat) : 'N/A',
+                        value: joinedAt ? getDateTime(joinedAt) : 'N/A',
                     },
                 ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityRole.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityRole.jsx
@@ -1,8 +1,6 @@
 import React, { useContext } from 'react';
-import { format } from 'date-fns';
 import { gql } from '@apollo/client';
 
-import dateTimeFormat from 'constants/dateTimeFormat';
 import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
 import CollapsibleSection from 'Components/CollapsibleSection';
@@ -15,6 +13,7 @@ import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
 import searchContext from 'Containers/searchContext';
 import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';
 import { getConfigMgmtCountQuery } from 'Containers/ConfigManagement/ConfigMgmt.utils';
 import EntityList from '../List/EntityList';
@@ -135,7 +134,7 @@ const ConfigManagementEntityRole = ({
                     { key: 'Role Type', value: type },
                     {
                         key: 'Created',
-                        value: createdAt ? format(createdAt, dateTimeFormat) : 'N/A',
+                        value: createdAt ? getDateTime(createdAt) : 'N/A',
                     },
                 ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySecret.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySecret.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
 import pluralize from 'pluralize';
 import { gql } from '@apollo/client';
 
@@ -13,10 +12,10 @@ import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
 import CollapsibleRow from 'Components/CollapsibleRow';
 import Widget from 'Components/Widget';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import { getConfigMgmtCountQuery } from 'Containers/ConfigManagement/ConfigMgmt.utils';
+import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';
 import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
@@ -42,11 +41,11 @@ const SecretDataMetadata = ({ metadata }) => {
             >
                 <div>
                     <span className="font-700 mr-4">Start Date:</span>
-                    <span>{startDate ? format(startDate, dateTimeFormat) : 'N/A'}</span>
+                    <span>{startDate ? getDateTime(startDate) : 'N/A'}</span>
                 </div>
                 <div>
                     <span className="font-700 mr-4">End Date:</span>
-                    <span>{endDate ? format(endDate, dateTimeFormat) : 'N/A'}</span>
+                    <span>{endDate ? getDateTime(endDate) : 'N/A'}</span>
                 </div>
             </Widget>
             <Widget
@@ -266,7 +265,7 @@ const ConfigManagementEntitySecret = ({
                 const metadataKeyValuePairs = [
                     {
                         key: 'Created',
-                        value: createdAt ? format(createdAt, dateTimeFormat) : 'N/A',
+                        value: createdAt ? getDateTime(createdAt) : 'N/A',
                     },
                 ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityServiceAccount.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityServiceAccount.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { format } from 'date-fns';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -9,12 +8,12 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntity from 'Components/RelatedEntity';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
 import ClusterScopedPermissions from 'Containers/ConfigManagement/Entity/widgets/ClusterScopedPermissions';
 import NamespaceScopedPermissions from 'Containers/ConfigManagement/Entity/widgets/NamespaceScopedPermissions';
 import searchContext from 'Containers/searchContext';
 import { getConfigMgmtCountQuery } from 'Containers/ConfigManagement/ConfigMgmt.utils';
+import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';
 import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
@@ -158,7 +157,7 @@ const ConfigManagementEntityServiceAccount = ({
                     { key: 'Automounted', value: automountToken.toString() },
                     {
                         key: 'Created',
-                        value: createdAt ? format(createdAt, dateTimeFormat) : 'N/A',
+                        value: createdAt ? getDateTime(createdAt) : 'N/A',
                     },
                 ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/ConfigManagementEntityDeployment.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/ConfigManagementEntityDeployment.jsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { format } from 'date-fns';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -9,7 +8,7 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntity from 'Components/RelatedEntity';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
-import dateTimeFormat from 'constants/dateTimeFormat';
+import { getDateTime } from 'utils/dateUtils';
 import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import { getConfigMgmtCountQuery } from 'Containers/ConfigManagement/ConfigMgmt.utils';
@@ -156,7 +155,7 @@ const ConfigManagementEntityDeployment = ({
                 const metadataKeyValuePairs = [
                     {
                         key: 'Created',
-                        value: created ? format(created, dateTimeFormat) : 'N/A',
+                        value: created ? getDateTime(created) : 'N/A',
                     },
                     {
                         key: 'Deployment Type',

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
@@ -4,8 +4,6 @@ import { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';
 import { sortSeverity } from 'sorters/sorters';
-import { format } from 'date-fns';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { BasePolicy } from 'types/policy.proto';
 
 import NoResultsMessage from 'Components/NoResultsMessage';
@@ -14,6 +12,7 @@ import Loader from 'Components/Loader';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import { formatLifecycleStages } from 'Containers/Policies/policies.utils';
+import { getDateTime } from 'utils/dateUtils';
 import TableWidget from './TableWidget';
 
 type FailedPolicy = Pick<
@@ -158,7 +157,7 @@ function FailedPoliciesAcrossDeployment({ deploymentID }: FailedPoliciesAcrossDe
                         Header: 'Violation Time',
                         headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                         className: `w-1/8 ${defaultColumnClassName}`,
-                        Cell: ({ original }) => format(original.time, dateTimeFormat),
+                        Cell: ({ original }) => getDateTime(original.time),
                         accessor: 'time',
                     },
                 ];

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import pluralize from 'pluralize';
-import { format } from 'date-fns';
 
 import {
     defaultHeaderClassName,
@@ -9,11 +8,11 @@ import {
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
 import { imageSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { IMAGES_QUERY } from 'queries/image';
+import { getDateTime } from 'utils/dateUtils';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import { getConfigMgmtPathForEntitiesAndId } from '../entities';
@@ -59,7 +58,7 @@ const buildTableColumns = (match, location, entityContext) => {
                 if (!metadata) {
                     return '-';
                 }
-                return format(metadata.v1.created, dateTimeFormat);
+                return getDateTime(metadata.v1.created);
             },
             id: imageSortFields.CREATED_TIME,
             sortField: imageSortFields.CREATED_TIME,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { gql } from '@apollo/client';
-import { format } from 'date-fns';
 import pluralize from 'pluralize';
 
 import {
@@ -10,10 +9,10 @@ import {
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
 import { nodeSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
+import { getDateTime } from 'utils/dateUtils';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import { getConfigMgmtPathForEntitiesAndId } from '../entities';
@@ -96,7 +95,7 @@ const buildTableColumns = (match, location, entityContext) => {
                 if (!joinedAt) {
                     return null;
                 }
-                return format(joinedAt, dateTimeFormat);
+                return getDateTime(joinedAt);
             },
             accessor: 'joinedAt',
             id: nodeSortFields.NODE_JOIN_TIME,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import pluralize from 'pluralize';
-import { format } from 'date-fns';
 
 import {
     defaultHeaderClassName,
@@ -9,11 +8,11 @@ import {
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
 import { roleSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { K8S_ROLES_QUERY } from 'queries/role';
+import { getDateTime } from 'utils/dateUtils';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import { getConfigMgmtPathForEntitiesAndId } from '../entities';
@@ -78,7 +77,7 @@ const buildTableColumns = (match, location, entityContext) => {
             className: `w-1/8 ${defaultColumnClassName}`,
             Cell: ({ original }) => {
                 const { createdAt } = original;
-                return format(createdAt, dateTimeFormat);
+                return getDateTime(createdAt);
             },
             accessor: 'createdAt',
             sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import uniq from 'lodash/uniq';
-import { format } from 'date-fns';
 import pluralize from 'pluralize';
 
 import {
@@ -10,11 +9,11 @@ import {
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { SECRETS_QUERY } from 'queries/secret';
 import { secretSortFields } from 'constants/sortFields';
+import { getDateTime } from 'utils/dateUtils';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import { getConfigMgmtPathForEntitiesAndId } from '../entities';
@@ -72,7 +71,7 @@ const buildTableColumns = (match, location, entityContext) => {
             className: `w-1/8 ${defaultColumnClassName}`,
             Cell: ({ original }) => {
                 const { createdAt } = original;
-                return format(createdAt, dateTimeFormat);
+                return getDateTime(createdAt);
             },
             accessor: 'createdAt',
             id: secretSortFields.CREATED,

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -11,6 +11,7 @@ import {
     vulnerabilitiesWorkloadCvesPath,
 } from 'routePaths';
 import { resourceTypes } from 'constants/entityTypes';
+import { getDateTime } from 'utils/dateUtils';
 import { generatePathWithQuery } from 'utils/searchUtils';
 
 import SummaryCount from './SummaryCount';
@@ -44,10 +45,6 @@ const tileNouns: Record<TileResource, string> = {
     Image: 'Image',
     Secret: 'Secret',
 };
-
-const locale = window.navigator.language ?? 'en-US';
-const dateFormatter = new Intl.DateTimeFormat(locale);
-const timeFormatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' });
 
 export type SummaryCountsProps = {
     hasReadAccessForResource: Record<TileResource, boolean>;
@@ -131,9 +128,7 @@ function SummaryCounts({ hasReadAccessForResource }: SummaryCountsProps): ReactE
                 </Split>
             </SplitItem>
             <div className="pf-v5-u-color-200 pf-v5-u-font-size-sm pf-v5-u-mr-md pf-v5-u-mr-lg-on-lg">
-                {`Last updated ${dateFormatter.format(lastUpdate)} at ${timeFormatter.format(
-                    lastUpdate
-                )}`}
+                {`Last updated ${getDateTime(lastUpdate)}`}
             </div>
         </Split>
     );

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
@@ -70,7 +70,7 @@ function MostRecentViolations({ alerts }: MostRecentViolationsProps) {
                                         </Flex>
                                     </Td>
                                     <Td
-                                        width={35}
+                                        modifier="nowrap"
                                         className="pf-v5-u-pr-0 pf-v5-u-text-align-right-on-md"
                                         dataLabel="Time of last violation occurrence"
                                     >

--- a/ui/apps/platform/src/Containers/Risk/DeploymentDetails.jsx
+++ b/ui/apps/platform/src/Containers/Risk/DeploymentDetails.jsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import dateFns from 'date-fns';
 import { Alert } from '@patternfly/react-core';
 
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { fetchDeployment } from 'services/DeploymentsService';
 import CollapsibleCard from 'Components/CollapsibleCard';
+import { getDateTime } from 'utils/dateUtils';
 import { portExposureLabels } from 'messages/common';
 import SecurityContext from './SecurityContext';
 import ContainerConfigurations from './ContainerConfigurations';
@@ -31,8 +30,7 @@ const deploymentDetailsMap = {
     replicas: { label: 'Replicas' },
     created: {
         label: 'Created',
-        formatValue: (timestamp) =>
-            timestamp ? dateFns.format(timestamp, dateTimeFormat) : 'not available',
+        formatValue: (timestamp) => (timestamp ? getDateTime(timestamp) : 'not available'),
     },
     labels: { label: 'Labels' },
     annotations: { label: 'Annotations' },

--- a/ui/apps/platform/src/Containers/Risk/EventTimeline/DeploymentEventTimeline/getPodEvents.js
+++ b/ui/apps/platform/src/Containers/Risk/EventTimeline/DeploymentEventTimeline/getPodEvents.js
@@ -1,7 +1,6 @@
-import { format } from 'date-fns';
 import pluralize from 'pluralize';
 
-import { timelineStartTimeFormat } from 'constants/dateTimeFormat';
+import { getDateTime } from 'utils/dateUtils';
 import { graphTypes } from 'constants/timelineTypes';
 import processEvents from '../eventTimelineUtils/processEvents';
 import filterByEventType from '../eventTimelineUtils/filterByEventType';
@@ -9,7 +8,7 @@ import filterByEventType from '../eventTimelineUtils/filterByEventType';
 const getPodEvents = (pods, selectedEventType) => {
     const podsWithEvents = pods.map(({ id, name, inactive, startTime, events, containerCount }) => {
         const filteredEvents = events.filter(filterByEventType(selectedEventType));
-        const formattedTime = inactive ? 'Inactive' : format(startTime, timelineStartTimeFormat);
+        const formattedTime = inactive ? 'Inactive' : `Started  ${getDateTime(startTime)}`;
         const processedEvents = processEvents(filteredEvents);
         const hasContainers = containerCount > 0;
         return {

--- a/ui/apps/platform/src/Containers/Risk/EventTimeline/PodEventTimeline/getContainerEvents.js
+++ b/ui/apps/platform/src/Containers/Risk/EventTimeline/PodEventTimeline/getContainerEvents.js
@@ -1,12 +1,10 @@
-import { format } from 'date-fns';
-
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { graphTypes } from 'constants/timelineTypes';
+import { getDateTime } from 'utils/dateUtils';
 import processEvents from '../eventTimelineUtils/processEvents';
 import filterByEventType from '../eventTimelineUtils/filterByEventType';
 
 export const getPod = ({ id, name, startTime }) => {
-    const formattedTime = startTime ? format(startTime, dateTimeFormat) : 'N/A';
+    const formattedTime = startTime ? getDateTime(startTime) : 'N/A';
     return {
         type: graphTypes.POD,
         id,
@@ -18,7 +16,7 @@ export const getPod = ({ id, name, startTime }) => {
 export const getContainerEvents = (containers, selectedEventType) => {
     const containersWithEvents = containers.map(({ id, name, startTime, events }) => {
         const filteredEvents = events.filter(filterByEventType(selectedEventType));
-        const formattedTime = startTime ? format(startTime, dateTimeFormat) : 'N/A';
+        const formattedTime = startTime ? getDateTime(startTime) : 'N/A';
         const processedEvents = processEvents(filteredEvents);
         return {
             type: graphTypes.CONTAINER,

--- a/ui/apps/platform/src/Containers/Risk/Process/Signal.jsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/Signal.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import dateFns from 'date-fns';
-import dateTimeFormat from 'constants/dateTimeFormat';
 
 import Table, {
     defaultHeaderClassName,
@@ -9,12 +7,13 @@ import Table, {
     wrapClassName,
 } from 'Components/Table';
 import NoResultsMessage from 'Components/NoResultsMessage';
+import { getDateTime } from 'utils/dateUtils';
 
 const columns = [
     {
         Header: 'Time',
         id: 'time',
-        accessor: (d) => dateFns.format(d.signal.time, dateTimeFormat),
+        accessor: (d) => getDateTime(d.signal.time),
         headerClassName: `${defaultHeaderClassName} w-1/4 pointer-events-none`,
         className: `${wrapClassName} ${defaultColumnClassName} w-1/4 cursor-auto`,
     },

--- a/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.jsx
+++ b/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.jsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import find from 'lodash/find';
-import dateFns from 'date-fns';
 import { Tooltip } from '@patternfly/react-core';
 import { CheckIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { sortValue, sortDate } from 'sorters/sorters';
 import { riskBasePath } from 'routePaths';
+import { getDateTime } from 'utils/dateUtils';
 
 function DeploymentNameColumn({ original }) {
     const isSuspicious = find(original.baselineStatuses, {
@@ -58,7 +57,7 @@ const riskTableColumnDescriptors = [
         Header: 'Created',
         accessor: 'deployment.created',
         searchField: 'Created',
-        Cell: ({ value }) => <span>{dateFns.format(value, dateTimeFormat)}</span>,
+        Cell: ({ value }) => <span>{getDateTime(value)}</span>,
         sortMethod: sortDate,
     },
     {

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -1,9 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import dateFns from 'date-fns';
 import { DescriptionList } from '@patternfly/react-core';
 
-import dateTimeFormat from 'constants/dateTimeFormat';
 import DescriptionListItem from 'Components/DescriptionListItem';
 import {
     vulnerabilitiesPlatformPath,
@@ -13,6 +11,7 @@ import {
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { AlertDeployment } from 'types/alert.proto';
 import { Deployment } from 'types/deployment.proto';
+import { getDateTime } from 'utils/dateUtils';
 
 import FlatObjectDescriptionList from './FlatObjectDescriptionList';
 
@@ -56,9 +55,7 @@ function DeploymentOverview({
                     <DescriptionListItem
                         term="Created"
                         desc={
-                            deployment.created
-                                ? dateFns.format(deployment.created, dateTimeFormat)
-                                : 'not available'
+                            deployment.created ? getDateTime(deployment.created) : 'not available'
                         }
                     />
                     <DescriptionListItem

--- a/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, useState } from 'react';
-import { format } from 'date-fns';
 import capitalize from 'lodash/capitalize';
 import {
     Card,
@@ -11,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import dateTimeFormat from 'constants/dateTimeFormat';
+import { getDateTime } from 'utils/dateUtils';
 
 type K8sCardProps = {
     keyValueAttrs?: {
@@ -43,7 +42,7 @@ function K8sCard({ message, keyValueAttrs = { attrs: [] }, time }: K8sCardProps)
                 <CardExpandableContent>
                     <CardBody className="pf-v5-u-mt-lg">
                         <DescriptionList isHorizontal>
-                            <DescriptionListItem term="Time" desc={format(time, dateTimeFormat)} />
+                            <DescriptionListItem term="Time" desc={getDateTime(time)} />
                             {keyValueAttrs.attrs.map(({ key, value }) => (
                                 <DescriptionListItem
                                     term={capitalize(key)}

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, useState } from 'react';
-import { format } from 'date-fns';
 import {
     Card,
     CardHeader,
@@ -10,8 +9,8 @@ import {
 } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { NetworkFlowInfo } from 'types/alert.proto';
+import { getDateTime } from 'utils/dateUtils';
 
 export type NetworkFlowCardProps = {
     networkFlowInfo: NetworkFlowInfo;
@@ -95,7 +94,7 @@ function NetworkFlowCard({ networkFlowInfo, message, time }: NetworkFlowCardProp
                             <DescriptionListItem term="Protocol" desc={networkFlowInfo.protocol} />
                             <DescriptionListItem
                                 term="Time"
-                                desc={time ? format(time, dateTimeFormat) : 'N/A'}
+                                desc={time ? getDateTime(time) : 'N/A'}
                             />
                         </DescriptionList>
                     </CardBody>

--- a/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.jsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { getTime, format } from 'date-fns';
+import { getTime } from 'date-fns';
 import {
     Card,
     CardHeader,
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import dateTimeFormat from 'constants/dateTimeFormat';
+import { getDateTime } from 'utils/dateUtils';
 import ProcessCardContent from './ProcessCardContent';
 
 function ProcessCard({ processes, message }) {
@@ -49,11 +49,11 @@ function ProcessCard({ processes, message }) {
                     >
                         <DescriptionListItem
                             term="First occurrence"
-                            desc={format(firstOccurrenceTimestamp, dateTimeFormat)}
+                            desc={getDateTime(firstOccurrenceTimestamp)}
                         />
                         <DescriptionListItem
                             term="Last occurrence"
-                            desc={format(lastOccurrenceTimestamp, dateTimeFormat)}
+                            desc={getDateTime(lastOccurrenceTimestamp)}
                         />
                     </DescriptionList>
                     {processes.map((process) => (

--- a/ui/apps/platform/src/Containers/Violations/Details/ProcessCardContent.jsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ProcessCardContent.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
 import { DescriptionList, Flex, Divider } from '@patternfly/react-core';
 
-import dateTimeFormat from 'constants/dateTimeFormat';
 import DescriptionListItem from 'Components/DescriptionListItem';
 import KeyValue from 'Components/KeyValue';
+import { getDateTime } from 'utils/dateUtils';
 
 function ProcessCardContent({ process }) {
     const { time, args, execFilePath, containerId, lineage, uid } = process.signal;
     const processTime = new Date(time);
-    const timeFormat = format(processTime, dateTimeFormat);
+    const timeFormat = getDateTime(processTime);
     let ancestors = null;
     if (Array.isArray(lineage) && lineage.length) {
         ancestors = (

--- a/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
@@ -1,14 +1,12 @@
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
-import dateFns from 'date-fns';
 import startCase from 'lodash/startCase';
 import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import { lifecycleStageLabels } from 'messages/common';
 import {
     BLOCKING_ENFORCEMENT_ACTIONS,
@@ -19,6 +17,7 @@ import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import { violationsBasePath } from 'routePaths';
 import { ListAlert } from 'types/alert.proto';
 import { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
+import { getDateTime } from 'utils/dateUtils';
 
 type EntityTableCellProps = {
     // original: ListAlert;
@@ -155,7 +154,7 @@ export function getViolationsTableColumnDescriptors(filteredWorkflowView: Filter
             Header: 'Time',
             accessor: 'time',
             sortField: 'Violation Time',
-            Cell: ({ value }): string => dateFns.format(value, dateTimeFormat),
+            Cell: ({ value }) => getDateTime(value),
         },
     ];
 }

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { format } from 'date-fns';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import CveType from 'Components/CveType';
 import Metadata from 'Components/Metadata';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import entityTypes from 'constants/entityTypes';
+import { getDateTime } from 'utils/dateUtils';
 import { isValidURL } from 'utils/urlUtils';
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
 
@@ -85,15 +84,15 @@ const VulnMgmtCveOverview = ({ data, entityContext }) => {
     const scanningDetails = [
         {
             key: 'Discovered Time',
-            value: createdAt ? format(createdAt, dateTimeFormat) : 'N/A',
+            value: createdAt ? getDateTime(createdAt) : 'N/A',
         },
         {
             key: 'Published',
-            value: publishedOn ? format(publishedOn, dateTimeFormat) : 'N/A',
+            value: publishedOn ? getDateTime(publishedOn) : 'N/A',
         },
         {
             key: 'Last modified',
-            value: lastModified ? format(lastModified, dateTimeFormat) : 'N/A',
+            value: lastModified ? getDateTime(lastModified) : 'N/A',
         },
         {
             key: 'Scoring version',

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import { format } from 'date-fns';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import Metadata from 'Components/Metadata';
@@ -11,7 +10,7 @@ import ScanDataMessage from 'Containers/VulnMgmt/Components/ScanDataMessage';
 import getNodeScanMessage from 'Containers/VulnMgmt/VulnMgmt.utils/getNodeScanMessage';
 import CvesByCvssScore from 'Containers/VulnMgmt/widgets/CvesByCvssScore';
 import workflowStateContext from 'Containers/workflowStateContext';
-import dateTimeFormat from 'constants/dateTimeFormat';
+import { getDateTime } from 'utils/dateUtils';
 import { entityGridContainerClassName } from '../WorkflowEntityPage';
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
 import TableWidgetFixableCves from '../TableWidgetFixableCves';
@@ -85,7 +84,7 @@ const VulnMgmtNodeOverview = ({ data, entityContext }) => {
         },
         {
             key: 'Join Time',
-            value: joinedAt ? format(joinedAt, dateTimeFormat) : 'N/A',
+            value: joinedAt ? getDateTime(joinedAt) : 'N/A',
         },
     ];
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
-import { format } from 'date-fns';
 
 import workflowStateContext from 'Containers/workflowStateContext';
 import Loader from 'Components/Loader';
@@ -10,9 +9,9 @@ import TextSelect from 'Components/TextSelect';
 import Widget from 'Components/Widget';
 import CVEStackedPill from 'Components/CVEStackedPill';
 import NoComponentVulnMessage from 'Components/NoComponentVulnMessage';
+import { getDateTime } from 'utils/dateUtils';
 import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import queryService from 'utils/queryService';
-import dateTimeFormat from 'constants/dateTimeFormat';
 import entityTypes from 'constants/entityTypes';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
 import { entitySortFieldsMap } from 'constants/sortFields';
@@ -269,7 +268,7 @@ const processData = (data, entityType, workflowState) => {
             const { critical, important, moderate, low } = vulnCounter;
 
             const scanTimeToUse = scan?.scanTime || lastScanned;
-            const formattedDate = format(scanTimeToUse, dateTimeFormat);
+            const formattedDate = getDateTime(scanTimeToUse);
             const tooltipTitle =
                 formattedDate && formattedDate !== 'Invalid Date'
                     ? formattedDate

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -119,7 +119,7 @@ export type RequestExpiresProps = {
     context: RequestContext;
 };
 
-export function getExpiresDate(exception: VulnerabilityException, context: RequestContext): string {
+export function getExpiresDate(exception: VulnerabilityException, context: RequestContext) {
     if (isDeferralException(exception)) {
         const shouldUseUpdatedRequest = getShouldUseUpdatedRequest(exception, context);
         const exceptionExpiry: ExceptionExpiry =

--- a/ui/apps/platform/src/Containers/Workflow/widgets/ViolationFindings.jsx
+++ b/ui/apps/platform/src/Containers/Workflow/widgets/ViolationFindings.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
 
-import dateTimeFormat from 'constants/dateTimeFormat';
 import Widget from 'Components/Widget';
 import NoResultsMessage from 'Components/NoResultsMessage';
+import { getDateTime } from 'utils/dateUtils';
 
 const processData = (data) => {
     if (!data.violations || !data.violations.length) {
@@ -24,7 +23,7 @@ const ViolationFindings = ({ data, message }) => {
                     className="s-1"
                     bodyClassName="flex flex-col p-4 leading-normal"
                 >
-                    {format(policyViolation.time, dateTimeFormat)}
+                    {getDateTime(policyViolation.time)}
                 </Widget>
                 <Widget
                     header="Enforcement"

--- a/ui/apps/platform/src/constants/dateTimeFormat.js
+++ b/ui/apps/platform/src/constants/dateTimeFormat.js
@@ -1,9 +1,0 @@
-export const timelineStartTimeFormat = '[Started] MMM DD, h:mmA';
-
-export const timeFormat = 'h:mm:ssA';
-
-export const dateFormat = 'MM/DD/YYYY';
-
-const dateTimeFormat = `${dateFormat} | ${timeFormat}`;
-
-export default dateTimeFormat;

--- a/ui/apps/platform/src/constants/listColumns.jsx
+++ b/ui/apps/platform/src/constants/listColumns.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { defaultHeaderClassName, defaultColumnClassName, wrapClassName } from 'Components/Table';
 import entityTypes, { resourceTypes } from 'constants/entityTypes';
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
-import { format } from 'date-fns';
-import dateTimeFormat from 'constants/dateTimeFormat';
+import { getDateTime } from 'utils/dateUtils';
 
 const nodesAcrossControlsColumns = [
     {
@@ -65,7 +64,7 @@ const imageColumns = [
         align: 'right',
         widthClassName: `text-left pr-3 ${wrapClassName} ${defaultHeaderClassName}`,
         className: `text-left pr-3 ${wrapClassName} ${defaultColumnClassName}`,
-        Cell: ({ original }) => format(original.created, dateTimeFormat),
+        Cell: ({ original }) => getDateTime(original.created),
     },
     {
         accessor: 'components.length',
@@ -123,7 +122,7 @@ const getDeploymentViolationsColumns = (entityContext) => {
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
             accessor: 'violationTime',
-            Cell: ({ original }) => format(original.time, dateTimeFormat),
+            Cell: ({ original }) => getDateTime(original.time),
         },
     ];
     return columns.filter((col) => col);

--- a/ui/apps/platform/src/utils/credentialExpiry.ts
+++ b/ui/apps/platform/src/utils/credentialExpiry.ts
@@ -1,16 +1,16 @@
-import { differenceInDays, distanceInWordsStrict, format } from 'date-fns';
+import { differenceInDays, distanceInWordsStrict } from 'date-fns';
 
 import { CertExpiryComponent } from 'types/credentialExpiryService.proto';
+import { getDateTime } from './dateUtils';
 
 export function getCredentialExpiryPhrase(expirationDate: string, currentDatetime: Date) {
-    return `expires in ${distanceInWordsStrict(expirationDate, currentDatetime)} on ${format(
-        expirationDate,
-        'MMMM D, YYYY'
-    )} at ${format(expirationDate, 'h:mm a')}`;
+    return `expires in ${distanceInWordsStrict(expirationDate, currentDatetime)} on ${getDateTime(
+        expirationDate
+    )}`;
 }
 
 export const daysForCredentialExpiryDanger = 3; // red banner if less than or equal to 3 days
-export const daysForCredentialExpiryWarning = 14; // yellow bannder if less than or equal to 14 days
+export const daysForCredentialExpiryWarning = 14; // yellow banner if less than or equal to 14 days
 
 export type CredentialExpiryVariant = 'danger' | 'warning' | 'success';
 

--- a/ui/apps/platform/src/utils/dateUtils.ts
+++ b/ui/apps/platform/src/utils/dateUtils.ts
@@ -1,6 +1,8 @@
 import { distanceInWordsStrict, format } from 'date-fns';
 
-import dateTimeFormat, { dateFormat, timeFormat } from 'constants/dateTimeFormat';
+const timeFormat = 'h:mm:ssA';
+const dateFormat = 'MM/DD/YYYY';
+const dateTimeFormat = `${dateFormat} | ${timeFormat}`;
 
 type DateLike = string | number | Date;
 

--- a/ui/apps/platform/src/utils/vulnerabilityUtils.jsx
+++ b/ui/apps/platform/src/utils/vulnerabilityUtils.jsx
@@ -2,14 +2,12 @@ import React from 'react';
 import pluralize from 'pluralize';
 import reduce from 'lodash/reduce';
 import startCase from 'lodash/startCase';
-import { format } from 'date-fns';
 
 import entityTypes from 'constants/entityTypes';
 import { severities } from 'constants/severities';
 import entityLabels from 'messages/entity';
 import useCaseLabels from 'messages/useCase';
-import dateTimeFormat from 'constants/dateTimeFormat';
-import { addBrandedTimestampToString } from 'utils/dateUtils';
+import { addBrandedTimestampToString, getDateTime } from 'utils/dateUtils';
 
 export function getCveExportName(useCase, pageEntityType, entityName) {
     const fileName = `${useCaseLabels[useCase]} ${startCase(
@@ -77,7 +75,7 @@ export function getTooltip(vuln) {
         summary,
     } = vuln;
     const titleDate = lastScanned || createdAt;
-    const tooltipTitle = titleDate ? format(titleDate, dateTimeFormat) : 'N/A';
+    const tooltipTitle = titleDate ? getDateTime(titleDate) : 'N/A';
     const tooltipBody = (
         <ul className="flex-1 border-base-300 overflow-hidden">
             <li className="py-1 flex flex-col">


### PR DESCRIPTION
### Description

Fully encapsulates all formatting of dates, times, and datetimes in the `dateUtils.ts` helper functions. This change removes all direct calls to `date-fns.format()`, except from within these helpers. The aim of this is to ease and simplify the transition to consistent date formatting throughout ACS. This does not actually change any dates that are displayed, except for a few opinionated changes:

This removes the "long" and "short" versions of the month in the two places it is used in the app, as well as slightly changing the display of the "Node Join Time" card in Compliance.

Staging event timeline:
![image](https://github.com/user-attachments/assets/2956afbc-d299-4d7a-a885-ce57edb429da)

After this change event timeline:
![image](https://github.com/user-attachments/assets/c859beb4-1ebe-4c3e-8db3-93221a280942)

Staging certificate expiry banners:
![image](https://github.com/user-attachments/assets/bab811fc-764f-48b2-a2be-fb5ebf73df0b)

After this change cert expiry banners:
![image](https://github.com/user-attachments/assets/a7362707-8831-4bb4-9b07-70f4d1f6f600)

Staging Compliance Node Join Time card:
![image](https://github.com/user-attachments/assets/1aaafbae-4505-40a2-befe-abaf9e25835d)

After this change Compliance Node Join Time card:
![image](https://github.com/user-attachments/assets/88922767-0582-45fa-9237-9c6acd8f2e30)

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Smoke testing of dates throughout the UI, in addition to individual testing of functional changes as described above.