### PR TITLE
ROX-27716: Enable Konflux builds to replace GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,10 +41,10 @@ jobs:
           source './scripts/ci/lib.sh'
 
           matrix='{
-            "pre_build_go_binaries": { "name":[], "arch":[] },
-            "build_and_push_main": { "name":[], "arch":[] },
-            "push_main_multiarch_manifests": { "name":[] },
-            "build_and_push_operator": { "name":[] },
+            "pre_build_go_binaries": { "name":[], "arch":[], "exclude":[] },
+            "build_and_push_main": { "name":[], "arch":[], "exclude":[] },
+            "push_main_multiarch_manifests": { "name":[], "exclude":[] },
+            "build_and_push_operator": { "name":[], "exclude":[] },
             "scan_images_with_roxctl": { "name":[], "image":[], "exclude":[] }
           }'
 
@@ -90,6 +90,13 @@ jobs:
             matrix="$(jq '.build_and_push_main.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "s390x" }]' <<< "$matrix")"
+          fi
+
+          if [[ "$( scripts/ci/should-konflux-replace-gha-build.sh )" == "BUILD_AND_PUSH_ONLY_KONFLUX" ]]; then
+            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "RHACS_BRANDING" }]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.exclude += [{ "name": "RHACS_BRANDING" }]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_operator.exclude += [{ "name": "RHACS_BRANDING" }]' <<< "$matrix")"
+            matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "RHACS_BRANDING" }]' <<< "$matrix")"
           fi
 
           echo "Job matrix after conditionals:"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -638,12 +638,13 @@ jobs:
           scripts/lib.sh retry 6 true make -C operator/ build docker-build
 
       - name: Check that Operator image is runnable
+        if: matrix.name == 'RHACS_BRANDING'
         run: docker run --rm "quay.io/rhacs-eng/stackrox-operator:$(make --quiet --no-print-directory -C operator tag)" --help
 
       - name: Push images
         # Skip for external contributions.
         if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+          (github.event_name == 'push' || !github.event.pull_request.head.repo.fork) && matrix.name == 'RHACS_BRANDING'
         run: |
           make -C operator/ docker-push docker-push-bundle | cat
 
@@ -651,14 +652,14 @@ jobs:
       - name: Build index
         # Skip for external contributions as the build relies on the previous image to be pushed.
         if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+          (github.event_name == 'push' || !github.event.pull_request.head.repo.fork) && matrix.name == 'RHACS_BRANDING'
         run: |
           make -C operator/ index-build
 
       - name: Push index image
         # Skip for external contributions.
         if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+          (github.event_name == 'push' || !github.event.pull_request.head.repo.fork) && matrix.name == 'RHACS_BRANDING'
         run: |
           make -C operator/ docker-push-index | cat
 

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -37,10 +37,10 @@ jobs:
 
         # If goarch is updated, be sure to update architectures in "push-scanner-manifests" below.
         matrix='{
-          "pre_build_scanner_go_binary": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"] },
+          "pre_build_scanner_go_binary": { "name":["default"], "goos":["linux"], "goarch":["amd64", "arm64"], "exclude":[] },
           "build_and_push_scanner": { },
-          "push_scanner_manifests": { "name":["default"], "registry":["quay.io/stackrox-io", "quay.io/rhacs-eng"] },
-          "scan_images_with_roxctl": { "image":["scanner-v4", "scanner-v4-db"], "registry":["quay.io/stackrox-io", "quay.io/rhacs-eng"] }
+          "push_scanner_manifests": { "name":["default"], "registry":["quay.io/stackrox-io", "quay.io/rhacs-eng"], "exclude":[] },
+          "scan_images_with_roxctl": { "image":["scanner-v4", "scanner-v4-db"], "registry":["quay.io/stackrox-io", "quay.io/rhacs-eng"], "exclude":[] }
         }'
 
         if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
@@ -63,6 +63,12 @@ jobs:
 
         matrix="$(jq '.build_and_push_scanner = .pre_build_scanner_go_binary' <<< "$matrix")"
         matrix="$(jq '.build_and_push_scanner.registry = .push_scanner_manifests.registry' <<< "$matrix")"
