### PR TITLE
fix: "replaced operator version" logic

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -156,6 +156,10 @@ help: ## Display this help.
 tag: ## Print the correct operator version (== image tag).
 	@echo $(VERSION)
 
+.PHONY: replaced-version
+replaced-version: ## Print the replaced operator version, without the v prefix.
+	@sed -E -n 's/^[[:space:]]*replaces:[[:space:]]*[^.]+\.v?(.*)$$/\1/p' build/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+
 .PHONY: image-flavor
 image-flavor: ## Print the current image flavor.
 	@echo $(ROX_IMAGE_FLAVOR)
@@ -456,12 +460,19 @@ bundle-post-process: test-bundle-helpers operator-sdk ## Post-process CSV file t
 		--operator-image $(IMG) \
 		--echo-replaced-version-only \
 		< bundle/manifests/rhacs-operator.clusterserviceversion.yaml); \
-	if ! ../scripts/ci/lib.sh check_rhacs_eng_image_exists $(INDEX_IMG_BASE) v$${candidate_version}; then unreleased_opt="--unreleased=$${candidate_version}"; fi; \
+	echo "Candidate version: $$candidate_version"; \
+	index_img_base=$(INDEX_IMG_BASE); \
+	if ! ../scripts/ci/lib.sh check_rhacs_eng_image_exists $${index_img_base##*/} v$${candidate_version}; then \
+		echo "Operator index image for this version does not exist (yet)."; \
+		unreleased_opt="--unreleased=$${candidate_version}"; \
+	else \
+		echo "Operator index image for this version exists"; \
+	fi; \
 	./bundle_helpers/patch-csv.py \
 		--use-version $(VERSION) \
 		--first-version $${first_version} \
 		--operator-image $(IMG) \
-		$${unreleased_opt} \
+		$${unreleased_opt:-} \
 		--related-images-mode=omit \
 		--add-supported-arch amd64 \
 		--add-supported-arch arm64 \


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Looks like this logic never worked, because the passed image name was fully qualified with the registry and org name, and the script expected a bare image name (without any slashes).

As a result, the replaced version was 4.6, fine for the currently released 4.7 operators, but wrong for the to-be-released 4.8.

This change:
* fixes this by trimming everything up to the last slash in the image name
* fixes the undefined variable error that was there all the time in the dead branch
* also adds a `replaced-version` target that I plan to use in https://github.com/stackrox/stackrox/pull/10288 or its replacement, and which is why I noticed this in the first place.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no changes to tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Ran `make -C operator bundle-post-process replaced-version` which now yields `4.7.0` as expected.