### PR TITLE
ROX-20499: Pagination for the listening endpoints API

### DIFF
--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -253,23 +253,6 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 	}
 
 	// Save new PLOP objects
-	log.Info("")
-	log.Info("")
-	log.Info("")
-	log.Info("")
-	log.Infof("len(newPlopObjects)= %d", len(newPlopObjects))
-	for _, newPlop := range newPlopObjects {
-		log.Infof("newPlop= %+v", newPlop)
-	}
-	log.Info("")
-	log.Info("")
-	log.Info("")
-	log.Info("")
-	log.Infof("len(updatePlopObjects)= %d", len(updatePlopObjects))
-	for _, updatePlop := range updatePlopObjects {
-		log.Infof("updatePlop= %+v", updatePlop)
-	}
-
 	err = ds.storage.UpsertMany(ctx, newPlopObjects)
 	if err != nil {
 		return err

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -253,6 +253,23 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 	}
 
 	// Save new PLOP objects
+	log.Info("")
+	log.Info("")
+	log.Info("")
+	log.Info("")
+	log.Infof("len(newPlopObjects)= %d", len(newPlopObjects))
+	for _, newPlop := range newPlopObjects {
+		log.Infof("newPlop= %+v", newPlop)
+	}
+	log.Info("")
+	log.Info("")
+	log.Info("")
+	log.Info("")
+	log.Infof("len(updatePlopObjects)= %d", len(updatePlopObjects))
+	for _, updatePlop := range updatePlopObjects {
+		log.Infof("updatePlop= %+v", updatePlop)
+	}
+
 	err = ds.storage.UpsertMany(ctx, newPlopObjects)
 	if err != nil {
 		return err

--- a/central/processlisteningonport/service/service_impl.go
+++ b/central/processlisteningonport/service/service_impl.go
@@ -51,6 +51,7 @@ func (s *serviceImpl) GetListeningEndpoints(
 	deployment := req.GetDeploymentId()
 	page := req.GetPagination()
 	processesListeningOnPorts, err := s.dataStore.GetProcessListeningOnPort(ctx, deployment)
+	totalListeningEndpoints := len(processesListeningOnPorts)
 
 	if err != nil {
 		return nil, err
@@ -62,5 +63,6 @@ func (s *serviceImpl) GetListeningEndpoints(
 
 	return &v1.GetProcessesListeningOnPortsResponse{
 		ListeningEndpoints: processesListeningOnPorts,
+		TotalListeningEndpoints: int32(totalListeningEndpoints),
 	}, nil
 }

--- a/central/processlisteningonport/service/service_impl.go
+++ b/central/processlisteningonport/service/service_impl.go
@@ -6,12 +6,12 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	datastore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"google.golang.org/grpc"
 )
 
@@ -57,8 +57,8 @@ func (s *serviceImpl) GetListeningEndpoints(
 	}
 
 	if page != nil {
-                processesListeningOnPorts = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), processesListeningOnPorts)
-        }
+		processesListeningOnPorts = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), processesListeningOnPorts)
+	}
 
 	return &v1.GetProcessesListeningOnPortsResponse{
 		ListeningEndpoints: processesListeningOnPorts,

--- a/central/processlisteningonport/service/service_impl.go
+++ b/central/processlisteningonport/service/service_impl.go
@@ -62,7 +62,7 @@ func (s *serviceImpl) GetListeningEndpoints(
 	}
 
 	return &v1.GetProcessesListeningOnPortsResponse{
-		ListeningEndpoints: processesListeningOnPorts,
+		ListeningEndpoints:      processesListeningOnPorts,
 		TotalListeningEndpoints: int32(totalListeningEndpoints),
 	}, nil
 }

--- a/central/processlisteningonport/service/service_impl.go
+++ b/central/processlisteningonport/service/service_impl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	datastore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -48,11 +49,16 @@ func (s *serviceImpl) GetListeningEndpoints(
 	req *v1.GetProcessesListeningOnPortsRequest,
 ) (*v1.GetProcessesListeningOnPortsResponse, error) {
 	deployment := req.GetDeploymentId()
+	page := req.GetPagination()
 	processesListeningOnPorts, err := s.dataStore.GetProcessListeningOnPort(ctx, deployment)
 
 	if err != nil {
 		return nil, err
 	}
+
+	if page != nil {
+                processesListeningOnPorts = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), processesListeningOnPorts)
+        }
 
 	return &v1.GetProcessesListeningOnPortsResponse{
 		ListeningEndpoints: processesListeningOnPorts,

--- a/central/processlisteningonport/service/service_impl.go
+++ b/central/processlisteningonport/service/service_impl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	datastore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authz"
@@ -21,6 +22,8 @@ var (
 			v1.ListeningEndpointsService_GetListeningEndpoints_FullMethodName,
 		},
 	})
+
+	log     = logging.LoggerForModule()
 )
 
 type serviceImpl struct {
@@ -52,6 +55,8 @@ func (s *serviceImpl) GetListeningEndpoints(
 	page := req.GetPagination()
 	processesListeningOnPorts, err := s.dataStore.GetProcessListeningOnPort(ctx, deployment)
 
+	log.Infof("len(processesListeningOnPorts)= %d", len(processesListeningOnPorts))
+
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +64,8 @@ func (s *serviceImpl) GetListeningEndpoints(
 	if page != nil {
                 processesListeningOnPorts = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), processesListeningOnPorts)
         }
+
+	log.Infof("len(processesListeningOnPorts)= %d", len(processesListeningOnPorts))
 
 	return &v1.GetProcessesListeningOnPortsResponse{
 		ListeningEndpoints: processesListeningOnPorts,

--- a/central/processlisteningonport/service/service_impl.go
+++ b/central/processlisteningonport/service/service_impl.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	datastore "github.com/stackrox/rox/central/processlisteningonport/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authz"
@@ -22,8 +21,6 @@ var (
 			v1.ListeningEndpointsService_GetListeningEndpoints_FullMethodName,
 		},
 	})