+
+        if [[ "$( scripts/ci/should-konflux-replace-gha-build.sh )" == "BUILD_AND_PUSH_ONLY_KONFLUX" ]]; then
+          matrix="$(jq '.build_and_push_scanner.exclude += [{ "registry": "quay.io/rhacs-eng" }]' <<< "$matrix")"
+          matrix="$(jq '.push_scanner_manifests.exclude += [{ "registry": "quay.io/rhacs-eng" }]' <<< "$matrix")"
+          matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "registry": "quay.io/rhacs-eng" }]' <<< "$matrix")"
+        fi
 
         echo "Job matrix after conditionals:"
         jq <<< "$matrix"

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
         - name: kind
           value: task
       resolver: bundles
@@ -168,7 +168,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -217,8 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-27716): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -217,7 +217,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        # TODO(ROX-27716): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
         - name: kind
           value: task
       resolver: bundles
@@ -168,7 +168,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -217,8 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-27716): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -238,7 +237,7 @@ spec:
       - name: name
         value: fetch-external-networks
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -217,7 +217,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        # TODO(ROX-27716): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
         - name: kind
           value: task
       resolver: bundles
@@ -270,7 +270,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -319,8 +319,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-27716): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -357,7 +356,7 @@ spec:
       - name: name
         value: wait-for-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -828,7 +827,7 @@ spec:
       - name: name
         value: create-snapshot
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -319,7 +319,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        # TODO(ROX-27716): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/retag-pipeline.yaml
+++ b/.tekton/retag-pipeline.yaml
@@ -35,7 +35,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
         - name: kind
           value: task
       resolver: bundles
@@ -138,8 +138,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-27716): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -157,7 +156,7 @@ spec:
         - name: name
           value: determine-dependency-image-tag
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
         - name: kind
           value: task
       resolver: bundles
@@ -177,7 +176,7 @@ spec:
       - name: name
         value: retag-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/retag-pipeline.yaml
+++ b/.tekton/retag-pipeline.yaml
@@ -138,7 +138,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        # TODO(ROX-27716): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
         - name: kind
           value: task
       resolver: bundles
@@ -168,7 +168,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -217,8 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        # TODO(ROX-27716): switch to latest
-        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles
@@ -238,7 +237,7 @@ spec:
       - name: name
         value: fetch-scanner-v4-vuln-mappings
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:60aa53405b42d2771a3370d2ca609f6ef6c7d2441c5151cc376cb9a555e22de5
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -217,7 +217,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:d3d0eb9f66831725a7c524faa76a675df1eaf82b361c8dff30e41a2ed17156c7
+        # TODO(ROX-27716): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-55@sha256:ee6fa6df247a9a991c732c69af9eb8feba1b2d490a3fab8357692b818406377d
       - name: kind
         value: task
       resolver: bundles

