### PR TITLE
doc: Clarify note about changing admin cred secret at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ After a few minutes, all resources should be deployed.
 **Credentials for the 'admin' user can be found in the `./deploy/k8s/central-deploy/password` file.**
 
 > **Note:**
-> While the password file is stored in plaintext on your local filesystem, the Kubernetes Secret StackRox uses is encrypted, and you will not be able to alter the secret at runtime. If you lose the password, you will have to redeploy central.
+> The password file is stored in plaintext on your local filesystem, but the Kubernetes Secret StackRox creates from it is encrypted, and you will not be able to alter it at runtime. If you lose the password, you will have to redeploy central.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ To install stackrox-central-services, you will need a secure password. This pass
 ```sh
 ROX_ADMIN_PASSWORD="$(openssl rand -base64 20 | tr -d '/=+')"
 ```
+From here, you can install stackrox-central-services to get Central and Scanner components deployed on your cluster.
 
-From here, you can install stackrox-central-services to get Central and Scanner components deployed on your cluster. Note that you need only one deployed instance of stackrox-central-services even if you plan to secure multiple clusters.
+> [!NOTE]
+> You need only one deployed instance of stackrox-central-services even if you plan to secure multiple clusters.
 
 To perform the installation, choose one of the following commands depending on your cluster size.
 
@@ -244,7 +246,8 @@ After a few minutes, all resources should be deployed.
 
 **Credentials for the 'admin' user can be found in the `./deploy/k8s/central-deploy/password` file.**
 
-**Note:** While the password file is stored in plaintext on your local filesystem, the Kubernetes Secret StackRox uses is encrypted, and you will not be able to alter the secret at runtime. If you lose the password, you will have to redeploy central.
+> [!NOTE]
+> While the password file is stored in plaintext on your local filesystem, the Kubernetes Secret StackRox uses is encrypted, and you will not be able to alter the secret at runtime. If you lose the password, you will have to redeploy central.
 
 </details>
 
@@ -268,7 +271,8 @@ After a few minutes, all resources should be deployed. The process will complete
 
 **Credentials for the 'admin' user can be found in the `./deploy/openshift/central-deploy/password` file.**
 
-**Note:** While the password file is stored in plaintext on your local filesystem, the Kubernetes Secret StackRox uses is encrypted, and you will not be able to alter the secret at runtime. If you loose the password, you will have to redeploy central.
+> [!NOTE]
+> While the password file is stored in plaintext on your local filesystem, the Kubernetes Secret StackRox uses is encrypted, and you will not be able to alter the secret at runtime. If you loose the password, you will have to redeploy central.
 
 </details>
 
