### PR TITLE
ROX-28996: Log additional info on DeclarativeConfigTest fail

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -252,6 +252,8 @@ splunk:
     }
 
     def cleanup() {
+        outputAdditionalDebugInfo()
+
         orchestrator.deleteConfigMap(CONFIGMAP_NAME, DEFAULT_NAMESPACE)
 
         // Ensure we do not have stale integration health info and only the Config Map one exists.
@@ -491,9 +493,6 @@ splunk:
                         .newBuilder().build())
                 .notifiersList.find { it.getName() == VALID_NOTIFIER.getName() }
         assert notifierAfterDeletion == null
-
-        cleanup:
-        outputAdditionalDebugInfo()
     }
 
     @Tag("BAT")
@@ -570,9 +569,6 @@ splunk:
             assert configMapHealth.getErrorMessage() == ""
             assert configMapHealth.getStatus() == Status.HEALTHY
         }
-
-        cleanup:
-        outputAdditionalDebugInfo()
     }
 
     @Tag("BAT")
@@ -791,9 +787,6 @@ splunk:
             assert configMapHealth.getErrorMessage() == ""
             assert configMapHealth.getStatus() == Status.HEALTHY
         }
-
-        cleanup:
-        outputAdditionalDebugInfo()
     }
 
     // Helpers


### PR DESCRIPTION
### Description

This PR is adding a collection of additional data on DeclarativeConfigTest test failures.

For additional information, please check the Jira ticket and the pinned comment.

We will collect:
- ConfigMap - to debug if the config map is not properly applied
- mounted files - to debug if data from the config map is properly mounted to the container

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] Run CI with DeclarativeConfigTest changes that will log information
- [x] Ensure we are getting the correct expected data on test fail