-
-	log     = logging.LoggerForModule()
 )
 
 type serviceImpl struct {
@@ -55,8 +52,6 @@ func (s *serviceImpl) GetListeningEndpoints(
 	page := req.GetPagination()
 	processesListeningOnPorts, err := s.dataStore.GetProcessListeningOnPort(ctx, deployment)
 
-	log.Infof("len(processesListeningOnPorts)= %d", len(processesListeningOnPorts))
-
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +59,6 @@ func (s *serviceImpl) GetListeningEndpoints(
 	if page != nil {
                 processesListeningOnPorts = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), processesListeningOnPorts)
         }
-
-	log.Infof("len(processesListeningOnPorts)= %d", len(processesListeningOnPorts))
 
 	return &v1.GetProcessesListeningOnPortsResponse{
 		ListeningEndpoints: processesListeningOnPorts,

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -1,0 +1,278 @@
+//go:build sql_integration
+
+package service
+
+// Uncomment or remove imports before merging
+import (
+	"context"
+	//"fmt"
+	//"math/rand"
+	//"sync"
+	"testing"
+	"time"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	deploymentStore "github.com/stackrox/rox/central/deployment/datastore"
+	processIndicatorDataStore "github.com/stackrox/rox/central/processindicator/datastore"
+	processIndicatorSearch "github.com/stackrox/rox/central/processindicator/search"
+	processIndicatorStorage "github.com/stackrox/rox/central/processindicator/store/postgres"
+	plopStore "github.com/stackrox/rox/central/processlisteningonport/store"
+	plopDataStore "github.com/stackrox/rox/central/processlisteningonport/datastore"
+	postgresStore "github.com/stackrox/rox/central/processlisteningonport/store/postgres"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	//"github.com/stackrox/rox/pkg/process/id"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	//"github.com/stackrox/rox/pkg/search"
+	//"github.com/stackrox/rox/pkg/set"
+	//"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestPLOPService(t *testing.T) {
+	suite.Run(t, new(PLOPServiceTestSuite))
+}
+
+type PLOPServiceTestSuite struct {
+	suite.Suite
+	datastore          plopDataStore.DataStore
+	store              plopStore.Store
+	indicatorDataStore processIndicatorDataStore.DataStore
+	service            *serviceImpl
+
+	postgres *pgtest.TestPostgres
+
+	hasNoneCtx  context.Context
+	hasReadCtx  context.Context
+	hasWriteCtx context.Context
+	hasAllCtx   context.Context
+}
+
+func (suite *PLOPServiceTestSuite) SetupSuite() {
+	suite.hasNoneCtx = sac.WithGlobalAccessScopeChecker(context.Background(), sac.DenyAllAccessScopeChecker())
+
+	suite.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.DeploymentExtension)))
+
+	suite.hasWriteCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.DeploymentExtension)))
+
+	suite.hasAllCtx = sac.WithAllAccess(context.Background())
+}
+
+func (suite *PLOPServiceTestSuite) SetupTest() {
+	suite.postgres = pgtest.ForT(suite.T())
+	suite.store = postgresStore.NewFullStore(suite.postgres.DB)
+
+	indicatorStorage := processIndicatorStorage.New(suite.postgres.DB)
+	indicatorSearcher := processIndicatorSearch.New(indicatorStorage)
+
+	suite.indicatorDataStore = processIndicatorDataStore.New(
+		indicatorStorage, suite.store, indicatorSearcher, nil)
+	suite.datastore = plopDataStore.New(suite.store, suite.indicatorDataStore, suite.postgres)
+	suite.service = &serviceImpl{
+		dataStore: suite.datastore,
+	}
+}
+
+func getIndicators() []*storage.ProcessIndicator {
+	indicators := []*storage.ProcessIndicator{
+		{
+			Id:            fixtureconsts.ProcessIndicatorID1,
+			DeploymentId:  fixtureconsts.Deployment1,
+			PodId:         fixtureconsts.PodName1,
+			PodUid:        fixtureconsts.PodUID1,
+			ClusterId:     fixtureconsts.Cluster1,
+			ContainerName: "test_container1",
+			Namespace:     fixtureconsts.Namespace1,
+
+			Signal: &storage.ProcessSignal{
+				Name:         "test_process1",
+				Args:         "test_arguments1",
+				ExecFilePath: "test_path1",
+			},
+		},
+		{
+			Id:            fixtureconsts.ProcessIndicatorID2,
+			DeploymentId:  fixtureconsts.Deployment2,
+			PodId:         fixtureconsts.PodName2,
+			PodUid:        fixtureconsts.PodUID2,
+			ClusterId:     fixtureconsts.Cluster1,
+			ContainerName: "test_container2",
+			Namespace:     fixtureconsts.Namespace1,
+
+			Signal: &storage.ProcessSignal{
+				Name:         "test_process2",
+				Args:         "test_arguments2",
+				ExecFilePath: "test_path2",
+			},
+		},
+	}
+	// Uncomment or remove before merging
+	//for _, indicator := range indicators {
+	//	id.SetIndicatorID(indicator)
+	//}
+
+	return indicators
+}
+
+var (
+	openPlopObject = storage.ProcessListeningOnPortFromSensor{
+		Port:           1234,
+		Protocol:       storage.L4Protocol_L4_PROTOCOL_TCP,
+		CloseTimestamp: nil,
+		Process: &storage.ProcessIndicatorUniqueKey{
+			PodId:               fixtureconsts.PodName1,
+			ContainerName:       "test_container1",
+			ProcessName:         "test_process1",
+			ProcessArgs:         "test_arguments1",
+			ProcessExecFilePath: "test_path1",
+		},
+		DeploymentId: fixtureconsts.Deployment1,
+		PodUid:       fixtureconsts.PodUID1,
+		ClusterId:    fixtureconsts.Cluster1,
+		Namespace:    fixtureconsts.Namespace1,
+	}
+
+	closedPlopObject = storage.ProcessListeningOnPortFromSensor{
+		Port:           1234,
+		Protocol:       storage.L4Protocol_L4_PROTOCOL_TCP,
+		CloseTimestamp: protoconv.ConvertTimeToTimestamp(time.Now()),
+		Process: &storage.ProcessIndicatorUniqueKey{
+			PodId:               fixtureconsts.PodName1,
+			ContainerName:       "test_container1",
+			ProcessName:         "test_process1",
+			ProcessArgs:         "test_arguments1",
+			ProcessExecFilePath: "test_path1",
+		},
+		DeploymentId: fixtureconsts.Deployment1,
+		PodUid:       fixtureconsts.PodUID1,
+		ClusterId:    fixtureconsts.Cluster1,
+		Namespace:    fixtureconsts.Namespace1,
+	}
+)
+
+func (suite *PLOPServiceTestSuite) addDeployments() {
+	deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)
+	suite.Nil(err)
+	suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, &storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1}))
+	suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, &storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1}))
+}
+
+func (suite *PLOPServiceTestSuite) TestPLOPCases() {
+	cases := map[string]struct{
+		plopsInDB		[]*storage.ProcessListeningOnPortStorage
+		processIndicators	[]*storage.ProcessIndicator
+		deployments		[]*storage.Deployment
+		// For now we don't know which PLOP will be returned when doing pagination
+		// so we just check the number of PLOPs returned. When sorting is added
+		// we will also check the values. Add the sorting ticket here before merging.
+		expectedPlopCount      int
+		request 		*v1.GetProcessesListeningOnPortsRequest
+	} {
+		"One plop is retrieved": {
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
+							fixtures.GetPlopStorage7(),
+						},
+			processIndicators: getIndicators(),
+			deployments: 	[]*storage.Deployment{
+						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
+						&storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
+					},
+			expectedPlopCount: 1,
+			request:	&v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId:	fixtureconsts.Deployment1,
+			},
+		},
+	}
+		
+	for name, c := range cases {
+		suite.T().Run(name, func(t *testing.T) {
+			suite.SetupTest()
+
+			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)
+			suite.Nil(err)
+
+			for _, deployment := range c.deployments{
+				suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, deployment))
+			}
+
+			suite.NoError(suite.indicatorDataStore.AddProcessIndicators(
+				suite.hasWriteCtx, c.processIndicators...))
+
+			err = suite.store.UpsertMany(suite.hasWriteCtx, c.plopsInDB)
+			suite.Nil(err)
+
+			response, err := suite.service.GetListeningEndpoints(suite.hasReadCtx, c.request)
+			suite.NoError(err)
+
+			suite.Equal(c.expectedPlopCount, len(response.ListeningEndpoints))
+		})
+	}
+
+}
+
+// Probably remove this before merging as it is redundant with the above
+func (suite *PLOPServiceTestSuite) TestPLOPHappyPath() {
+	indicators := getIndicators()
+
+	plopObjects := []*storage.ProcessListeningOnPortFromSensor{&openPlopObject}
+
+	suite.addDeployments()
+
+	// Prepare indicators for FK
+	suite.NoError(suite.indicatorDataStore.AddProcessIndicators(
+		suite.hasWriteCtx, indicators...))
+
+	// Add PLOP referencing those indicators
+	suite.NoError(suite.datastore.AddProcessListeningOnPort(
+		suite.hasWriteCtx, fixtureconsts.Cluster1, plopObjects...))
+
+	request := &v1.GetProcessesListeningOnPortsRequest{
+		DeploymentId: fixtureconsts.Deployment3,
+	}
+	// Check a deployment that doesn't exist
+	response, err := suite.service.GetListeningEndpoints(suite.hasReadCtx, request)
+	suite.NoError(err)
+
+	newPlops := response.ListeningEndpoints
+	suite.Len(newPlops, 0)
+
+	request = &v1.GetProcessesListeningOnPortsRequest{
+		DeploymentId: fixtureconsts.Deployment1,
+	}
+	// Check a deployment that doesn't exist
+	response, err = suite.service.GetListeningEndpoints(suite.hasReadCtx, request)
+	suite.NoError(err)
+
+	newPlops = response.ListeningEndpoints
+	suite.Len(newPlops, 1)
+
+	protoassert.Equal(suite.T(), newPlops[0], &storage.ProcessListeningOnPort{
+		ContainerName: "test_container1",
+		PodId:         fixtureconsts.PodName1,
+		PodUid:        fixtureconsts.PodUID1,
+		DeploymentId:  fixtureconsts.Deployment1,
+		ClusterId:     fixtureconsts.Cluster1,
+		Namespace:     fixtureconsts.Namespace1,
+		Endpoint: &storage.ProcessListeningOnPort_Endpoint{
+			Port:     1234,
+			Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+		Signal: &storage.ProcessSignal{
+			Name:         "test_process1",
+			Args:         "test_arguments1",
+			ExecFilePath: "test_path1",
+		},
+	})
+
+}

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -2,14 +2,9 @@
 
 package service
 
-// Uncomment or remove imports before merging
 import (
 	"context"
-	//"fmt"
-	//"math/rand"
-	//"sync"
 	"testing"
-	//"time"
 
 	deploymentStore "github.com/stackrox/rox/central/deployment/datastore"
 	processIndicatorDataStore "github.com/stackrox/rox/central/processindicator/datastore"
@@ -23,14 +18,8 @@ import (
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
-	//"github.com/stackrox/rox/pkg/process/id"
-	//"github.com/stackrox/rox/pkg/protoassert"
-	//"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
-	//"github.com/stackrox/rox/pkg/search"
-	//"github.com/stackrox/rox/pkg/set"
-	//"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -36,15 +36,12 @@ type PLOPServiceTestSuite struct {
 
 	postgres *pgtest.TestPostgres
 
-	hasNoneCtx  context.Context
 	hasReadCtx  context.Context
 	hasWriteCtx context.Context
 	hasAllCtx   context.Context
 }
 
 func (suite *PLOPServiceTestSuite) SetupSuite() {
-	suite.hasNoneCtx = sac.WithGlobalAccessScopeChecker(context.Background(), sac.DenyAllAccessScopeChecker())
-
 	suite.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -134,6 +134,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 		// so we just check the number of PLOPs returned. When sorting is added
 		// we will also check the values. Add the sorting ticket here before merging.
 		expectedPlopCount int
+		expectedTotalListeningEndpoints int32
 		request           *v1.GetProcessesListeningOnPortsRequest
 	}{
 		"One plop is retrieved": {
@@ -141,6 +142,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
 			deployments:       []*storage.Deployment{deployment1, deployment2},
 			expectedPlopCount: 1,
+			expectedTotalListeningEndpoints: 1,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 			},
@@ -150,6 +152,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
 			deployments:       []*storage.Deployment{deployment1, deployment2},
 			expectedPlopCount: 0,
+			expectedTotalListeningEndpoints: 0,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment2,
 			},
@@ -159,6 +162,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
 			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 3,
+			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 			},
@@ -168,6 +172,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
 			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
+			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 				Pagination: &v1.Pagination{
@@ -181,6 +186,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
 			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 2,
+			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 				Pagination: &v1.Pagination{
@@ -194,6 +200,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
 			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 3,
+			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 				Pagination: &v1.Pagination{
@@ -207,6 +214,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
 			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
+			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 				Pagination: &v1.Pagination{
@@ -220,6 +228,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
 			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 2,
+			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 				Pagination: &v1.Pagination{
@@ -233,6 +242,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
 			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
+			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 				Pagination: &v1.Pagination{
@@ -264,6 +274,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			suite.NoError(err)
 
 			suite.Equal(c.expectedPlopCount, len(response.ListeningEndpoints))
+			suite.Equal(c.expectedTotalListeningEndpoints, response.TotalListeningEndpoints)
 		})
 	}
 

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -133,45 +133,45 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 		// For now we don't know which PLOP will be returned when doing pagination
 		// so we just check the number of PLOPs returned. When sorting is added
 		// we will also check the values. Add the sorting ticket here before merging.
-		expectedPlopCount int
+		expectedPlopCount               int
 		expectedTotalListeningEndpoints int32
-		request           *v1.GetProcessesListeningOnPortsRequest
+		request                         *v1.GetProcessesListeningOnPortsRequest
 	}{
 		"One plop is retrieved": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
-			deployments:       []*storage.Deployment{deployment1, deployment2},
-			expectedPlopCount: 1,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2},
+			deployments:                     []*storage.Deployment{deployment1, deployment2},
+			expectedPlopCount:               1,
 			expectedTotalListeningEndpoints: 1,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 			},
 		},
 		"No plops are retrieved since the deployment is wrong": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
-			deployments:       []*storage.Deployment{deployment1, deployment2},
-			expectedPlopCount: 0,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2},
+			deployments:                     []*storage.Deployment{deployment1, deployment2},
+			expectedPlopCount:               0,
 			expectedTotalListeningEndpoints: 0,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment2,
 			},
 		},
 		"Multiple plops are retrieved": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments:       []*storage.Deployment{deployment1},
