### PR TITLE
test: scanner v4 secured cluster CR tests

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -614,13 +614,11 @@ EOT
     fi
 
     # shellcheck disable=SC2030,SC2031
-    export ROX_SCANNER_V4="true"
+    export ROX_SCANNER_V4="" # Relying on new defaulting for Scanner V4 installation.
     # shellcheck disable=SC2030,SC2031
     export DEPLOY_STACKROX_VIA_OPERATOR="true"
     # shellcheck disable=SC2030,SC2031
     export SENSOR_SCANNER_SUPPORT=true
-    # shellcheck disable=SC2030,SC2031
-    export SENSOR_SCANNER_V4_SUPPORT=true
 
     _begin "deploy-stackrox"
 
@@ -648,13 +646,11 @@ EOT
     fi
 
     # shellcheck disable=SC2030,SC2031
-    export ROX_SCANNER_V4="true"
+    export ROX_SCANNER_V4="" # Relying on new defaulting for Scanner V4 installation.
     # shellcheck disable=SC2030,SC2031
     export DEPLOY_STACKROX_VIA_OPERATOR="true"
     # shellcheck disable=SC2030,SC2031
     export SENSOR_SCANNER_SUPPORT=true
-    # shellcheck disable=SC2030,SC2031
-    export SENSOR_SCANNER_V4_SUPPORT=true
 
     _begin "deploy-stackrox"
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -614,7 +614,7 @@ EOT
     fi
 
     # shellcheck disable=SC2030,SC2031
-    export ROX_SCANNER_V4="" # Relying on new defaulting for Scanner V4 installation.
+    export ROX_SCANNER_V4="" # Scanner V4 enabled by default.
     # shellcheck disable=SC2030,SC2031
     export DEPLOY_STACKROX_VIA_OPERATOR="true"
     # shellcheck disable=SC2030,SC2031
@@ -646,7 +646,7 @@ EOT
     fi
 
     # shellcheck disable=SC2030,SC2031
-    export ROX_SCANNER_V4="" # Relying on new defaulting for Scanner V4 installation.
+    export ROX_SCANNER_V4="" # Scanner V4 enabled by default.
     # shellcheck disable=SC2030,SC2031
     export DEPLOY_STACKROX_VIA_OPERATOR="true"
     # shellcheck disable=SC2030,SC2031


### PR DESCRIPTION
### Description

This PR adapts the install test suite slightly to the recently merged scanner V4 defaulting changes: It removes the setting for opting-into scanner V4, thus relying on the default to kick in. So, effectively this now tests that scanner V4 is installed by default.


### User-facing documentation

- [x] CHANGELOG update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Just CI.
