### PR TITLE
ROX-24313: Minimal fix for the failing network graph test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -174,7 +174,6 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
     }
 
     @Tag("NetworkFlowVisualization")
-    @Ignore("ROX-24313: This started failing regularly after merging PR14538")
     def "Verify two flows co-exist if larger network entity added first"() {
         when:
         "Supernet external source is created before subnet external source"
@@ -195,17 +194,18 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         String externalSource31Name = generateNameWithPrefix("external-source-31")
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, CF_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
+        assert externalSource31 != null
         assert externalSource31ID != null
 
         then:
-        "Verify edge exists from deployment to subnet external source"
+        "Verify edge exists from deployment ${deploymentUid} to subnet external source ${externalSource31ID}"
         withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID, null, 180)
         }
 
         and:
-        "Verify edge from deployment to supernet exists in older network graph"
-        withRetry(4, 30) {
+        "Verify edge from deployment ${deploymentUid} to supernet ${externalSource30ID} exists in older network graph"
+        withRetry(20, 30) {
             assert NetworkGraphUtil.checkForEdge(
                     deploymentUid,
                     externalSource30ID,
@@ -213,8 +213,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
 
         and:
-        "Verify no edge from deployment to supernet exists in recent network graph"
-        withRetry(4, 30) {
+        "Verify no edge from deployment ${deploymentUid} to supernet ${externalSource30ID} exists in recent network graph"
+        withRetry(20, 30) {
             assert verifyNoEdge(
                     deploymentUid,
                     externalSource30ID,


### PR DESCRIPTION
### Description

This is the minimal version of #15156

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- [ ] CI `gke-qa-e2e-tests` must pass.
