### PR TITLE
ROX-28991: fix roxctl sensor http retry

### DIFF
--- a/roxctl/common/client.go
+++ b/roxctl/common/client.go
@@ -84,7 +84,7 @@ func GetRoxctlHTTPClient(config *HttpClientConfig) (RoxctlHTTPClient, error) {
 			return false, err //nolint:wrapcheck
 		}
 		if err != nil {
-			config.Logger.ErrfLn(err.Error())
+			config.Logger.WarnfLn(err.Error())
 		}
 		return true, err //nolint:wrapcheck
 	}
@@ -94,12 +94,6 @@ func GetRoxctlHTTPClient(config *HttpClientConfig) (RoxctlHTTPClient, error) {
 	retryClient.RetryWaitMin = config.RetryDelay
 	// Silence the default log output of the HTTP retry client to not pollute output.
 	retryClient.Logger = nil
-	retryClient.RequestLogHook = func(_ retryablehttp.Logger, _ *http.Request, attempt int) {
-		// The initial attempt starts at zero.
-		if attempt > 0 {
-			config.Logger.InfofLn("Retrying request: attempt %d out of %d retries", attempt, retryClient.RetryMax)
-		}
-	}
 
 	if !config.RetryExponentialBackoff {
 		// Disable the exponential backoff, in some scenarios the backoff makes roxctl appear

--- a/roxctl/common/client_options.go
+++ b/roxctl/common/client_options.go
@@ -20,7 +20,6 @@ type HttpClientConfig struct {
 	RetryExponentialBackoff bool
 	RetryCount              int
 	RetryDelay              time.Duration
-	ReturnRespBodyOnError   bool
 	Timeout                 time.Duration
 	UseInsecure             bool
 }
@@ -81,15 +80,6 @@ func WithRetryCount(retryCount int) HttpClientOption {
 func WithRetryDelay(d time.Duration) HttpClientOption {
 	return func(hco *HttpClientConfig) {
 		hco.RetryDelay = d
-	}
-}
-
-// WithReturnErrorResponseBody when true indicates that on error the response body
-// should be returned. By default the response body is empty with no messaging
-// to indicate what the error is or why it occurred.
-func WithReturnErrorResponseBody(returnErrRespBody bool) HttpClientOption {
-	return func(hco *HttpClientConfig) {
-		hco.ReturnRespBodyOnError = returnErrRespBody
 	}
 }
 

--- a/roxctl/common/client_options_test.go
+++ b/roxctl/common/client_options_test.go
@@ -40,10 +40,6 @@ func TestFunctionalOptions(t *testing.T) {
 	WithRetryDelay(1 * time.Second)(cfg)
 	assert.NotZero(t, cfg.RetryDelay)
 
-	assert.Zero(t, cfg.ReturnRespBodyOnError)
-	WithReturnErrorResponseBody(true)(cfg)
-	assert.NotZero(t, cfg.ReturnRespBodyOnError)
-
 	assert.Zero(t, cfg.Timeout)
 	WithTimeout(1 * time.Second)(cfg)
 	assert.NotZero(t, cfg.Timeout)

--- a/roxctl/image/sbom/sbom.go
+++ b/roxctl/image/sbom/sbom.go
@@ -81,8 +81,6 @@ func (i *imageSBOMCommand) construct(cobraCmd *cobra.Command) error {
 		flags.Timeout(cobraCmd),
 		// Disable exponential backoff so that roxctl does not appear stuck.
 		common.WithRetryExponentialBackoff(false),
-		// Ensure error response is made available for troubleshooting failures.
-		common.WithReturnErrorResponseBody(true),
 		common.WithRetryDelay(time.Duration(i.retryDelay)*time.Second),
 		common.WithRetryCount(i.retryCount),
 	)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

I noticed that `DefaultRetryPolicy` does not propagate any errors - hence we did not retry in cases where we should have. This is likely what caused the CI flake ROX-28991.

The code now relies on the `retry` return value to decide if we should retry. I also switched to `ErrorPropagatedRetryPolicy`, such that we can actually log a warning after each attempt. I removed the `ReturnRespBodyOnError` flag and set it to always true. This makes sure that the final error message contains Central specific error messages.

```
$ roxctl sensor generate openshift --output-dir=sensor-bundle --name remote3201 --insecure-skip-tls-verify=true

WARN:	unexpected HTTP status 500 Internal Server Error
WARN:	unexpected HTTP status 500 Internal Server Error
WARN:	unexpected HTTP status 500 Internal Server Error
WARN:	unexpected HTTP status 500 Internal Server Error
ERROR:	error getting cluster zip file: could not download zip: could not download zip: expected status code 200, but received 500. Response Body: {"code":13,"message":"dummy error"}
```

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

see description