### PR TITLE
chore: Add extra TODO note to `SensorIntegrationOCP`

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -269,6 +269,7 @@ class SensorIntegration(BaseTest):
 
 class SensorIntegrationOCP(SensorIntegration):
     def run(self):
+        # TODO(ROX-17875): make them work on OCP.
         print("Skipping the Sensor Integration Tests for OCP")
 
 


### PR DESCRIPTION
### Description

One note exists there https://github.com/stackrox/stackrox/blob/98b1f48a08a176b27cea2f537ef9a4146d83d76c/scripts/ci/jobs/ocp_sensor_integration_tests.py#L21-L21 but why not introduce yet another?

Ref https://redhat-internal.slack.com/archives/CC5UHD0KA/p1746470685429499

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

No change.

#### How I validated my change

Should just work.
