### PR TITLE
fix(ui): Improve detection of specific locale for date formats

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/clustersCertificateExpiration.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersCertificateExpiration.test.js
@@ -126,7 +126,7 @@ describe('Clusters Certificate Expiration', () => {
     });
 
     describe('Sensor is up to date with Central', () => {
-        const expectedExpiration = 'in 29 days on 09/29/2020'; // Degraded
+        const expectedExpiration = 'in 29 days on Sep 29, 2020'; // Degraded
         const fixturePath = 'clusters/certExpirationDegraded.json';
 
         it('should enable the upgrade option', () => {

--- a/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
@@ -73,7 +73,7 @@ describe('Clusters Health Status', () => {
                 cloudProvider: 'GCP us-west1',
                 clusterStatus: 'Unhealthy',
                 sensorUpgrade: 'Up to date with Central',
-                credentialExpiration: 'in 29 days on 09/29/2020',
+                credentialExpiration: 'in 29 days on Sep 29, 2020',
                 clusterDeletion: 'Not applicable',
             },
             expectedInSide: {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -10,7 +10,7 @@ import { selectors } from './WorkloadCves.selectors';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 export function getDateString(date) {
-    return format(date, 'MM/DD/YYYY');
+    return format(date, 'MMM DD, YYYY');
 }
 
 /**

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionDate.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Button, DatePicker, Flex, SelectOption } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
+import { format } from 'date-fns';
 
-import { getDate } from 'utils/dateUtils';
 import { ensureString } from 'utils/ensure';
 import { dateConditions } from '../utils/utils';
 
@@ -15,6 +15,10 @@ export type ConditionDateProps = {
     onChange: (value: ConditionDate) => void;
     onSearch: (value: ConditionDate) => void;
 };
+
+function dateFormat(date: Date): string {
+    return format(date, 'MM/DD/YYYY');
+}
 
 function dateParse(date: string): Date {
     const split = date.split('/');
@@ -61,7 +65,7 @@ function ConditionDate({ value, onChange, onSearch }: ConditionDateProps) {
                 onChange={(_, newValue) => {
                     onChange({ ...value, date: newValue });
                 }}
-                dateFormat={getDate}
+                dateFormat={dateFormat}
                 dateParse={dateParse}
                 placeholder="MM/DD/YYYY"
                 invalidFormatText="Enter valid date: MM/DD/YYYY"

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -133,7 +133,7 @@ describe('cluster helpers', () => {
 
             const displayValue = formatBuildDate(orchestratorMetadata);
 
-            expect(displayValue).toEqual('10/26/2022');
+            expect(displayValue).toEqual('Oct 26, 2022');
         });
 
         it('should return appropriate message if orchestrator metadata response not available', () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.test.ts
@@ -131,7 +131,7 @@ describe('utils', () => {
 
             const text = getCVEsDiscoveredSinceText(reportParameters);
 
-            expect(text).toBe('10/02/2023');
+            expect(text).toBe('Oct 02, 2023');
         });
     });
 });

--- a/ui/apps/platform/src/utils/dateUtils.test.ts
+++ b/ui/apps/platform/src/utils/dateUtils.test.ts
@@ -14,7 +14,6 @@ describe('dateUtils', () => {
     describe('addBrandedTimestampToString', () => {
         it('should return string with branding prepended, and current data appended', () => {
             const currentDate = new Date();
-            const month = `0${currentDate.getMonth() + 1}`.slice(-2);
             const dayOfMonth = `0${currentDate.getDate()}`.slice(-2);
             const year = currentDate.getFullYear();
 
@@ -22,7 +21,9 @@ describe('dateUtils', () => {
 
             const fileName = addBrandedTimestampToString(baseName);
 
-            expect(fileName).toEqual(`StackRox:${baseName}-${month}/${dayOfMonth}/${year}`);
+            expect(fileName).toMatch(
+                new RegExp(`StackRox:${baseName}-\\w{3} ${dayOfMonth}, ${year}`)
+            );
         });
     });
 });
@@ -38,14 +39,14 @@ describe('displayDateTimeAsISO8601', () => {
 describe('getDateTime', () => {
     it('should format a datetime string with timezone', () => {
         const result = getDateTime(new Date('2024-01-04T12:34:56Z'), 'en-US');
-        expect(result).toBe('01/04/2024, 12:34:56 PM UTC');
+        expect(result).toBe('Jan 04, 2024, 12:34:56 PM UTC');
     });
 });
 
 describe('getDate', () => {
     it('should format only the date portion', () => {
         const result = getDate(new Date('2024-01-04T00:00:00Z'), 'en-US');
-        expect(result).toBe('01/04/2024');
+        expect(result).toBe('Jan 04, 2024');
     });
 });
 

--- a/ui/apps/platform/src/utils/dateUtils.ts
+++ b/ui/apps/platform/src/utils/dateUtils.ts
@@ -1,11 +1,13 @@
 import Raven from 'raven-js';
 import { distanceInWordsStrict } from 'date-fns';
 
+const userLanguages = navigator.languages;
+
 export type DateLike = string | number | Date;
 
 const defaultDateFormatOptions: Readonly<Intl.DateTimeFormatOptions> = {
     year: 'numeric',
-    month: '2-digit',
+    month: 'short',
     day: '2-digit',
 };
 
@@ -28,12 +30,15 @@ function convertDateLikeToDate(dateLike: DateLike): Date {
 
 function formatLocalizedDateTime(
     dateLike: DateLike,
-    locales: Intl.LocalesArgument = undefined,
+    locales: Intl.LocalesArgument = userLanguages,
     dateTimeFormatOptions: Intl.DateTimeFormatOptions = {}
 ): string {
     try {
+        const preferredLocale: string | Intl.Locale | undefined = Array.isArray(locales)
+            ? locales[0]
+            : locales;
         const date = convertDateLikeToDate(dateLike);
-        return new Intl.DateTimeFormat(locales, {
+        return new Intl.DateTimeFormat(preferredLocale, {
             ...dateTimeFormatOptions,
         }).format(date);
     } catch (e: unknown) {
@@ -66,7 +71,7 @@ export function displayDateTimeAsISO8601(dateLike: DateLike) {
  */
 export function getDateTime(
     dateLike: DateLike,
-    locales: Intl.LocalesArgument = undefined,
+    locales: Intl.LocalesArgument = userLanguages,
     dateTimeFormatOptionOverrides: Intl.DateTimeFormatOptions = {}
 ) {
     return formatLocalizedDateTime(dateLike, locales, {
@@ -84,7 +89,7 @@ export function getDateTime(
  */
 export function getDate(
     dateLike: DateLike,
-    locales: Intl.LocalesArgument = undefined,
+    locales: Intl.LocalesArgument = userLanguages,
     dateTimeFormatOptionOverrides: Intl.DateTimeFormatOptions = {}
 ): string {
     return formatLocalizedDateTime(dateLike, locales, {
@@ -102,7 +107,7 @@ export function getDate(
  */
 export function getTime(
     dateLike: DateLike,
-    locales: Intl.LocalesArgument = undefined,
+    locales: Intl.LocalesArgument = userLanguages,
     dateTimeFormatOptionOverrides: Intl.DateTimeFormatOptions = {}
 ): string {
     return formatLocalizedDateTime(dateLike, locales, {
@@ -120,7 +125,7 @@ export function getTime(
  */
 export function getTimeHoursMinutes(
     timestamp: DateLike,
-    locales: Intl.LocalesArgument = undefined,
+    locales: Intl.LocalesArgument = userLanguages,
     dateTimeFormatOptionOverrides: Intl.DateTimeFormatOptions = {}
 ): string {
     return getTime(timestamp, locales, {


### PR DESCRIPTION
### Description

Fixes detection of user locales by explicitly checking `navigator.languages` instead of using `undefined` and relying on auto-detection. I have found sources online that state that the resolution of locale when using `undefined` does not always select the first option, leading to unexpected results. Unfortunately I have not found any primary sources in the spec or implementation that confirms this, but I can confirm with the following behavior when setting my browser to use `en-GB` as the default language.

```
navigator.languages
// ['en-GB', 'en']

let fmt = Intl.DateTimeFormat(undefined)
fmt.resolvedOptions().locale
// 'en-US'
```

This behavior results in US formatting still being used for other English locales, such as GB and AU.

In addition, for extra clarity in the case where month/day are _still_ ambiguous, I've switched to display the month short version (3 characters) instead of numeric. This does not take up any additional space, and increases the clarity of the overall date format.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![image](https://github.com/user-attachments/assets/3c18c40a-59d1-4539-beaf-6e71b436dda3)
