### PR TITLE
ROX-24719: add --namespace flag for roxctl image scan/check

### DIFF
--- a/central/delegatedregistryconfig/delegator/delegator.go
+++ b/central/delegatedregistryconfig/delegator/delegator.go
@@ -86,7 +86,7 @@ func (d *delegatorImpl) DelegateScanImage(ctx context.Context, imgName *storage.
 		return nil, errors.New("missing cluster id")
 	}
 
-	// If a namespace is specified, we verify access to it and fail if no access it granted.
+	// If a namespace is specified, we verify access to it and fail if no access is granted.
 	// If no namespace is specified, we attempt to infer a namespace based on the registry to
 	// accommodate images from the OCP integrated registry.
 	if namespace != "" {

--- a/central/delegatedregistryconfig/delegator/delegator.go
+++ b/central/delegatedregistryconfig/delegator/delegator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/delegatedregistry"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
@@ -80,12 +81,23 @@ func (d *delegatorImpl) GetDelegateClusterID(ctx context.Context, imgName *stora
 }
 
 // DelegateScanImage sends a scan request to the provided cluster.
-func (d *delegatorImpl) DelegateScanImage(ctx context.Context, imgName *storage.ImageName, clusterID string, force bool) (*storage.Image, error) {
+func (d *delegatorImpl) DelegateScanImage(ctx context.Context, imgName *storage.ImageName, clusterID string, namespace string, force bool) (*storage.Image, error) {
 	if clusterID == "" {
 		return nil, errors.New("missing cluster id")
 	}
 
-	namespace := d.inferNamespace(ctx, imgName, clusterID)
+	// If a namespace is specified, we verify access to it and fail if no access it granted.
+	// If no namespace is specified, we attempt to infer a namespace based on the registry to
+	// accommodate images from the OCP integrated registry.
+	if namespace != "" {
+		if ok, err := d.hasNamespaceAccess(ctx, clusterID, namespace); err != nil {
+			return nil, errors.Wrapf(err, "verifying access to namespace %q on cluster %q", namespace, clusterID)
+		} else if !ok {
+			return nil, errox.NotAuthorized.CausedByf("no access to namespace %q on cluster %q", namespace, clusterID)
+		}
+	} else {
+		namespace = d.inferNamespace(ctx, imgName, clusterID)
+	}
 
 	w, err := d.scanWaiterManager.NewWaiter()
 	if err != nil {
@@ -131,19 +143,31 @@ func (d *delegatorImpl) inferNamespace(ctx context.Context, imgName *storage.Ima
 
 	defer centralMetrics.SetFunctionSegmentDuration(time.Now(), "ScanDelegatorInferNamespace")
 
-	namespaces, err := d.namespaceSACHelper.GetNamespacesForClusterAndPermissions(ctx, clusterID, inferNamespacePermissions)
-	if err != nil {
+	if ok, err := d.hasNamespaceAccess(ctx, clusterID, namespace); err != nil {
 		log.Warnf("Skipping namespace inference for %q (%s) and cluster %q due to error: %v", imgName.GetFullName(), namespace, clusterID, err)
 		return ""
+	} else if !ok {
+		return ""
+	}
+
+	return namespace
+}
+
+func (d *delegatorImpl) hasNamespaceAccess(ctx context.Context, clusterID string, namespace string) (bool, error) {
+	defer centralMetrics.SetFunctionSegmentDuration(time.Now(), "ScanDelegatorCheckNamespaceAccess")
+
+	namespaces, err := d.namespaceSACHelper.GetNamespacesForClusterAndPermissions(ctx, clusterID, inferNamespacePermissions)
+	if err != nil {
+		return false, errors.Wrapf(err, "getting allowed namespaces for cluster %q", clusterID)
 	}
 
 	for _, ns := range namespaces {
 		if ns.GetName() == namespace {
-			return namespace
+			return true, nil
 		}
 	}
 
-	return ""
+	return false, nil
 }
 
 func (d *delegatorImpl) shouldDelegate(imgName *storage.ImageName, config *storage.DelegatedRegistryConfig) (bool, string) {

--- a/central/delegatedregistryconfig/delegator/delegator_test.go
+++ b/central/delegatedregistryconfig/delegator/delegator_test.go
@@ -264,7 +264,6 @@ func TestDelegateEnrichImage(t *testing.T) {
 
 	t.Run("empty cluster id", func(t *testing.T) {
 		setup(t)
-		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		image, err := d.DelegateScanImage(ctxBG, nil, "", "", false)
 		assert.ErrorContains(t, err, "cluster id")
 		assert.Nil(t, image)

--- a/central/delegatedregistryconfig/delegator/delegator_test.go
+++ b/central/delegatedregistryconfig/delegator/delegator_test.go
@@ -11,6 +11,7 @@ import (
 	connMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/protoassert"
 	waiterMocks "github.com/stackrox/rox/pkg/waiter/mocks"
 	"github.com/stretchr/testify/assert"
@@ -258,51 +259,64 @@ func TestDelegateEnrichImage(t *testing.T) {
 		namespaceSACHelper = sacHelperMocks.NewMockClusterNamespaceSacHelper(ctrl)
 
 		waiter.EXPECT().ID().Return(fakeWaiterID).AnyTimes()
-		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		d = New(deleClusterDS, connMgr, waiterMgr, namespaceSACHelper)
 	}
 
 	t.Run("empty cluster id", func(t *testing.T) {
 		setup(t)
-		image, err := d.DelegateScanImage(ctxBG, nil, "", false)
+		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		image, err := d.DelegateScanImage(ctxBG, nil, "", "", false)
 		assert.ErrorContains(t, err, "cluster id")
+		assert.Nil(t, image)
+	})
+
+	t.Run("no access to namespace", func(t *testing.T) {
+		setup(t)
+		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		image, err := d.DelegateScanImage(ctxBG, nil, fakeClusterID, "no-access-ns", false)
+		assert.ErrorIs(t, err, errox.NotAuthorized)
 		assert.Nil(t, image)
 	})
 
 	t.Run("waiter create error", func(t *testing.T) {
 		setup(t)
+		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		waiterMgr.EXPECT().NewWaiter().Return(nil, errBroken)
 
-		image, err := d.DelegateScanImage(ctxBG, nil, fakeClusterID, false)
+		image, err := d.DelegateScanImage(ctxBG, nil, fakeClusterID, "", false)
 		assert.ErrorIs(t, err, errBroken)
 		assert.Nil(t, image)
 	})
 
 	t.Run("send msg error", func(t *testing.T) {
 		setup(t)
+		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		waiterMgr.EXPECT().NewWaiter().Return(waiter, nil)
 		waiter.EXPECT().Close()
 		connMgr.EXPECT().SendMessage(fakeClusterID, gomock.Any()).Return(errBroken)
 
-		image, err := d.DelegateScanImage(ctxBG, nil, fakeClusterID, false)
+		image, err := d.DelegateScanImage(ctxBG, nil, fakeClusterID, "", false)
 		assert.ErrorIs(t, err, errBroken)
 		assert.Nil(t, image)
 	})
 
 	t.Run("wait error", func(t *testing.T) {
 		setup(t)
+		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		waiterMgr.EXPECT().NewWaiter().Return(waiter, nil)
 		waiter.EXPECT().Wait(gomock.Any()).Return(nil, errBroken)
 		waiter.EXPECT().Close()
 		connMgr.EXPECT().SendMessage(fakeClusterID, gomock.Any())
 
-		image, err := d.DelegateScanImage(ctxBG, nil, fakeClusterID, false)
+		image, err := d.DelegateScanImage(ctxBG, nil, fakeClusterID, "", false)
 		assert.ErrorIs(t, err, errBroken)
 		assert.Nil(t, image)
 	})
 
 	t.Run("success round trip", func(t *testing.T) {
 		setup(t)
+		namespaceSACHelper.EXPECT().GetNamespacesForClusterAndPermissions(ctxBG, fakeClusterID,
+			inferNamespacePermissions).Return([]*v1.ScopeObject{{Name: "repo"}}, nil)
 		fakeImage := &storage.Image{
 			Name: &storage.ImageName{
 				FullName: fakeImageFullName,
@@ -314,7 +328,7 @@ func TestDelegateEnrichImage(t *testing.T) {
 		waiter.EXPECT().Close()
 		connMgr.EXPECT().SendMessage(fakeClusterID, gomock.Any())
 
-		image, err := d.DelegateScanImage(ctxBG, fakeImgName, fakeClusterID, false)
+		image, err := d.DelegateScanImage(ctxBG, fakeImgName, fakeClusterID, "repo", false)
 		assert.NoError(t, err)
 		protoassert.Equal(t, fakeImage, image)
 	})

--- a/central/detection/service/service_impl.go
+++ b/central/detection/service/service_impl.go
@@ -160,10 +160,14 @@ func (s *serviceImpl) DetectBuildTime(ctx context.Context, req *apiV1.BuildDetec
 
 	img := types.ToImage(image)
 
-	enrichmentContext := enricher.EnrichmentContext{}
 	fetchOpt, err := getFetchOptionFromRequest(req)
 	if err != nil {
 		return nil, err
+	}
+	enrichmentContext := enricher.EnrichmentContext{
+		Delegable: true,
+		FetchOpt:  fetchOpt,
+		Namespace: req.GetNamespace(),
 	}
 
 	if req.GetCluster() != "" {
@@ -176,8 +180,6 @@ func (s *serviceImpl) DetectBuildTime(ctx context.Context, req *apiV1.BuildDetec
 		enrichmentContext.ClusterID = clusterID
 	}
 
-	enrichmentContext.FetchOpt = fetchOpt
-	enrichmentContext.Delegable = true
 	enrichResult, err := s.imageEnricher.EnrichImage(ctx, enrichmentContext, img)
 	if err != nil {
 		return nil, err

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -387,6 +387,7 @@ func (s *serviceImpl) ScanImage(ctx context.Context, request *v1.ScanImageReques
 	enrichmentCtx := enricher.EnrichmentContext{
 		FetchOpt:  enricher.UseCachesIfPossible,
 		Delegable: true,
+		Namespace: request.GetNamespace(),
 	}
 	if request.GetForce() {
 		enrichmentCtx.FetchOpt = enricher.UseImageNamesRefetchCachedValues

--- a/generated/api/v1/detection_service.pb.go
+++ b/generated/api/v1/detection_service.pb.go
@@ -35,7 +35,11 @@ type BuildDetectionRequest struct {
 	Force              bool                             `protobuf:"varint,6,opt,name=force,proto3" json:"force,omitempty"`
 	PolicyCategories   []string                         `protobuf:"bytes,5,rep,name=policy_categories,json=policyCategories,proto3" json:"policy_categories,omitempty"`
 	// Cluster to delegate scan to, may be the cluster's name or ID.
-	Cluster       string `protobuf:"bytes,7,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Cluster string `protobuf:"bytes,7,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	// Namespace on the secured cluster from which to read context information
+	// when delegating image scans, specifically pull secrets to access the image
+	// registry.
+	Namespace     string `protobuf:"bytes,8,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -126,6 +130,13 @@ func (x *BuildDetectionRequest) GetPolicyCategories() []string {
 func (x *BuildDetectionRequest) GetCluster() string {
 	if x != nil {
 		return x.Cluster
+	}
+	return ""
+}
+
+func (x *BuildDetectionRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
 	}
 	return ""
 }
@@ -611,7 +622,7 @@ var File_api_v1_detection_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_detection_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1eapi/v1/detection_service.proto\x12\x02v1\x1a\x1cgoogle/api/annotations.proto\x1a\x13storage/alert.proto\x1a\x18storage/deployment.proto\"\xb3\x02\n" +
+	"\x1eapi/v1/detection_service.proto\x12\x02v1\x1a\x1cgoogle/api/annotations.proto\x1a\x13storage/alert.proto\x1a\x18storage/deployment.proto\"\xd1\x02\n" +
 	"\x15BuildDetectionRequest\x12/\n" +
 	"\x05image\x18\x01 \x01(\v2\x17.storage.ContainerImageH\x00R\x05image\x12\x1f\n" +
 	"\n" +
@@ -620,7 +631,8 @@ const file_api_v1_detection_service_proto_rawDesc = "" +
 	"\x12send_notifications\x18\x04 \x01(\bR\x11sendNotifications\x12\x14\n" +
 	"\x05force\x18\x06 \x01(\bR\x05force\x12+\n" +
 	"\x11policy_categories\x18\x05 \x03(\tR\x10policyCategories\x12\x18\n" +
-	"\acluster\x18\a \x01(\tR\aclusterB\n" +
+	"\acluster\x18\a \x01(\tR\acluster\x12\x1c\n" +
+	"\tnamespace\x18\b \x01(\tR\tnamespaceB\n" +
 	"\n" +
 	"\bResource\"@\n" +
 	"\x16BuildDetectionResponse\x12&\n" +

--- a/generated/api/v1/detection_service.swagger.json
+++ b/generated/api/v1/detection_service.swagger.json
@@ -1576,6 +1576,10 @@
         "cluster": {
           "type": "string",
           "description": "Cluster to delegate scan to, may be the cluster's name or ID."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace on the secured cluster from which to read context information\nwhen delegating image scans, specifically pull secrets to access the image\nregistry."
         }
       }
     },

--- a/generated/api/v1/detection_service_vtproto.pb.go
+++ b/generated/api/v1/detection_service_vtproto.pb.go
@@ -30,6 +30,7 @@ func (m *BuildDetectionRequest) CloneVT() *BuildDetectionRequest {
 	r.SendNotifications = m.SendNotifications
 	r.Force = m.Force
 	r.Cluster = m.Cluster
+	r.Namespace = m.Namespace
 	if m.Resource != nil {
 		r.Resource = m.Resource.(interface {
 			CloneVT() isBuildDetectionRequest_Resource
@@ -328,6 +329,9 @@ func (this *BuildDetectionRequest) EqualVT(that *BuildDetectionRequest) bool {
 		return false
 	}
 	if this.Cluster != that.Cluster {
+		return false
+	}
+	if this.Namespace != that.Namespace {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -761,6 +765,13 @@ func (m *BuildDetectionRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 			return 0, err
 		}
 		i -= size
+	}
+	if len(m.Namespace) > 0 {
+		i -= len(m.Namespace)
+		copy(dAtA[i:], m.Namespace)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Namespace)))
+		i--
+		dAtA[i] = 0x42
 	}
 	if len(m.Cluster) > 0 {
 		i -= len(m.Cluster)
@@ -1404,6 +1415,10 @@ func (m *BuildDetectionRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.Namespace)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1891,6 +1906,38 @@ func (m *BuildDetectionRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Cluster = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Namespace = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3261,6 +3308,42 @@ func (m *BuildDetectionRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.Cluster = stringValue
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Namespace = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/api/v1/image_service.pb.go
+++ b/generated/api/v1/image_service.pb.go
@@ -231,7 +231,11 @@ type ScanImageRequest struct {
 	Force          bool                   `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
 	IncludeSnoozed bool                   `protobuf:"varint,3,opt,name=include_snoozed,json=includeSnoozed,proto3" json:"include_snoozed,omitempty"`
 	// Cluster to delegate scan to, may be the cluster's name or ID.
-	Cluster       string `protobuf:"bytes,4,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Cluster string `protobuf:"bytes,4,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	// Namespace on the secured cluster from which to read context information
+	// when delegating image scans, specifically pull secrets to access the image
+	// registry.
+	Namespace     string `protobuf:"bytes,5,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -290,6 +294,13 @@ func (x *ScanImageRequest) GetIncludeSnoozed() bool {
 func (x *ScanImageRequest) GetCluster() string {
 	if x != nil {
 		return x.Cluster
+	}
+	return ""
+}
+
+func (x *ScanImageRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
 	}
 	return ""
 }
@@ -1215,13 +1226,14 @@ const file_api_v1_image_service_proto_rawDesc = "" +
 	"\x12ListImagesResponse\x12*\n" +
 	"\x06images\x18\x01 \x03(\v2\x12.storage.ListImageR\x06images\"+\n" +
 	"\x13CountImagesResponse\x12\x14\n" +
-	"\x05count\x18\x01 \x01(\x05R\x05count\"\x8a\x01\n" +
+	"\x05count\x18\x01 \x01(\x05R\x05count\"\xa8\x01\n" +
 	"\x10ScanImageRequest\x12\x1d\n" +
 	"\n" +
 	"image_name\x18\x01 \x01(\tR\timageName\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\x12'\n" +
 	"\x0finclude_snoozed\x18\x03 \x01(\bR\x0eincludeSnoozed\x12\x18\n" +
-	"\acluster\x18\x04 \x01(\tR\acluster\"\xa2\x02\n" +
+	"\acluster\x18\x04 \x01(\tR\acluster\x12\x1c\n" +
+	"\tnamespace\x18\x05 \x01(\tR\tnamespace\"\xa2\x02\n" +
 	"\x18ScanImageInternalRequest\x12-\n" +
 	"\x05image\x18\x01 \x01(\v2\x17.storage.ContainerImageR\x05image\x12\x1f\n" +
 	"\vcached_only\x18\x03 \x01(\bR\n" +

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -1823,6 +1823,10 @@
         "cluster": {
           "type": "string",
           "description": "Cluster to delegate scan to, may be the cluster's name or ID."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace on the secured cluster from which to read context information\nwhen delegating image scans, specifically pull secrets to access the image\nregistry."
         }
       }
     },

--- a/generated/api/v1/image_service_vtproto.pb.go
+++ b/generated/api/v1/image_service_vtproto.pb.go
@@ -95,6 +95,7 @@ func (m *ScanImageRequest) CloneVT() *ScanImageRequest {
 	r.Force = m.Force
 	r.IncludeSnoozed = m.IncludeSnoozed
 	r.Cluster = m.Cluster
+	r.Namespace = m.Namespace
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -595,6 +596,9 @@ func (this *ScanImageRequest) EqualVT(that *ScanImageRequest) bool {
 		return false
 	}
 	if this.Cluster != that.Cluster {
+		return false
+	}
+	if this.Namespace != that.Namespace {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1263,6 +1267,13 @@ func (m *ScanImageRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Namespace) > 0 {
+		i -= len(m.Namespace)
+		copy(dAtA[i:], m.Namespace)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Namespace)))
+		i--
+		dAtA[i] = 0x2a
 	}
 	if len(m.Cluster) > 0 {
 		i -= len(m.Cluster)
@@ -2425,6 +2436,10 @@ func (m *ScanImageRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.Namespace)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3244,6 +3259,38 @@ func (m *ScanImageRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Cluster = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Namespace = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5955,6 +6002,42 @@ func (m *ScanImageRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.Cluster = stringValue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Namespace = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/delegatedregistry/delegator.go
+++ b/pkg/delegatedregistry/delegator.go
@@ -20,7 +20,7 @@ type Delegator interface {
 	GetDelegateClusterID(ctx context.Context, imgName *storage.ImageName) (string, bool, error)
 
 	// DelegateScanImage sends a scan request to the provided cluster.
-	DelegateScanImage(ctx context.Context, imgName *storage.ImageName, clusterID string, force bool) (*storage.Image, error)
+	DelegateScanImage(ctx context.Context, imgName *storage.ImageName, clusterID string, namespace string, force bool) (*storage.Image, error)
 
 	// ValidateCluster returns nil if a cluster is a valid target for delegation, returns an
 	// error otherwise.

--- a/pkg/delegatedregistry/mocks/delegator.go
+++ b/pkg/delegatedregistry/mocks/delegator.go
@@ -42,18 +42,18 @@ func (m *MockDelegator) EXPECT() *MockDelegatorMockRecorder {
 }
 
 // DelegateScanImage mocks base method.
-func (m *MockDelegator) DelegateScanImage(ctx context.Context, imgName *storage.ImageName, clusterID string, force bool) (*storage.Image, error) {
+func (m *MockDelegator) DelegateScanImage(ctx context.Context, imgName *storage.ImageName, clusterID, namespace string, force bool) (*storage.Image, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DelegateScanImage", ctx, imgName, clusterID, force)
+	ret := m.ctrl.Call(m, "DelegateScanImage", ctx, imgName, clusterID, namespace, force)
 	ret0, _ := ret[0].(*storage.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DelegateScanImage indicates an expected call of DelegateScanImage.
-func (mr *MockDelegatorMockRecorder) DelegateScanImage(ctx, imgName, clusterID, force any) *gomock.Call {
+func (mr *MockDelegatorMockRecorder) DelegateScanImage(ctx, imgName, clusterID, namespace, force any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegateScanImage", reflect.TypeOf((*MockDelegator)(nil).DelegateScanImage), ctx, imgName, clusterID, force)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegateScanImage", reflect.TypeOf((*MockDelegator)(nil).DelegateScanImage), ctx, imgName, clusterID, namespace, force)
 }
 
 // GetDelegateClusterID mocks base method.

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -72,7 +72,9 @@ type EnrichmentContext struct {
 	// Used to override the delegated registry configuration.
 	ClusterID string
 
-	// Namespace contains the name of the namespace used to filter NetworkPolicies for Deployments.
+	// Namespace is used for context information in the enrichment. It may be specified to:
+	// - Filter NetworkPolicies for Deployments.
+	// - Read pull secrets from a namespace in the delegated cluster to access the image registry.
 	Namespace string
 
 	Source *RequestSource

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -174,7 +174,7 @@ func (e *enricherImpl) delegateEnrichImage(ctx context.Context, enrichCtx Enrich
 
 	// Send image to secured cluster for enrichment.
 	force := enrichCtx.FetchOpt.forceRefetchCachedValues() || enrichCtx.FetchOpt == UseImageNamesRefetchCachedValues
-	scannedImage, err := e.scanDelegator.DelegateScanImage(ctx, image.GetName(), clusterID, force)
+	scannedImage, err := e.scanDelegator.DelegateScanImage(ctx, image.GetName(), clusterID, enrichCtx.Namespace, force)
 	if err != nil {
 		return true, err
 	}
@@ -829,7 +829,7 @@ func (e *enricherImpl) enrichWithSignature(ctx context.Context, enrichmentContex
 			if !errors.Is(err, errox.NotAuthorized) {
 				log.Errorf("Error fetching image signatures for image %q: %v", imgName, err)
 			} else {
-				// Log errox.NotAuthorized erros only in debug mode, since we expect them to occur often.
+				// Log errox.NotAuthorized errors only in debug mode, since we expect them to occur often.
 				log.Debugf("Unauthorized error fetching image signatures for image %q: %v",
 					imgName, err)
 			}

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -1184,7 +1184,7 @@ func TestDelegateEnrichImage(t *testing.T) {
 		setup(t)
 		fakeImage := &storage.Image{}
 		dele.EXPECT().GetDelegateClusterID(emptyCtx, gomock.Any()).Return("cluster-id", true, nil)
-		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", gomock.Any()).Return(fakeImage, nil)
+		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", "", gomock.Any()).Return(fakeImage, nil)
 
 		should, err := e.delegateEnrichImage(emptyCtx, deleEnrichCtx, fakeImage)
 		assert.True(t, should)
@@ -1194,7 +1194,7 @@ func TestDelegateEnrichImage(t *testing.T) {
 	t.Run("delegate enrich error", func(t *testing.T) {
 		setup(t)
 		dele.EXPECT().GetDelegateClusterID(emptyCtx, gomock.Any()).Return("cluster-id", true, nil)
-		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", gomock.Any()).Return(nil, errBroken)
+		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", "", gomock.Any()).Return(nil, errBroken)
 
 		should, err := e.delegateEnrichImage(emptyCtx, deleEnrichCtx, nil)
 		assert.True(t, should)
@@ -1221,7 +1221,7 @@ func TestDelegateEnrichImage(t *testing.T) {
 		setup(t)
 		fakeImage := &storage.Image{}
 		dele.EXPECT().ValidateCluster("cluster-id").Return(nil)
-		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", gomock.Any()).Return(fakeImage, nil)
+		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", "", gomock.Any()).Return(fakeImage, nil)
 
 		deleEnrichCtx := EnrichmentContext{Delegable: true, ClusterID: "cluster-id"}
 
@@ -1271,7 +1271,7 @@ func TestEnrichImage_Delegate(t *testing.T) {
 		setup(t)
 		fakeImage := &storage.Image{}
 		dele.EXPECT().GetDelegateClusterID(emptyCtx, gomock.Any()).Return("cluster-id", true, nil)
-		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", gomock.Any()).Return(fakeImage, nil)
+		dele.EXPECT().DelegateScanImage(emptyCtx, gomock.Any(), "cluster-id", "", gomock.Any()).Return(fakeImage, nil)
 
 		result, err := e.EnrichImage(emptyCtx, deleEnrichCtx, fakeImage)
 		assert.Equal(t, result.ScanResult, ScanSucceeded)

--- a/proto/api/v1/detection_service.proto
+++ b/proto/api/v1/detection_service.proto
@@ -20,6 +20,10 @@ message BuildDetectionRequest {
   repeated string policy_categories = 5;
   // Cluster to delegate scan to, may be the cluster's name or ID.
   string cluster = 7;
+  // Namespace on the secured cluster from which to read context information
+  // when delegating image scans, specifically pull secrets to access the image
+  // registry.
+  string namespace = 8;
 }
 
 message BuildDetectionResponse {

--- a/proto/api/v1/image_service.proto
+++ b/proto/api/v1/image_service.proto
@@ -34,6 +34,10 @@ message ScanImageRequest {
   bool include_snoozed = 3;
   // Cluster to delegate scan to, may be the cluster's name or ID.
   string cluster = 4;
+  // Namespace on the secured cluster from which to read context information
+  // when delegating image scans, specifically pull secrets to access the image
+  // registry.
+  string namespace = 5;
 }
 
 message ScanImageInternalRequest {

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -124,6 +124,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.Flags().IntVarP(&imageScanCmd.retryDelay, "retry-delay", "d", 3, "Set time to wait between retries in seconds.")
 	c.Flags().IntVarP(&imageScanCmd.retryCount, "retries", "r", 3, "Number of retries before exiting as error.")
 	c.Flags().StringVar(&imageScanCmd.cluster, "cluster", "", "Cluster name or ID to delegate image scan to.")
+	c.Flags().StringVar(&imageScanCmd.namespace, "namespace", "", "Namespace on the secured cluster from which to read context information when delegating image scans, specifically pull secrets to access the image registry.")
 	c.Flags().StringSliceVar(&imageScanCmd.severities, "severity", []string{
 		lowCVESeverity.String(),
 		moderateCVESeverity.String(),
@@ -154,6 +155,7 @@ type imageScanCommand struct {
 	retryCount     int
 	timeout        time.Duration
 	cluster        string
+	namespace      string
 	severities     []string
 	failOnFinding  bool
 
@@ -278,6 +280,7 @@ func (i *imageScanCommand) getImageResultFromService() (*storage.Image, error) {
 		Force:          i.force,
 		IncludeSnoozed: i.includeSnoozed,
 		Cluster:        i.cluster,
+		Namespace:      i.namespace,
 	})
 	return image, errors.Wrapf(err, "could not scan image: %q", i.image)
 }

--- a/roxctl/maincommand/command_tree_debug.yaml
+++ b/roxctl/maincommand/command_tree_debug.yaml
@@ -1710,6 +1710,7 @@ image:
       - image
       - json
       - json-fail-on-policy-violations
+      - namespace
       - print-all-violations
       - retries
       - retry-delay
@@ -1768,6 +1769,7 @@ image:
       - format
       - image
       - include-snoozed
+      - namespace
       - retries
       - retry-delay
       - severity

--- a/roxctl/maincommand/command_tree_release.yaml
+++ b/roxctl/maincommand/command_tree_release.yaml
@@ -1671,6 +1671,7 @@ image:
       - image
       - json
       - json-fail-on-policy-violations
+      - namespace
       - print-all-violations
       - retries
       - retry-delay
@@ -1729,6 +1730,7 @@ image:
       - format
       - image
       - include-snoozed
+      - namespace
       - retries
       - retry-delay
       - severity


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Add a `--namespace` flag to `roxctl image scan` and `roxctl image check`. The idea behind this change is to give users the ability to let Sensor read context information from a namespace in the delegated cluster. Specifically, this allows Sensor to use a namespace scoped pull secret to access the image container registry. Consequently, we can integrate with image registries via short-lived credentials created by external secrets operator.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Setting up external secrets 

```
apiVersion: v1
kind: Namespace
metadata:
  name: quay-keyless
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: quay
  namespace: quay-keyless
---
apiVersion: generators.external-secrets.io/v1alpha1
kind: QuayAccessToken
metadata:
  name: quay-token
  namespace: quay-keyless
spec:
  url: quay.io
  robotAccount: keyless+test
  serviceAccountRef:
    name: quay
    namespace: quay-keyless
---
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: quay-credentials
  namespace: quay-keyless
spec:
  dataFrom:
    - sourceRef:
        generatorRef:
          apiVersion: generators.external-secrets.io/v1alpha1
          kind: QuayAccessToken
          name: quay-token
  refreshInterval: 55m # Tokens are good for 1 hour
  target:
    name: quay-credentials
    template:
      type: kubernetes.io/dockerconfigjson
      data:
        .dockerconfigjson: |
          {
            "auths": {
              "{{ .registry }}": {
                "auth": "{{ .auth }}"
              }
            }
          }
```

Scan/check image:
```
roxctl image scan --image=quay.io/keyless/nginx:1.25 --insecure-skip-tls-verify --cluster=remote --force --namespace=quay-keyless
roxctl image check --image=quay.io/keyless/nginx:1.25 --insecure-skip-tls-verify --cluster=remote --force --namespace=quay-keyless
```