### PR TITLE
ROX-29165: @Retry in groups service

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/GroupService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GroupService.groovy
@@ -3,6 +3,7 @@ package services
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
+import io.stackrox.annotations.Retry
 import io.stackrox.proto.api.v1.GroupServiceGrpc
 import io.stackrox.proto.api.v1.GroupServiceOuterClass
 import io.stackrox.proto.api.v1.GroupServiceOuterClass.GetGroupsRequest
@@ -35,32 +36,28 @@ class GroupService extends BaseService {
         }
     }
 
+    @Retry
     static createGroup(Group group) {
-        try {
-            return getGroupService().createGroup(group)
-        } catch (Exception e) {
-            log.error("Error creating new Group", e)
-        }
+        return getGroupService().createGroup(group)
     }
 
+    @Retry
     static deleteGroup(GroupProperties props) {
-        try {
-            return getGroupService().deleteGroup(GroupServiceOuterClass.DeleteGroupRequest.newBuilder()
-                    .setAuthProviderId(props.authProviderId)
-                    .setId(props.id)
-                    .setKey(props.key)
-                    .setValue(props.value)
-                    .build()
-            )
-        } catch (Exception e) {
-            log.error("Error deleting group", e)
-        }
+        return getGroupService().deleteGroup(GroupServiceOuterClass.DeleteGroupRequest.newBuilder()
+                .setAuthProviderId(props.authProviderId)
+                .setId(props.id)
+                .setKey(props.key)
+                .setValue(props.value)
+                .build()
+        )
     }
 
+    @Retry
     static Group getGroup(GroupProperties props) {
         return getGroupService().getGroup(props)
     }
 
+    @Retry
     static GroupServiceOuterClass.GetGroupsResponse getGroups(GetGroupsRequest req) {
         return getGroupService().getGroups(req)
     }


### PR DESCRIPTION
### Description

Currently we log exceptions but this leads to a wrong test configuration causing failures in different places. Instead let's retry network calls and do not catch exception if it occurs to fail fast.

- [x] CHANGELOG update is not needed
- [x] Documentation is not needed
### Testing
- [x] inspected CI results
#### Automated testing
- [x] modified existing tests
- [x] contributed **no automated tests**
#### How I validated my change
CI