@@ -400,7 +404,9 @@ $ make image
 Now, you need to bring up a Kubernetes cluster *yourself* before proceeding.
 Development can either happen in GCP or locally with
 [Docker Desktop](https://docs.docker.com/desktop/kubernetes/), [Colima](https://github.com/abiosoft/colima#kubernetes), [minikube](https://minikube.sigs.k8s.io/docs/start/).
-Note that Docker Desktop and Colima are more suited for macOS development, because the cluster will have access to images built with `make image` locally without additional configuration. Also, Collector has better support for these than minikube where drivers may not be available.
+
+> [!NOTE]
+> Docker Desktop and Colima are more suited for macOS development, because the cluster will have access to images built with `make image` locally without additional configuration. Also, Collector has better support for these than minikube where drivers may not be available.
 
 ```bash
 # To keep the StackRox Central's Postgres DB state between database upgrades and restarts, set:
@@ -597,8 +603,9 @@ Now Central has been deployed. Use the UI to deploy Sensor.
 
 <details><summary>OpenShift</summary>
 
-Note: If using a host mount, you need to allow the container to access it by using
-`sudo chcon -Rt svirt_sandbox_file_t <full volume path>`
+> [!NOTE]
+> If using a host mount, you need to allow the container to access it by using
+> `sudo chcon -Rt svirt_sandbox_file_t <full volume path>`
 
 Take the image-setup.sh script from this repo and run it to do the pull/push to
 local OpenShift registry. This is a prerequisite for every new cluster.

--- a/README.md
+++ b/README.md
@@ -601,6 +601,12 @@ Now Central has been deployed. Use the UI to deploy Sensor.
 
 </details>
 
+> [!NOTE]
+> Will it work **here**?
+> If using a host mount, you need to allow the container to access it by using
+> `sudo chcon -Rt svirt_sandbox_file_t <full volume path>`
+
+
 <details><summary>OpenShift</summary>
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ After a few minutes, all resources should be deployed.
 **Credentials for the 'admin' user can be found in the `./deploy/k8s/central-deploy/password` file.**
 
 > **Note:**
-> The password file is stored in plaintext on your local filesystem, but the Kubernetes Secret StackRox creates from it is encrypted, and you will not be able to alter it at runtime. If you lose the password, you will have to redeploy central.
+> The password file is stored in plaintext on your local filesystem, but the Kubernetes Secret that StackRox creates from it is encrypted. You will not be able to alter the password at runtime. If you lose the password, you will have to redeploy central.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ ROX_ADMIN_PASSWORD="$(openssl rand -base64 20 | tr -d '/=+')"
 ```
 From here, you can install stackrox-central-services to get Central and Scanner components deployed on your cluster.
 
-> [!NOTE]
+> **Note:**
 > You need only one deployed instance of stackrox-central-services even if you plan to secure multiple clusters.
 
 To perform the installation, choose one of the following commands depending on your cluster size.
@@ -246,7 +246,7 @@ After a few minutes, all resources should be deployed.
 
 **Credentials for the 'admin' user can be found in the `./deploy/k8s/central-deploy/password` file.**
 
-> [!NOTE]
+> **Note:**
 > While the password file is stored in plaintext on your local filesystem, the Kubernetes Secret StackRox uses is encrypted, and you will not be able to alter the secret at runtime. If you lose the password, you will have to redeploy central.
 
 </details>
@@ -271,7 +271,7 @@ After a few minutes, all resources should be deployed. The process will complete
 
 **Credentials for the 'admin' user can be found in the `./deploy/openshift/central-deploy/password` file.**
 
-> [!NOTE]
+> **Note:**
 > While the password file is stored in plaintext on your local filesystem, the Kubernetes Secret StackRox uses is encrypted, and you will not be able to alter the secret at runtime. If you loose the password, you will have to redeploy central.
 
 </details>
@@ -405,7 +405,7 @@ Now, you need to bring up a Kubernetes cluster *yourself* before proceeding.
 Development can either happen in GCP or locally with
 [Docker Desktop](https://docs.docker.com/desktop/kubernetes/), [Colima](https://github.com/abiosoft/colima#kubernetes), [minikube](https://minikube.sigs.k8s.io/docs/start/).
 
-> [!NOTE]
+> **Note:**
 > Docker Desktop and Colima are more suited for macOS development, because the cluster will have access to images built with `make image` locally without additional configuration. Also, Collector has better support for these than minikube where drivers may not be available.
 
 ```bash
@@ -601,15 +601,9 @@ Now Central has been deployed. Use the UI to deploy Sensor.
 
 </details>
 
-> [!NOTE]
-> Will it work **here**?
-> If using a host mount, you need to allow the container to access it by using
-> `sudo chcon -Rt svirt_sandbox_file_t <full volume path>`
-
-
 <details><summary>OpenShift</summary>
 
-> [!NOTE]
+> **Note:**
 > If using a host mount, you need to allow the container to access it by using
 > `sudo chcon -Rt svirt_sandbox_file_t <full volume path>`
 


### PR DESCRIPTION
### Description

The section about deploying StackRox in k8s providers contained the following
sentence:

  > While the password file is stored in plaintext on your local filesystem, the
    Kubernetes Secret StackRox uses is encrypted, and you will not be able to
    alter the secret at runtime. If you lose the password, you will have to
    redeploy central.

The initial "while" could be interpreted as duration, equivalent to: "as
long as the password is stored in plain text, the secret is encrypted".

This is incorrect: the initial "while" is meant to highlight that even
if the plain text password file can be edited at any time, that change
won't be picked up by Central and redeployment will be needed.

This commit removes that word altogether and rewords the sentence to
prevent confusion.

