### PR TITLE
ROX-27490: Generate failed cluster report

### DIFF
--- a/central/complianceoperator/v2/report/manager/format/formatter.go
+++ b/central/complianceoperator/v2/report/manager/format/formatter.go
@@ -13,7 +13,9 @@ import (
 )
 
 const (
-	EmptyValue = "Data not found for the cluster"
+	EmptyValue           = "Data not found for the cluster"
+	successfulClusterFmt = "cluster_%s.csv"
+	failedClusterFmt     = "failed_cluster_%s.csv"
 )
 
 var (
@@ -69,15 +71,14 @@ func (f *FormatterImpl) FormatCSVReport(results map[string][]*report.ResultRow, 
 			errRet = errors.Wrap(err, "unable to create a zip file of the compliance report")
 		}
 	}()
-	for clusterID, res := range results {
-		fileName := fmt.Sprintf("cluster_%s.csv", clusterID)
-		if failedCluster, ok := failedClusters[clusterID]; ok {
-			fileName = fmt.Sprintf("failed_%s", fileName)
-			if err := f.createFailedClusterFileInZip(zipWriter, fileName, failedCluster); err != nil {
-				return nil, errors.Wrap(err, "error creating failed cluster report")
-			}
-			continue
+	for clusterID, failedCluster := range failedClusters {
+		fileName := fmt.Sprintf(failedClusterFmt, clusterID)
+		if err := f.createFailedClusterFileInZip(zipWriter, fileName, failedCluster); err != nil {
+			return nil, errors.Wrap(err, "error creating failed cluster report")
 		}
+	}
+	for clusterID, res := range results {
+		fileName := fmt.Sprintf(successfulClusterFmt, clusterID)
 		err := f.createCSVInZip(zipWriter, fileName, res)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating csv report")

--- a/central/complianceoperator/v2/report/manager/format/formatter.go
+++ b/central/complianceoperator/v2/report/manager/format/formatter.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
@@ -141,7 +142,7 @@ func generateFailRecord(failedCluster *storage.ComplianceOperatorReportSnapshotV
 	return []string{
 		failedCluster.GetClusterId(),
 		failedCluster.GetClusterName(),
-		failedCluster.GetReason(),
+		strings.Join(failedCluster.GetReasons(), ", "),
 		failedCluster.GetOperatorVersion(),
 	}
 }

--- a/central/complianceoperator/v2/report/manager/format/formatter_test.go
+++ b/central/complianceoperator/v2/report/manager/format/formatter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report/manager/format/mocks"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/csv"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -27,39 +28,93 @@ type ComplianceReportingFormatterSuite struct {
 }
 
 func (s *ComplianceReportingFormatterSuite) Test_FormatCSVReportNoError() {
-	matcher := &valueMatcher{
-		data: getFakeReportData(),
-	}
-	s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, nil)
-	s.csvWriter.EXPECT().AddValue(matcher).Times(2).Do(func(_ any) {
-		matcher.recordNumber++
+	s.Run("with empty failed clusters", func() {
+		matcher := &valueMatcher{
+			data: getFakeReportData(),
+		}
+		s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, nil)
+		s.csvWriter.EXPECT().AddValue(matcher).Times(2).Do(func(_ any) {
+			matcher.recordNumber++
+		})
+		s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(nil)
+		s.zipWriter.EXPECT().Close().Times(1).Return(nil)
+
+		buf, err := s.formatter.FormatCSVReport(getFakeReportData(), getFakeEmptyFailedClusters())
+		s.Require().NoError(err)
+		s.Require().NotNil(buf)
 	})
-	s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(nil)
+	s.Run("with nil failed clusters", func() {
+		matcher := &valueMatcher{
+			data: getFakeReportData(),
+		}
+		s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, nil)
+		s.csvWriter.EXPECT().AddValue(matcher).Times(2).Do(func(_ any) {
+			matcher.recordNumber++
+		})
+		s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(nil)
+		s.zipWriter.EXPECT().Close().Times(1).Return(nil)
+
+		buf, err := s.formatter.FormatCSVReport(getFakeReportData(), nil)
+		s.Require().NoError(err)
+		s.Require().NotNil(buf)
+	})
+}
+
+func (s *ComplianceReportingFormatterSuite) Test_FormatCSVReportWithFailedClusterNoError() {
+	matcher := &failedClusterValueMatcher{}
+	matcher.data, matcher.failed = getFakeReportDataWithFailedCluster()
+	s.zipWriter.EXPECT().Create(gomock.Any()).Times(2).Return(nil, nil)
+	s.csvWriter.EXPECT().AddValue(matcher).Times(3)
+	s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(2).Return(nil)
 	s.zipWriter.EXPECT().Close().Times(1).Return(nil)
 
-	buf, err := s.formatter.FormatCSVReport(getFakeReportData())
+	buf, err := s.formatter.FormatCSVReport(getFakeReportDataWithFailedCluster())
 	s.Require().NoError(err)
 	s.Require().NotNil(buf)
 }
 
 func (s *ComplianceReportingFormatterSuite) Test_FormatCSVReportCreateError() {
-	s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, errors.New("error"))
-	s.zipWriter.EXPECT().Close().Times(1).Return(nil)
+	s.Run("report data", func() {
+		s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, errors.New("error"))
+		s.zipWriter.EXPECT().Close().Times(1).Return(nil)
 
-	buf, err := s.formatter.FormatCSVReport(getFakeReportData())
-	s.Require().Error(err)
-	s.Require().Nil(buf)
+		buf, err := s.formatter.FormatCSVReport(getFakeReportData(), getFakeEmptyFailedClusters())
+		s.Require().Error(err)
+		s.Require().Nil(buf)
+	})
+	s.Run("failed cluster data", func() {
+		s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, errors.New("error"))
+		s.zipWriter.EXPECT().Close().Times(1).Return(nil)
+
+		buf, err := s.formatter.FormatCSVReport(getFakeReportDataOnlyFailedCluster())
+		s.Require().Error(err)
+		s.Require().Nil(buf)
+	})
 }
 
 func (s *ComplianceReportingFormatterSuite) Test_FormatCSVReportWriteError() {
-	s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, nil)
-	s.csvWriter.EXPECT().AddValue(gomock.Any()).Times(2)
-	s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(errors.New("error"))
-	s.zipWriter.EXPECT().Close().Times(1).Return(nil)
+	s.Run("report date", func() {
+		s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, nil)
+		s.csvWriter.EXPECT().AddValue(gomock.Any()).Times(2)
+		s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(errors.New("error"))
+		s.zipWriter.EXPECT().Close().Times(1).Return(nil)
 
-	buf, err := s.formatter.FormatCSVReport(getFakeReportData())
-	s.Require().Error(err)
-	s.Require().Nil(buf)
+		buf, err := s.formatter.FormatCSVReport(getFakeReportData(), getFakeEmptyFailedClusters())
+		s.Require().Error(err)
+		s.Require().Nil(buf)
+	})
+	s.Run("failed cluster date", func() {
+		matcher := &failedClusterValueMatcher{}
+		matcher.data, matcher.failed = getFakeReportDataOnlyFailedCluster()
+		s.zipWriter.EXPECT().Create(gomock.Any()).Times(1).Return(nil, nil)
+		s.csvWriter.EXPECT().AddValue(matcher).Times(1)
+		s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(errors.New("error"))
+		s.zipWriter.EXPECT().Close().Times(1).Return(nil)
+
+		buf, err := s.formatter.FormatCSVReport(getFakeReportDataOnlyFailedCluster())
+		s.Require().Error(err)
+		s.Require().Nil(buf)
+	})
 }
 
 func (s *ComplianceReportingFormatterSuite) Test_FormatCSVReportCloseError() {
@@ -68,7 +123,7 @@ func (s *ComplianceReportingFormatterSuite) Test_FormatCSVReportCloseError() {
 	s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(nil)
 	s.zipWriter.EXPECT().Close().Times(1).Return(errors.New("error"))
 
-	buf, err := s.formatter.FormatCSVReport(getFakeReportData())
+	buf, err := s.formatter.FormatCSVReport(getFakeReportData(), getFakeEmptyFailedClusters())
 	s.Require().Error(err)
 	s.Require().Nil(buf)
 }
@@ -82,7 +137,7 @@ func (s *ComplianceReportingFormatterSuite) Test_FormatCSVReportEmptyReportNoErr
 	s.csvWriter.EXPECT().WriteCSV(gomock.Any()).Times(1).Return(nil)
 	s.zipWriter.EXPECT().Close().Times(1).Return(nil)
 
-	buf, err := s.formatter.FormatCSVReport(getFakeEmptyReportData())
+	buf, err := s.formatter.FormatCSVReport(getFakeEmptyReportData(), getFakeEmptyFailedClusters())
 	s.Require().NoError(err)
 	s.Require().NotNil(buf)
 }
