### PR TITLE
ROX-29036: Optimize central API endpoint bringup

### DIFF
--- a/central/cloudsources/datastore/singleton.go
+++ b/central/cloudsources/datastore/singleton.go
@@ -13,7 +13,7 @@ var (
 	once sync.Once
 )
 
-// Singleton returns the singleton providing access to the external backups store.
+// Singleton returns the singleton providing access to the cloud sources store.
 func Singleton() DataStore {
 	once.Do(func() {
 		store := pgStore.New(globaldb.GetPostgres())


### PR DESCRIPTION
### Description
Optimize central startup time to get the API endpoint up and running sooner. Refactoring the startup of the services to a go routine.

Note: I intend to merge the PR only after 4.8 is cut to get improved soak times.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
CI perf tests
Manual scaled cluster with 10 fake sensors running 10-sensors workflow and randomly restarting central - for over 3-4 hours. No crashes observed.