-			expectedPlopCount: 3,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments:                     []*storage.Deployment{deployment1},
+			expectedPlopCount:               3,
 			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
 			},
 		},
 		"One plop is retrieved due to pagination": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments:       []*storage.Deployment{deployment1},
-			expectedPlopCount: 1,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments:                     []*storage.Deployment{deployment1},
+			expectedPlopCount:               1,
 			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
@@ -182,10 +182,10 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Two plops are retrieved due to pagination": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments:       []*storage.Deployment{deployment1},
-			expectedPlopCount: 2,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments:                     []*storage.Deployment{deployment1},
+			expectedPlopCount:               2,
 			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
@@ -196,10 +196,10 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Limit is greater than the number of plops": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments:       []*storage.Deployment{deployment1},
-			expectedPlopCount: 3,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments:                     []*storage.Deployment{deployment1},
+			expectedPlopCount:               3,
 			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
@@ -210,10 +210,10 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Limit and offset are one": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments:       []*storage.Deployment{deployment1},
-			expectedPlopCount: 1,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments:                     []*storage.Deployment{deployment1},
+			expectedPlopCount:               1,
 			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
@@ -224,10 +224,10 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Two plops returned due to offset": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments:       []*storage.Deployment{deployment1},
-			expectedPlopCount: 2,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments:                     []*storage.Deployment{deployment1},
+			expectedPlopCount:               2,
 			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,
@@ -238,10 +238,10 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Only one plop returned due to offset": {
-			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
-			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments:       []*storage.Deployment{deployment1},
-			expectedPlopCount: 1,
+			plopsInDB:                       []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators:               []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments:                     []*storage.Deployment{deployment1},
+			expectedPlopCount:               1,
 			expectedTotalListeningEndpoints: 3,
 			request: &v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId: fixtureconsts.Deployment1,

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -11,14 +11,14 @@ import (
 	"testing"
 	//"time"
 
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	deploymentStore "github.com/stackrox/rox/central/deployment/datastore"
 	processIndicatorDataStore "github.com/stackrox/rox/central/processindicator/datastore"
 	processIndicatorSearch "github.com/stackrox/rox/central/processindicator/search"
 	processIndicatorStorage "github.com/stackrox/rox/central/processindicator/store/postgres"
-	plopStore "github.com/stackrox/rox/central/processlisteningonport/store"
 	plopDataStore "github.com/stackrox/rox/central/processlisteningonport/datastore"
+	plopStore "github.com/stackrox/rox/central/processlisteningonport/store"
 	postgresStore "github.com/stackrox/rox/central/processlisteningonport/store/postgres"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
@@ -137,123 +137,123 @@ var (
 )
 
 func (suite *PLOPServiceTestSuite) TestPLOPCases() {
-	cases := map[string]struct{
-		plopsInDB		[]*storage.ProcessListeningOnPortStorage
-		processIndicators	[]*storage.ProcessIndicator
-		deployments		[]*storage.Deployment
+	cases := map[string]struct {
+		plopsInDB         []*storage.ProcessListeningOnPortStorage
+		processIndicators []*storage.ProcessIndicator
+		deployments       []*storage.Deployment
 		// For now we don't know which PLOP will be returned when doing pagination
 		// so we just check the number of PLOPs returned. When sorting is added
 		// we will also check the values. Add the sorting ticket here before merging.
-		expectedPlopCount      int
-		request 		*v1.GetProcessesListeningOnPortsRequest
-	} {
+		expectedPlopCount int
+		request           *v1.GetProcessesListeningOnPortsRequest
+	}{
 		"One plop is retrieved": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
-			deployments: 	[]*storage.Deployment{deployment1, deployment2},
+			deployments:       []*storage.Deployment{deployment1, deployment2},
 			expectedPlopCount: 1,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
 			},
 		},
 		"No plops are retrieved since the deployment is wrong": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
-			deployments: 	[]*storage.Deployment{deployment1, deployment2},
+			deployments:       []*storage.Deployment{deployment1, deployment2},
 			expectedPlopCount: 0,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment2,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment2,
 			},
 		},
 		"Multiple plops are retrieved": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments: 	[]*storage.Deployment{deployment1},
+			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 3,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
 			},
 		},
 		"One plop is retrieved due to pagination": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments: 	[]*storage.Deployment{deployment1},
+			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
-				Pagination:	&v1.Pagination{
-					Limit: 1,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
+				Pagination: &v1.Pagination{
+					Limit:  1,
 					Offset: 0,
 				},
 			},
 		},
 		"Two plops are retrieved due to pagination": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments: 	[]*storage.Deployment{deployment1},
+			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 2,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
-				Pagination:	&v1.Pagination{
-					Limit: 2,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
+				Pagination: &v1.Pagination{
+					Limit:  2,
 					Offset: 0,
 				},
 			},
 		},
 		"Limit is greater than the number of plops": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments: 	[]*storage.Deployment{deployment1},
+			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 3,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
-				Pagination:	&v1.Pagination{
-					Limit: 4,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
+				Pagination: &v1.Pagination{
+					Limit:  4,
 					Offset: 0,
 				},
 			},
 		},
 		"Limit and offset are one": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments: 	[]*storage.Deployment{deployment1},
+			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
-				Pagination:	&v1.Pagination{
-					Limit: 1,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
+				Pagination: &v1.Pagination{
+					Limit:  1,
 					Offset: 1,
 				},
 			},
 		},
 		"Two plops returned due to offset": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments: 	[]*storage.Deployment{deployment1},
+			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 2,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
-				Pagination:	&v1.Pagination{
-					Limit: 10,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
+				Pagination: &v1.Pagination{
+					Limit:  10,
 					Offset: 1,
 				},
 			},
 		},
 		"Only one plop returned due to offset": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			plopsInDB:         []*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
-			deployments: 	[]*storage.Deployment{deployment1},
+			deployments:       []*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
-			request:	&v1.GetProcessesListeningOnPortsRequest{
-				DeploymentId:	fixtureconsts.Deployment1,
-				Pagination:	&v1.Pagination{
-					Limit: 10,
+			request: &v1.GetProcessesListeningOnPortsRequest{
+				DeploymentId: fixtureconsts.Deployment1,
+				Pagination: &v1.Pagination{
+					Limit:  10,
 					Offset: 2,
 				},
 			},
 		},
 	}
-		
+
 	for name, c := range cases {
 		suite.T().Run(name, func(t *testing.T) {
 			suite.SetupTest()
@@ -261,7 +261,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)
 			suite.Nil(err)
 
-			for _, deployment := range c.deployments{
+			for _, deployment := range c.deployments {
 				suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, deployment))
 			}
 

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -84,47 +84,6 @@ func (suite *PLOPServiceTestSuite) SetupTest() {
 	}
 }
 
-func getIndicators() []*storage.ProcessIndicator {
-	indicators := []*storage.ProcessIndicator{
-		{
-			Id:            fixtureconsts.ProcessIndicatorID1,
-			DeploymentId:  fixtureconsts.Deployment1,
-			PodId:         fixtureconsts.PodName1,
-			PodUid:        fixtureconsts.PodUID1,
-			ClusterId:     fixtureconsts.Cluster1,
-			ContainerName: "test_container1",
-			Namespace:     fixtureconsts.Namespace1,
-
-			Signal: &storage.ProcessSignal{
-				Name:         "test_process1",
-				Args:         "test_arguments1",
-				ExecFilePath: "test_path1",
-			},
-		},
-		{
-			Id:            fixtureconsts.ProcessIndicatorID2,
-			DeploymentId:  fixtureconsts.Deployment2,
-			PodId:         fixtureconsts.PodName2,
-			PodUid:        fixtureconsts.PodUID2,
-			ClusterId:     fixtureconsts.Cluster1,
-			ContainerName: "test_container2",
-			Namespace:     fixtureconsts.Namespace1,
-
-			Signal: &storage.ProcessSignal{
-				Name:         "test_process2",
-				Args:         "test_arguments2",
-				ExecFilePath: "test_path2",
-			},
-		},
-	}
-	// Uncomment or remove before merging
-	//for _, indicator := range indicators {
-	//	id.SetIndicatorID(indicator)
-	//}
-
-	return indicators
-}
-
 var (
 	indicator1 = &storage.ProcessIndicator{
 		Id:            fixtureconsts.ProcessIndicatorID1,
@@ -174,13 +133,6 @@ var (
 	}
 )
 
-func (suite *PLOPServiceTestSuite) addDeployments() {
-	deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)
-	suite.Nil(err)
-	suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, &storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1}))
-	suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, &storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1}))
-}
-
 func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 	cases := map[string]struct{
 		plopsInDB		[]*storage.ProcessListeningOnPortStorage
@@ -196,7 +148,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
 							fixtures.GetPlopStorage7(),
 						},
