### PR TITLE
ROX-28786: Switch to UBI9 for UI build stage in konflux

### DIFF
--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p image/rhel/docs/api/v1 && \
 RUN make copy-go-binaries-to-image-dir
 
 
-FROM registry.access.redhat.com/ubi8/nodejs-20:latest@sha256:fa392685003effa2e9836f83e912fd57df6eeab560ecd53742627c170386b563 AS ui-builder
+FROM registry.access.redhat.com/ubi9/nodejs-20:latest@sha256:8cbfbca4dbbbd98b0d87dd7f29f44723e3d76f376948463a9be69375fec010b4 AS ui-builder
 
 WORKDIR /go/src/github.com/stackrox/rox/app
 


### PR DESCRIPTION
### Description

Switches from UBI8 to UBI9 for the intermediate UI build stage _only_, reverting back to UBI8 as the base for the final image artifact.

This is a prerequisite for an [upcoming change](https://github.com/stackrox/stackrox/pull/13281) to the UI build system that uses binary components that require a version of GLIBC not available on UBI8.

An equivalent change is available in MR 4250 in the rhacs-midstream repo as well.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI

Manual testing of image created by Konflux (TBD)