### PR TITLE
ROX-29012: Add filters and max height to policy dropdowns

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTacticSelect.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTacticSelect.tsx
@@ -43,6 +43,7 @@ function MitreTacticSelect({
             onToggle={(_event, val) => setIsOpen(val)}
             placeholderText={label}
             selections={tacticId}
+            maxHeight="300px"
         >
             {mitreAttackVectors.map(({ tactic: { id, name } }) => {
                 // See MitreAttackVectorsFormSection.css for name and id style rules.

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.tsx
@@ -40,6 +40,7 @@ function MitreTechniqueSelect({
             onToggle={(_event, val) => setIsOpen(val)}
             placeholderText={label}
             selections={techniqueId}
+            maxHeight="300px"
         >
             {mitreTechniques.map(({ id, name }) => {
                 const optionClassName = id.includes('.')

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
@@ -51,6 +51,7 @@ function PolicyCategoriesSelectField(): ReactElement {
                 onToggle={(_event, isOpen) => onCategoriesToggle(isOpen)}
                 onClear={clearSelection}
                 isCreatable={false}
+                maxHeight="300px"
             >
                 {policyCategories.map(({ id, name }) => (
                     <SelectOption key={id} value={name} />

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
@@ -121,6 +121,8 @@ function PolicyScopeCard({
                                     isOpen={isClusterSelectOpen}
                                     selections={value.cluster || scope?.cluster}
                                     placeholderText="Select a cluster"
+                                    hasInlineFilter
+                                    maxHeight="300px"
                                 >
                                     {clusters.map((cluster) => (
                                         <SelectOption key={cluster.name} value={cluster.id}>
@@ -155,6 +157,8 @@ function PolicyScopeCard({
                                         selections={value.name}
                                         placeholderText="Select a deployment"
                                         isDisabled={hasAuditLogEventSource}
+                                        hasInlineFilter
+                                        maxHeight="300px"
                                     >
                                         {deployments.map((deployment) => (
                                             <SelectOption

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -200,6 +200,7 @@ function PolicyScopeForm() {
                             isDisabled={hasAuditLogEventSource || !hasBuildLifecycle}
                             onClear={() => setFieldValue('excludedImageNames', [])}
                             placeholderText="Select images to exclude"
+                            maxHeight="300px"
                         >
                             {images?.map((image) => (
                                 <SelectOption key={image.name} value={image.name}>


### PR DESCRIPTION
### Description

Adds `maxHeight` to policy wizard dropdowns to prevent menus from flowing off the page.

Adds inline filters to policy exclusion cluster and deployment dropdowns so that results can be filtered instead of endlessly scrolling.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Via the policy wizard.

Policy category dropdown:
![image](https://github.com/user-attachments/assets/94c31843-c522-43bd-8d11-8c2cd8ec2a8d)

MITRE tactic dropdown:
![image](https://github.com/user-attachments/assets/5642bdd4-173f-4a7f-a680-7ff8d0f31d76)


MITRE technique dropdown:
![image](https://github.com/user-attachments/assets/d2013cb5-48bd-4a0a-ad36-9390383aee89)


Cluster exclusion dropdown:
![image](https://github.com/user-attachments/assets/81a9a261-d455-4ab0-9879-714fd936eaa5)
![image](https://github.com/user-attachments/assets/838daf4d-2ae5-471e-b8ef-9f76dbb3c313)
![image](https://github.com/user-attachments/assets/563ed1f3-57d4-4dcc-b3c0-68d2d39dfc54)

Deployment exclusion dropdown:
![image](https://github.com/user-attachments/assets/941bd75d-00c1-488f-9ea3-8f0116f4aba5)
![image](https://github.com/user-attachments/assets/d1659fae-493d-4744-81f9-6a516a47a246)

Exclude images dropdown:
![image](https://github.com/user-attachments/assets/4652befb-4bb1-4fe6-a4de-626514948243)


