### PR TITLE
ROX-24313: Re-enable test & wait longer for edge to disappear

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,10 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[**.groovy]
+indent_style = space
+indent_size = 4
+
 [{*.go,*.go2}]
 # ij_ settings meaning can be mapped from https://www.jetbrains.com/help/idea/code-style-go.html
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,10 +9,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[**.groovy]
-indent_style = space
-indent_size = 4
-
 [{*.go,*.go2}]
 # ij_ settings meaning can be mapped from https://www.jetbrains.com/help/idea/code-style-go.html
 indent_style = tab

--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -3,6 +3,7 @@ package services
 import com.google.protobuf.Timestamp
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.grpc.StatusRuntimeException
 
 import io.stackrox.proto.api.v1.Common.ResourceByID
 import io.stackrox.proto.api.v1.NetworkGraphServiceGrpc
@@ -46,6 +47,7 @@ class NetworkGraphService extends BaseService {
     }
 
     static createNetworkEntity(String clusterId, String name, String cidr, Boolean isSystemGenerated) {
+        NetworkEntity result = null
         try {
             if (clusterId == null) {
                 throw new RuntimeException("Cluster ID is required to create a network entity")
@@ -72,7 +74,11 @@ class NetworkGraphService extends BaseService {
                             .setEntity(entity)
                             .build()
 
-            return getNetworkGraphClient().createExternalNetworkEntity(request)
+            result = getNetworkGraphClient().createExternalNetworkEntity(request)
+            return result
+        } catch (StatusRuntimeException ge) {
+            log.info("Resource already exists", ge)
+            return result
         } catch (Exception e) {
             log.error("Exception while creating network entity", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkGraphService.groovy
@@ -3,7 +3,6 @@ package services
 import com.google.protobuf.Timestamp
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import io.grpc.StatusRuntimeException
 
 import io.stackrox.proto.api.v1.Common.ResourceByID
 import io.stackrox.proto.api.v1.NetworkGraphServiceGrpc
@@ -47,7 +46,6 @@ class NetworkGraphService extends BaseService {
     }
 
     static createNetworkEntity(String clusterId, String name, String cidr, Boolean isSystemGenerated) {
-        NetworkEntity result = null
         try {
             if (clusterId == null) {
                 throw new RuntimeException("Cluster ID is required to create a network entity")
@@ -74,11 +72,7 @@ class NetworkGraphService extends BaseService {
                             .setEntity(entity)
                             .build()
 
-            result = getNetworkGraphClient().createExternalNetworkEntity(request)
-            return result
-        } catch (StatusRuntimeException ge) {
-            log.info("Resource already exists", ge)
-            return result
+            return getNetworkGraphClient().createExternalNetworkEntity(request)
         } catch (Exception e) {
             log.error("Exception while creating network entity", e)
         }

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -192,7 +192,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         Set<String> potentiallyConflictingCIDRs = [CF_CIDR_30, CF_CIDR_31, "1.1.1.0/30", "1.1.1.0/31"] as Set<String>
         Set<String> allCIDRs = getAllCIDRs()
-        Set<String> similarCIDRs = allCIDRs.findAll{ it.startsWith("1.1.")}
+        Set<String> similarCIDRs = allCIDRs.findAll { it.startsWith("1.1.") }
         Sets.SetView<String> conflictingCIDRs = Sets.intersection(potentiallyConflictingCIDRs, similarCIDRs)
         if (conflictingCIDRs.isEmpty()) {
             log.debug("Found no CIDRs conflicting with ${potentiallyConflictingCIDRs}." +

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -203,14 +203,14 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
                 "All custom CIDRs currently in Central: ${similarCIDRs}")
         }
 
-        deleteConflictingCIDRs("1.1.1.").forEach {it ->
+        getMatchingCIDRs(CF_CIDR_30).forEach { it ->
             log.warn("Deleting conflicting CIDR " +
                 "id: ${it.getId()}, " +
                 "name: ${it.getExternalSource().name}, " +
                 "cidr: ${it.getExternalSource().cidr}")
             deleteNetworkEntity(it.getId())
         }
-        log.info("All conflicting external entities deleted")
+        log.info("All external entities conflicting with ${CF_CIDR_30} have been deleted")
 
         String externalSource30Name = generateNameWithPrefix("external-source-30")
         log.info("Creating external source '${externalSource30Name}' with CIDR ${CF_CIDR_30}")
@@ -226,6 +226,16 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         log.info "Add smaller subnet subnet external source"
+
+        getMatchingCIDRs(CF_CIDR_31).forEach { it ->
+            log.warn("Deleting conflicting CIDR " +
+                "id: ${it.getId()}, " +
+                "name: ${it.getExternalSource().name}, " +
+                "cidr: ${it.getExternalSource().cidr}")
+            deleteNetworkEntity(it.getId())
+        }
+        log.info("All external entities conflicting with ${CF_CIDR_31} have been deleted")
+
         String externalSource31Name = generateNameWithPrefix("external-source-31")
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, CF_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
@@ -289,7 +299,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         return existingCidrs
     }
 
-    private static Set<NetworkFlowOuterClass.NetworkEntityInfo> deleteConflictingCIDRs(String prefix) {
+    private static Set<NetworkFlowOuterClass.NetworkEntityInfo> getMatchingCIDRs(String prefix) {
         def clusterId = ClusterService.getClusterId()
         assert clusterId
         def request = NetworkGraphServiceOuterClass.GetExternalNetworkEntitiesRequest

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -192,7 +192,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         Set<String> potentiallyConflictingCIDRs = [CF_CIDR_30, CF_CIDR_31, "1.1.1.0/30", "1.1.1.0/31"] as Set<String>
         Set<String> allCIDRs = getAllCIDRs()
-        Set<String> similarCIDRs = allCIDRs.findAll{it.startsWith("1.1.")}
+        Set<String> similarCIDRs = allCIDRs.findAll{ it.startsWith("1.1.")}
         Sets.SetView<String> conflictingCIDRs = Sets.intersection(potentiallyConflictingCIDRs, similarCIDRs)
         if (conflictingCIDRs.isEmpty()) {
             log.debug("Found no CIDRs conflicting with ${potentiallyConflictingCIDRs}." +
@@ -308,11 +308,9 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
             .build()
         def response = NetworkGraphService.getNetworkGraphClient().getExternalNetworkEntities(request)
 
-        return response.getEntitiesList().findAll {
+        return response.getEntitiesList().findAll({
             it.getInfo().hasExternalSource() && it.getInfo().getExternalSource().cidr.startsWith(prefix)
-        }.collect {
-            it.getInfo()
-        } as Set
+        })*.getInfo() as Set
     }
 
     private static createNetworkEntityExternalSource(String name, String cidr) {

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -57,6 +57,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         for (Deployment deployment : DEPLOYMENTS) {
             orchestrator.deleteDeployment(deployment)
         }
+        Set<String> similarCIDRs = getAllCIDRs().findAll { it.startsWith("1.1.") }
+        log.info("Post-cleanup state of similar CIDRs: ${similarCIDRs}")
     }
 
     private static String generateNameWithPrefix(String prefix) {
@@ -84,6 +86,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         cleanup:
+        Set<String> similarCIDRs = getAllCIDRs().findAll { it.startsWith("1.1.") }
+        log.info("Pre-case-cleanup state of similar CIDRs: ${similarCIDRs}")
         "Remove the external source and associated deployments"
         deleteNetworkEntity(externalSourceID)
     }
@@ -125,6 +129,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         cleanup:
+        Set<String> similarCIDRs = getAllCIDRs().findAll { it.startsWith("1.1.") }
+        log.info("Pre-case-cleanup state of similar CIDRs: ${similarCIDRs}")
         deleteNetworkEntity(externalSource30ID)
         deleteNetworkEntity(externalSource31ID)
     }
@@ -172,6 +178,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         cleanup:
+        Set<String> similarCIDRs = getAllCIDRs().findAll { it.startsWith("1.1.") }
+        log.info("Pre-case-cleanup state of similar CIDRs: ${similarCIDRs}")
         deleteNetworkEntity(externalSource30ID)
     }
 
@@ -277,6 +285,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         cleanup:
+        Set<String> similarCIDRs2 = getAllCIDRs().findAll { it.startsWith("1.1.") }
+        log.info("Pre-case-cleanup state of similar CIDRs: ${similarCIDRs2}")
         deleteNetworkEntity(externalSource30ID)
         deleteNetworkEntity(externalSource31ID)
     }

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -204,7 +204,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         log.info "Verify edge exists from deployment 'external-connection' to " +
             "supernet external source '$externalSource30Name'"
-        withRetry(0, 30) {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID)
         }
 
@@ -212,6 +212,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         String externalSource31Name = generateNameWithPrefix("external-source-31")
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, CF_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
+        assert externalSource31 != null
         assert externalSource31ID != null
 
         then:

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -188,8 +188,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         String deploymentUid = DEP_EXTERNALCONNECTION.deploymentUid
         assert deploymentUid != null
 
-        List<String> conflictingCIDRs = getConflictingCIDRs([CF_CIDR_30,CF_CIDR_31])
-        assert conflictingCIDRs.size() == 0 : "found existing CIDR blocks ${conflictingCIDRs} that conflict with this test case."
+        List<String> conflictingCIDRs = getConflictingCIDRs([CF_CIDR_30, CF_CIDR_31])
+        assert conflictingCIDRs.size() == 0: "found existing CIDR blocks ${conflictingCIDRs} that conflict with this test case."
 
         String externalSource30Name = generateNameWithPrefix("external-source-30")
         log.info("Creating external source '${externalSource30Name}' with CIDR ${CF_CIDR_30}")
@@ -242,8 +242,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         cleanup:
-          deleteNetworkEntity(externalSource30ID)
-          deleteNetworkEntity(externalSource31ID)
+        deleteNetworkEntity(externalSource30ID)
+        deleteNetworkEntity(externalSource31ID)
 
     }
 

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -189,8 +189,10 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert deploymentUid != null
 
         List<String> conflictingCIDRs = getConflictingCIDRs([CF_CIDR_30, CF_CIDR_31])
-        assert conflictingCIDRs.size() == 0:
-            "found existing CIDR blocks ${conflictingCIDRs} that conflict with this test case."
+        if (conflictingCIDRs.size() > 0) {
+            log.warn("found existing CIDR blocks ${conflictingCIDRs} that conflict with this test case." +
+                "Check the cleanup of other tests if the interference causes this test to fail.")
+        }
 
         String externalSource30Name = generateNameWithPrefix("external-source-30")
         log.info("Creating external source '${externalSource30Name}' with CIDR ${CF_CIDR_30}")
@@ -218,8 +220,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         and:
-        "Verify edge from deployment 'external-connection' to supernet external source '$externalSource30Name' exists " +
-            "in the network graph for last 60 minutes"
+        "Verify edge from deployment 'external-connection' to supernet external source '$externalSource30Name' exists" +
+            " in the network graph for last 60 minutes"
         withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(
                 deploymentUid,

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -101,7 +101,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         log.info "Create a smaller network external source containing Cloudflare's IP address"
         String externalSource31Name = generateNameWithPrefix("external-source-31")
-        NetworkEntity externalSource31 = createNetworkEntityExternalSource(log,externalSource31Name, CF_CIDR_31)
+        NetworkEntity externalSource31 = createNetworkEntityExternalSource(log, externalSource31Name, CF_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
         assert externalSource31ID != null
 
@@ -112,7 +112,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         log.info "Create a supernet external source containing Cloudflare's IP address"
         String externalSource30Name = generateNameWithPrefix("external-source-30")
-        NetworkEntity externalSource30 = createNetworkEntityExternalSource(log,externalSource30Name, CF_CIDR_30)
+        NetworkEntity externalSource30 = createNetworkEntityExternalSource(log, externalSource30Name, CF_CIDR_30)
         String externalSource30ID = externalSource30?.getInfo()?.getId()
         assert externalSource30ID != null
 

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -189,7 +189,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert deploymentUid != null
 
         List<String> conflictingCIDRs = getConflictingCIDRs([CF_CIDR_30, CF_CIDR_31])
-        assert conflictingCIDRs.size() == 0: "found existing CIDR blocks ${conflictingCIDRs} that conflict with this test case."
+        assert conflictingCIDRs.size() == 0:
+            "found existing CIDR blocks ${conflictingCIDRs} that conflict with this test case."
 
         String externalSource30Name = generateNameWithPrefix("external-source-30")
         log.info("Creating external source '${externalSource30Name}' with CIDR ${CF_CIDR_30}")
@@ -198,7 +199,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert externalSource30 != null
         assert externalSource30ID != null
 
-        log.info "Verify edge exists from deployment 'external-connection' to supernet external source '$externalSource30Name'"
+        log.info "Verify edge exists from deployment 'external-connection' to " +
+            "supernet external source '$externalSource30Name'"
         withRetry(0, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID)
         }
@@ -216,7 +218,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         and:
-        "Verify edge from deployment 'external-connection' to supernet external source '$externalSource30Name' exists in network graph for last 60 minutes"
+        "Verify edge from deployment 'external-connection' to supernet external source '$externalSource30Name' exists " +
+            "in the network graph for last 60 minutes"
         withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(
                 deploymentUid,
@@ -225,7 +228,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         and:
-        "Verify no edge exists from deployment 'external-connection' to supernet external source '$externalSource30Name' in network graph for last 60 seconds"
+        "Verify no edge exists from 'external-connection' to supernet external source '$externalSource30Name' " +
+            "in the network graph for last 60 seconds"
         withRetry(20, 30) {
             // We need to wait for at least (i.e., the sum of all the following):
             // - another enrichment to happen - at least 30s.
@@ -244,7 +248,6 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         cleanup:
         deleteNetworkEntity(externalSource30ID)
         deleteNetworkEntity(externalSource31ID)
-
     }
 
     private static List<String> getConflictingCIDRs(List<String> cidrs) {


### PR DESCRIPTION
### Description

I left my summary of the groovy test in question in the comment (not AI-generated). I noticed, that the test waits only for 2 minutes for an edge on the graph to disappear. This is not long enough and I provide calculations why we need to wait longer.

Moreover, I add a helper function that makes it easier to run this test locally when connected to remote cluster and with cleanup disabled. It will fail if any other test creates CIDR blocks in Central that would conflict with this test case.

The changes in the indentation is the doing of my IDE; I think, we don't have `.editorconfig` for groovy files, so I did my best not to break stuff.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- [ ] CI
- [x] I run this test locally ~10 times against a GKE cluster
- [x] I manually traced the messages sent from Sensor to Central for a particular deployment in question and confirmed the delay between those messages. Note that opening (last_seen_timestamp empty) and closing (last_seen_timestamp set) of the connection are 5m30s apart in that example:
```
common/networkflow/manager: 2025/05/02 12:41:06.406165 manager_impl.go:548: Debug: Flow update : (...) updated:{props:{src_entity:{type:DEPLOYMENT id:"1804c725-f064-4290-9f72-d49844cdcd99"} dst_entity:{type:EXTERNAL_SOURCE id:"8e4d0423-5aa0-4000-b7b1-8d3139a9002a__MS4xLjEuMC8zMA"} dst_port:80 l4protocol:L4_PROTOCOL_TCP}} (...)
common/networkflow/manager: 2025/05/02 12:46:36.400872 manager_impl.go:548: Debug: Flow update : (...) updated:{props:{src_entity:{type:DEPLOYMENT id:"1804c725-f064-4290-9f72-d49844cdcd99"} dst_entity:{type:EXTERNAL_SOURCE id:"8e4d0423-5aa0-4000-b7b1-8d3139a9002a__MS4xLjEuMC8zMA"} dst_port:80 l4protocol:L4_PROTOCOL_TCP} last_seen_timestamp:{seconds:1746189635 nanos:954397000}} (...)

```
