### PR TITLE
ROX-29229: Compliance dashboard widgets should show control percent

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.jsx
@@ -57,7 +57,7 @@ const StandardsAcrossEntity = ({ entityType, bodyClassName, className }) => {
     const headerText = `Passing standards across ${entityNounOrdinaryCasePlural[entityType]}`;
 
     function processData(data, type) {
-        if (!data || !data.results || !data.results.results.length) {
+        if (!data || !data.controls || !data.controls.results.length) {
             return [];
         }
         const standardsMapping = merge(
@@ -67,9 +67,9 @@ const StandardsAcrossEntity = ({ entityType, bodyClassName, className }) => {
         );
 
         const barData = Object.keys(standardsMapping).map((standardId) => {
-            const { checks } = standardsMapping[standardId];
-            const { passing: passingChecks, total: totalChecks } = checks;
-            const percentagePassing = Math.round((passingChecks / totalChecks) * 100) || 0;
+            const { controls } = standardsMapping[standardId];
+            const { passing: passingControls, total: totalControls } = controls;
+            const percentagePassing = Math.round((passingControls / totalControls) * 100) || 0;
             const link = URLService.getURL(match, location)
                 .base(entityTypes.CONTROL)
                 .query({

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.jsx
@@ -20,12 +20,12 @@ import { entityNounOrdinaryCaseSingular } from '../entitiesForCompliance';
 import VerticalClusterBar from './VerticalClusterBar';
 
 function processData(match, location, data, entityType, searchParam) {
-    if (!data || !data.results.results.length || !data.entityList) {
+    if (!data || !data.controls.results.length || !data.entityList) {
         return [];
     }
     const standardsGrouping = {};
-    const { results, entityList, complianceStandards } = data;
-    results.results.forEach((result) => {
+    const { controls, entityList, complianceStandards } = data;
+    controls.results.forEach((result) => {
         const entity = entityList.find(
             (entityObject) => entityObject.id === result.aggregationKeys[1].id
         );


### PR DESCRIPTION
### Description

Switch the compliance dashboard widgets to use control level percentages instead of check level percentages.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Before:
![Screenshot 2025-05-08 at 5 31 04 PM](https://github.com/user-attachments/assets/bd5411b3-2020-436a-9937-403ca24aa37b)


After:
![Screenshot 2025-05-08 at 5 31 19 PM](https://github.com/user-attachments/assets/55d6abf7-4fa5-4eec-87a3-d64070454609)