-			processIndicators: getIndicators(),
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
 			deployments: 	[]*storage.Deployment{
 						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
 						&storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
@@ -210,7 +162,7 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
 							fixtures.GetPlopStorage7(),
 						},
-			processIndicators: getIndicators(),
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
 			deployments: 	[]*storage.Deployment{
 						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
 						&storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -131,6 +131,9 @@ var (
 			ExecFilePath: "test_path3",
 		},
 	}
+
+	deployment1 = &storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1}
+	deployment2 = &storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1}
 )
 
 func (suite *PLOPServiceTestSuite) TestPLOPCases() {
@@ -145,66 +148,36 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 		request 		*v1.GetProcessesListeningOnPortsRequest
 	} {
 		"One plop is retrieved": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-						},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-						&storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			deployments: 	[]*storage.Deployment{deployment1, deployment2},
 			expectedPlopCount: 1,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,
 			},
 		},
 		"No plops are retrieved since the deployment is wrong": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-						},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7()},
 			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-						&storage.Deployment{Id: fixtureconsts.Deployment2, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			deployments: 	[]*storage.Deployment{deployment1, deployment2},
 			expectedPlopCount: 0,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment2,
 			},
 		},
 		"Multiple plops are retrieved": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-							fixtures.GetPlopStorage8(),
-							fixtures.GetPlopStorage9(),
-						},
-			processIndicators: []*storage.ProcessIndicator{
-							indicator1,
-							indicator2,
-							indicator3,
-			},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments: 	[]*storage.Deployment{deployment1},
 			expectedPlopCount: 3,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,
 			},
 		},
 		"One plop is retrieved due to pagination": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-							fixtures.GetPlopStorage8(),
-							fixtures.GetPlopStorage9(),
-						},
-			processIndicators: []*storage.ProcessIndicator{
-							indicator1,
-							indicator2,
-							indicator3,
-			},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments: 	[]*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,
@@ -215,19 +188,9 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Two plops are retrieved due to pagination": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-							fixtures.GetPlopStorage8(),
-							fixtures.GetPlopStorage9(),
-						},
-			processIndicators: []*storage.ProcessIndicator{
-							indicator1,
-							indicator2,
-							indicator3,
-			},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments: 	[]*storage.Deployment{deployment1},
 			expectedPlopCount: 2,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,
@@ -238,19 +201,9 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Limit is greater than the number of plops": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-							fixtures.GetPlopStorage8(),
-							fixtures.GetPlopStorage9(),
-						},
-			processIndicators: []*storage.ProcessIndicator{
-							indicator1,
-							indicator2,
-							indicator3,
-			},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments: 	[]*storage.Deployment{deployment1},
 			expectedPlopCount: 3,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,
@@ -261,19 +214,9 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Limit and offset are one": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-							fixtures.GetPlopStorage8(),
-							fixtures.GetPlopStorage9(),
-						},
-			processIndicators: []*storage.ProcessIndicator{
-							indicator1,
-							indicator2,
-							indicator3,
-			},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments: 	[]*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,
@@ -284,19 +227,9 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Two plops returned due to offset": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-							fixtures.GetPlopStorage8(),
-							fixtures.GetPlopStorage9(),
-						},
-			processIndicators: []*storage.ProcessIndicator{
-							indicator1,
-							indicator2,
-							indicator3,
-			},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments: 	[]*storage.Deployment{deployment1},
 			expectedPlopCount: 2,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,
