### PR TITLE
chore(scanner): update autovacuum configs

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4-db/postgresql.conf.default
+++ b/image/templates/helm/shared/config-templates/scanner-v4-db/postgresql.conf.default
@@ -33,6 +33,7 @@ ssl_key_file = '/run/secrets/stackrox.io/certs/server.key'
 shared_buffers = 750MB
 work_mem = 16MB
 maintenance_work_mem = 128MB
+autovacuum_work_mem = 256MB
 dynamic_shared_memory_type = posix
 
 #------------------------------------------------------------------------------
@@ -43,6 +44,12 @@ dynamic_shared_memory_type = posix
 
 max_wal_size = 3GB
 min_wal_size = 80MB
+
+#------------------------------------------------------------------------------
+# AUTOMATIC VACUUMING
+#------------------------------------------------------------------------------
+
+autovacuum_max_workers = 2
 
 #------------------------------------------------------------------------------
 # REPORTING AND LOGGING


### PR DESCRIPTION
### Description

Scanner V4 DB has a small number of very large tables, so having more autovacuum workers with a small amount of memory allocated for each will not be as useful as having a smaller number of workers with more memory allocated for each.

This change reduces the number of workers from the default, 3, to 2 and doubles the memory allocated to each worker (and separates it from the `maintenance_work_mem` config). Note: This means the max amount of memory used by autovacuum workers is 512MB, which is within the 1GB limit. See https://www.postgresql.org/docs/15/runtime-config-resource.html for more information.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

no

#### How I validated my change

We have experimented with changing these settings in a large environment, and they seem to be ok. The main thing we learned is that we have a few very large tables and the rest are relatively small.

In this environment, we saw `manifest_index`, `enrichment`, `uo_vuln`, `package_scanartifact`, `vuln`, and `scanned_layer` had somewhere between 2 - 32 million live tuples, and the rest were sub 600k.