### PR TITLE
chore(scanner): one more CVE-2025-24813 entry

### DIFF
--- a/scanner/updater/manual/vulns.yaml
+++ b/scanner/updater/manual/vulns.yaml
@@ -367,7 +367,28 @@ vulnerabilities:
     URI: https://repo1.maven.apache.org/maven2
 
 # Vuln: CVE-2025-24813/GHSA-83qj-6fr2-vhqg
-# Reason: The Tomcat JAR does not contain a pom.properties file, so cannot match the finding to OSV's data.
+# Reason: The Tomcat JAR does not contain a pom.properties file, so cannot
+#  match the finding to OSV's data. This entry and next entry have the same
+#  Package.Version but not the same Package.Name. This is due to older 9.X.Y
+#  tomcat-embed-core packages containing different MANIFEST.MF than the rest.
+# Source: https://osv.dev/vulnerability/GHSA-83qj-6fr2-vhqg
+- Name: CVE-2025-24813
+  Description: 'Apache Tomcat: Potential RCE and/or information disclosure and/or information corruption with partial PUT'
+  Issued: '2025-03-10T18:31:56Z'
+  Links: https://nvd.nist.gov/vuln/detail/CVE-2025-24813
+  Severity: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  NormalizedSeverity: Critical
+  Package:
+    Name: tomcat-embed-core
+    Kind: Binary
+    RepositoryHint: Maven
+  FixedInVersion: introduced=9.0.0.M1&fixed=9.0.99
+  Repo:
+    Name: maven
+    URI: https://repo1.maven.apache.org/maven2
+
+# Vuln: CVE-2025-24813/GHSA-83qj-6fr2-vhqg
+# Reason: Same as previous entry but with different package name.
 # Source: https://osv.dev/vulnerability/GHSA-83qj-6fr2-vhqg
 - Name: CVE-2025-24813
   Description: 'Apache Tomcat: Potential RCE and/or information disclosure and/or information corruption with partial PUT'


### PR DESCRIPTION
### Description

Follow up from on https://github.com/stackrox/stackrox/pull/15161.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

No.

#### How I validated my change

@RTann helped validate this.
