### PR TITLE
ROX-29215: Fix SecurityPolicy CRD upgrade regressions

### DIFF
--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -75,6 +75,16 @@ type SecurityPolicySpec struct {
 	// PolicySections define the violation criteria for this policy.
 	PolicySections     []PolicySection      `json:"policySections"`
 	MitreAttackVectors []MitreAttackVectors `json:"mitreAttackVectors,omitempty"`
+
+	// +optional
+	// CriteriaLocked is unused and deprecated
+	CriteriaLocked bool `json:"criteriaLocked,omitempty"`
+	// +optional
+	// IsDefault is unused
+	IsDefault bool `json:"isDefault,omitempty"`
+	// +optional
+	// MitreVetorsLocked is unused and deprecated
+	MitreVectorsLocked bool `json:"mitreVectorsLocked,omitempty"`
 }
 
 type Exclusion struct {
@@ -151,17 +161,29 @@ const (
 
 // SecurityPolicyCondition defines the observed state of SecurityPolicy
 type SecurityPolicyCondition struct {
-	Type               SecurityPolicyConditionType `json:"type"`
-	Status             string                      `json:"status"`
-	Message            string                      `json:"message"`
-	LastTransitionTime metav1.Time                 `json:"lastTransitionTime"`
+	// +optional
+	Type SecurityPolicyConditionType `json:"type,omitempty"`
+	// +optional
+	Status string `json:"status,omitempty"`
+	// +optional
+	Message string `json:"message,omitempty"`
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 }
 
 type SecurityPolicyConditions []SecurityPolicyCondition
 
 type SecurityPolicyStatus struct {
-	Conditions SecurityPolicyConditions `json:"conditions"`
-	PolicyId   string                   `json:"policyId"`
+	// +optional
+	Conditions SecurityPolicyConditions `json:"conditions,omitempty"`
+	// +optional
+	PolicyId string `json:"policyId,omitempty"`
+	// +optional
+	// Accepted is deprecated in favor of conditions
+	Accepted bool `json:"accepted,omitempty"`
+	// +optional
+	// Message is deprecated in favor of conditions
+	Message string `json:"messge,omitempty"`
 }
 
 // IsValid runs validation checks against the SecurityPolicy spec

--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -183,7 +183,7 @@ type SecurityPolicyStatus struct {
 	Accepted bool `json:"accepted,omitempty"`
 	// +optional
 	// Message is deprecated in favor of conditions
-	Message string `json:"messge,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // IsValid runs validation checks against the SecurityPolicy spec

--- a/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
+++ b/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
@@ -280,7 +280,7 @@ spec:
                       type: string
                   type: object
                 type: array
-              messge:
+              message:
                 description: Message is deprecated in favor of conditions
                 type: string
               policyId:

--- a/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
+++ b/config-controller/config/crd/bases/config.stackrox.io_securitypolicies.yaml
@@ -48,6 +48,9 @@ spec:
                   type: string
                 minItems: 1
                 type: array
+              criteriaLocked:
+                description: CriteriaLocked is unused and deprecated
+                type: boolean
               description:
                 description: Description is a free-form text description of this policy.
                 pattern: ^[^\$]{0,800}$
@@ -120,6 +123,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              isDefault:
+                description: IsDefault is unused
+                type: boolean
               lifecycleStages:
                 description: LifecycleStages describes which policy lifecylce stages
                   this policy applies to.  Choices are DEPLOY, BUILD, and RUNTIME.
@@ -142,6 +148,9 @@ spec:
                       type: array
                   type: object
                 type: array
+              mitreVectorsLocked:
+                description: MitreVetorsLocked is unused and deprecated
+                type: boolean
               notifiers:
                 description: Notifiers is a list of IDs or names of the notifiers
                   that should be triggered when a violation from this policy is identified.  IDs
@@ -252,6 +261,9 @@ spec:
             type: object
           status:
             properties:
+              accepted:
+                description: Accepted is deprecated in favor of conditions
+                type: boolean
               conditions:
                 items:
                   description: SecurityPolicyCondition defines the observed state
@@ -266,18 +278,13 @@ spec:
                       type: string
                     type:
                       type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - status
-                  - type
                   type: object
                 type: array
+              messge:
+                description: Message is deprecated in favor of conditions
+                type: string
               policyId:
                 type: string
-            required:
-            - conditions
-            - policyId
             type: object
         type: object
     served: true

--- a/image/templates/helm/stackrox-central/internal/config.stackrox.io_securitypolicies.yaml
+++ b/image/templates/helm/stackrox-central/internal/config.stackrox.io_securitypolicies.yaml
@@ -280,7 +280,7 @@ spec:
                       type: string
                   type: object
                 type: array
-              messge:
+              message:
                 description: Message is deprecated in favor of conditions
                 type: string
               policyId:

--- a/image/templates/helm/stackrox-central/internal/config.stackrox.io_securitypolicies.yaml
+++ b/image/templates/helm/stackrox-central/internal/config.stackrox.io_securitypolicies.yaml
@@ -48,6 +48,9 @@ spec:
                   type: string
                 minItems: 1
                 type: array
+              criteriaLocked:
+                description: CriteriaLocked is unused and deprecated
+                type: boolean
               description:
                 description: Description is a free-form text description of this policy.
                 pattern: ^[^\$]{0,800}$
@@ -120,6 +123,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              isDefault:
+                description: IsDefault is unused
+                type: boolean
               lifecycleStages:
                 description: LifecycleStages describes which policy lifecylce stages
                   this policy applies to.  Choices are DEPLOY, BUILD, and RUNTIME.
@@ -142,6 +148,9 @@ spec:
                       type: array
                   type: object
                 type: array
+              mitreVectorsLocked:
+                description: MitreVetorsLocked is unused and deprecated
+                type: boolean
               notifiers:
                 description: Notifiers is a list of IDs or names of the notifiers
                   that should be triggered when a violation from this policy is identified.  IDs
@@ -252,6 +261,9 @@ spec:
             type: object
           status:
             properties:
+              accepted:
+                description: Accepted is deprecated in favor of conditions
+                type: boolean
               conditions:
                 items:
                   description: SecurityPolicyCondition defines the observed state
@@ -266,18 +278,13 @@ spec:
                       type: string
                     type:
                       type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - status
-                  - type
                   type: object
                 type: array
+              messge:
+                description: Message is deprecated in favor of conditions
+                type: string
               policyId:
                 type: string
-            required:
-            - conditions
-            - policyId
             type: object
         type: object
     served: true


### PR DESCRIPTION
Trying to fix these issues identified by the new CRD upgrade test:

```
ERROR: "NoFieldRemoval": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.spec.criteriaLocked may not be removed
ERROR: "NoFieldRemoval": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.spec.isDefault may not be removed
ERROR: "NoFieldRemoval": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.spec.mitreVectorsLocked may not be removed
ERROR: "NoFieldRemoval": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.status.accepted may not be removed
ERROR: "NoFieldRemoval": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.status.message may not be removed
ERROR: "NoNewRequiredFields": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.status.conditions is new and may not be required
ERROR: "NoNewRequiredFields": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.status.conditions[*].lastTransitionTime is new and may not be required
ERROR: "NoNewRequiredFields": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.status.conditions[*].message is new and may not be required
ERROR: "NoNewRequiredFields": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.status.conditions[*].status is new and may not be required
ERROR: "NoNewRequiredFields": crd/securitypolicies.config.stackrox.io version/v1alpha1 field/^.status.conditions[*].type is new and may not be required
```

I am considering Policy-as-code E2E and CRD upgrade tests passing sufficient validation.