### PR TITLE
ROX-29147: Comment out totalAdvisories that was removed from MVP

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -198,6 +198,8 @@ function ImagePageVulnerabilities({
     // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
     // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isEpssProbabilityColumnEnabled = false;
+    // totalAdvisories out of scope for MVP
+    /*
     const isAdvisoryColumnEnabled =
         isFeatureFlagEnabled('ROX_SCANNER_V4') &&
         isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
@@ -207,6 +209,13 @@ function ImagePageVulnerabilities({
             (key !== 'nvdCvss' || isNvdCvssColumnEnabled) &&
             (key !== 'epssProbability' || isEpssProbabilityColumnEnabled) &&
             (key !== 'totalAdvisories' || isAdvisoryColumnEnabled)
+    );
+    */
+    const filteredColumns = filterManagedColumns(
+        defaultColumns,
+        (key) =>
+            (key !== 'nvdCvss' || isNvdCvssColumnEnabled) &&
+            (key !== 'epssProbability' || isEpssProbabilityColumnEnabled)
     );
     const managedColumnState = useManagedColumns(tableId, filteredColumns);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -48,7 +48,9 @@ import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayo
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import { infoForEpssProbability } from './infoForTh';
-import { formatEpssProbabilityAsPercent, formatTotalAdvisories } from './table.utils';
+// totalAdvisories out of scope for MVP
+// import { formatEpssProbabilityAsPercent, formatTotalAdvisories } from './table.utils';
+import { formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCvesImageVulnerabilitiesTable';
 export const defaultColumns = {
@@ -72,10 +74,13 @@ export const defaultColumns = {
         title: 'EPSS probability',
         isShownByDefault: true,
     },
+    // totalAdvisories out of scope for MVP
+    /*
     totalAdvisories: {
         title: 'Advisories',
         isShownByDefault: true,
     },
+    */
     affectedComponents: {
         title: 'Affected components',
         isShownByDefault: true,
@@ -169,15 +174,19 @@ function ImageVulnerabilitiesTable({
     // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
     // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isEpssProbabilityColumnEnabled = false;
+    // totalAdvisories out of scope for MVP
+    /*
     const isAdvisoryColumnEnabled =
         isFeatureFlagEnabled('ROX_SCANNER_V4') &&
         isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
+    */
 
     const colSpan =
         7 +
         (isNvdCvssColumnEnabled ? 1 : 0) +
         (isEpssProbabilityColumnEnabled ? 1 : 0) +
-        (isAdvisoryColumnEnabled ? 1 : 0) +
+        // totalAdvisories out of scope for MVP
+        // (isAdvisoryColumnEnabled ? 1 : 0) +
         (canSelectRows ? 1 : 0) +
         (createTableActions ? 1 : 0) +
         (showExceptionDetailsLink ? 1 : 0) +
@@ -215,9 +224,9 @@ function ImageVulnerabilitiesTable({
                             EPSS probability
                         </Th>
                     )}
-                    {isAdvisoryColumnEnabled && (
+                    {/* isAdvisoryColumnEnabled && (
                         <Th className={getVisibilityClass('totalAdvisories')}>Advisories</Th>
-                    )}
+                    ) */}
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}
@@ -266,7 +275,8 @@ function ImageVulnerabilitiesTable({
                         );
                         const isFixableInImage = getIsSomeVulnerabilityFixable(vulnerabilities);
                         const epssProbability = cveBaseInfo?.epss?.epssProbability;
-                        const totalAdvisories = undefined;
+                        // totalAdvisories out of scope for MVP
+                        // const totalAdvisories = undefined;
                         const isExpanded = expandedRowSet.has(cve);
 
                         return (
@@ -351,7 +361,7 @@ function ImageVulnerabilitiesTable({
                                             {formatEpssProbabilityAsPercent(epssProbability)}
                                         </Td>
                                     )}
-                                    {isAdvisoryColumnEnabled && (
+                                    {/* isAdvisoryColumnEnabled && (
                                         <Td
                                             className={getVisibilityClass('totalAdvisories')}
                                             modifier="nowrap"
@@ -359,7 +369,7 @@ function ImageVulnerabilitiesTable({
                                         >
                                             {formatTotalAdvisories(totalAdvisories)}
                                         </Td>
-                                    )}
+                                    ) */}
                                     <Td
                                         className={getVisibilityClass('affectedComponents')}
                                         dataLabel="Affected components"


### PR DESCRIPTION
### Description

Prerequisite to turn on ROX_CVE_ADVISORY_SEPARATION feature flag.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform folder
2. `npm run build` in ui/apps/platform folder