### PR TITLE
chore: Scanner V4 DB ARM64 GPG fix

### DIFF
--- a/scanner/image/db/scripts/download.sh
+++ b/scanner/image/db/scripts/download.sh
@@ -8,7 +8,7 @@ pg_rhel_major=8
 
 arch="$(uname -m)"
 dnf_list_args=()
-if [[ "$arch" == "arm64" ]]; then
+if [[ "$arch" == "arm64" || "$arch" == "aarch64" ]]; then
   arch="aarch64"
   # Workaround for ARM64 build failures due to "Error: Failed to download metadata for repo 'pgdg15': repomd.xml GPG signature verification error: Bad GPG signature"
   dnf_list_args=('--nogpgcheck')

--- a/scanner/image/db/scripts/download.sh
+++ b/scanner/image/db/scripts/download.sh
@@ -10,6 +10,8 @@ arch="$(uname -m)"
 dnf_list_args=()
 if [[ "$arch" == "arm64" ]]; then
   arch="aarch64"
+  # Workaround for ARM64 build failures due to "Error: Failed to download metadata for repo 'pgdg15': repomd.xml GPG signature verification error: Bad GPG signature"
+  dnf_list_args=('--nogpgcheck')
 fi
 output_dir="/rpms"
 mkdir $output_dir


### PR DESCRIPTION
### Description

Upstream Scanner V4 DB builds [have been failing](https://github.com/stackrox/stackrox/actions/runs/14875106657/attempts/4) due to `Error: Failed to download metadata for repo 'pgdg15': repomd.xml GPG signature verification error: Bad GPG signature`

The equiv Central DB build (in the past) had skipped this verification for some time:

https://github.com/stackrox/stackrox/blob/9b13e8441c95fd17901c4a06d61ac7f79a730268/image/postgres/download.sh#L10-L14

Now Central DB is built [entirely different](https://github.com/stackrox/stackrox/commit/a39cdf328bda6fe4a34c46444b771e8b00f39f7f) (does not install RPMs)

This PR adds the same check to Scanner V4 DB builds until/if ROX-29205 is implemented that gets rid of the rpm install.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

Existing CI

#### How I validated my change

CI