### PR TITLE
fix(deduper): Add missing deduper type

### DIFF
--- a/pkg/deduperkey/key.go
+++ b/pkg/deduperkey/key.go
@@ -42,6 +42,7 @@ var (
 		&central.SensorEvent_ComplianceOperatorScanSettingBindingV2{},
 		&central.SensorEvent_ComplianceOperatorScan{},
 		&central.SensorEvent_ComplianceOperatorScanV2{},
+		&central.SensorEvent_ComplianceOperatorSuiteV2{},
 		&central.SensorEvent_AlertResults{},
 	}
 )

--- a/pkg/deduperkey/key_test.go
+++ b/pkg/deduperkey/key_test.go
@@ -45,6 +45,8 @@ var (
 		eventPkg.FormatKey("ComplianceOperatorRule", stubID):                stubHash,
 		eventPkg.FormatKey("ComplianceOperatorScanSettingBinding", stubID):  stubHash,
 		eventPkg.FormatKey("ComplianceOperatorScan", stubID):                stubHash,
+		eventPkg.FormatKey("ComplianceOperatorScanV2", stubID):              stubHash,
+		eventPkg.FormatKey("ComplianceOperatorSuiteV2", stubID):             stubHash,
 		eventPkg.FormatKey("AlertResults", stubID):                          stubHash,
 	}
 	expectedStateWithAll = map[Key]uint64{
@@ -67,6 +69,8 @@ var (
 		withKey(&central.SensorEvent_ComplianceOperatorRule{}, stubID):                stubHash,
 		withKey(&central.SensorEvent_ComplianceOperatorScanSettingBinding{}, stubID):  stubHash,
 		withKey(&central.SensorEvent_ComplianceOperatorScan{}, stubID):                stubHash,
+		withKey(&central.SensorEvent_ComplianceOperatorScanV2{}, stubID):              stubHash,
+		withKey(&central.SensorEvent_ComplianceOperatorSuiteV2{}, stubID):             stubHash,
 		withKey(&central.SensorEvent_AlertResults{}, stubID):                          stubHash,
 	}
 )


### PR DESCRIPTION
### Description

When analyzing customer logs, I noticed the following message:

```
pkg/deduperkey: 2025/05/13 08:30:40.888036 key.go:87: Warn: Deduper state has malformed entry: ComplianceOperatorSuiteV2:87dd96f6-0ddb-49d2-81c5-5829cd7de0ce->9529564071028443379: map type: invalid type: ComplianceOperatorSuiteV2
```

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- I haven't, not sure if CI is enough, but that is a trivial change