@@ -307,19 +240,9 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 			},
 		},
 		"Only one plop returned due to offset": {
-			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{
-							fixtures.GetPlopStorage7(),
-							fixtures.GetPlopStorage8(),
-							fixtures.GetPlopStorage9(),
-						},
-			processIndicators: []*storage.ProcessIndicator{
-							indicator1,
-							indicator2,
-							indicator3,
-			},
-			deployments: 	[]*storage.Deployment{
-						&storage.Deployment{Id: fixtureconsts.Deployment1, Namespace: fixtureconsts.Namespace1, ClusterId: fixtureconsts.Cluster1},
-					},
+			plopsInDB:	[]*storage.ProcessListeningOnPortStorage{fixtures.GetPlopStorage7(), fixtures.GetPlopStorage8(), fixtures.GetPlopStorage9()},
+			processIndicators: []*storage.ProcessIndicator{indicator1, indicator2, indicator3},
+			deployments: 	[]*storage.Deployment{deployment1},
 			expectedPlopCount: 1,
 			request:	&v1.GetProcessesListeningOnPortsRequest{
 				DeploymentId:	fixtureconsts.Deployment1,

--- a/central/processlisteningonport/service/service_impl_test.go
+++ b/central/processlisteningonport/service/service_impl_test.go
@@ -130,9 +130,9 @@ func (suite *PLOPServiceTestSuite) TestPLOPCases() {
 		plopsInDB         []*storage.ProcessListeningOnPortStorage
 		processIndicators []*storage.ProcessIndicator
 		deployments       []*storage.Deployment
-		// For now we don't know which PLOP will be returned when doing pagination
-		// so we just check the number of PLOPs returned. When sorting is added
-		// we will also check the values. Add the sorting ticket here before merging.
+		// TODO(ROX-19888): For now we don't know which PLOPs will be returned
+		// when doing pagination so we just check the number of PLOPs returned.
+		// When sorting is added we will also check the values.
 		expectedPlopCount               int
 		expectedTotalListeningEndpoints int32
 		request                         *v1.GetProcessesListeningOnPortsRequest

--- a/generated/api/v1/process_listening_on_port_service.pb.go
+++ b/generated/api/v1/process_listening_on_port_service.pb.go
@@ -26,6 +26,7 @@ const (
 type GetProcessesListeningOnPortsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"`
+	Pagination    *Pagination            `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -65,6 +66,13 @@ func (x *GetProcessesListeningOnPortsRequest) GetDeploymentId() string {
 		return x.DeploymentId
 	}
 	return ""
+}
+
+func (x *GetProcessesListeningOnPortsRequest) GetPagination() *Pagination {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
 }
 
 type GetProcessesListeningOnPortsResponse struct {
@@ -115,9 +123,12 @@ var File_api_v1_process_listening_on_port_service_proto protoreflect.FileDescrip
 
 const file_api_v1_process_listening_on_port_service_proto_rawDesc = "" +
 	"\n" +
-	".api/v1/process_listening_on_port_service.proto\x12\x02v1\x1a\x1cgoogle/api/annotations.proto\x1a'storage/process_listening_on_port.proto\"J\n" +
+	".api/v1/process_listening_on_port_service.proto\x12\x02v1\x1a\x1cgoogle/api/annotations.proto\x1a\x17api/v1/pagination.proto\x1a'storage/process_listening_on_port.proto\"z\n" +
 	"#GetProcessesListeningOnPortsRequest\x12#\n" +
-	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\"x\n" +
+	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12.\n" +
+	"\n" +
+	"pagination\x18\x02 \x01(\v2\x0e.v1.PaginationR\n" +
+	"pagination\"x\n" +
 	"$GetProcessesListeningOnPortsResponse\x12P\n" +
 	"\x13listening_endpoints\x18\x01 \x03(\v2\x1f.storage.ProcessListeningOnPortR\x12listeningEndpoints2\xc4\x01\n" +
 	"\x19ListeningEndpointsService\x12\xa6\x01\n" +
@@ -140,17 +151,19 @@ var file_api_v1_process_listening_on_port_service_proto_msgTypes = make([]protoi
 var file_api_v1_process_listening_on_port_service_proto_goTypes = []any{
 	(*GetProcessesListeningOnPortsRequest)(nil),  // 0: v1.GetProcessesListeningOnPortsRequest
 	(*GetProcessesListeningOnPortsResponse)(nil), // 1: v1.GetProcessesListeningOnPortsResponse
-	(*storage.ProcessListeningOnPort)(nil),       // 2: storage.ProcessListeningOnPort
+	(*Pagination)(nil),                           // 2: v1.Pagination
+	(*storage.ProcessListeningOnPort)(nil),       // 3: storage.ProcessListeningOnPort
 }
 var file_api_v1_process_listening_on_port_service_proto_depIdxs = []int32{
-	2, // 0: v1.GetProcessesListeningOnPortsResponse.listening_endpoints:type_name -> storage.ProcessListeningOnPort
-	0, // 1: v1.ListeningEndpointsService.GetListeningEndpoints:input_type -> v1.GetProcessesListeningOnPortsRequest
-	1, // 2: v1.ListeningEndpointsService.GetListeningEndpoints:output_type -> v1.GetProcessesListeningOnPortsResponse
-	2, // [2:3] is the sub-list for method output_type
-	1, // [1:2] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 0: v1.GetProcessesListeningOnPortsRequest.pagination:type_name -> v1.Pagination
+	3, // 1: v1.GetProcessesListeningOnPortsResponse.listening_endpoints:type_name -> storage.ProcessListeningOnPort
+	0, // 2: v1.ListeningEndpointsService.GetListeningEndpoints:input_type -> v1.GetProcessesListeningOnPortsRequest
+	1, // 3: v1.ListeningEndpointsService.GetListeningEndpoints:output_type -> v1.GetProcessesListeningOnPortsResponse
+	3, // [3:4] is the sub-list for method output_type
+	2, // [2:3] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_process_listening_on_port_service_proto_init() }
@@ -158,6 +171,7 @@ func file_api_v1_process_listening_on_port_service_proto_init() {
 	if File_api_v1_process_listening_on_port_service_proto != nil {
 		return
 	}
+	file_api_v1_pagination_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/generated/api/v1/process_listening_on_port_service.pb.go
+++ b/generated/api/v1/process_listening_on_port_service.pb.go
@@ -123,7 +123,7 @@ var File_api_v1_process_listening_on_port_service_proto protoreflect.FileDescrip
 
 const file_api_v1_process_listening_on_port_service_proto_rawDesc = "" +
 	"\n" +
-	".api/v1/process_listening_on_port_service.proto\x12\x02v1\x1a\x1cgoogle/api/annotations.proto\x1a\x17api/v1/pagination.proto\x1a'storage/process_listening_on_port.proto\"z\n" +
+	".api/v1/process_listening_on_port_service.proto\x12\x02v1\x1a\x17api/v1/pagination.proto\x1a\x1cgoogle/api/annotations.proto\x1a'storage/process_listening_on_port.proto\"z\n" +
 	"#GetProcessesListeningOnPortsRequest\x12#\n" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12.\n" +
 	"\n" +
@@ -133,7 +133,7 @@ const file_api_v1_process_listening_on_port_service_proto_rawDesc = "" +
 	"\x13listening_endpoints\x18\x01 \x03(\v2\x1f.storage.ProcessListeningOnPortR\x12listeningEndpoints2\xc4\x01\n" +
 	"\x19ListeningEndpointsService\x12\xa6\x01\n" +
 	"\x15GetListeningEndpoints\x12'.v1.GetProcessesListeningOnPortsRequest\x1a(.v1.GetProcessesListeningOnPortsResponse\":\x82\xd3\xe4\x93\x024\x122/v1/listening_endpoints/deployment/{deployment_id}B'\n" +
-	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x00b\x06proto3"
+	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x01b\x06proto3"
 
 var (
 	file_api_v1_process_listening_on_port_service_proto_rawDescOnce sync.Once

--- a/generated/api/v1/process_listening_on_port_service.pb.go
+++ b/generated/api/v1/process_listening_on_port_service.pb.go
@@ -76,10 +76,11 @@ func (x *GetProcessesListeningOnPortsRequest) GetPagination() *Pagination {
 }
 
 type GetProcessesListeningOnPortsResponse struct {
-	state              protoimpl.MessageState            `protogen:"open.v1"`
-	ListeningEndpoints []*storage.ProcessListeningOnPort `protobuf:"bytes,1,rep,name=listening_endpoints,json=listeningEndpoints,proto3" json:"listening_endpoints,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	state                   protoimpl.MessageState            `protogen:"open.v1"`
+	ListeningEndpoints      []*storage.ProcessListeningOnPort `protobuf:"bytes,1,rep,name=listening_endpoints,json=listeningEndpoints,proto3" json:"listening_endpoints,omitempty"`
+	TotalListeningEndpoints int32                             `protobuf:"varint,2,opt,name=total_listening_endpoints,json=totalListeningEndpoints,proto3" json:"total_listening_endpoints,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *GetProcessesListeningOnPortsResponse) Reset() {
@@ -119,6 +120,13 @@ func (x *GetProcessesListeningOnPortsResponse) GetListeningEndpoints() []*storag
 	return nil
 }
 
+func (x *GetProcessesListeningOnPortsResponse) GetTotalListeningEndpoints() int32 {
+	if x != nil {
+		return x.TotalListeningEndpoints
+	}
+	return 0
+}
+
 var File_api_v1_process_listening_on_port_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_process_listening_on_port_service_proto_rawDesc = "" +
@@ -128,9 +136,10 @@ const file_api_v1_process_listening_on_port_service_proto_rawDesc = "" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12.\n" +
 	"\n" +
 	"pagination\x18\x02 \x01(\v2\x0e.v1.PaginationR\n" +
-	"pagination\"x\n" +
+	"pagination\"\xb4\x01\n" +
 	"$GetProcessesListeningOnPortsResponse\x12P\n" +
-	"\x13listening_endpoints\x18\x01 \x03(\v2\x1f.storage.ProcessListeningOnPortR\x12listeningEndpoints2\xc4\x01\n" +
+	"\x13listening_endpoints\x18\x01 \x03(\v2\x1f.storage.ProcessListeningOnPortR\x12listeningEndpoints\x12:\n" +
+	"\x19total_listening_endpoints\x18\x02 \x01(\x05R\x17totalListeningEndpoints2\xc4\x01\n" +
 	"\x19ListeningEndpointsService\x12\xa6\x01\n" +
 	"\x15GetListeningEndpoints\x12'.v1.GetProcessesListeningOnPortsRequest\x1a(.v1.GetProcessesListeningOnPortsResponse\":\x82\xd3\xe4\x93\x024\x122/v1/listening_endpoints/deployment/{deployment_id}B'\n" +
 	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x01b\x06proto3"

--- a/generated/api/v1/process_listening_on_port_service.pb.gw.go
+++ b/generated/api/v1/process_listening_on_port_service.pb.gw.go
@@ -35,6 +35,8 @@ var (
 	_ = metadata.Join
 )
 
+var filter_ListeningEndpointsService_GetListeningEndpoints_0 = &utilities.DoubleArray{Encoding: map[string]int{"deployment_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+
 func request_ListeningEndpointsService_GetListeningEndpoints_0(ctx context.Context, marshaler runtime.Marshaler, client ListeningEndpointsServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetProcessesListeningOnPortsRequest
@@ -49,6 +51,12 @@ func request_ListeningEndpointsService_GetListeningEndpoints_0(ctx context.Conte
 	protoReq.DeploymentId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "deployment_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ListeningEndpointsService_GetListeningEndpoints_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := client.GetListeningEndpoints(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -67,6 +75,12 @@ func local_request_ListeningEndpointsService_GetListeningEndpoints_0(ctx context
 	protoReq.DeploymentId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "deployment_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ListeningEndpointsService_GetListeningEndpoints_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := server.GetListeningEndpoints(ctx, &protoReq)
 	return msg, metadata, err

--- a/generated/api/v1/process_listening_on_port_service.swagger.json
+++ b/generated/api/v1/process_listening_on_port_service.swagger.json
@@ -40,6 +40,51 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "pagination.limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pagination.offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pagination.sortOption.field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pagination.sortOption.reversed",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "pagination.sortOption.aggregateBy.aggrFunc",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "UNSET",
+              "COUNT",
+              "MIN",
+              "MAX"
+            ],
+            "default": "UNSET"
+          },
+          {
+            "name": "pagination.sortOption.aggregateBy.distinct",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [
@@ -217,6 +262,27 @@
         }
       }
     },
+    "v1AggregateBy": {
+      "type": "object",
+      "properties": {
+        "aggrFunc": {
+          "$ref": "#/definitions/v1Aggregation"
+        },
+        "distinct": {
+          "type": "boolean"
+        }
+      }
+    },
+    "v1Aggregation": {
+      "type": "string",
+      "enum": [
+        "UNSET",
+        "COUNT",
+        "MIN",
+        "MAX"
+      ],
+      "default": "UNSET"
+    },
     "v1GetProcessesListeningOnPortsResponse": {
       "type": "object",
       "properties": {
@@ -226,6 +292,45 @@
             "type": "object",
             "$ref": "#/definitions/storageProcessListeningOnPort"
           }
+        }
+      }
+    },
+    "v1Pagination": {
+      "type": "object",
+      "properties": {
+        "limit": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sortOption": {
+          "$ref": "#/definitions/v1SortOption"
+        },
+        "sortOptions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SortOption"
+          },
+          "description": "This field is under development. It is not supported on any REST APIs."
+        }
+      }
+    },
+    "v1SortOption": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "reversed": {
+          "type": "boolean"
+        },
+        "aggregateBy": {
+          "$ref": "#/definitions/v1AggregateBy",
+          "description": "This field is under development. It is not supported on any REST APIs."
         }
       }
     }

--- a/generated/api/v1/process_listening_on_port_service.swagger.json
+++ b/generated/api/v1/process_listening_on_port_service.swagger.json
@@ -292,6 +292,10 @@
             "type": "object",
             "$ref": "#/definitions/storageProcessListeningOnPort"
           }
+        },
+        "totalListeningEndpoints": {
+          "type": "integer",
+          "format": "int32"
         }
       }
     },

--- a/generated/api/v1/process_listening_on_port_service_vtproto.pb.go
+++ b/generated/api/v1/process_listening_on_port_service_vtproto.pb.go
@@ -44,6 +44,7 @@ func (m *GetProcessesListeningOnPortsResponse) CloneVT() *GetProcessesListeningO
 		return (*GetProcessesListeningOnPortsResponse)(nil)
 	}
 	r := new(GetProcessesListeningOnPortsResponse)
+	r.TotalListeningEndpoints = m.TotalListeningEndpoints
 	if rhs := m.ListeningEndpoints; rhs != nil {
 		tmpContainer := make([]*storage.ProcessListeningOnPort, len(rhs))
 		for k, v := range rhs {
@@ -118,6 +119,9 @@ func (this *GetProcessesListeningOnPortsResponse) EqualVT(that *GetProcessesList
 				return false
 			}
 		}
+	}
+	if this.TotalListeningEndpoints != that.TotalListeningEndpoints {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -209,6 +213,11 @@ func (m *GetProcessesListeningOnPortsResponse) MarshalToSizedBufferVT(dAtA []byt
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.TotalListeningEndpoints != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TotalListeningEndpoints))
+		i--
+		dAtA[i] = 0x10
+	}
 	if len(m.ListeningEndpoints) > 0 {
 		for iNdEx := len(m.ListeningEndpoints) - 1; iNdEx >= 0; iNdEx-- {
 			if vtmsg, ok := interface{}(m.ListeningEndpoints[iNdEx]).(interface {
@@ -271,6 +280,9 @@ func (m *GetProcessesListeningOnPortsResponse) SizeVT() (n int) {
 			}
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.TotalListeningEndpoints != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.TotalListeningEndpoints))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -466,6 +478,25 @@ func (m *GetProcessesListeningOnPortsResponse) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalListeningEndpoints", wireType)
+			}
+			m.TotalListeningEndpoints = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalListeningEndpoints |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -682,6 +713,25 @@ func (m *GetProcessesListeningOnPortsResponse) UnmarshalVTUnsafe(dAtA []byte) er
 				}
 			}
 			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalListeningEndpoints", wireType)
+			}
+			m.TotalListeningEndpoints = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalListeningEndpoints |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/api/v1/process_listening_on_port_service_vtproto.pb.go
+++ b/generated/api/v1/process_listening_on_port_service_vtproto.pb.go
@@ -27,6 +27,7 @@ func (m *GetProcessesListeningOnPortsRequest) CloneVT() *GetProcessesListeningOn
 	}
 	r := new(GetProcessesListeningOnPortsRequest)
 	r.DeploymentId = m.DeploymentId
+	r.Pagination = m.Pagination.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -74,6 +75,9 @@ func (this *GetProcessesListeningOnPortsRequest) EqualVT(that *GetProcessesListe
 		return false
 	}
 	if this.DeploymentId != that.DeploymentId {
+		return false
+	}
+	if !this.Pagination.EqualVT(that.Pagination) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -155,6 +159,16 @@ func (m *GetProcessesListeningOnPortsRequest) MarshalToSizedBufferVT(dAtA []byte
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Pagination != nil {
+		size, err := m.Pagination.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.DeploymentId) > 0 {
 		i -= len(m.DeploymentId)
 		copy(dAtA[i:], m.DeploymentId)
@@ -230,6 +244,10 @@ func (m *GetProcessesListeningOnPortsRequest) SizeVT() (n int) {
 	_ = l
 	l = len(m.DeploymentId)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -318,6 +336,42 @@ func (m *GetProcessesListeningOnPortsRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.DeploymentId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &Pagination{}
+			}
+			if err := m.Pagination.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -498,6 +552,42 @@ func (m *GetProcessesListeningOnPortsRequest) UnmarshalVTUnsafe(dAtA []byte) err
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.DeploymentId = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &Pagination{}
+			}
+			if err := m.Pagination.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/fixtures/fixtureconsts/fixture_consts.go
+++ b/pkg/fixtures/fixtureconsts/fixture_consts.go
@@ -61,6 +61,7 @@ const (
 
 	PodName1 = "nginx-7db9fccd9b-92hfs"
 	PodName2 = "visa-processor"
+	PodName3 = "yet-another-pod-dbfcfbbdd-pkz98"
 
 	ClusterName1 = "Cluster1"
 	ClusterName2 = "Cluster2"

--- a/pkg/fixtures/process_listening_on_port.go
+++ b/pkg/fixtures/process_listening_on_port.go
@@ -187,6 +187,48 @@ func GetPlopStorage6() *storage.ProcessListeningOnPortStorage {
 	}
 }
 
+// GetPlopStorage7 Return a plop for the database
+func GetPlopStorage7() *storage.ProcessListeningOnPortStorage {
+	return &storage.ProcessListeningOnPortStorage{
+		Id:                 fixtureconsts.PlopUID1,
+		Port:               1234,
+		Protocol:           storage.L4Protocol_L4_PROTOCOL_TCP,
+		ProcessIndicatorId: fixtureconsts.ProcessIndicatorID1,
+		CloseTimestamp:     nil,
+		Closed:             false,
+		DeploymentId:       fixtureconsts.Deployment1,
+		PodUid:             fixtureconsts.PodUID1,
+	}
+}
+
+// GetPlopStorage8 Return a plop for the database
+func GetPlopStorage8() *storage.ProcessListeningOnPortStorage {
+	return &storage.ProcessListeningOnPortStorage{
+		Id:                 fixtureconsts.PlopUID2,
+		Port:               1234,
+		Protocol:           storage.L4Protocol_L4_PROTOCOL_TCP,
+		ProcessIndicatorId: fixtureconsts.ProcessIndicatorID2,
+		CloseTimestamp:     nil,
+		Closed:             false,
+		DeploymentId:       fixtureconsts.Deployment5,
+		PodUid:             fixtureconsts.PodUID3,
+	}
+}
+
+// GetPlopStorage9 Return a plop for the database
+func GetPlopStorage9() *storage.ProcessListeningOnPortStorage {
+	return &storage.ProcessListeningOnPortStorage{
+		Id:                 fixtureconsts.PlopUID3,
+		Port:               1234,
+		Protocol:           storage.L4Protocol_L4_PROTOCOL_TCP,
+		ProcessIndicatorId: fixtureconsts.ProcessIndicatorID3,
+		CloseTimestamp:     nil,
+		Closed:             false,
+		DeploymentId:       fixtureconsts.Deployment3,
+		PodUid:             fixtureconsts.PodUID3,
+	}
+}
+
 // GetPlopStorageExpired1 Return an expired plop for the database
 func GetPlopStorageExpired1() *storage.ProcessListeningOnPortStorage {
 	return &storage.ProcessListeningOnPortStorage{

--- a/pkg/fixtures/process_listening_on_port.go
+++ b/pkg/fixtures/process_listening_on_port.go
@@ -205,12 +205,12 @@ func GetPlopStorage7() *storage.ProcessListeningOnPortStorage {
 func GetPlopStorage8() *storage.ProcessListeningOnPortStorage {
 	return &storage.ProcessListeningOnPortStorage{
 		Id:                 fixtureconsts.PlopUID2,
-		Port:               1234,
+		Port:               4321,
 		Protocol:           storage.L4Protocol_L4_PROTOCOL_TCP,
 		ProcessIndicatorId: fixtureconsts.ProcessIndicatorID2,
 		CloseTimestamp:     nil,
 		Closed:             false,
-		DeploymentId:       fixtureconsts.Deployment5,
+		DeploymentId:       fixtureconsts.Deployment1,
 		PodUid:             fixtureconsts.PodUID3,
 	}
 }
@@ -219,12 +219,12 @@ func GetPlopStorage8() *storage.ProcessListeningOnPortStorage {
 func GetPlopStorage9() *storage.ProcessListeningOnPortStorage {
 	return &storage.ProcessListeningOnPortStorage{
 		Id:                 fixtureconsts.PlopUID3,
-		Port:               1234,
+		Port:               80,
 		Protocol:           storage.L4Protocol_L4_PROTOCOL_TCP,
 		ProcessIndicatorId: fixtureconsts.ProcessIndicatorID3,
 		CloseTimestamp:     nil,
 		Closed:             false,
-		DeploymentId:       fixtureconsts.Deployment3,
+		DeploymentId:       fixtureconsts.Deployment1,
 		PodUid:             fixtureconsts.PodUID3,
 	}
 }

--- a/proto/api/v1/process_listening_on_port_service.proto
+++ b/proto/api/v1/process_listening_on_port_service.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package v1;
 
-import weak "google/api/annotations.proto";
 import "api/v1/pagination.proto";
+import weak "google/api/annotations.proto";
 import "storage/process_listening_on_port.proto";
 
 option go_package = "./api/v1;v1";

--- a/proto/api/v1/process_listening_on_port_service.proto
+++ b/proto/api/v1/process_listening_on_port_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package v1;
 
 import weak "google/api/annotations.proto";
+import "api/v1/pagination.proto";
 import "storage/process_listening_on_port.proto";
 
 option go_package = "./api/v1;v1";
@@ -10,6 +11,7 @@ option java_package = "io.stackrox.proto.api.v1";
 
 message GetProcessesListeningOnPortsRequest {
   string deployment_id = 1;
+  Pagination pagination = 2;
 }
 
 message GetProcessesListeningOnPortsResponse {

--- a/proto/api/v1/process_listening_on_port_service.proto
+++ b/proto/api/v1/process_listening_on_port_service.proto
@@ -16,6 +16,7 @@ message GetProcessesListeningOnPortsRequest {
 
 message GetProcessesListeningOnPortsResponse {
   repeated storage.ProcessListeningOnPort listening_endpoints = 1;
+  int32 total_listening_endpoints = 2;
 }
 
 // ListeningEndpointsService API can be used to list listening endpoints and the processes that opened them.

--- a/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
@@ -25,16 +25,12 @@ class ProcessesListeningOnPortsService extends BaseService {
                         .setDeploymentId(deploymentId)
 
         if (pagination != null) {
-           log.info "pagination.offset= ${pagination.offset}"
-           log.info "pagination.limit= ${pagination.limit}"
            PaginationOuterClass.Pagination.Builder pbuilder =
                PaginationOuterClass.Pagination.newBuilder()
                    .setOffset(pagination.offset)
                    .setLimit(pagination.limit)
                request.setPagination(pbuilder.build())
         }
-
-        log.info "request= ${request}"
 
         def processesListeningOnPorts = getProcessesListeningOnPortsService()
                         .getListeningEndpoints(request.build())

--- a/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
@@ -25,11 +25,11 @@ class ProcessesListeningOnPortsService extends BaseService {
                         .setDeploymentId(deploymentId)
 
         if (pagination != null) {
-           PaginationOuterClass.Pagination.Builder pbuilder =
+            PaginationOuterClass.Pagination.Builder pbuilder =
                PaginationOuterClass.Pagination.newBuilder()
                    .setOffset(pagination.offset)
                    .setLimit(pagination.limit)
-               request.setPagination(pbuilder.build())
+            request.setPagination(pbuilder.build())
         }
 
         def processesListeningOnPorts = getProcessesListeningOnPortsService()

--- a/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
@@ -3,6 +3,7 @@ package services
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
+import io.stackrox.annotations.Retry
 import io.stackrox.proto.api.v1.PaginationOuterClass
 import io.stackrox.proto.api.v1.ListeningEndpointsServiceGrpc
 import io.stackrox.proto.api.v1.ProcessListeningOnPortService.GetProcessesListeningOnPortsRequest
@@ -17,6 +18,7 @@ class ProcessesListeningOnPortsService extends BaseService {
         return ListeningEndpointsServiceGrpc.newBlockingStub(getChannel())
     }
 
+    @Retry
     static GetProcessesListeningOnPortsResponse getProcessesListeningOnPortsResponse(
         String deploymentId, Pagination pagination = null) {
 

--- a/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ProcessesListeningOnPortsService.groovy
@@ -3,9 +3,12 @@ package services
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
+import io.stackrox.proto.api.v1.PaginationOuterClass
 import io.stackrox.proto.api.v1.ListeningEndpointsServiceGrpc
 import io.stackrox.proto.api.v1.ProcessListeningOnPortService.GetProcessesListeningOnPortsRequest
 import io.stackrox.proto.api.v1.ProcessListeningOnPortService.GetProcessesListeningOnPortsResponse
+
+import objects.Pagination
 
 @Slf4j
 @CompileStatic
@@ -15,15 +18,26 @@ class ProcessesListeningOnPortsService extends BaseService {
     }
 
     static GetProcessesListeningOnPortsResponse getProcessesListeningOnPortsResponse(
-        String deploymentId) {
+        String deploymentId, Pagination pagination = null) {
 
-        GetProcessesListeningOnPortsRequest request =
+        GetProcessesListeningOnPortsRequest.Builder request =
                 GetProcessesListeningOnPortsRequest.newBuilder()
                         .setDeploymentId(deploymentId)
-                        .build()
+
+        if (pagination != null) {
+           log.info "pagination.offset= ${pagination.offset}"
+           log.info "pagination.limit= ${pagination.limit}"
+           PaginationOuterClass.Pagination.Builder pbuilder =
+               PaginationOuterClass.Pagination.newBuilder()
+                   .setOffset(pagination.offset)
+                   .setLimit(pagination.limit)
+               request.setPagination(pbuilder.build())
+        }
+
+        log.info "request= ${request}"
 
         def processesListeningOnPorts = getProcessesListeningOnPortsService()
-                        .getListeningEndpoints(request)
+                        .getListeningEndpoints(request.build())
 
         return processesListeningOnPorts
     }

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -112,32 +112,35 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def list = processesListeningOnPorts.listeningEndpointsList
         assert list.size() == 2
+        assert processesListeningOnPorts.totalListeningEndpoints == 2
 
         def endpoint1 = list.find { it.endpoint.port == 80 }
 
-        assert endpoint1
-        assert endpoint1.deploymentId
-        assert endpoint1.podId
-        assert endpoint1.podUid
-        assert endpoint1.clusterId
-        assert endpoint1.Namespace
-        assert endpoint1.containerName == TCPCONNECTIONTARGET1
-        assert endpoint1.signal.name == "socat"
-        assert endpoint1.signal.execFilePath == "/usr/bin/socat"
-        assert endpoint1.signal.args == "-d -d -v TCP-LISTEN:80,fork STDOUT"
+        verifyAll(endpoint1) {
+                deploymentId
+                podId
+                podUid
+                clusterId
+                Namespace
+                containerName == TCPCONNECTIONTARGET1
+                signal.name == "socat"
+                signal.execFilePath == "/usr/bin/socat"
+                signal.args == "-d -d -v TCP-LISTEN:80,fork STDOUT"
+        }
 
         def endpoint2 = list.find { it.endpoint.port == 8080 }
 
-        assert endpoint2
-        assert endpoint2.deploymentId
-        assert endpoint2.podId
-        assert endpoint2.podUid
-        assert endpoint2.clusterId
-        assert endpoint2.Namespace
-        assert endpoint2.containerName == TCPCONNECTIONTARGET1
-        assert endpoint2.signal.name == "socat"
-        assert endpoint2.signal.execFilePath == "/usr/bin/socat"
-        assert endpoint2.signal.args == "-d -d -v TCP-LISTEN:8080,fork STDOUT"
+        verifyAll(endpoint2) {
+                deploymentId
+                podId
+                podUid
+                clusterId
+                Namespace
+                containerName == TCPCONNECTIONTARGET1
+                signal.name == "socat"
+                signal.execFilePath == "/usr/bin/socat"
+                signal.args == "-d -d -v TCP-LISTEN:8080,fork STDOUT"
+        }
 
         processesListeningOnPorts = waitForResponseToHaveNumElements(1, deploymentId2, 240)
 
@@ -145,19 +148,21 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         list = processesListeningOnPorts.listeningEndpointsList
         assert list.size() == 1
+        assert processesListeningOnPorts.totalListeningEndpoints == 2
 
         def endpoint = list.find { it.endpoint.port == 8081 }
 
-        assert endpoint
-        assert endpoint.deploymentId
-        assert endpoint.podId
-        assert endpoint.podUid
-        assert endpoint.clusterId
-        assert endpoint.Namespace
-        assert endpoint.containerName == TCPCONNECTIONTARGET2
-        assert endpoint.signal.name == "socat"
-        assert endpoint.signal.execFilePath == "/usr/bin/socat"
-        assert endpoint.signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
+        verifyAll(endpoint) {
+                deploymentId
+                podId
+                podUid
+                clusterId
+                Namespace
+                containerName == TCPCONNECTIONTARGET2
+                signal.name == "socat"
+                signal.execFilePath == "/usr/bin/socat"
+                signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
+        }
     }
 
     def "Networking endpoints are no longer in the API when deployments are deleted"() {
@@ -173,6 +178,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def list2 = processesListeningOnPorts.listeningEndpointsList
         assert list2.size() == 0
+        assert processesListeningOnPorts.totalListeningEndpoints == 0
 
         processesListeningOnPorts = waitForResponseToHaveNumElements(0, deploymentId2, 240)
 
@@ -180,6 +186,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def list3 = processesListeningOnPorts.listeningEndpointsList
         assert list3.size() == 0
+        assert processesListeningOnPorts.totalListeningEndpoints == 0
     }
 
     def "Verify networking endpoints disappear when process is terminated"() {
@@ -195,19 +202,21 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def list = processesListeningOnPorts.listeningEndpointsList
         assert list.size() == 1
+        assert processesListeningOnPorts.totalListeningEndpoints == 1
 
         def endpoint = list.find { it.endpoint.port == 8082 }
 
-        assert endpoint
-        assert endpoint.deploymentId
-        assert endpoint.podId
-        assert endpoint.podUid
-        assert endpoint.clusterId
-        assert endpoint.Namespace
-        assert endpoint.containerName == TCPCONNECTIONTARGET3
-        assert endpoint.signal.name == "socat"
-        assert endpoint.signal.execFilePath == "/usr/bin/socat"
-        assert endpoint.signal.args == "-d -d -v TCP-LISTEN:8082,fork STDOUT"
+        verifyAll(endpoint) {
+                deploymentId
+                podId
+                podUid
+                clusterId
+                Namespace
+                containerName == TCPCONNECTIONTARGET3
+                signal.name == "socat"
+                signal.execFilePath == "/usr/bin/socat"
+                signal.args == "-d -d -v TCP-LISTEN:8082,fork STDOUT"
+        }
 
         // Allow enough time for the process and port to close and check that it is not in the API response
         processesListeningOnPorts = waitForResponseToHaveNumElements(0, deploymentId3, 180)
@@ -233,16 +242,18 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def endpoint = list.find { it.endpoint.port == 8081 }
 
-        assert endpoint
-        assert endpoint.deploymentId
-        assert endpoint.podId
-        assert endpoint.podUid
-        assert endpoint.clusterId
-        assert endpoint.Namespace
-        assert endpoint.containerName == TCPCONNECTIONTARGET2
-        assert endpoint.signal.name == "socat"
-        assert endpoint.signal.execFilePath == "/usr/bin/socat"
-        assert endpoint.signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
+        verifyAll(endpoint) {
+                deploymentId
+                podId
+                podUid
+                clusterId
+                Namespace
+                containerName == TCPCONNECTIONTARGET2
+                signal.name == "socat"
+                signal.execFilePath == "/usr/bin/socat"
+                signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
+        }
+
 
         sleep 65000 // Sleep for 65 seconds
         processesListeningOnPorts = evaluateWithRetry(10, 10) {
@@ -252,6 +263,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         // Confirm that the listening endpoint still appears in the API 65 seconds later
         list = processesListeningOnPorts.listeningEndpointsList
         assert list.size() == 1
+        assert processesListeningOnPorts.totalListeningEndpoints == 1
 
         destroyDeployments()
     }
@@ -275,10 +287,11 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         // The size of the list depends upon the number of colletors
         // which can vary based upon the environment
         assert list.size() > 1
+        assert processesListeningOnPorts.totalListeningEndpoints >= 2
 
         def endpoint1 = list.find { it.endpoint.port == 8080 }
 
-	verifyAll(endpoint1) {
+        verifyAll(endpoint1) {
                 deploymentId
                 podId
                 podUid
@@ -291,7 +304,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def endpoint2 = list.find { it.endpoint.port == 9090 }
 
-	verifyAll(endpoint2) {
+        verifyAll(endpoint2) {
                 deploymentId
                 podId
                 podUid
@@ -311,6 +324,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 1
+        assert processesListeningOnPortsPaginated.totalListeningEndpoints >= 2
 
         pagination = new Pagination(1, 1)
         processesListeningOnPortsPaginated = evaluateWithRetry(10, 10) {
@@ -321,6 +335,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 1
+        assert processesListeningOnPortsPaginated.totalListeningEndpoints >= 2
 
         pagination = new Pagination(2, 0)
         processesListeningOnPortsPaginated = evaluateWithRetry(10, 10) {
@@ -331,6 +346,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 2
+        assert processesListeningOnPortsPaginated.totalListeningEndpoints >= 2
     }
 
     private waitForResponseToHaveNumElements(int numElements,

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -148,7 +148,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         list = processesListeningOnPorts.listeningEndpointsList
         assert list.size() == 1
-        assert processesListeningOnPorts.totalListeningEndpoints == 2
+        assert processesListeningOnPorts.totalListeningEndpoints == 1
 
         def endpoint = list.find { it.endpoint.port == 8081 }
 
@@ -253,7 +253,6 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 signal.execFilePath == "/usr/bin/socat"
                 signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
         }
-
 
         sleep 65000 // Sleep for 65 seconds
         processesListeningOnPorts = evaluateWithRetry(10, 10) {

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -269,7 +269,8 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         String collectorUid = orchestrator.getDaemonSetId(new DaemonSet(name: "collector", namespace: "stackrox"))
         log.info "collectorUid= ${collectorUid}"
 
-        def processesListeningOnPorts = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid)
+        def processesListeningOnPorts = ProcessesListeningOnPortsService
+                                                .getProcessesListeningOnPortsResponse(collectorUid)
 
         // First check that the listening endpoint appears in the API
         assert processesListeningOnPorts
@@ -307,21 +308,24 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         }
 
         def pagination = new Pagination(1, 0)
-        def processesListeningOnPortsPaginated = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid, pagination)
+        def processesListeningOnPortsPaginated = ProcessesListeningOnPortsService
+                                                         .getProcessesListeningOnPortsResponse(collectorUid, pagination)
 
         def listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 1
         assert processesListeningOnPortsPaginated.totalListeningEndpoints >= 2
 
         pagination = new Pagination(1, 1)
-        processesListeningOnPortsPaginated = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid, pagination)
+        processesListeningOnPortsPaginated = ProcessesListeningOnPortsService
+                                                     .getProcessesListeningOnPortsResponse(collectorUid, pagination)
 
         listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 1
         assert processesListeningOnPortsPaginated.totalListeningEndpoints >= 2
 
         pagination = new Pagination(2, 0)
-        processesListeningOnPortsPaginated = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid, pagination)
+        processesListeningOnPortsPaginated = ProcessesListeningOnPortsService
+                                                     .getProcessesListeningOnPortsResponse(collectorUid, pagination)
 
         listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 2
@@ -335,7 +339,8 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         int waitTime
 
         for (waitTime = 0; waitTime <= timeoutSeconds / intervalSeconds; waitTime++) {
-            def processesListeningOnPorts = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(deploymentId)
+            def processesListeningOnPorts = ProcessesListeningOnPortsService
+                                                    .getProcessesListeningOnPortsResponse(deploymentId)
 
             def list = processesListeningOnPorts.listeningEndpointsList
 

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -1,5 +1,3 @@
-import static util.Helpers.evaluateWithRetry
-
 import objects.Deployment
 import objects.DaemonSet
 import objects.Pagination
@@ -255,9 +253,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         }
 
         sleep 65000 // Sleep for 65 seconds
-        processesListeningOnPorts = evaluateWithRetry(10, 10) {
-            ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(deploymentId2)
-        }
+        processesListeningOnPorts = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(deploymentId2)
 
         // Confirm that the listening endpoint still appears in the API 65 seconds later
         list = processesListeningOnPorts.listeningEndpointsList
@@ -273,11 +269,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         String collectorUid = orchestrator.getDaemonSetId(new DaemonSet(name: "collector", namespace: "stackrox"))
         log.info "collectorUid= ${collectorUid}"
 
-        def processesListeningOnPorts = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(collectorUid)
-                return temp
-        }
+        def processesListeningOnPorts = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid)
 
         // First check that the listening endpoint appears in the API
         assert processesListeningOnPorts
@@ -315,33 +307,21 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         }
 
         def pagination = new Pagination(1, 0)
-        def processesListeningOnPortsPaginated = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(collectorUid, pagination)
-                return temp
-        }
+        def processesListeningOnPortsPaginated = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid, pagination)
 
         def listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 1
         assert processesListeningOnPortsPaginated.totalListeningEndpoints >= 2
 
         pagination = new Pagination(1, 1)
-        processesListeningOnPortsPaginated = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(collectorUid, pagination)
-                return temp
-        }
+        processesListeningOnPortsPaginated = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid, pagination)
 
         listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 1
         assert processesListeningOnPortsPaginated.totalListeningEndpoints >= 2
 
         pagination = new Pagination(2, 0)
-        processesListeningOnPortsPaginated = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(collectorUid, pagination)
-                return temp
-        }
+        processesListeningOnPortsPaginated = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(collectorUid, pagination)
 
         listPaginated = processesListeningOnPortsPaginated.listeningEndpointsList
         assert listPaginated.size() == 2
@@ -355,11 +335,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         int waitTime
 
         for (waitTime = 0; waitTime <= timeoutSeconds / intervalSeconds; waitTime++) {
-            def processesListeningOnPorts = evaluateWithRetry(10, 10) {
-                    def temp = ProcessesListeningOnPortsService
-                            .getProcessesListeningOnPortsResponse(deploymentId)
-                    return temp
-            }
+            def processesListeningOnPorts = ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(deploymentId)
 
             def list = processesListeningOnPorts.listeningEndpointsList
 

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -278,27 +278,29 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         def endpoint1 = list.find { it.endpoint.port == 8080 }
 
-        assert endpoint1
-        assert endpoint1.deploymentId
-        assert endpoint1.podId
-        assert endpoint1.podUid
-        assert endpoint1.clusterId
-        assert endpoint1.Namespace
-        assert endpoint1.containerName == "collector"
-        assert endpoint1.signal.name == "collector"
-        assert endpoint1.signal.execFilePath == "/usr/local/bin/collector"
+	verifyAll(endpoint1) {
+                deploymentId
+                podId
+                podUid
+                clusterId
+                Namespace
+                containerName == "collector"
+                signal.name == "collector"
+                signal.execFilePath == "/usr/local/bin/collector"
+        }
 
         def endpoint2 = list.find { it.endpoint.port == 9090 }
 
-        assert endpoint2
-        assert endpoint2.deploymentId
-        assert endpoint2.podId
-        assert endpoint2.podUid
-        assert endpoint2.clusterId
-        assert endpoint2.Namespace
-        assert endpoint2.containerName == "collector"
-        assert endpoint2.signal.name == "collector"
-        assert endpoint2.signal.execFilePath == "/usr/local/bin/collector"
+	verifyAll(endpoint2) {
+                deploymentId
+                podId
+                podUid
+                clusterId
+                Namespace
+                containerName == "collector"
+                signal.name == "collector"
+                signal.execFilePath == "/usr/local/bin/collector"
+        }
 
         def pagination = new Pagination(1, 0)
         def processesListeningOnPortsPaginated = evaluateWithRetry(10, 10) {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds pagination to the processes listening on ports service. Currently if a deployment has a large number of listening endpoints they are all returned, regardless of how many there are. This can mean a slow response from the API endpoint and can cause the UI to freeze up. This does not do pagination for the UI. That will be done at a later time.

The service endpoint also now returns the number of listening endpoints in addition to the listening endpoint themselves. This is because users will want to know how many listening endpoints there are when the service doesn't return all of them.

The pagination is done in central rather than by the query, because central does some filtering so using `LIMIT` in the query does not guarantee the number of listening endpoints in the response.

E2e tests are added, which checks listening endpoints from collector, with and without pagination. Unit tests are also added.

The next step after pagination is sorting of the listening endpoints. There was a PR a long time ago to sort the listening endpoints. It was suggested that before merging the PR to sort listening endpoints, that pagination be implemented. https://github.com/stackrox/stackrox/pull/7951

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Did some manual testing, but CI is sufficient.
