### PR TITLE
ROX-29230: Clicking 'View more' should show full rule(s)

### DIFF
--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 import {
-    Button,
     Card,
     CardBody,
     CardTitle,
@@ -9,13 +8,14 @@ import {
     Grid,
     GridItem,
     Stack,
-    StackItem,
     Text,
 } from '@patternfly/react-core';
 
 import { PlatformComponentRule, PlatformComponentsConfig } from 'types/config.proto';
 
 import './PlatformComponentsConfigDetails.css';
+import RedHatLayeredProductsCard from './components/RedHatLayeredProductsCard';
+import CustomPlatformComponentsCard from './components/CustomPlatformComponentsCard';
 
 // @TODO: Remove hardcoded value and add platformComponentsConfig as a prop
 const platformComponentsConfig: PlatformComponentsConfig = {
@@ -84,66 +84,10 @@ const PlatformComponentsConfigDetails = (): ReactElement => {
                 </Card>
             </GridItem>
             <GridItem sm={12} md={6} lg={4}>
-                <Card isFlat>
-                    <CardTitle>Red Hat layered products</CardTitle>
-                    <CardBody>
-                        <Stack hasGutter>
-                            <Text>
-                                Components found in Red Hat layered and partner product namespaces
-                                are included in the platform definition by default.
-                            </Text>
-                            <Divider component="div" />
-                            <Text component="small" className="pf-v5-u-color-200">
-                                Namespaces match (Regex)
-                            </Text>
-                            <CodeBlock>
-                                <div className="truncate-multiline">
-                                    {redHatLayeredProductsRule?.namespaceRule.regex}
-                                </div>
-                            </CodeBlock>
-                            <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
-                                <Button variant="link" isInline>
-                                    View more
-                                </Button>
-                            </StackItem>
-                        </Stack>
-                    </CardBody>
-                </Card>
+                <RedHatLayeredProductsCard rule={redHatLayeredProductsRule} />
             </GridItem>
             <GridItem sm={12} md={6} lg={4}>
-                <Card isFlat>
-                    <CardTitle>Custom components</CardTitle>
-                    <CardBody>
-                        <Stack hasGutter>
-                            <Text>
-                                Extend the platform definition by defining namespaces for additional
-                                applications and products.
-                            </Text>
-                            <Divider component="div" />
-                            <Text component="small" className="pf-v5-u-color-200">
-                                Namespaces match (Regex)
-                            </Text>
-                            {customRules.length === 0 && <CodeBlock>None</CodeBlock>}
-                            {customRules.length >= 1 && (
-                                <CodeBlock>
-                                    <Text component="small" className="pf-v5-u-color-200">
-                                        {customRules[0].name}
-                                    </Text>
-                                    <div className="truncate-multiline">
-                                        {customRules[0].namespaceRule.regex}
-                                    </div>
-                                </CodeBlock>
-                            )}
-                            {customRules.length > 1 && (
-                                <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
-                                    <Button variant="link" isInline>
-                                        View more
-                                    </Button>
-                                </StackItem>
-                            )}
-                        </Stack>
-                    </CardBody>
-                </Card>
+                <CustomPlatformComponentsCard customRules={customRules} />
             </GridItem>
         </Grid>
     );

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {
+    Button,
+    Card,
+    CardBody,
+    CardTitle,
+    CodeBlock,
+    Divider,
+    Modal,
+    pluralize,
+    Stack,
+    StackItem,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+
+import useModal from 'hooks/useModal';
+import { PlatformComponentRule } from 'types/config.proto';
+
+export type CustomPlatformComponentsCardProps = {
+    customRules: PlatformComponentRule[];
+};
+
+function CustomPlatformComponentsCard({ customRules }: CustomPlatformComponentsCardProps) {
+    const { isModalOpen, openModal, closeModal } = useModal();
+
+    return (
+        <>
+            <Card isFlat>
+                <CardTitle>Custom components</CardTitle>
+                <CardBody>
+                    <Stack hasGutter>
+                        <Text>
+                            Extend the platform definition by defining namespaces for additional
+                            applications and products.
+                        </Text>
+                        <Divider component="div" />
+                        <Text component="small" className="pf-v5-u-color-200">
+                            Namespaces match (Regex)
+                        </Text>
+                        {customRules.length === 0 && <CodeBlock>None</CodeBlock>}
+                        {customRules.length >= 1 && (
+                            <CodeBlock>
+                                <Text component="small" className="pf-v5-u-color-200">
+                                    {customRules[0].name}
+                                </Text>
+                                <div className="truncate-multiline">
+                                    {customRules[0].namespaceRule.regex}
+                                </div>
+                            </CodeBlock>
+                        )}
+                        {customRules.length > 1 && (
+                            <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
+                                <Button variant="link" isInline onClick={openModal}>
+                                    View more
+                                </Button>
+                            </StackItem>
+                        )}
+                    </Stack>
+                </CardBody>
+            </Card>
+            <Modal
+                variant="small"
+                title="All custom components"
+                description="View all namespace matches (Regex) for custom components"
+                isOpen={isModalOpen}
+                onClose={closeModal}
+            >
+                <Stack hasGutter>
+                    <Title headingLevel="h2" className="pf-v5-u-color-100">
+                        {pluralize(customRules.length, 'result')} found
+                    </Title>
+                    {customRules.map((rule) => {
+                        return (
+                            <CodeBlock>
+                                <Text component="small" className="pf-v5-u-color-200">
+                                    {rule.name}
+                                </Text>
+                                <div>{rule.namespaceRule.regex}</div>
+                            </CodeBlock>
+                        );
+                    })}
+                </Stack>
+            </Modal>
+        </>
+    );
+}
+
+export default CustomPlatformComponentsCard;

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Button,
     Card,
@@ -14,7 +14,6 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import useModal from 'hooks/useModal';
 import { PlatformComponentRule } from 'types/config.proto';
 
 export type CustomPlatformComponentsCardProps = {
@@ -22,7 +21,11 @@ export type CustomPlatformComponentsCardProps = {
 };
 
 function CustomPlatformComponentsCard({ customRules }: CustomPlatformComponentsCardProps) {
-    const { isModalOpen, openModal, closeModal } = useModal();
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    function toggleModal() {
+        setIsModalOpen((value) => !value);
+    }
 
     return (
         <>
@@ -51,7 +54,7 @@ function CustomPlatformComponentsCard({ customRules }: CustomPlatformComponentsC
                         )}
                         {customRules.length > 1 && (
                             <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
-                                <Button variant="link" isInline onClick={openModal}>
+                                <Button variant="link" isInline onClick={toggleModal}>
                                     View more
                                 </Button>
                             </StackItem>
@@ -64,7 +67,7 @@ function CustomPlatformComponentsCard({ customRules }: CustomPlatformComponentsC
                 title="All custom components"
                 description="View all namespace matches (Regex) for custom components"
                 isOpen={isModalOpen}
-                onClose={closeModal}
+                onClose={toggleModal}
                 tabIndex={0} // enables keyboard-accessible scrolling of a modal’s content
             >
                 <Stack hasGutter>
@@ -73,7 +76,7 @@ function CustomPlatformComponentsCard({ customRules }: CustomPlatformComponentsC
                     </Title>
                     {customRules.map((rule) => {
                         return (
-                            <CodeBlock>
+                            <CodeBlock key={rule.name}>
                                 <Text component="small" className="pf-v5-u-color-200">
                                     {rule.name}
                                 </Text>

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
@@ -65,6 +65,7 @@ function CustomPlatformComponentsCard({ customRules }: CustomPlatformComponentsC
                 description="View all namespace matches (Regex) for custom components"
                 isOpen={isModalOpen}
                 onClose={closeModal}
+                tabIndex={0} // enables keyboard-accessible scrolling of a modal’s content
             >
                 <Stack hasGutter>
                     <Title headingLevel="h2" className="pf-v5-u-color-100">

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Button,
     Card,
@@ -12,7 +12,6 @@ import {
     Text,
 } from '@patternfly/react-core';
 
-import useModal from 'hooks/useModal';
 import { PlatformComponentRule } from 'types/config.proto';
 
 export type RedHatLayeredProductsCardProps = {
@@ -20,7 +19,11 @@ export type RedHatLayeredProductsCardProps = {
 };
 
 function RedHatLayeredProductsCard({ rule }: RedHatLayeredProductsCardProps) {
-    const { isModalOpen, openModal, closeModal } = useModal();
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    function toggleModal() {
+        setIsModalOpen((value) => !value);
+    }
 
     return (
         <>
@@ -40,7 +43,7 @@ function RedHatLayeredProductsCard({ rule }: RedHatLayeredProductsCardProps) {
                             <div className="truncate-multiline">{rule?.namespaceRule.regex}</div>
                         </CodeBlock>
                         <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
-                            <Button variant="link" isInline onClick={openModal}>
+                            <Button variant="link" isInline onClick={toggleModal}>
                                 View more
                             </Button>
                         </StackItem>
@@ -52,7 +55,7 @@ function RedHatLayeredProductsCard({ rule }: RedHatLayeredProductsCardProps) {
                 title="All Red Hat layered products"
                 description="View all namespace matches (Regex) in Red Hat layered products"
                 isOpen={isModalOpen}
-                onClose={closeModal}
+                onClose={toggleModal}
             >
                 <CodeBlock>{rule?.namespaceRule.regex}</CodeBlock>
             </Modal>

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {
+    Button,
+    Card,
+    CardBody,
+    CardTitle,
+    CodeBlock,
+    Divider,
+    Modal,
+    Stack,
+    StackItem,
+    Text,
+} from '@patternfly/react-core';
+
+import useModal from 'hooks/useModal';
+import { PlatformComponentRule } from 'types/config.proto';
+
+export type RedHatLayeredProductsCardProps = {
+    rule: PlatformComponentRule | undefined;
+};
+
+function RedHatLayeredProductsCard({ rule }: RedHatLayeredProductsCardProps) {
+    const { isModalOpen, openModal, closeModal } = useModal();
+
+    return (
+        <>
+            <Card isFlat>
+                <CardTitle>Red Hat layered products</CardTitle>
+                <CardBody>
+                    <Stack hasGutter>
+                        <Text>
+                            Components found in Red Hat layered and partner product namespaces are
+                            included in the platform definition by default.
+                        </Text>
+                        <Divider component="div" />
+                        <Text component="small" className="pf-v5-u-color-200">
+                            Namespaces match (Regex)
+                        </Text>
+                        <CodeBlock>
+                            <div className="truncate-multiline">{rule?.namespaceRule.regex}</div>
+                        </CodeBlock>
+                        <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
+                            <Button variant="link" isInline onClick={openModal}>
+                                View more
+                            </Button>
+                        </StackItem>
+                    </Stack>
+                </CardBody>
+            </Card>
+            <Modal
+                variant="small"
+                title="All Red Hat layered products"
+                description="View all namespace matches (Regex) in Red Hat layered products"
+                isOpen={isModalOpen}
+                onClose={closeModal}
+            >
+                <CodeBlock>{rule?.namespaceRule.regex}</CodeBlock>
+            </Modal>
+        </>
+    );
+}
+
+export default RedHatLayeredProductsCard;


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR adds the ability to click on "View more" to show a modal that displays the full rule (or rules for custom components). Some things, not in this PR, that will come in subsequent PRs:

1. Editing the Platform Components Configuration

The "View more" button shows the full Red Hat layered products rule
<img width="1435" alt="Screenshot 2025-05-08 at 5 24 23 PM" src="https://github.com/user-attachments/assets/ea68b6c1-85a1-4fdc-9635-7b17aa2ab202" />

The "View more" button shows the full custom component rules
<img width="1432" alt="Screenshot 2025-05-08 at 5 24 31 PM" src="https://github.com/user-attachments/assets/3ca8e1b5-c5b8-4136-88d4-a7275a39081a" />

Showing multiple custom component rules
<img width="1436" alt="Screenshot 2025-05-08 at 5 31 40 PM" src="https://github.com/user-attachments/assets/6a8bba93-c1b3-4d8e-bd69-36b6a1a5ad75" />

Scrolling multiple custom component rules
<img width="1434" alt="Screenshot 2025-05-08 at 5 31 48 PM" src="https://github.com/user-attachments/assets/e404976e-e7e3-4af4-be54-f0beb1b7b29f" />

Tabbing to show that the scrollable area is highlighted. Pressing the "down" key will scroll down
<img width="1434" alt="Screenshot 2025-05-08 at 5 33 36 PM" src="https://github.com/user-attachments/assets/f7c10d85-2dd1-4591-aa16-41170a3bbadb" />

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [x] added regression tests
- [x] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

TBD