@@ -139,6 +194,36 @@ func getFakeReportData() map[string][]*report.ResultRow {
 		},
 	}
 	return results
+}
+
+func getFakeReportDataWithFailedCluster() (map[string][]*report.ResultRow, map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster) {
+	failedClusters := make(map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster)
+	failedClusters["cluster-2"] = &storage.ComplianceOperatorReportSnapshotV2_FailedCluster{
+		ClusterName:     "test_cluster-2",
+		ClusterId:       "test_cluster-2-id",
+		Reason:          "timeout",
+		OperatorVersion: "v1.6.0",
+	}
+	results := getFakeReportData()
+	results["cluster-2"] = []*report.ResultRow{}
+	return results, failedClusters
+}
+
+func getFakeReportDataOnlyFailedCluster() (map[string][]*report.ResultRow, map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster) {
+	failedClusters := make(map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster)
+	failedClusters["cluster-2"] = &storage.ComplianceOperatorReportSnapshotV2_FailedCluster{
+		ClusterName:     "test_cluster-2",
+		ClusterId:       "test_cluster-2-id",
+		Reason:          "timeout",
+		OperatorVersion: "v1.6.0",
+	}
+	results := make(map[string][]*report.ResultRow)
+	results["cluster-2"] = []*report.ResultRow{}
+	return results, failedClusters
+}
+
+func getFakeEmptyFailedClusters() map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster {
+	return make(map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster)
 }
 
 type emptyValueMatcher struct {
@@ -202,5 +287,39 @@ func compareStringSlice(a []string, b []string) bool {
 }
 
 func (m *valueMatcher) String() string {
+	return m.error
+}
+
+type failedClusterValueMatcher struct {
+	data   map[string][]*report.ResultRow
+	failed map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster
+	error  string
+}
+
+func (m *failedClusterValueMatcher) Matches(target interface{}) bool {
+	record, ok := target.(csv.Value)
+	if !ok {
+		m.error = "target is not of type csv.Value"
+		return false
+	}
+	for _, clusterData := range m.data {
+		for _, check := range clusterData {
+			if compareStringSlice(record, generateRecord(check)) {
+				return true
+			}
+		}
+	}
+
+	for _, failedCluster := range m.failed {
+		if compareStringSlice(record, generateFailRecord(failedCluster)) {
+			return true
+		}
+	}
+
+	m.error = fmt.Sprintf("AddValue called with an unexpected record %v", record)
+	return false
+}
+
+func (m *failedClusterValueMatcher) String() string {
 	return m.error
 }

--- a/central/complianceoperator/v2/report/manager/format/formatter_test.go
+++ b/central/complianceoperator/v2/report/manager/format/formatter_test.go
@@ -261,7 +261,7 @@ func getFakeReportDataWithFailedCluster() (map[string][]*report.ResultRow, map[s
 	failedClusters[clusterID2] = &storage.ComplianceOperatorReportSnapshotV2_FailedCluster{
 		ClusterName:     "test_cluster-2",
 		ClusterId:       "test_cluster-2-id",
-		Reason:          "timeout",
+		Reasons:         []string{"timeout"},
 		OperatorVersion: "v1.6.0",
 	}
 	results := getFakeReportData()
@@ -273,7 +273,7 @@ func getFakeReportDataOnlyFailedCluster() (map[string][]*report.ResultRow, map[s
 	failedClusters[clusterID2] = &storage.ComplianceOperatorReportSnapshotV2_FailedCluster{
 		ClusterName:     "test_cluster-2",
 		ClusterId:       "test_cluster-2-id",
-		Reason:          "timeout",
+		Reasons:         []string{"timeout"},
 		OperatorVersion: "v1.6.0",
 	}
 	results := make(map[string][]*report.ResultRow)

--- a/central/complianceoperator/v2/report/manager/generator/mocks/report_gen.go
+++ b/central/complianceoperator/v2/report/manager/generator/mocks/report_gen.go
@@ -94,18 +94,18 @@ func (m *MockFormatter) EXPECT() *MockFormatterMockRecorder {
 }
 
 // FormatCSVReport mocks base method.
-func (m *MockFormatter) FormatCSVReport(arg0 map[string][]*report.ResultRow) (*bytes.Buffer, error) {
+func (m *MockFormatter) FormatCSVReport(arg0 map[string][]*report.ResultRow, arg1 map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster) (*bytes.Buffer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FormatCSVReport", arg0)
+	ret := m.ctrl.Call(m, "FormatCSVReport", arg0, arg1)
 	ret0, _ := ret[0].(*bytes.Buffer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FormatCSVReport indicates an expected call of FormatCSVReport.
-func (mr *MockFormatterMockRecorder) FormatCSVReport(arg0 any) *gomock.Call {
+func (mr *MockFormatterMockRecorder) FormatCSVReport(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatCSVReport", reflect.TypeOf((*MockFormatter)(nil).FormatCSVReport), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatCSVReport", reflect.TypeOf((*MockFormatter)(nil).FormatCSVReport), arg0, arg1)
 }
 
 // MockResultsAggregator is a mock of ResultsAggregator interface.

--- a/central/complianceoperator/v2/report/manager/generator/report_gen.go
+++ b/central/complianceoperator/v2/report/manager/generator/report_gen.go
@@ -34,7 +34,7 @@ type ComplianceReportGenerator interface {
 //
 //go:generate mockgen-wrapper
 type Formatter interface {
-	FormatCSVReport(map[string][]*report.ResultRow) (*bytes.Buffer, error)
+	FormatCSVReport(map[string][]*report.ResultRow, map[string]*storage.ComplianceOperatorReportSnapshotV2_FailedCluster) (*bytes.Buffer, error)
 }
 
 // ResultsAggregator interface is used to generate the report data

--- a/central/complianceoperator/v2/report/manager/generator/report_gen_impl.go
+++ b/central/complianceoperator/v2/report/manager/generator/report_gen_impl.go
@@ -82,7 +82,7 @@ func (rg *complianceReportGeneratorImpl) ProcessReportRequest(req *report.Reques
 
 	reportData := rg.resultsAggregator.GetReportData(req)
 
-	zipData, err := rg.formatter.FormatCSVReport(reportData.ResultCSVs)
+	zipData, err := rg.formatter.FormatCSVReport(reportData.ResultCSVs, nil)
 	if err != nil {
 		if dbErr := reportUtils.UpdateSnapshotOnError(req.Ctx, snapshot, report.ErrReportGeneration, rg.snapshotDS); dbErr != nil {
 			return errors.Wrap(dbErr, "unable to update the snapshot on report generation failure")

--- a/central/complianceoperator/v2/report/manager/generator/report_gen_impl_test.go
+++ b/central/complianceoperator/v2/report/manager/generator/report_gen_impl_test.go
@@ -111,7 +111,7 @@ func (s *ComplainceReportingTestSuite) TestProcessReportRequest() {
 				ReportStatus: &storage.ComplianceOperatorReportStatus{},
 			}, true, nil)
 		s.resultsAggregator.EXPECT().GetReportData(gomock.Any()).Times(1).Return(&report.Results{})
-		s.formatter.EXPECT().FormatCSVReport(gomock.Any()).Times(1)
+		s.formatter.EXPECT().FormatCSVReport(gomock.Any(), gomock.Any()).Times(1)
 		s.snapshotDS.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).
 			DoAndReturn(func(_ any, snapshot *storage.ComplianceOperatorReportSnapshotV2) error {
 				s.Require().Equal(storage.ComplianceOperatorReportStatus_GENERATED, snapshot.GetReportStatus().GetRunState())
@@ -128,7 +128,7 @@ func (s *ComplainceReportingTestSuite) TestProcessReportRequest() {
 				ReportStatus: &storage.ComplianceOperatorReportStatus{},
 			}, true, nil)
 		s.resultsAggregator.EXPECT().GetReportData(gomock.Any()).Times(1).Return(&report.Results{})
-		s.formatter.EXPECT().FormatCSVReport(gomock.Any()).Times(1)
+		s.formatter.EXPECT().FormatCSVReport(gomock.Any(), gomock.Any()).Times(1)
 		gomock.InOrder(
 			s.snapshotDS.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).
 				DoAndReturn(func(_ any, snapshot *storage.ComplianceOperatorReportSnapshotV2) error {
@@ -170,7 +170,7 @@ func (s *ComplainceReportingTestSuite) TestProcessReportRequest() {
 				ReportStatus: &storage.ComplianceOperatorReportStatus{},
 			}, true, nil)
 		s.resultsAggregator.EXPECT().GetReportData(gomock.Any()).Times(1).Return(&report.Results{})
-		s.formatter.EXPECT().FormatCSVReport(gomock.Any()).Times(1)
+		s.formatter.EXPECT().FormatCSVReport(gomock.Any(), gomock.Any()).Times(1)
 		gomock.InOrder(
 			s.snapshotDS.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).
 				DoAndReturn(func(_ any, snapshot *storage.ComplianceOperatorReportSnapshotV2) error {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Given a map of failed clusters. The CSV formatter will generate a file per failed cluster with the reason for the failure.

- depends on #15201

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit tests added
- The entire functionality is tested in #15232
