### PR TITLE
chore(scanner): manual entry for CVE-2025-24813

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -239,7 +239,8 @@ jobs:
 
     - name: Run updater (multi bundle)
       run: |
-        scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" --split bundles
+        # TODO: DELETE
+        scanner/bin/updater export --manual-url "https://raw.githubusercontent.com/stackrox/stackrox/cve-2025-24813/scanner/updater/manual/vulns.yaml" --split bundles
         zip definitions/${{ github.event.pull_request.number }}/vulnerabilities.zip bundles/*.json.zst
 
     # PR owner is responsible for verifying vulnerability bundles are generated

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -239,8 +239,7 @@ jobs:
 
     - name: Run updater (multi bundle)
       run: |
-        # TODO: DELETE
-        scanner/bin/updater export --manual-url "https://raw.githubusercontent.com/stackrox/stackrox/cve-2025-24813/scanner/updater/manual/vulns.yaml" --split bundles
+        scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" --split bundles
         zip definitions/${{ github.event.pull_request.number }}/vulnerabilities.zip bundles/*.json.zst
 
     # PR owner is responsible for verifying vulnerability bundles are generated

--- a/scanner/updater/manual/vulns.yaml
+++ b/scanner/updater/manual/vulns.yaml
@@ -365,3 +365,57 @@ vulnerabilities:
   Repo:
     Name: maven
     URI: https://repo1.maven.apache.org/maven2
+
+# Vuln: CVE-2025-24813/GHSA-83qj-6fr2-vhqg
+# Reason: The Tomcat JAR does not contain a pom.properties file, so cannot match the finding to OSV's data.
+# Source: https://osv.dev/vulnerability/GHSA-83qj-6fr2-vhqg
+- Name: CVE-2025-24813
+  Description: 'Apache Tomcat: Potential RCE and/or information disclosure and/or information corruption with partial PUT'
+  Issued: '2025-03-10T18:31:56Z'
+  Links: https://nvd.nist.gov/vuln/detail/CVE-2025-24813
+  Severity: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  NormalizedSeverity: Critical
+  Package:
+    Name: org.apache.tomcat-embed-core:tomcat-embed-core
+    Kind: Binary
+    RepositoryHint: Maven
+  FixedInVersion: introduced=9.0.0.M1&fixed=9.0.99
+  Repo:
+    Name: maven
+    URI: https://repo1.maven.apache.org/maven2
+
+# Vuln: CVE-2025-24813/GHSA-83qj-6fr2-vhqg
+# Reason: Same as previous entry but with different vulnerable range.
+# Source: https://osv.dev/vulnerability/GHSA-83qj-6fr2-vhqg
+- Name: CVE-2025-24813
+  Description: 'Apache Tomcat: Potential RCE and/or information disclosure and/or information corruption with partial PUT'
+  Issued: '2025-03-10T18:31:56Z'
+  Links: https://nvd.nist.gov/vuln/detail/CVE-2025-24813
+  Severity: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  NormalizedSeverity: Critical
+  Package:
+    Name: org.apache.tomcat-embed-core:tomcat-embed-core
+    Kind: Binary
+    RepositoryHint: Maven
+  FixedInVersion: introduced=10.1.0-M1&fixed=10.1.35
+  Repo:
+    Name: maven
+    URI: https://repo1.maven.apache.org/maven2
+
+# Vuln: CVE-2025-24813/GHSA-83qj-6fr2-vhqg
+# Reason: Same as previous entry but with different vulnerable range.
+# Source: https://osv.dev/vulnerability/GHSA-83qj-6fr2-vhqg
+- Name: CVE-2025-24813
+  Description: 'Apache Tomcat: Potential RCE and/or information disclosure and/or information corruption with partial PUT'
+  Issued: '2025-03-10T18:31:56Z'
+  Links: https://nvd.nist.gov/vuln/detail/CVE-2025-24813
+  Severity: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  NormalizedSeverity: Critical
+  Package:
+    Name: org.apache.tomcat-embed-core:tomcat-embed-core
+    Kind: Binary
+    RepositoryHint: Maven
+  FixedInVersion: introduced=11.0.0-M1&fixed=11.0.3
+  Repo:
+    Name: maven
+    URI: https://repo1.maven.apache.org/maven2


### PR DESCRIPTION
### Description

The Tomcat JAR does not contain a pom.properties file, so we cannot construct a quality `groupID:artifactID` pairing. Until we can reach out to Maven, we'll have to keep this entry around.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

no

#### How I validated my change

Deployed this version of StackRox to a cluster and let Scanner V4 DB get populated.

You'll find the following:

```
# SELECT name, package_name, fixed_in_version FROM vuln WHERE updater = 'stackrox-manual';
      name      |                  package_name                  |            fixed_in_version            
----------------+------------------------------------------------+----------------------------------------
 CVE-2022-22963 | spring-cloud-function-context                  | introduced=0&fixed=3.1.7
 CVE-2022-22963 | spring-cloud-function-context                  | introduced=3.2.0&fixed=3.2.3
 CVE-2022-22965 | spring-beans                                   | introduced=0&fixed=5.2.20.RELEASE
 CVE-2022-22965 | spring-beans                                   | introduced=5.3.0&fixed=5.3.18
 CVE-2022-22965 | spring-webmvc                                  | introduced=0&fixed=5.2.20.RELEASE
 CVE-2022-22965 | spring-webmvc                                  | introduced=5.3.0&fixed=5.3.18
 CVE-2022-22965 | spring-boot-starter-web                        | introduced=0&fixed=2.5.12
 CVE-2022-22965 | spring-boot-starter-web                        | introduced=2.6.0&fixed=2.6.6
 CVE-2022-22965 | spring-webflux                                 | introduced=0&fixed=5.2.20.RELEASE
 CVE-2022-22965 | spring-webflux                                 | introduced=5.3.0&fixed=5.3.18
 CVE-2022-22965 | spring-boot-starter-webflux                    | introduced=0&fixed=2.5.12
 CVE-2022-22965 | spring-boot-starter-webflux                    | introduced=2.6.0&fixed=2.6.6
 CVE-2022-22978 | spring-security-core                           | introduced=0&fixed=5.5.7
 CVE-2022-22978 | spring-security-core                           | introduced=5.6.0&fixed=5.6.4
 CVE-2022-29885 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=8.5.38&lastAffected=8.5.78
 CVE-2022-29885 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=9.0.13&lastAffected=9.0.62
 CVE-2022-29885 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=10.0.0&lastAffected=10.0.20
 CVE-2023-28708 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=8.5.0&fixed=8.5.86
 CVE-2023-28708 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=9.0.0&fixed=9.0.72
 CVE-2023-28708 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=10.1.0&fixed=10.1.6
(20 rows)
```

After that, I updated the Scanner V4 Matcher ConfigMap to point to https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/cve-2025-24813/vulnerabilities.zip which has the manual entries from this PR.

Once deleting the Scanner V4 Matcher pods to recreate new ones, I waited until the update cycle was over and rechecked the DB:

```
# SELECT name, package_name, fixed_in_version FROM vuln WHERE updater = 'stackrox-manual';
      name      |                  package_name                  |            fixed_in_version            
----------------+------------------------------------------------+----------------------------------------
 CVE-2022-22963 | spring-cloud-function-context                  | introduced=0&fixed=3.1.7
 CVE-2022-22963 | spring-cloud-function-context                  | introduced=3.2.0&fixed=3.2.3
 CVE-2022-22965 | spring-beans                                   | introduced=0&fixed=5.2.20.RELEASE
 CVE-2022-22965 | spring-beans                                   | introduced=5.3.0&fixed=5.3.18
 CVE-2022-22965 | spring-webmvc                                  | introduced=0&fixed=5.2.20.RELEASE
 CVE-2022-22965 | spring-webmvc                                  | introduced=5.3.0&fixed=5.3.18
 CVE-2022-22965 | spring-boot-starter-web                        | introduced=0&fixed=2.5.12
 CVE-2022-22965 | spring-boot-starter-web                        | introduced=2.6.0&fixed=2.6.6
 CVE-2022-22965 | spring-webflux                                 | introduced=0&fixed=5.2.20.RELEASE
 CVE-2022-22965 | spring-webflux                                 | introduced=5.3.0&fixed=5.3.18
 CVE-2022-22965 | spring-boot-starter-webflux                    | introduced=0&fixed=2.5.12
 CVE-2022-22965 | spring-boot-starter-webflux                    | introduced=2.6.0&fixed=2.6.6
 CVE-2022-22978 | spring-security-core                           | introduced=0&fixed=5.5.7
 CVE-2022-22978 | spring-security-core                           | introduced=5.6.0&fixed=5.6.4
 CVE-2022-29885 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=8.5.38&lastAffected=8.5.78
 CVE-2022-29885 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=9.0.13&lastAffected=9.0.62
 CVE-2022-29885 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=10.0.0&lastAffected=10.0.20
 CVE-2023-28708 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=8.5.0&fixed=8.5.86
 CVE-2023-28708 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=9.0.0&fixed=9.0.72
 CVE-2023-28708 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=10.1.0&fixed=10.1.6
 CVE-2025-24813 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=9.0.0.M1&fixed=9.0.99
 CVE-2025-24813 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=10.1.0-M1&fixed=10.1.35
 CVE-2025-24813 | org.apache.tomcat-embed-core:tomcat-embed-core | introduced=11.0.0-M1&fixed=11.0.3
(23 rows)
```

I also scanned a sample image with an affected tomcat JAR, and we were able to find the vuln:

```
...
{
        "name": "org.apache.tomcat-embed-core:tomcat-embed-core",
        "version": "9.0.48",
        "vulns": [
          {
            "cve": "CVE-2025-24813",
            "cvss": 9.8,
            "summary": "Apache Tomcat: Potential RCE and/or information disclosure and/or information corruption with partial PUT",
            "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-24813",
            "fixedBy": "9.0.99",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "exploitabilityScore": 3.9,
              "impactScore": 5.9,
              "attackVector": "ATTACK_NETWORK",
              "confidentiality": "IMPACT_HIGH",
              "integrity": "IMPACT_HIGH",
              "availability": "IMPACT_HIGH",
              "score": 9.8,
              "severity": "CRITICAL"
            },
            "publishedOn": "2025-03-10T18:31:56Z",
            "vulnerabilityType": "IMAGE_VULNERABILITY",
            "severity": "CRITICAL_VULNERABILITY_SEVERITY",
            "cvssMetrics": [
              {
                "source": "SOURCE_NVD",
                "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-24813",
                "cvssv3": {
                  "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
                  "exploitabilityScore": 3.9,
                  "impactScore": 5.9,
                  "attackVector": "ATTACK_NETWORK",
                  "confidentiality": "IMPACT_HIGH",
                  "integrity": "IMPACT_HIGH",
                  "availability": "IMPACT_HIGH",
                  "score": 9.8,
                  "severity": "CRITICAL"
                }
              }
            ],
            "epss": {
              "epssProbability": 0.9351,
              "epssPercentile": 0.99813
            }
          },
...
```
