### PR TITLE
ROX-29058: Inconsistent compliance results between table & side panel

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
@@ -70,10 +70,10 @@ const EntityCompliance = ({ entityType, entityName, clusterName }) => {
         <Query query={AGGREGATED_RESULTS} variables={variables}>
             {({ loading, data }) => {
                 let contents = <Loader />;
-                if (!loading && data && data.results) {
-                    // Frontend filtering of results.
+                if (!loading && data && data.controls) {
+                    // Frontend filtering of control results.
                     const { complianceStandards } = data;
-                    const results = data.results.results.filter((result) => {
+                    const results = data.controls.results.filter((result) => {
                         const standardId = result.aggregationKeys[0].id;
                         return complianceStandards.some(({ id }) => id === standardId);
                     });

--- a/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
@@ -18,7 +18,7 @@ import searchContext from 'Containers/searchContext';
 import { entityNounSentenceCaseSingular } from '../entitiesForCompliance';
 import VerticalBarChart from './VerticalBarChart';
 
-const EntityCompliance = ({ entityType, entityName, clusterName }) => {
+const EntityCompliance = ({ entityId, entityType, entityName, clusterName }) => {
     const entityTypeLabel = entityNounSentenceCaseSingular[entityType];
     const searchParam = useContext(searchContext);
     const match = useWorkflowMatch();
@@ -60,7 +60,7 @@ const EntityCompliance = ({ entityType, entityName, clusterName }) => {
         navigate(URL);
     }
 
-    const whereClause = { [entityType]: entityName, [entityTypes.CLUSTER]: clusterName };
+    const whereClause = { [`${entityType} ID`]: entityId, [entityTypes.CLUSTER]: clusterName };
     const variables = {
         unit: entityTypes.CHECK,
         groupBy: [entityTypes.STANDARD, entityType],
@@ -117,6 +117,7 @@ const EntityCompliance = ({ entityType, entityName, clusterName }) => {
     );
 };
 EntityCompliance.propTypes = {
+    entityId: PropTypes.string.isRequired,
     entityType: PropTypes.string.isRequired,
     entityName: PropTypes.string,
     clusterName: PropTypes.string,


### PR DESCRIPTION
### Description

Two separate problems that made the data in the list table and the side-panel get out of sync.

1. Mismatched granularity between table and side-panel – we want control level
    - The list shows results **per control**.
    - The side-panel was showing results **per check**.
2. Loose matching in the `where` clause of the graphql request
    - The backend does prefix matching on names, so a search on `apiserver` would return results for `apiserver` and `apiserver-another` 
    - `getAggregatedResults` call only filtered on the `${entityType}` name and `CLUSTER` name,  identically‑named resources in other namespaces were still getting included.

Before:
```
{
  "groupBy": ["STANDARD", "DEPLOYMENT"],
  "unit": "CHECK",
  "where": "DEPLOYMENT:apiserver+CLUSTER:staging-secured-cluster"
}
```

After:
```
{
  "groupBy": ["STANDARD", "DEPLOYMENT"],
  "unit": "CHECK",
  "where": "DEPLOYMENT ID:12345678-aaaa-bbbb-cccc-1234567890ab+CLUSTER:staging-secured-cluster"
}
```


### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before:
- Table showing 7% overall (control results) while side panel shows 38% (check results)
![Screenshot 2025-05-05 at 3 08 40 PM](https://github.com/user-attachments/assets/5b7fae90-6ea9-40be-8774-3ca9bd8a8ab2)



After:
- Table showing 7% overall (control results) and side panel shows 7% (control results)
![Screenshot 2025-05-05 at 3 09 23 PM](https://github.com/user-attachments/assets/456a8aa2-c3d4-4fc1-874e-e71f6be7e67a)

