### PR TITLE
ROX-28673: refactor roxctl tlsconfigopts

### DIFF
--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -61,7 +61,7 @@ func getURL(path string) (string, error) {
 
 // GetRoxctlHTTPClient returns a new instance of RoxctlHTTPClient with the given configuration
 func GetRoxctlHTTPClient(config *HttpClientConfig) (RoxctlHTTPClient, error) {
-	tlsConf, err := tlsConfigForCentral(config.Logger)
+	tlsConf, err := tlsConfigForCentral()
 	if err != nil {
 		return nil, errors.Wrap(err, "instantiating TLS configuration for central")
 	}

--- a/roxctl/common/connection.go
+++ b/roxctl/common/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"strings"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
@@ -15,10 +16,11 @@ import (
 	"github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/flags"
-	"github.com/stackrox/rox/roxctl/common/logger"
 	http1DowngradeClient "golang.stackrox.io/grpc-http1/client"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // GRPCOption encodes behavior of a gRPC connection.
@@ -32,7 +34,7 @@ func WithRetryTimeout(timeout time.Duration) GRPCOption {
 }
 
 // GetGRPCConnection gets a grpc connection to Central with the correct auth
-func GetGRPCConnection(am auth.Method, logger logger.Logger, connectionOpts ...GRPCOption) (*grpc.ClientConn, error) {
+func GetGRPCConnection(am auth.Method, connectionOpts ...GRPCOption) (*grpc.ClientConn, error) {
 	endpoint, serverName, usePlaintext, err := ConnectNames()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get endpoint for gRPC connection")
@@ -41,7 +43,7 @@ func GetGRPCConnection(am auth.Method, logger logger.Logger, connectionOpts ...G
 	if err != nil {
 		return nil, errors.Wrapf(err, "obtaining auth information for %s", endpoint)
 	}
-	clientOpts, err := getClientOpts(logger)
+	clientOpts, err := getClientOpts()
 	if err != nil {
 		return nil, err
 	}
@@ -91,6 +93,22 @@ func addCommandHeaderStreamInterceptor(ctx context.Context, desc *grpc.StreamDes
 	return streamer(makeCtxWithCommandHeader(ctx), desc, cc, method, opts...)
 }
 
+func shouldRetry(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if strings.Contains(err.Error(), "x509: certificate") {
+		return false
+	}
+	if grpcErr, ok := status.FromError(err); ok {
+		code := grpcErr.Code()
+		if code != codes.Unavailable && code != codes.ResourceExhausted {
+			return false
+		}
+	}
+	return true
+}
+
 func createGRPCConn(c grpcConfig) (*grpc.ClientConn, error) {
 	const initialBackoffDuration = 100 * time.Millisecond
 	retryOpts := []grpc_retry.CallOption{
@@ -98,6 +116,7 @@ func createGRPCConn(c grpcConfig) (*grpc.ClientConn, error) {
 		// First retry after 100ms, last retry after 51.2s.
 		grpc_retry.WithMax(10),
 		grpc_retry.WithPerRetryTimeout(c.retryTimeout),
+		grpc_retry.WithRetriable(shouldRetry),
 	}
 
 	grpcDialOpts := []grpc.DialOption{
@@ -144,8 +163,8 @@ func createGRPCConn(c grpcConfig) (*grpc.ClientConn, error) {
 	return connection, errors.WithStack(err)
 }
 
-func getClientOpts(logger logger.Logger) (clientconn.Options, error) {
-	tlsOpts, err := tlsConfigOptsForCentral(logger)
+func getClientOpts() (clientconn.Options, error) {
+	tlsOpts, err := tlsConfigOptsForCentral()
 	if err != nil {
 		return clientconn.Options{}, err
 	}

--- a/roxctl/common/environment/environment-impl.go
+++ b/roxctl/common/environment/environment-impl.go
@@ -94,7 +94,7 @@ func (c *cliEnvironmentImpl) GRPCConnection(connectionOpts ...common.GRPCOption)
 	if err != nil {
 		return nil, errors.Wrap(err, "determining auth method")
 	}
-	connection, err := common.GetGRPCConnection(am, c.Logger(), connectionOpts...)
+	connection, err := common.GetGRPCConnection(am, connectionOpts...)
 	return connection, errors.WithStack(err)
 }
 

--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -4,56 +4,14 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"net"
 	"os"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/netutil"
-	"github.com/stackrox/rox/pkg/tlscheck"
 	"github.com/stackrox/rox/roxctl/common/flags"
-	"github.com/stackrox/rox/roxctl/common/logger"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
-
-const errorMsg = `The remote endpoint failed TLS validation: %v
-
-  Do one of the following:
-  1. Obtain a valid certificate for your Central instance/Load Balancer.
-  2. Use the --ca option to specify a custom CA certificate (PEM format).
-     This certificate can be obtained by running "roxctl central cert".
-  3. Use the --insecure-skip-tls-verify option to suppress this error
-     and not validate TLS certificates (NOT RECOMMENDED).
-`
-
-type grpcPermissionDenied struct{ error }
-
-func (p *grpcPermissionDenied) GRPCStatus() *status.Status {
-	return status.New(codes.PermissionDenied, p.Error())
-}
-
-type insecureVerifierWithError struct {
-	logger logger.Logger
-}
-
-func (v *insecureVerifierWithError) VerifyPeerCertificate(leaf *x509.Certificate, chainRest []*x509.Certificate, conf *tls.Config) error {
-	verifyOpts := x509.VerifyOptions{
-		DNSName:       conf.ServerName,
-		Intermediates: tlscheck.NewCertPool(chainRest...),
-		Roots:         conf.RootCAs,
-	}
-	v.logger.InfofLn("trying to verify cert for %s, signed by %s (CA %v)", leaf.Subject, leaf.Issuer, leaf.IsCA)
-	for i, c := range chainRest {
-		v.logger.InfofLn("%d cert in chain %s, signed by %s (CA %v)", i, c.Subject, c.Issuer, c.IsCA)
-	}
-	if _, err := leaf.Verify(verifyOpts); err != nil {
-		v.logger.ErrfLn(errorMsg, err)
-		return &grpcPermissionDenied{err}
-	}
-	return nil
-}
 
 // ConnectNames returns the endpoint and (SNI) server name given by the
 // --endpoint and --server-name flags respectively and information about plaintext.
@@ -88,69 +46,57 @@ func getServerName(endpoint string) (string, error) {
 	return serverName, nil
 }
 
-func tlsConfigOptsForCentral(logger logger.Logger) (*clientconn.TLSConfigOptions, error) {
+func tlsConfigOptsForCentral() (*clientconn.TLSConfigOptions, error) {
 	_, serverName, _, err := ConnectNames()
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing central endpoint")
 	}
 
-	var dialContext func(ctx context.Context, addr string) (net.Conn, error)
-
-	skipVerify := flags.SkipTLSValidation() != nil && *flags.SkipTLSValidation()
-	var roots *x509.CertPool
-	var customVerifier tlscheck.TLSCertVerifier
-	var ca []byte
-	if skipVerify {
-		if flags.CAFile() != "" {
-			logger.WarnfLn("--insecure-skip-tls-verify has no effect when --ca is set")
-		}
-	} else {
-		customVerifier = &insecureVerifierWithError{
-			logger: logger,
-		}
-		if flags.CAFile() != "" {
-			var err error
-			if ca, err = os.ReadFile(flags.CAFile()); err != nil {
-				return nil, errors.Wrap(err, "failed to parse CA certificates from file")
-			}
-		} else {
-			// Read the CA from the central secret.
-			if flags.UseKubeContext() {
-				_, core, namespace, err := getConfigs()
-				if err != nil {
-					return nil, err
-				}
-				var warn error
-				// Proceed with no CA on error. Return the error as warning later.
-				ca, warn = getCentralCA(context.Background(), core, namespace)
-				if warn != nil {
-					logger.WarnfLn("Failed to read the central CA: %v", warn)
-				}
-			}
-		}
-	}
-
-	if ca != nil {
-		roots = x509.NewCertPool()
-		if !roots.AppendCertsFromPEM(ca) {
-			return nil, errors.Errorf("CA certificates file %s contains no certificates!", flags.CAFile())
-		}
-	}
-	if flags.UseKubeContext() {
-		dialContext = getForwardingDialContext()
-	}
-
-	return &clientconn.TLSConfigOptions{
+	opts := &clientconn.TLSConfigOptions{
 		ServerName:         serverName,
-		InsecureSkipVerify: skipVerify,
-		CustomCertVerifier: customVerifier,
-		RootCAs:            roots,
-		DialContext:        dialContext,
-	}, nil
+		InsecureSkipVerify: flags.SkipTLSValidation() != nil && *flags.SkipTLSValidation(),
+	}
+
+	if !opts.InsecureSkipVerify {
+		if opts.RootCAs, err = getCertPool(); err != nil {
+			return nil, err
+		}
+	}
+
+	if flags.UseKubeContext() {
+		opts.DialContext = getForwardingDialContext()
+	}
+
+	return opts, nil
 }
 
-func tlsConfigForCentral(logger logger.Logger) (*tls.Config, error) {
-	opts, err := tlsConfigOptsForCentral(logger)
+func getCertPool() (*x509.CertPool, error) {
+	roots := x509.NewCertPool()
+	if caFile := flags.CAFile(); caFile != "" {
+		// Read the CA from the given file.
+		if ca, err := os.ReadFile(caFile); err != nil {
+			return nil, errors.Wrap(err, "failed to parse CA certificates from file")
+		} else if !roots.AppendCertsFromPEM(ca) {
+			return nil, errors.Errorf("CA certificates file %s contains no certificates", caFile)
+		}
+	} else if flags.UseKubeContext() {
+		// Read the CA from the central secret.
+		_, core, namespace, err := getConfigs()
+		if err != nil {
+			return nil, err
+		}
+		ca, err := getCentralCA(context.Background(), core, namespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read the central CA from the central-tls secret")
+		} else if !roots.AppendCertsFromPEM(ca) {
+			return nil, errors.New("central-tls secret contains no certificates")
+		}
+	}
+	return roots, nil
+}
+
+func tlsConfigForCentral() (*tls.Config, error) {
+	opts, err := tlsConfigOptsForCentral()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Refactor and fix the gRPC retries and connection error handling in roxctl:

- removed the "insecure verifier", which was a leftover from the old code where we would print a warning on TLS verification errors.
- string comparison for gRPC `code.Unavailable` errors, to avoid retries for certificate validation errors.
- removed the now unused logging parameter.

The refactored code now properly ignores TLS errors when `--insecure-skip-tls-verify` is passed.

This change is driven by the CI failures where roxctl is confused with the server name set in the environment.

### User-facing documentation

- [x] CHANGELOG is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

<!--
General Availability requirements: https://github.com/stackrox/stackrox/blob/master/PR_GA.md
Feature Flags usage: https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md
-->

- [x] the change is production ready: the change is GA or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI.

*Manual tests*

No server name error with `--insecure-skip-tls-verify`:

```console
sh$ bin/linux_amd64/roxctl central whoami -s "bad-name" --use-current-k8s-context -p admin-password --insecure-skip-tls-verify
UserID:
	admin
```

Even with provided `--ca`:

```console
sh$ bin/linux_amd64/roxctl central whoami -e localhost:8000 -p admin-password --ca central-ca.crt
ERROR:	rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for *.demos.rox.systems, not localhost"

sh$ bin/linux_amd64/roxctl central whoami -e localhost:8000 -p admin-password --ca central-ca.crt --insecure-skip-tls-verify
UserID:
	admin
```

No retry on certificate error:

```console
sh$ bin/linux_amd64/roxctl central whoami -e localhost:8000
ERROR:	rpc error: code = Unavailable desc = connection error: desc = "transport: authentication 
handshake failed: x509: certificate is valid for *.demos.rox.systems, not localhost"

sh$
```