--- a/scripts/ci/should-konflux-replace-gha-build.bats
+++ b/scripts/ci/should-konflux-replace-gha-build.bats
@@ -13,7 +13,7 @@ function setup() {
 
 function run_cmd() {
     # We copy the script to a temporary directory and run it from there so that it does not find
-    # should-konflux-replace-gha-build.hold file if that's present in the repo.
+    # should-konflux-replace-gha-build.hold file if that's still present in the repo.
 
     cp -a "${BATS_TEST_DIRNAME}/should-konflux-replace-gha-build.sh" "${BATS_TEST_TMPDIR}/our-script.sh"
     run --separate-stderr "${BATS_TEST_TMPDIR}/our-script.sh"
@@ -90,7 +90,7 @@ function assert_stderr_contains() {
 
 # Release (or release-like) branch push
 
-@test "Konflux: should tell only Konflux when release-like branch pushed" {
+@test "Konflux: should tell only Konflux when release branch pushed" {
     export SOURCE_BRANCH=release-4.8
     export TARGET_BRANCH=release-4.8
     check_gha_suppressed
@@ -131,7 +131,7 @@ function assert_stderr_contains() {
 
 # PR towards a non-release branch
 
-@test "Konflux: should tell Both when PR branch name is not magic" {
+@test "Konflux: should tell Both when PR targets non-release branch" {
     export SOURCE_BRANCH=author/my-useful-feature
     export TARGET_BRANCH=master
     check_both_go

--- a/scripts/ci/should-konflux-replace-gha-build.bats
+++ b/scripts/ci/should-konflux-replace-gha-build.bats
@@ -62,7 +62,7 @@ function assert_stderr_contains() {
     check_gha_suppressed
 }
 
-@test "Konflux: should tell Both when a different tag pushed" {
+@test "Konflux: should tell Both when non-release tag pushed" {
     export SOURCE_BRANCH=refs/tags/4.10.56-nightly.20250515
     export TARGET_BRANCH=refs/tags/4.10.56-nightly.20250515
     check_both_go
@@ -105,7 +105,7 @@ function assert_stderr_contains() {
     check_gha_suppressed
 }
 
-@test "GHA: should tell Both when different tag pushed" {
+@test "GHA: should tell Both when non-release tag pushed" {
     export GITHUB_REF=refs/tags/0.0.0-author-testing
     check_both_go
 }

--- a/scripts/ci/should-konflux-replace-gha-build.bats
+++ b/scripts/ci/should-konflux-replace-gha-build.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+load "../test_helpers.bats"
+
+function setup() {
+    unset SOURCE_BRANCH
+    unset TARGET_BRANCH
+    unset GITHUB_BASE_REF
+    unset GITHUB_HEAD_REF
+    unset GITHUB_REF
+    bats_require_minimum_version 1.5.0
+}
+
+function run_cmd() {
+    # We copy the script to a temporary directory and run it from there so that it does not find
+    # should-konflux-replace-gha-build.hold file if that's present in the repo.
+
+    cp -a "${BATS_TEST_DIRNAME}/should-konflux-replace-gha-build.sh" "${BATS_TEST_TMPDIR}/our-script.sh"
+    run --separate-stderr "${BATS_TEST_TMPDIR}/our-script.sh"
+}
+
+function check_both_go() {
+    run_cmd
+    assert_success
+    assert_output "BUILD_AND_PUSH_BOTH"
+    assert_stderr_contains "does not look like"
+    assert_stderr_contains "release"
+    assert_stderr_contains "branch or tag"
+}
+
+function check_gha_suppressed() {
+    run_cmd
+    assert_success
+    assert_output "BUILD_AND_PUSH_ONLY_KONFLUX"
+    assert_stderr_contains "looks like"
+    assert_stderr_contains "release"
+    assert_stderr_contains "branch or tag"
+}
+
+function check_gha_suppressed_for_pr() {
+    run_cmd
+    assert_success
+    assert_output "BUILD_AND_PUSH_ONLY_KONFLUX"
+    assert_stderr_contains "magic"
+}
+
+# BATS libraries in our builder image don't have assert_stderr.
+function assert_stderr_contains() {
+    assert grep -F "$1" <<< "${stderr_lines[@]}"
+}
+
+@test "should fail when required values are not set" {
+    run_cmd
+    assert_failure 2
+}
+
+# When executing in Konflux
+
+@test "Konflux: should tell only Konflux when rc tag pushed" {
+    export SOURCE_BRANCH=refs/tags/4.10.56-rc.172
+    export TARGET_BRANCH=refs/tags/4.10.56-rc.172
+    check_gha_suppressed
+}
+
+@test "Konflux: should tell Both when a different tag pushed" {
+    export SOURCE_BRANCH=refs/tags/4.10.56-nightly.20250515
+    export TARGET_BRANCH=refs/tags/4.10.56-nightly.20250515
+    check_both_go
+}
+
+@test "Konflux: should tell only Konflux when release-like branch pushed" {
+    export SOURCE_BRANCH=release-4.8
+    export TARGET_BRANCH=release-4.8
+    check_gha_suppressed
+}
+
+@test "Konflux: should tell Both when non-release branch pushed" {
+    export SOURCE_BRANCH=author/ROX-27716-useful-feature
+    export TARGET_BRANCH=author/ROX-27716-useful-feature
+    check_both_go
+}
+
+@test "Konflux: should tell only Konflux when PR branch name includes magic" {
+    export SOURCE_BRANCH=author/konflux-release-like
+    export TARGET_BRANCH=master
+    check_gha_suppressed_for_pr
+}
+
+@test "Konflux: should tell Both when PR branch name is not magic" {
+    export SOURCE_BRANCH=author/my-useful-feature
+    export TARGET_BRANCH=master
+    check_both_go
+}
+
+@test "Konflux: should tell only Konflux when PR targets release branch" {
+    export SOURCE_BRANCH=author/my-useful-feature
+    export TARGET_BRANCH=release-4.8
+    check_gha_suppressed
+}
+
+# When executing in GHA
+
+@test "GHA: should tell only Konflux when release tag pushed" {
+    export GITHUB_REF=refs/tags/24.58.60
+    check_gha_suppressed
+}
+
+@test "GHA: should tell Both when different tag pushed" {
+    export GITHUB_REF=refs/tags/0.0.0-author-testing
+    check_both_go
+}
+
+@test "GHA: should tell only Konflux when release-like branch pushed" {
+    export GITHUB_REF=refs/heads/release-x.y
+    check_gha_suppressed
+}
+
+@test "GHA: should tell Both when non-release branch pushed" {
+    export GITHUB_REF=refs/heads/many-funky/parts/with-useful/slashes
+    check_both_go
+}
+
+@test "GHA: should fail when PR but variables are not set" {
+    export GITHUB_REF=refs/pull/1005006/merge
+    run_cmd
+    assert_failure 3
+}
+
+@test "GHA: should tell only Konflux when PR targets release-like branch" {
+    export GITHUB_REF=refs/pull/15309/merge
+    export GITHUB_BASE_REF=release-x.y
+    export GITHUB_HEAD_REF=author/my-useful-feature
+    check_gha_suppressed
+}
+
+@test "GHA: should tell Both when PR targets non-release branch" {
+    export GITHUB_REF=refs/pull/15309/merge
+    export GITHUB_BASE_REF=master
+    export GITHUB_HEAD_REF=author/my-useful-feature
+    check_both_go
+}
+
+@test "GHA: should tell only Konflux when PR branch name includes magic" {
+    export GITHUB_REF=refs/pull/15309/merge
+    export GITHUB_BASE_REF=master
+    export GITHUB_HEAD_REF=author/konflux-release-like
+    check_gha_suppressed_for_pr
+}
+
+# Holdfile logic
+
+@test "should respect holdfile when release push" {
+    export SOURCE_BRANCH=release-4.8
+    export TARGET_BRANCH=release-4.8
+    create_holdfile
+    run_cmd
+    assert_success
+    assert_output "BUILD_AND_PUSH_BOTH"
+    assert_stderr_contains "holdfile"
+}
+
+@test "should ignore holdfile when PR with magic branch" {
+    export SOURCE_BRANCH=author/konflux-release-like
+    export TARGET_BRANCH=master
+    create_holdfile
+    check_gha_suppressed_for_pr
+}
+
+function create_holdfile() {
+    touch "${BATS_TEST_TMPDIR}/should-konflux-replace-gha-build.hold"
+}

--- a/scripts/ci/should-konflux-replace-gha-build.hold
+++ b/scripts/ci/should-konflux-replace-gha-build.hold
@@ -1,0 +1,6 @@
+The existence of this file is a disabling feature flag that prevents Konflux replacing GHA for building and pushing
+release images.
+It is recognized by should-konflux-replace-gha-build.sh
+
+We should remove this file (should-konflux-replace-gha-build.hold) once we're ready to be releasing with Konflux.
+See https://issues.redhat.com/browse/ROX-29357

--- a/scripts/ci/should-konflux-replace-gha-build.sh
+++ b/scripts/ci/should-konflux-replace-gha-build.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# This script determines where quay.io/rhacs-eng/* images should be built and pushed and communicates that via stdout.
+#
+# For non-release branches, PRs and tags we want to build both:
+# 1. quay.io/rhacs-eng/<image>:<tag> in GHA, and
+# 2. quay.io/rhacs-eng/<image>:<tag>-fast in Konflux.
+#
+# For releases and RCs we need GHA builds to be suppressed and Konflux builds go to quay.io/rhacs-eng/<image>:<tag>
+# (without "-fast" suffix) because this way image tag information which is "baked" in the Konflux-built binaries is
+# correct for self-managed (on-prem) release (a.k.a. Stable Stream) and we can further release these images to
+# customers.
+#
+# We want the same for PRs targeting the release branches because we want E2E tests run against Konflux-built images
+# just as it happens for release branch pushes.
+#
+# Additionally, the same behavior will be in any PR when the PR source branch has 'konflux-release-like' in its name.
+#
+# Note: this script is also called by https://github.com/stackrox/konflux-tasks/blob/main/tasks/determine-image-tag-task.yaml
+
+set -euo pipefail
+
+# Log to stderr to not mess up stdout of any calling code.
+function log() {
+    >&2 echo "$@"
+}
+
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+holdfile="${script_dir}/should-konflux-replace-gha-build.hold"
+
+if [[ ( -z "${SOURCE_BRANCH:-}" || -z "${TARGET_BRANCH:-}" ) && -z "${GITHUB_REF:-}" ]]; then
+    log "Either SOURCE_BRANCH+TARGET_BRANCH or GITHUB_REF must be set"
+    exit 2
+fi
+
+# Branch or tag name when in Konflux CI.
+# '<branch_name>' for branch push, 'refs/tags/<tag_name>' for tag push.
+# For PRs this is '<branch_name>' where the PR is targeted to be merged.
+log "Konflux TARGET_BRANCH: ${TARGET_BRANCH:-}"
+
+# Same value as $TARGET_BRANCH for tag and branch pushes. For PRs this is '<branch_name>' of the PR source branch.
+log "Konflux SOURCE_BRANCH: ${SOURCE_BRANCH:-}"
+
+# Note that $TARGET_BRANCH and $SOURCE_BRANCH must be explicitly made available as environment variables by/in the
+# Tekton step, i.e. they are not provided out of the box unlike the GITHUB_* variables in GHA.
+
+# Branch or tag name when in GHA CI.
+# 'refs/heads/<branch_name>' for branch push, 'refs/tags/<tag_name>' for tag push, 'refs/pull/<pr_number>/merge' for PR.
+log "GitHub GITHUB_REF: ${GITHUB_REF:-}"
+
+# '<branch_name>' of the PR target branch when it's in GHA CI.
+log "GitHub GITHUB_BASE_REF: ${GITHUB_BASE_REF:-}"
+
+# '<branch_name>' of the PR source branch when it's in GHA CI.
+log "GitHub GITHUB_HEAD_REF: ${GITHUB_HEAD_REF:-}"
+
+the_ref="${TARGET_BRANCH:-${GITHUB_REF}}"
+pr_source_branch="${SOURCE_BRANCH:-}"
+
+if [[ "${GITHUB_REF:-}" == refs/pull/*/merge ]]; then
+    if [[ -z "${GITHUB_BASE_REF:-}" || -z "${GITHUB_HEAD_REF:-}" ]]; then
+        log "Both GITHUB_BASE_REF and GITHUB_HEAD_REF must be set for PRs"
+        exit 3
+    fi
+
+    the_ref="${GITHUB_BASE_REF}"
+    pr_source_branch="${GITHUB_HEAD_REF}"
+fi
+
+if [[ "${pr_source_branch}" == *konflux-release-like* ]]; then
+    log "This looks like a PR branch containing the magic string. GHA quay.io/rhacs-eng/* builds must be suppressed in favor of the Konflux ones."
+    echo "BUILD_AND_PUSH_ONLY_KONFLUX"
+    exit
+fi
+
+if grep -qE '^((refs/heads/)?release-[0-9a-z]+\.[0-9a-z]+|refs/tags/[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' <<< "${the_ref}"; then
+    log "This looks like a release branch or tag push. GHA quay.io/rhacs-eng/* builds must be suppressed in favor of the Konflux ones."
+    if [[ -f "${holdfile}" ]]; then
+        # TODO(ROX-29357): remove the holdfile logic after our tests are happy with Konflux-built product.
+        log "... would have done that but the 'holdfile' ${holdfile} exists and so not suppressing GHA."
+        echo "BUILD_AND_PUSH_BOTH"
+    else
+        echo "BUILD_AND_PUSH_ONLY_KONFLUX"
+    fi
+else
+    log "This does not look like a release branch or tag push. Both GHA and Konflux should build and push quay.io/rhacs-eng/* images (with different tags)."
+    echo "BUILD_AND_PUSH_BOTH"
+fi


### PR DESCRIPTION
### Description

For release builds, for `quay.io/rhacs-eng` images.

Paired with https://github.com/stackrox/konflux-tasks/pull/55

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

No change.

#### How I validated my change

See https://github.com/stackrox/konflux-tasks/pull/55
