### PR TITLE
ROX-27963: Support for CA rotation in Central

### DIFF
--- a/central/metadata/service/service.go
+++ b/central/metadata/service/service.go
@@ -24,8 +24,14 @@ type Service interface {
 
 // New returns a new instance of service.
 func New() Service {
+	return NewWithCertificateProvider(&defaultCertificateProvider{})
+}
+
+// NewWithCertificateProvider returns a new instance of service with a custom certificate provider.
+func NewWithCertificateProvider(certProvider CertificateProvider) Service {
 	return &serviceImpl{
 		db:              globaldb.GetPostgres(),
 		systemInfoStore: systemInfoStorage.Singleton(),
+		certProvider:    certProvider,
 	}
 }

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -191,17 +191,12 @@ func (s *serviceImpl) TLSChallenge(_ context.Context, req *v1.TLSChallengeReques
 		return nil, errors.Errorf("Could not create central challenge: %s", err)
 	}
 
-	certProvider := s.certProvider
-	if certProvider == nil {
-		certProvider = &defaultCertificateProvider{}
-	}
-
-	_, caCertDERBytes, err := certProvider.GetPrimaryCACert()
+	_, caCertDERBytes, err := s.certProvider.GetPrimaryCACert()
 	if err != nil {
 		return nil, errors.Errorf("Could not read CA cert and private key: %s", err)
 	}
 
-	leafCert, err := certProvider.GetPrimaryLeafCert()
+	leafCert, err := s.certProvider.GetPrimaryLeafCert()
 	if err != nil {
 		return nil, errors.Errorf("Could not load leaf certificate: %s", err)
 	}
@@ -232,9 +227,9 @@ func (s *serviceImpl) TLSChallenge(_ context.Context, req *v1.TLSChallengeReques
 	}
 
 	// if a secondary CA exists, add its chain to TrustInfo
-	secondaryLeafCert, secondaryLeafCertErr := certProvider.GetSecondaryLeafCert()
+	secondaryLeafCert, secondaryLeafCertErr := s.certProvider.GetSecondaryLeafCert()
 	if secondaryLeafCertErr == nil {
-		_, secondaryCACertDERBytes, secondaryCACertErr := certProvider.GetSecondaryCACert()
+		_, secondaryCACertDERBytes, secondaryCACertErr := s.certProvider.GetSecondaryCACert()
 
 		if secondaryCACertErr == nil {
 			trustInfo.SecondaryCertChain = [][]byte{

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -388,7 +388,7 @@ func (s *serviceImplTestSuite) TestTLSChallengeWithSecondaryCA() {
 			ChallengeToken: validChallengeToken,
 		}
 
-		resp, err := service.TLSChallenge(context.TODO(), req)
+		resp, err := service.TLSChallenge(context.Background(), req)
 		s.Require().NoError(err) // broken secondary CA should not fail the entire request
 		s.Require().NotNil(resp)
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -44,7 +44,7 @@ func TestServiceImpl(t *testing.T) {
 }
 
 func TestAuthz(t *testing.T) {
-	testutils.AssertAuthzWorks(t, &serviceImpl{})
+	testutils.AssertAuthzWorks(t, New().(*serviceImpl))
 }
 
 type serviceImplTestSuite struct {
@@ -67,7 +67,7 @@ func (s *serviceImplTestSuite) SetupTest() {
 }
 
 func (s *serviceImplTestSuite) TestTLSChallenge() {
-	service := serviceImpl{}
+	service := New().(*serviceImpl)
 	req := &v1.TLSChallengeRequest{
 		ChallengeToken: validChallengeToken,
 	}
@@ -97,7 +97,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge() {
 }
 
 func (s *serviceImplTestSuite) TestTLSChallenge_VerifySignatureWithCACert_ShouldFail() {
-	service := serviceImpl{}
+	service := New().(*serviceImpl)
 	req := &v1.TLSChallengeRequest{
 		ChallengeToken: validChallengeToken,
 	}
@@ -122,7 +122,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge_VerifySignatureWithCACert_Should
 }
 
 func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithoutChallenge() {
-	service := serviceImpl{}
+	service := New().(*serviceImpl)
 	req := &v1.TLSChallengeRequest{}
 
 	resp, err := service.TLSChallenge(context.TODO(), req)
@@ -132,7 +132,7 @@ func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithoutChallenge() {
 }
 
 func (s *serviceImplTestSuite) TestTLSChallenge_ShouldFailWithInvalidToken() {
-	service := serviceImpl{}
+	service := New().(*serviceImpl)
 	req := &v1.TLSChallengeRequest{
 		ChallengeToken: invalidChallengeToken,
 	}
@@ -208,7 +208,7 @@ func (s *serviceImplTestSuite) TestGetCentralCapabilities() {
 	s.Run("when managed central", func() {
 		s.T().Setenv("ROX_MANAGED_CENTRAL", "true")
 
-		caps, err := (&serviceImpl{}).GetCentralCapabilities(ctx, nil)
+		caps, err := New().GetCentralCapabilities(ctx, nil)
 
 		s.NoError(err)
 		s.Equal(v1.CentralServicesCapabilities_CapabilityDisabled, caps.GetCentralScanningCanUseContainerIamRoleForEcr())
@@ -224,7 +224,7 @@ func (s *serviceImplTestSuite) TestGetCentralCapabilities() {
 		s.Run(fmt.Sprintf("when not managed central (%s)", name), func() {
 			s.T().Setenv("ROX_MANAGED_CENTRAL", val)
 
-			caps, err := (&serviceImpl{}).GetCentralCapabilities(ctx, nil)
+			caps, err := New().GetCentralCapabilities(ctx, nil)
 
 			s.NoError(err)
 			s.Equal(v1.CentralServicesCapabilities_CapabilityAvailable, caps.CentralScanningCanUseContainerIamRoleForEcr)
@@ -356,7 +356,6 @@ func (s *serviceImplTestSuite) TestTLSChallengeWithSecondaryCA() {
 		s.Require().NoError(err)
 		s.Require().NotNil(resp)
 
-		// Parse trust info
 		trustInfo := &v1.TrustInfo{}
 		err = trustInfo.UnmarshalVTUnsafe(resp.GetTrustInfoSerialized())
 		s.Require().NoError(err)
@@ -388,7 +387,7 @@ func (s *serviceImplTestSuite) TestTLSChallengeWithSecondaryCA() {
 			ChallengeToken: validChallengeToken,
 		}
 
-		resp, err := service.TLSChallenge(context.Background(), req)
+		resp, err := service.TLSChallenge(context.TODO(), req)
 		s.Require().NoError(err) // broken secondary CA should not fail the entire request
 		s.Require().NotNil(resp)
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -4,13 +4,17 @@ package service
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/initca"
 	cTLS "github.com/google/certificate-transparency-go/tls"
 	systemInfoStorage "github.com/stackrox/rox/central/systeminfo/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -19,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	mockIdentity "github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
+	"github.com/stackrox/rox/pkg/mtls"
 	testutilsMTLS "github.com/stackrox/rox/pkg/mtls/testutils"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
@@ -228,4 +233,171 @@ func (s *serviceImplTestSuite) TestGetCentralCapabilities() {
 			s.Equal(v1.CentralServicesCapabilities_CapabilityAvailable, caps.CentralCanUpdateCert)
 		})
 	}
+}
+
+func (s *serviceImplTestSuite) TestIssueSecondaryCALeafCert() {
+	secondaryCA := s.createTestCA("Test Secondary CA", "17520h")
+
+	s.Run("successful certificate generation", func() {
+		mockProvider := &testCertificateProvider{
+			secondaryCA:         secondaryCA,
+			shouldFailSecondary: false,
+		}
+
+		cert, err := issueSecondaryCALeafCert(mockProvider)
+		s.Require().NoError(err)
+		s.Require().NotNil(cert.PrivateKey)
+		s.Require().Len(cert.Certificate, 1)
+
+		parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+		s.Require().NoError(err)
+		s.Equal(mtls.CentralSubject.CN(), parsedCert.Subject.CommonName)
+	})
+
+	s.Run("secondary CA loading failure", func() {
+		mockProvider := &testCertificateProvider{
+			secondaryCA:         secondaryCA,
+			shouldFailSecondary: true,
+			failSecondaryErr:    errors.New("secondary CA file not found"),
+		}
+
+		_, err := issueSecondaryCALeafCert(mockProvider)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "failed to load secondary CA for signing")
+		s.Contains(err.Error(), "secondary CA file not found")
+	})
+}
+
+func (s *serviceImplTestSuite) createTestCA(commonName, expiry string) mtls.CA {
+	caCert, _, caKey, err := initca.New(&csr.CertificateRequest{
+		CN:         commonName,
+		KeyRequest: csr.NewKeyRequest(),
+		CA: &csr.CAConfig{
+			Expiry: expiry,
+		},
+	})
+	s.Require().NoError(err)
+
+	ca, err := mtls.LoadCAForSigning(caCert, caKey)
+	s.Require().NoError(err)
+	return ca
+}
+
+type testCertificateProvider struct {
+	primaryCA           mtls.CA
+	secondaryCA         mtls.CA
+	primaryLeafCert     tls.Certificate
+	shouldFailSecondary bool
+	failSecondaryErr    error
+}
+
+func (m *testCertificateProvider) GetPrimaryCACert() (*x509.Certificate, []byte, error) {
+	cert := m.primaryCA.Certificate()
+	return cert, cert.Raw, nil
+}
+
+func (m *testCertificateProvider) GetPrimaryLeafCert() (tls.Certificate, error) {
+	return m.primaryLeafCert, nil
+}
+
+func (m *testCertificateProvider) GetSecondaryCAForSigning() (mtls.CA, error) {
+	if m.shouldFailSecondary {
+		if m.failSecondaryErr != nil {
+			return nil, m.failSecondaryErr
+		}
+		return nil, errors.New("secondary CA not found")
+	}
+	return m.secondaryCA, nil
+}
+
+func (m *testCertificateProvider) GetSecondaryCACert() (*x509.Certificate, []byte, error) {
+	if m.shouldFailSecondary {
+		if m.failSecondaryErr != nil {
+			return nil, nil, m.failSecondaryErr
+		}
+		return nil, nil, errors.New("secondary CA not found")
+	}
+	cert := m.secondaryCA.Certificate()
+	return cert, cert.Raw, nil
+}
+
+func (m *testCertificateProvider) GetSecondaryLeafCert() (tls.Certificate, error) {
+	return issueSecondaryCALeafCert(m)
+}
+
+func (s *serviceImplTestSuite) TestTLSChallengeWithSecondaryCA() {
+	// Create test CAs
+	primaryCA := s.createTestCA("Test Primary CA", "8760h")
+	secondaryCA := s.createTestCA("Test Secondary CA", "17520h")
+
+	// Create a primary leaf certificate
+	issuedCert, err := primaryCA.IssueCertForSubject(mtls.CentralSubject)
+	s.Require().NoError(err)
+	primaryLeafCert, err := tls.X509KeyPair(issuedCert.CertPEM, issuedCert.KeyPEM)
+	s.Require().NoError(err)
+
+	s.Run("with both primary and secondary CA", func() {
+		mockProvider := &testCertificateProvider{
+			primaryCA:           primaryCA,
+			secondaryCA:         secondaryCA,
+			primaryLeafCert:     primaryLeafCert,
+			shouldFailSecondary: false,
+		}
+
+		service := &serviceImpl{
+			certProvider: mockProvider,
+		}
+
+		req := &v1.TLSChallengeRequest{
+			ChallengeToken: validChallengeToken,
+		}
+
+		resp, err := service.TLSChallenge(context.TODO(), req)
+		s.Require().NoError(err)
+		s.Require().NotNil(resp)
+
+		// Parse trust info
+		trustInfo := &v1.TrustInfo{}
+		err = trustInfo.UnmarshalVTUnsafe(resp.GetTrustInfoSerialized())
+		s.Require().NoError(err)
+
+		// Verify primary certificate chain
+		s.Require().Len(trustInfo.GetCertChain(), 2)
+		s.Equal(validChallengeToken, trustInfo.GetSensorChallenge())
+		s.NotEmpty(trustInfo.GetCentralChallenge())
+
+		// Verify secondary certificate chain and signature are present
+		s.Require().Len(trustInfo.GetSecondaryCertChain(), 2)
+		s.NotEmpty(resp.GetSignatureSecondaryCa())
+		s.NotEqual(trustInfo.GetCertChain()[0], trustInfo.GetSecondaryCertChain()[0])
+	})
+
+	s.Run("with broken secondary CA", func() {
+		mockProvider := &testCertificateProvider{
+			primaryCA:           primaryCA,
+			secondaryCA:         secondaryCA,
+			primaryLeafCert:     primaryLeafCert,
+			shouldFailSecondary: true,
+		}
+
+		service := &serviceImpl{
+			certProvider: mockProvider,
+		}
+
+		req := &v1.TLSChallengeRequest{
+			ChallengeToken: validChallengeToken,
+		}
+
+		resp, err := service.TLSChallenge(context.TODO(), req)
+		s.Require().NoError(err) // broken secondary CA should not fail the entire request
+		s.Require().NotNil(resp)
+
+		trustInfo := &v1.TrustInfo{}
+		err = trustInfo.UnmarshalVTUnsafe(resp.GetTrustInfoSerialized())
+		s.Require().NoError(err)
+
+		s.Require().Len(trustInfo.GetCertChain(), 2)
+		s.Empty(trustInfo.GetSecondaryCertChain())
+		s.Empty(resp.GetSignatureSecondaryCa())
+	})
 }

--- a/central/securedclustercertgen/certificates.go
+++ b/central/securedclustercertgen/certificates.go
@@ -1,6 +1,8 @@
 package securedclustercertgen
 
 import (
+	"os"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
@@ -48,7 +50,10 @@ func IssueSecuredClusterCerts(namespace string, clusterID string, sensorSupports
 	if sensorSupportsCARotation {
 		secondaryCA, err = mtls.SecondaryCAForSigning()
 		if err != nil {
-			secondaryCA = nil // If loading secondary CA fails, just use nil
+			if !errors.Is(err, os.ErrNotExist) {
+				log.Warnf("Failed to load secondary CA for signing (certificates will still be issued): %v", err)
+			}
+			secondaryCA = nil
 		}
 	}
 

--- a/central/securedclustercertgen/certificates.go
+++ b/central/securedclustercertgen/certificates.go
@@ -6,8 +6,13 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/certgen"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/set"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 // secretDataMap represents data stored as part of a secret.
@@ -25,14 +30,37 @@ var securedClusterServiceTypes = set.NewFrozenSet[storage.ServiceType](
 var allSupportedServiceTypes = securedClusterServiceTypes.Union(localScannerServiceTypes)
 
 type certIssuerImpl struct {
-	serviceTypes set.FrozenSet[storage.ServiceType]
+	serviceTypes             set.FrozenSet[storage.ServiceType]
+	signingCA                mtls.CA
+	sensorSupportsCARotation bool
 }
 
 // IssueSecuredClusterCerts issues certificates for all the services of a secured cluster (including local scanner).
-func IssueSecuredClusterCerts(namespace string, clusterID string) (*storage.TypedServiceCertificateSet, error) {
-	certIssuer := certIssuerImpl{
-		serviceTypes: allSupportedServiceTypes,
+func IssueSecuredClusterCerts(namespace string, clusterID string, sensorSupportsCARotation bool) (*storage.TypedServiceCertificateSet, error) {
+	primaryCA, err := mtls.CAForSigning()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load CA for signing")
 	}
+	signingCA := primaryCA
+
+	if sensorSupportsCARotation {
+		secondaryCA, err := mtls.SecondaryCAForSigning()
+		if err == nil {
+			primaryCACert := primaryCA.Certificate()
+			secondaryCACert := secondaryCA.Certificate()
+
+			if secondaryCACert.NotAfter.After(primaryCACert.NotAfter) {
+				signingCA = secondaryCA
+			}
+		}
+	}
+
+	certIssuer := certIssuerImpl{
+		serviceTypes:             allSupportedServiceTypes,
+		signingCA:                signingCA,
+		sensorSupportsCARotation: sensorSupportsCARotation,
+	}
+
 	return certIssuer.issueCertificates(namespace, clusterID)
 }
 
@@ -45,8 +73,15 @@ func IssueLocalScannerCerts(namespace string, clusterID string) (*storage.TypedS
 		serviceTypes = localScannerServiceTypes
 	}
 
+	ca, err := mtls.CAForSigning()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load CA for signing")
+	}
+
 	certIssuer := certIssuerImpl{
-		serviceTypes: serviceTypes,
+		serviceTypes:             serviceTypes,
+		signingCA:                ca,
+		sensorSupportsCARotation: false, // Local scanner doesn't need CA rotation support
 	}
 
 	return certIssuer.issueCertificates(namespace, clusterID)
@@ -81,6 +116,18 @@ func (c *certIssuerImpl) issueCertificates(namespace string, clusterID string) (
 		CaPem:        caPem,
 		ServiceCerts: serviceCerts,
 	}
+
+	// Populate CA bundle for rotation-capable Sensors
+	if c.sensorSupportsCARotation {
+		caBundlePem, err := buildCABundle()
+		if err != nil {
+			log.Warnf("Failed to build CA bundle for rotation-capable Sensor (certificates will still be issued): %v", err)
+		} else {
+			certsSet.CaBundlePem = caBundlePem
+			log.Debug("Populated CA bundle for rotation-capable Sensor")
+		}
+	}
+
 	return &certsSet, nil
 }
 
@@ -106,21 +153,37 @@ func (c *certIssuerImpl) generateServiceCertMap(serviceType storage.ServiceType,
 			serviceType)
 	}
 
-	ca, err := mtls.CAForSigning()
-	if err != nil {
-		return nil, errors.Wrap(err, "could not load CA for signing")
-	}
-
 	numServiceCertDataEntries := 3 // cert pem + key pem + ca pem
 	fileMap := make(secretDataMap, numServiceCertDataEntries)
 	subject := mtls.NewSubject(clusterID, serviceType)
 	issueOpts := []mtls.IssueCertOption{
 		mtls.WithNamespace(namespace),
 	}
-	if err := certgen.IssueServiceCert(fileMap, ca, subject, "", issueOpts...); err != nil {
+	if err := certgen.IssueServiceCert(fileMap, c.signingCA, subject, "", issueOpts...); err != nil {
 		return nil, errors.Wrap(err, "error generating service certificate")
 	}
-	certgen.AddCACertToFileMap(fileMap, ca)
+	certgen.AddCACertToFileMap(fileMap, c.signingCA)
 
 	return fileMap, nil
+}
+
+// buildCABundle creates a PEM-concatenated CA bundle from available CA certificates.
+// This bundle contains all CA certificates that Central trusts for CA rotation.
+func buildCABundle() ([]byte, error) {
+	var allCertsPEM []byte
+
+	// Always include the primary CA
+	primaryCA, err := mtls.CAForSigning()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not load primary CA for signing")
+	}
+	allCertsPEM = append(allCertsPEM, primaryCA.CertPEM()...)
+
+	// Include secondary CA if it exists
+	secondaryCA, err := mtls.SecondaryCAForSigning()
+	if err == nil {
+		allCertsPEM = append(allCertsPEM, secondaryCA.CertPEM()...)
+	}
+
+	return allCertsPEM, nil
 }

--- a/central/securedclustercertgen/certificates_test.go
+++ b/central/securedclustercertgen/certificates_test.go
@@ -2,10 +2,13 @@ package securedclustercertgen
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
+	"github.com/cloudflare/cfssl/initca"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/certgen"
 	"github.com/stackrox/rox/pkg/features"
@@ -23,6 +26,7 @@ const (
 
 func TestHandler(t *testing.T) {
 	suite.Run(t, new(securedClusterCertGenSuite))
+	suite.Run(t, new(securedClusterCARotationSuite))
 }
 
 type securedClusterCertGenSuite struct {
@@ -297,4 +301,231 @@ func (s *securedClusterCertGenSuite) TestServiceIssueSecuredClusterCerts() {
 			s.Empty(expectedServiceTypes.AsSlice(), "[%s] not all expected certificates were returned by IssueSecuredClusterCerts", tcName)
 		})
 	}
+}
+
+type securedClusterCARotationSuite struct {
+	suite.Suite
+	primaryCA   mtls.CA
+	secondaryCA mtls.CA
+}
+
+func (s *securedClusterCARotationSuite) SetupTest() {
+	// Load the standard test CA as primary
+	err := testutilsMTLS.LoadTestMTLSCerts(s.T())
+	s.Require().NoError(err)
+
+	s.primaryCA, err = mtls.CAForSigning()
+	s.Require().NoError(err)
+
+	// Create a test secondary CA with a future expiration
+	s.secondaryCA = s.createTestCA("Test Secondary CA", "87600h") // 10 years
+}
+
+func (s *securedClusterCARotationSuite) createTestCA(commonName, expiry string) mtls.CA {
+	caCert, _, caKey, err := initca.New(&csr.CertificateRequest{
+		CN:         commonName,
+		KeyRequest: csr.NewKeyRequest(),
+		CA: &csr.CAConfig{
+			Expiry: expiry,
+		},
+	})
+	s.Require().NoError(err)
+
+	ca, err := mtls.LoadCAForSigning(caCert, caKey)
+	s.Require().NoError(err)
+	return ca
+}
+
+func (s *securedClusterCARotationSuite) verifyServiceCertsSignedByCA(caCertPEM []byte, certs *storage.TypedServiceCertificateSet) {
+	// Verify that the signing CA certificate matches the primary CA
+	s.Equal(caCertPEM, certs.GetCaPem())
+
+	// Verify that all service certs are actually signed by the expected CA
+	caCert, err := helpers.ParseCertificatePEM(caCertPEM)
+	s.Require().NoError(err)
+	for _, serviceCert := range certs.GetServiceCerts() {
+		certPEM := serviceCert.GetCert().GetCertPem()
+		cert, err := helpers.ParseCertificatePEM(certPEM)
+		s.Require().NoError(err)
+		s.Equal(caCert.Subject, cert.Issuer, "Service cert not signed by expected CA")
+	}
+}
+
+func (s *securedClusterCARotationSuite) TestIssueSecuredClusterCertsWithCAs() {
+	// Create an older secondary CA that expires before the primary CA
+	olderSecondaryCA := s.createTestCA("Older Secondary CA", "1h") // 1 hour
+
+	testCases := []struct {
+		name                     string
+		sensorSupportsCARotation bool
+		primaryCA                mtls.CA
+		secondaryCA              mtls.CA
+		expectedSigningCA        mtls.CA
+		expectedBundleCertCount  int
+		shouldHaveBundle         bool
+	}{
+		{
+			name:                     "no CA rotation support",
+			sensorSupportsCARotation: false,
+			primaryCA:                s.primaryCA,
+			secondaryCA:              s.secondaryCA,
+			expectedSigningCA:        s.primaryCA,
+			expectedBundleCertCount:  0, // No bundle when rotation disabled
+			shouldHaveBundle:         false,
+		},
+		{
+			name:                     "primary CA only",
+			sensorSupportsCARotation: true,
+			primaryCA:                s.primaryCA,
+			secondaryCA:              nil,
+			expectedSigningCA:        s.primaryCA,
+			expectedBundleCertCount:  1,
+			shouldHaveBundle:         true,
+		},
+		{
+			name:                     "secondary CA newer than primary",
+			sensorSupportsCARotation: true,
+			primaryCA:                s.primaryCA,
+			secondaryCA:              s.secondaryCA,
+			expectedSigningCA:        s.secondaryCA,
+			expectedBundleCertCount:  2,
+			shouldHaveBundle:         true,
+		},
+		{
+			name:                     "secondary CA older than primary",
+			sensorSupportsCARotation: true,
+			primaryCA:                s.primaryCA,
+			secondaryCA:              olderSecondaryCA,
+			expectedSigningCA:        s.primaryCA,
+			expectedBundleCertCount:  2,
+			shouldHaveBundle:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			certs, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, tc.sensorSupportsCARotation, tc.primaryCA, tc.secondaryCA)
+			s.Require().NoError(err)
+			s.Require().NotNil(certs)
+			s.Require().NotEmpty(certs.GetCaPem())
+			s.Require().NotEmpty(certs.GetServiceCerts())
+
+			// Verify the expected CA was used for signing
+			s.verifyServiceCertsSignedByCA(tc.expectedSigningCA.CertPEM(), certs)
+
+			// Verify CA bundle content
+			if tc.shouldHaveBundle {
+				s.Require().NotEmpty(certs.GetCaBundlePem())
+				caBundleString := string(certs.GetCaBundlePem())
+				s.Contains(caBundleString, "BEGIN CERTIFICATE")
+				s.Contains(caBundleString, "END CERTIFICATE")
+
+				certCount := strings.Count(caBundleString, "BEGIN CERTIFICATE")
+				s.Equal(tc.expectedBundleCertCount, certCount)
+
+				if tc.expectedBundleCertCount >= 1 {
+					// Primary CA should always be in the bundle
+					s.Contains(caBundleString, string(tc.primaryCA.CertPEM()))
+				}
+				if tc.expectedBundleCertCount >= 2 && tc.secondaryCA != nil {
+					// Secondary CA should be in the bundle when present
+					s.Contains(caBundleString, string(tc.secondaryCA.CertPEM()))
+				}
+			} else {
+				s.Empty(certs.GetCaBundlePem())
+			}
+		})
+	}
+}
+
+func (s *securedClusterCARotationSuite) TestBuildCABundle() {
+	s.Run("primary CA only", func() {
+		issuer := certIssuerImpl{
+			serviceTypes:             allSupportedServiceTypes,
+			signingCA:                s.primaryCA,
+			secondaryCA:              nil,
+			sensorSupportsCARotation: true,
+		}
+
+		bundle, err := issuer.buildCABundle()
+		s.Require().NoError(err)
+		s.Require().NotEmpty(bundle)
+
+		bundleString := string(bundle)
+		s.Contains(bundleString, "BEGIN CERTIFICATE")
+		s.Contains(bundleString, "END CERTIFICATE")
+
+		certCount := strings.Count(bundleString, "BEGIN CERTIFICATE")
+		s.Equal(1, certCount)
+
+		s.Contains(bundleString, string(s.primaryCA.CertPEM()))
+	})
+
+	s.Run("primary and secondary CA", func() {
+		issuer := certIssuerImpl{
+			serviceTypes:             allSupportedServiceTypes,
+			signingCA:                s.primaryCA,
+			secondaryCA:              s.secondaryCA,
+			sensorSupportsCARotation: true,
+		}
+
+		bundle, err := issuer.buildCABundle()
+		s.Require().NoError(err)
+		s.Require().NotEmpty(bundle)
+
+		bundleString := string(bundle)
+		s.Contains(bundleString, "BEGIN CERTIFICATE")
+		s.Contains(bundleString, "END CERTIFICATE")
+
+		certCount := strings.Count(bundleString, "BEGIN CERTIFICATE")
+		s.Equal(2, certCount)
+
+		s.Contains(bundleString, string(s.primaryCA.CertPEM()))
+		s.Contains(bundleString, string(s.secondaryCA.CertPEM()))
+	})
+}
+
+func (s *securedClusterCARotationSuite) TestServiceCertificateGeneration() {
+	certs, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, true, s.primaryCA, s.secondaryCA)
+	s.Require().NoError(err)
+	s.Require().NotNil(certs)
+
+	// Verify all expected service types are present
+	expectedServiceTypes := allSupportedServiceTypes.Unfreeze()
+	for _, cert := range certs.ServiceCerts {
+		certService := cert.GetServiceType()
+		s.Contains(expectedServiceTypes, certService)
+		expectedServiceTypes.Remove(certService)
+
+		// Verify certificate has required fields
+		s.NotEmpty(cert.GetCert().GetCertPem())
+		s.NotEmpty(cert.GetCert().GetKeyPem())
+
+		// Verify the certificate can be parsed
+		parsedCert, err := helpers.ParseCertificatePEM(cert.GetCert().GetCertPem())
+		s.Require().NoError(err)
+		s.NotNil(parsedCert)
+	}
+
+	// Verify all expected service types were generated
+	s.Empty(expectedServiceTypes.AsSlice())
+}
+
+func (s *securedClusterCARotationSuite) TestErrorHandling() {
+	s.Run("empty namespace", func() {
+		_, err := IssueSecuredClusterCertsWithCAs("", clusterID, true, s.primaryCA, s.secondaryCA)
+		s.Error(err)
+		s.Contains(err.Error(), "namespace is required")
+	})
+
+	s.Run("empty cluster ID", func() {
+		_, err := IssueSecuredClusterCertsWithCAs(namespace, "", true, s.primaryCA, s.secondaryCA)
+		s.Error(err)
+	})
+
+	s.Run("nil primary CA", func() {
+		_, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, true, nil, s.secondaryCA)
+		s.Error(err)
+		s.Contains(err.Error(), "primary CA is required")
+	})
 }

--- a/central/securedclustercertgen/certificates_test.go
+++ b/central/securedclustercertgen/certificates_test.go
@@ -44,8 +44,13 @@ func (s *securedClusterCertGenSuite) TestCertMapContainsExpectedFiles() {
 		{storage.ServiceType_SENSOR_SERVICE, true},
 	}
 
+	ca, err := mtls.CAForSigning()
+	s.Require().NoError(err)
+
 	certIssuer := certIssuerImpl{
-		serviceTypes: localScannerServiceTypes,
+		serviceTypes:             localScannerServiceTypes,
+		signingCA:                ca,
+		sensorSupportsCARotation: false,
 	}
 	for _, tc := range testCases {
 		s.Run(tc.service.String(), func() {
@@ -70,8 +75,13 @@ func (s *securedClusterCertGenSuite) TestValidateServiceCertificate() {
 		storage.ServiceType_SCANNER_DB_SERVICE,
 	}
 
+	ca, err := mtls.CAForSigning()
+	s.Require().NoError(err)
+
 	certIssuer := certIssuerImpl{
-		serviceTypes: localScannerServiceTypes,
+		serviceTypes:             localScannerServiceTypes,
+		signingCA:                ca,
+		sensorSupportsCARotation: false,
 	}
 	for _, serviceType := range testCases {
 		s.Run(serviceType.String(), func() {
@@ -100,8 +110,13 @@ func (s *securedClusterCertGenSuite) TestLocalScannerCertificateGeneration() {
 			[]string{"scanner-v4-db.stackrox", "scanner-v4-db.stackrox.svc", "scanner-v4-db.namespace", "scanner-v4-db.namespace.svc"}},
 	}
 
+	ca, err := mtls.CAForSigning()
+	s.Require().NoError(err)
+
 	certIssuer := certIssuerImpl{
-		serviceTypes: localScannerServiceTypes,
+		serviceTypes:             localScannerServiceTypes,
+		signingCA:                ca,
+		sensorSupportsCARotation: false,
 	}
 	for _, tc := range testCases {
 		s.Run(tc.service.String(), func() {
@@ -138,8 +153,13 @@ func (s *securedClusterCertGenSuite) TestSecuredClusterCertificateGeneration() {
 			[]string{"admission-control.stackrox", "admission-control.stackrox.svc", "admission-control.namespace", "admission-control.namespace.svc"}},
 	}
 
+	ca, err := mtls.CAForSigning()
+	s.Require().NoError(err)
+
 	certIssuer := certIssuerImpl{
-		serviceTypes: securedClusterServiceTypes,
+		serviceTypes:             securedClusterServiceTypes,
+		signingCA:                ca,
+		sensorSupportsCARotation: false,
 	}
 	for _, tc := range testCases {
 		s.Run(tc.service.String(), func() {
@@ -256,7 +276,7 @@ func (s *securedClusterCertGenSuite) TestServiceIssueSecuredClusterCerts() {
 
 	for tcName, tc := range testCases {
 		s.Run(tcName, func() {
-			certs, err := IssueSecuredClusterCerts(tc.namespace, tc.clusterID)
+			certs, err := IssueSecuredClusterCerts(tc.namespace, tc.clusterID, false)
 			if tc.shouldFail {
 				s.Require().Error(err)
 				return

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -400,7 +400,8 @@ func (c *sensorConnection) processIssueSecuredClusterCertsRequest(ctx context.Co
 		err = errors.New("requestID is required to issue the certificates for a Secured Cluster")
 	} else {
 		var certificates *storage.TypedServiceCertificateSet
-		certificates, err = securedclustercertgen.IssueSecuredClusterCerts(namespace, clusterID)
+		certificates, err = securedclustercertgen.IssueSecuredClusterCerts(namespace, clusterID,
+			c.capabilities.Contains(centralsensor.SensorCARotationSupported))
 		response = &central.IssueSecuredClusterCertsResponse{
 			RequestId: requestID,
 			Response: &central.IssueSecuredClusterCertsResponse_Certificates{

--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -154,10 +154,8 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 
 		if err := safe.RunE(func() error {
 			sensorNamespace := sensorHello.GetDeploymentIdentification().GetAppNamespace()
-			sensorCapabilities := set.NewSet(sliceutils.
-				FromStringSlice[centralsensor.SensorCapability](sensorHello.GetCapabilities()...)...)
-			certificateSet, err := securedclustercertgen.IssueSecuredClusterCerts(sensorNamespace, clusterID,
-				sensorCapabilities.Contains(centralsensor.SensorCARotationSupported))
+			certificateSet, err := securedclustercertgen.IssueSecuredClusterCerts(
+				sensorNamespace, clusterID, isCARotationSupported(sensorHello))
 			if err != nil {
 				return errors.Wrapf(err, "issuing a certificate bundle for cluster %s", cluster.GetName())
 			}
@@ -193,6 +191,12 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 	log.Infof("Cluster %s (%s) has successfully connected to Central", cluster.GetName(), cluster.GetId())
 
 	return s.manager.HandleConnection(server.Context(), sensorHello, cluster, eventPipeline, server)
+}
+
+func isCARotationSupported(sensorHello *central.SensorHello) bool {
+	capabilities := sliceutils.FromStringSlice[centralsensor.SensorCapability](sensorHello.GetCapabilities()...)
+	capSet := set.NewSet(capabilities...)
+	return capSet.Contains(centralsensor.SensorCARotationSupported)
 }
 
 func getCertExpiryStatus(identity authn.Identity) (*storage.ClusterCertExpiryStatus, error) {

--- a/central/sensor/service/service_impl_test.go
+++ b/central/sensor/service/service_impl_test.go
@@ -76,6 +76,48 @@ func TestGetCertExpiryStatus(t *testing.T) {
 	}
 }
 
+func TestIsCARotationSupported(t *testing.T) {
+	testCases := map[string]struct {
+		capabilities []string
+		expected     bool
+	}{
+		"should return true when CA rotation capability is present": {
+			capabilities: []string{
+				string(centralsensor.ComplianceInNodesCap),
+				string(centralsensor.SensorCARotationSupported),
+				string(centralsensor.ScannerV4Supported),
+			},
+			expected: true,
+		},
+		"should return false when CA rotation capability is missing": {
+			capabilities: []string{
+				string(centralsensor.ComplianceInNodesCap),
+				string(centralsensor.ScannerV4Supported),
+			},
+			expected: false,
+		},
+		"should return false when no capabilities are provided": {
+			capabilities: []string{},
+			expected:     false,
+		},
+		"should return false when nil capabilities": {
+			capabilities: nil,
+			expected:     false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			sensorHello := &central.SensorHello{
+				Capabilities: tc.capabilities,
+			}
+
+			result := isCARotationSupported(sensorHello)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 // CRS Test Suite.
 
 type crsTestSuite struct {

--- a/central/tlsconfig/manager_impl.go
+++ b/central/tlsconfig/manager_impl.go
@@ -45,6 +45,11 @@ func newManager(namespace string) (*managerImpl, error) {
 	}
 	trustRoots := []*x509.Certificate{ca}
 
+	secondaryCA, _, err := mtls.SecondaryCACert()
+	if err == nil {
+		trustRoots = append(trustRoots, secondaryCA)
+	}
+
 	internalCerts, err := getInternalCertificates(namespace)
 	if err != nil {
 		return nil, err

--- a/generated/api/v1/metadata_service.pb.go
+++ b/generated/api/v1/metadata_service.pb.go
@@ -340,7 +340,7 @@ type TLSChallengeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// signed data which is returned to the caller, is validated against the signature
 	TrustInfoSerialized []byte `protobuf:"bytes,1,opt,name=trust_info_serialized,json=trustInfoSerialized,proto3" json:"trust_info_serialized,omitempty"`
-	// signature signature (by key from TrustInfo.cert_chain[0])
+	// primary signature (by key from TrustInfo.cert_chain[0])
 	Signature []byte `protobuf:"bytes,2,opt,name=signature,proto3" json:"signature,omitempty"`
 	// optional signature by key from TrustInfo.secondary_cert_chain[0].
 	SignatureSecondaryCa []byte `protobuf:"bytes,3,opt,name=signature_secondary_ca,json=signatureSecondaryCa,proto3" json:"signature_secondary_ca,omitempty"`

--- a/generated/api/v1/metadata_service.pb.go
+++ b/generated/api/v1/metadata_service.pb.go
@@ -257,16 +257,18 @@ func (x *Metadata) GetLicenseStatus() Metadata_LicenseStatus {
 
 type TrustInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// holds the certificate chain hold by central
+	// holds the certificate chain held by Central
 	CertChain [][]byte `protobuf:"bytes,1,rep,name=cert_chain,json=certChain,proto3" json:"cert_chain,omitempty"`
-	// sensor challenge string
+	// Sensor challenge string
 	SensorChallenge string `protobuf:"bytes,2,opt,name=sensor_challenge,json=sensorChallenge,proto3" json:"sensor_challenge,omitempty"`
-	// central challenge string
+	// Central challenge string
 	CentralChallenge string `protobuf:"bytes,3,opt,name=central_challenge,json=centralChallenge,proto3" json:"central_challenge,omitempty"`
-	// additional CA certs configured in central in DER format
+	// additional CA certs configured in Central in DER format
 	AdditionalCas [][]byte `protobuf:"bytes,4,rep,name=additional_cas,json=additionalCas,proto3" json:"additional_cas,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// an optional certificate chain, if Central has a secondary CA
+	SecondaryCertChain [][]byte `protobuf:"bytes,5,rep,name=secondary_cert_chain,json=secondaryCertChain,proto3" json:"secondary_cert_chain,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *TrustInfo) Reset() {
@@ -327,13 +329,23 @@ func (x *TrustInfo) GetAdditionalCas() [][]byte {
 	return nil
 }
 
+func (x *TrustInfo) GetSecondaryCertChain() [][]byte {
+	if x != nil {
+		return x.SecondaryCertChain
+	}
+	return nil
+}
+
 type TLSChallengeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// signed data which is returned to the caller, is validated against the signature
 	TrustInfoSerialized []byte `protobuf:"bytes,1,opt,name=trust_info_serialized,json=trustInfoSerialized,proto3" json:"trust_info_serialized,omitempty"`
-	Signature           []byte `protobuf:"bytes,2,opt,name=signature,proto3" json:"signature,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// signature signature (by key from TrustInfo.cert_chain[0])
+	Signature []byte `protobuf:"bytes,2,opt,name=signature,proto3" json:"signature,omitempty"`
+	// optional signature by key from TrustInfo.secondary_cert_chain[0].
+	SignatureSecondaryCa []byte `protobuf:"bytes,3,opt,name=signature_secondary_ca,json=signatureSecondaryCa,proto3" json:"signature_secondary_ca,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *TLSChallengeResponse) Reset() {
@@ -376,6 +388,13 @@ func (x *TLSChallengeResponse) GetTrustInfoSerialized() []byte {
 func (x *TLSChallengeResponse) GetSignature() []byte {
 	if x != nil {
 		return x.Signature
+	}
+	return nil
+}
+
+func (x *TLSChallengeResponse) GetSignatureSecondaryCa() []byte {
+	if x != nil {
+		return x.SignatureSecondaryCa
 	}
 	return nil
 }
@@ -645,16 +664,18 @@ const file_api_v1_metadata_service_proto_rawDesc = "" +
 	"\aEXPIRED\x10\x02\x1a\x02\b\x01\x12\x12\n" +
 	"\n" +
 	"RESTARTING\x10\x03\x1a\x02\b\x01\x12\t\n" +
-	"\x05VALID\x10\x04\"\xa9\x01\n" +
+	"\x05VALID\x10\x04\"\xdb\x01\n" +
 	"\tTrustInfo\x12\x1d\n" +
 	"\n" +
 	"cert_chain\x18\x01 \x03(\fR\tcertChain\x12)\n" +
 	"\x10sensor_challenge\x18\x02 \x01(\tR\x0fsensorChallenge\x12+\n" +
 	"\x11central_challenge\x18\x03 \x01(\tR\x10centralChallenge\x12%\n" +
-	"\x0eadditional_cas\x18\x04 \x03(\fR\radditionalCas\"h\n" +
+	"\x0eadditional_cas\x18\x04 \x03(\fR\radditionalCas\x120\n" +
+	"\x14secondary_cert_chain\x18\x05 \x03(\fR\x12secondaryCertChain\"\x9e\x01\n" +
 	"\x14TLSChallengeResponse\x122\n" +
 	"\x15trust_info_serialized\x18\x01 \x01(\fR\x13trustInfoSerialized\x12\x1c\n" +
-	"\tsignature\x18\x02 \x01(\fR\tsignature\">\n" +
+	"\tsignature\x18\x02 \x01(\fR\tsignature\x124\n" +
+	"\x16signature_secondary_ca\x18\x03 \x01(\fR\x14signatureSecondaryCa\">\n" +
 	"\x13TLSChallengeRequest\x12'\n" +
 	"\x0fchallenge_token\x18\x01 \x01(\tR\x0echallengeToken\"\x9b\x02\n" +
 	"\x0eDatabaseStatus\x12-\n" +

--- a/generated/api/v1/metadata_service.swagger.json
+++ b/generated/api/v1/metadata_service.swagger.json
@@ -315,7 +315,7 @@
         "signature": {
           "type": "string",
           "format": "byte",
-          "title": "signature signature (by key from TrustInfo.cert_chain[0])"
+          "title": "primary signature (by key from TrustInfo.cert_chain[0])"
         },
         "signatureSecondaryCa": {
           "type": "string",

--- a/generated/api/v1/metadata_service.swagger.json
+++ b/generated/api/v1/metadata_service.swagger.json
@@ -314,7 +314,13 @@
         },
         "signature": {
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "title": "signature signature (by key from TrustInfo.cert_chain[0])"
+        },
+        "signatureSecondaryCa": {
+          "type": "string",
+          "format": "byte",
+          "description": "optional signature by key from TrustInfo.secondary_cert_chain[0]."
         }
       }
     }

--- a/generated/api/v1/metadata_service_vtproto.pb.go
+++ b/generated/api/v1/metadata_service_vtproto.pb.go
@@ -66,6 +66,15 @@ func (m *TrustInfo) CloneVT() *TrustInfo {
 		}
 		r.AdditionalCas = tmpContainer
 	}
+	if rhs := m.SecondaryCertChain; rhs != nil {
+		tmpContainer := make([][]byte, len(rhs))
+		for k, v := range rhs {
+			tmpBytes := make([]byte, len(v))
+			copy(tmpBytes, v)
+			tmpContainer[k] = tmpBytes
+		}
+		r.SecondaryCertChain = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -91,6 +100,11 @@ func (m *TLSChallengeResponse) CloneVT() *TLSChallengeResponse {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
 		r.Signature = tmpBytes
+	}
+	if rhs := m.SignatureSecondaryCa; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.SignatureSecondaryCa = tmpBytes
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -242,6 +256,15 @@ func (this *TrustInfo) EqualVT(that *TrustInfo) bool {
 			return false
 		}
 	}
+	if len(this.SecondaryCertChain) != len(that.SecondaryCertChain) {
+		return false
+	}
+	for i, vx := range this.SecondaryCertChain {
+		vy := that.SecondaryCertChain[i]
+		if string(vx) != string(vy) {
+			return false
+		}
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -262,6 +285,9 @@ func (this *TLSChallengeResponse) EqualVT(that *TLSChallengeResponse) bool {
 		return false
 	}
 	if string(this.Signature) != string(that.Signature) {
+		return false
+	}
+	if string(this.SignatureSecondaryCa) != string(that.SignatureSecondaryCa) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -469,6 +495,15 @@ func (m *TrustInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.SecondaryCertChain) > 0 {
+		for iNdEx := len(m.SecondaryCertChain) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SecondaryCertChain[iNdEx])
+			copy(dAtA[i:], m.SecondaryCertChain[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SecondaryCertChain[iNdEx])))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
 	if len(m.AdditionalCas) > 0 {
 		for iNdEx := len(m.AdditionalCas) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.AdditionalCas[iNdEx])
@@ -533,6 +568,13 @@ func (m *TLSChallengeResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.SignatureSecondaryCa) > 0 {
+		i -= len(m.SignatureSecondaryCa)
+		copy(dAtA[i:], m.SignatureSecondaryCa)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SignatureSecondaryCa)))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.Signature) > 0 {
 		i -= len(m.Signature)
@@ -819,6 +861,12 @@ func (m *TrustInfo) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
+	if len(m.SecondaryCertChain) > 0 {
+		for _, b := range m.SecondaryCertChain {
+			l = len(b)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -834,6 +882,10 @@ func (m *TLSChallengeResponse) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.Signature)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.SignatureSecondaryCa)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -1234,6 +1286,38 @@ func (m *TrustInfo) UnmarshalVT(dAtA []byte) error {
 			m.AdditionalCas = append(m.AdditionalCas, make([]byte, postIndex-iNdEx))
 			copy(m.AdditionalCas[len(m.AdditionalCas)-1], dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SecondaryCertChain", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SecondaryCertChain = append(m.SecondaryCertChain, make([]byte, postIndex-iNdEx))
+			copy(m.SecondaryCertChain[len(m.SecondaryCertChain)-1], dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -1351,6 +1435,40 @@ func (m *TLSChallengeResponse) UnmarshalVT(dAtA []byte) error {
 			m.Signature = append(m.Signature[:0], dAtA[iNdEx:postIndex]...)
 			if m.Signature == nil {
 				m.Signature = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SignatureSecondaryCa", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SignatureSecondaryCa = append(m.SignatureSecondaryCa[:0], dAtA[iNdEx:postIndex]...)
+			if m.SignatureSecondaryCa == nil {
+				m.SignatureSecondaryCa = []byte{}
 			}
 			iNdEx = postIndex
 		default:
@@ -2166,6 +2284,37 @@ func (m *TrustInfo) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.AdditionalCas = append(m.AdditionalCas, dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SecondaryCertChain", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SecondaryCertChain = append(m.SecondaryCertChain, dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2278,6 +2427,37 @@ func (m *TLSChallengeResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Signature = dAtA[iNdEx:postIndex]
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SignatureSecondaryCa", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SignatureSecondaryCa = dAtA[iNdEx:postIndex]
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/storage/service_identity.pb.go
+++ b/generated/storage/service_identity.pb.go
@@ -322,9 +322,11 @@ func (x *TypedServiceCertificate) GetCert() *ServiceCertificate {
 }
 
 type TypedServiceCertificateSet struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
-	CaPem         []byte                     `protobuf:"bytes,1,opt,name=ca_pem,json=caPem,proto3" json:"ca_pem,omitempty"`
-	ServiceCerts  []*TypedServiceCertificate `protobuf:"bytes,2,rep,name=service_certs,json=serviceCerts,proto3" json:"service_certs,omitempty"`
+	state        protoimpl.MessageState     `protogen:"open.v1"`
+	CaPem        []byte                     `protobuf:"bytes,1,opt,name=ca_pem,json=caPem,proto3" json:"ca_pem,omitempty"`
+	ServiceCerts []*TypedServiceCertificate `protobuf:"bytes,2,rep,name=service_certs,json=serviceCerts,proto3" json:"service_certs,omitempty"`
+	// Optional: all CA certificates that Central trusts (primary + secondary)
+	CaBundlePem   []byte `protobuf:"bytes,3,opt,name=ca_bundle_pem,json=caBundlePem,proto3" json:"ca_bundle_pem,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -373,6 +375,13 @@ func (x *TypedServiceCertificateSet) GetServiceCerts() []*TypedServiceCertificat
 	return nil
 }
 
+func (x *TypedServiceCertificateSet) GetCaBundlePem() []byte {
+	if x != nil {
+		return x.CaBundlePem
+	}
+	return nil
+}
+
 var File_storage_service_identity_proto protoreflect.FileDescriptor
 
 const file_storage_service_identity_proto_rawDesc = "" +
@@ -391,10 +400,11 @@ const file_storage_service_identity_proto_rawDesc = "" +
 	"\akey_pem\x18\x02 \x01(\fR\x06keyPem\"\x83\x01\n" +
 	"\x17TypedServiceCertificate\x127\n" +
 	"\fservice_type\x18\x01 \x01(\x0e2\x14.storage.ServiceTypeR\vserviceType\x12/\n" +
-	"\x04cert\x18\x02 \x01(\v2\x1b.storage.ServiceCertificateR\x04cert\"z\n" +
+	"\x04cert\x18\x02 \x01(\v2\x1b.storage.ServiceCertificateR\x04cert\"\x9e\x01\n" +
 	"\x1aTypedServiceCertificateSet\x12\x15\n" +
 	"\x06ca_pem\x18\x01 \x01(\fR\x05caPem\x12E\n" +
-	"\rservice_certs\x18\x02 \x03(\v2 .storage.TypedServiceCertificateR\fserviceCerts*\xd1\x03\n" +
+	"\rservice_certs\x18\x02 \x03(\v2 .storage.TypedServiceCertificateR\fserviceCerts\x12\"\n" +
+	"\rca_bundle_pem\x18\x03 \x01(\fR\vcaBundlePem*\xd1\x03\n" +
 	"\vServiceType\x12\x13\n" +
 	"\x0fUNKNOWN_SERVICE\x10\x00\x12\x12\n" +
 	"\x0eSENSOR_SERVICE\x10\x01\x12\x13\n" +

--- a/generated/storage/service_identity_vtproto.pb.go
+++ b/generated/storage/service_identity_vtproto.pb.go
@@ -113,6 +113,11 @@ func (m *TypedServiceCertificateSet) CloneVT() *TypedServiceCertificateSet {
 		}
 		r.ServiceCerts = tmpContainer
 	}
+	if rhs := m.CaBundlePem; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.CaBundlePem = tmpBytes
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -250,6 +255,9 @@ func (this *TypedServiceCertificateSet) EqualVT(that *TypedServiceCertificateSet
 				return false
 			}
 		}
+	}
+	if string(this.CaBundlePem) != string(that.CaBundlePem) {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -466,6 +474,13 @@ func (m *TypedServiceCertificateSet) MarshalToSizedBufferVT(dAtA []byte) (int, e
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.CaBundlePem) > 0 {
+		i -= len(m.CaBundlePem)
+		copy(dAtA[i:], m.CaBundlePem)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CaBundlePem)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.ServiceCerts) > 0 {
 		for iNdEx := len(m.ServiceCerts) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := m.ServiceCerts[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
@@ -575,6 +590,10 @@ func (m *TypedServiceCertificateSet) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	l = len(m.CaBundlePem)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1086,6 +1105,40 @@ func (m *TypedServiceCertificateSet) UnmarshalVT(dAtA []byte) error {
 			m.ServiceCerts = append(m.ServiceCerts, &TypedServiceCertificate{})
 			if err := m.ServiceCerts[len(m.ServiceCerts)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CaBundlePem", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CaBundlePem = append(m.CaBundlePem[:0], dAtA[iNdEx:postIndex]...)
+			if m.CaBundlePem == nil {
+				m.CaBundlePem = []byte{}
 			}
 			iNdEx = postIndex
 		default:
@@ -1620,6 +1673,37 @@ func (m *TypedServiceCertificateSet) UnmarshalVTUnsafe(dAtA []byte) error {
 			if err := m.ServiceCerts[len(m.ServiceCerts)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CaBundlePem", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CaBundlePem = dAtA[iNdEx:postIndex]
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -64,6 +64,10 @@ const (
 	// SecuredClusterCertificatesRefresh identifies the capability to maintain the Secured Cluster TLS certificates refreshed
 	SecuredClusterCertificatesRefresh SensorCapability = "SecuredClusterCertificatesRefresh"
 
+	// SensorCARotationSupported identifies the capability of Sensor to connect to a Central that presents a TLS certificate signed
+	// by a different CA than the one that signed Sensor's certificate.
+	SensorCARotationSupported SensorCapability = "SensorCARotationSupported"
+
 	// ClusterRegistrationSecretSupported identifies the capability of Central to register new secured clusters
 	// using a Cluster Registration Secret (CRS).
 	ClusterRegistrationSecretSupported = "ClusterRegistrationSecretSupported"

--- a/pkg/grpc/authn/servicecerttoken/extractor.go
+++ b/pkg/grpc/authn/servicecerttoken/extractor.go
@@ -69,6 +69,11 @@ func NewExtractorWithCertValidation(maxLeeway time.Duration, validator authn.Val
 	trustPool := x509.NewCertPool()
 	trustPool.AddCert(ca)
 
+	secondaryCA, _, err := mtls.SecondaryCACert()
+	if err == nil {
+		trustPool.AddCert(secondaryCA)
+	}
+
 	verifyOpts := x509.VerifyOptions{
 		Roots: trustPool,
 	}

--- a/pkg/mtls/crypto.go
+++ b/pkg/mtls/crypto.go
@@ -53,6 +53,10 @@ const (
 	defaultCACertFilePath = CertsPrefix + CACertFileName
 	// defaultCAKeyFilePath is where the key is stored.
 	defaultCAKeyFilePath = CertsPrefix + CAKeyFileName
+	// defaultSecondaryCACertFilePath is where the secondary CA certificate is stored.
+	defaultSecondaryCACertFilePath = CertsPrefix + SecondaryCACertFileName
+	// defaultSecondaryCAKeyFilePath is where the key of the secondary CA certificate is stored.
+	defaultSecondaryCAKeyFilePath = CertsPrefix + SecondaryCAKeyFileName
 
 	// defaultCertFilePath is where the certificate is stored.
 	defaultCertFilePath = CertsPrefix + ServiceCertFileName
@@ -128,13 +132,27 @@ var (
 	caCertFileContents []byte
 	caCertErr          error
 
+	readSecondaryCACertOnce     sync.Once
+	secondaryCACert             *x509.Certificate
+	secondaryCACertDER          []byte
+	secondaryCACertFileContents []byte
+	secondaryCACertErr          error
+
 	readCAKeyOnce     sync.Once
 	caKeyFileContents []byte
 	caKeyErr          error
 
+	readSecondaryCAKeyOnce     sync.Once
+	secondaryCAKeyFileContents []byte
+	secondaryCAKeyErr          error
+
 	caForSigningOnce sync.Once
 	caForSigning     CA
 	caForSigningErr  error
+
+	secondaryCAForSigningOnce sync.Once
+	secondaryCAForSigning     CA
+	secondaryCAForSigningErr  error
 )
 
 // IssuedCert is a representation of an issued certificate
@@ -176,37 +194,63 @@ func readCAKey() ([]byte, error) {
 
 func readCA() (*x509.Certificate, []byte, []byte, error) {
 	readCACertOnce.Do(func() {
-		caBytes, err := os.ReadFile(caFilePathSetting.Setting())
-		if err != nil {
-			caCertErr = errors.Wrap(err, "reading CA file")
-			return
-		}
-
-		der, err := x509utils.ConvertPEMToDERs(caBytes)
-		if err != nil {
-			caCertErr = errors.Wrap(err, "CA cert could not be decoded")
-			return
-		}
-		if len(der) == 0 {
-			caCertErr = errors.New("reading CA file failed")
-			return
-		}
-
-		cert, err := x509.ParseCertificate(der[0])
-		if err != nil {
-			caCertErr = errors.Wrap(err, "CA cert could not be parsed")
-			return
-		}
-		caCertFileContents = caBytes
-		caCert = cert
-		caCertDER = der[0]
+		caCert, caCertFileContents, caCertDER, caCertErr = readCAFromFile(caFilePathSetting.Setting())
 	})
 	return caCert, caCertFileContents, caCertDER, caCertErr
+}
+
+func readSecondaryCAKey() ([]byte, error) {
+	readSecondaryCAKeyOnce.Do(func() {
+		caKeyBytes, err := os.ReadFile(secondaryCAKeyFilePathSetting.Setting())
+		if err != nil {
+			secondaryCAKeyErr = errors.Wrap(err, "reading secondary CA key")
+			return
+		}
+		secondaryCAKeyFileContents = caKeyBytes
+	})
+	return secondaryCAKeyFileContents, secondaryCAKeyErr
+}
+
+func readSecondaryCA() (*x509.Certificate, []byte, []byte, error) {
+	readSecondaryCACertOnce.Do(func() {
+		secondaryCACert, secondaryCACertFileContents, secondaryCACertDER, secondaryCACertErr = readCAFromFile(
+			secondaryCAFilePathSetting.Setting())
+	})
+	return secondaryCACert, secondaryCACertFileContents, secondaryCACertDER, secondaryCACertErr
+}
+
+func readCAFromFile(filePath string) (*x509.Certificate, []byte, []byte, error) {
+	caBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "reading CA file")
+	}
+
+	der, err := x509utils.ConvertPEMToDERs(caBytes)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "CA cert could not be decoded")
+	}
+	if len(der) == 0 {
+		return nil, nil, nil, errors.New("reading CA file failed")
+	}
+
+	cert, err := x509.ParseCertificate(der[0])
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "CA cert could not be parsed")
+
+	}
+	return cert, caBytes, der[0], nil
 }
 
 // CACert reads the cert from the local file system and returns the cert and the DER encoding.
 func CACert() (*x509.Certificate, []byte, error) {
 	caCert, _, caCertDER, caCertErr := readCA()
+	return caCert, caCertDER, caCertErr
+}
+
+// SecondaryCACert reads the secondary CA cert from the local file system and returns the cert and the DER encoding.
+// Note that the secondary CA cert is optional, and may only be present in Operator-based installations.
+func SecondaryCACert() (*x509.Certificate, []byte, error) {
+	caCert, _, caCertDER, caCertErr := readSecondaryCA()
 	return caCert, caCertDER, caCertErr
 }
 
@@ -229,6 +273,26 @@ func CAForSigning() (CA, error) {
 	})
 
 	return caForSigning, caForSigningErr
+}
+
+func SecondaryCAForSigning() (CA, error) {
+	secondaryCAForSigningOnce.Do(func() {
+		_, certPEM, _, err := readSecondaryCA()
+		if err != nil {
+			secondaryCAForSigningErr = errors.Wrap(err, "could not read secondary CA certificate PEM")
+			return
+		}
+
+		keyPEM, err := readSecondaryCAKey()
+		if err != nil {
+			secondaryCAForSigningErr = errors.Wrap(err, "could not read secondary CA key PEM")
+			return
+		}
+
+		secondaryCAForSigning, secondaryCAForSigningErr = LoadCAForSigning(certPEM, keyPEM)
+	})
+
+	return secondaryCAForSigning, secondaryCAForSigningErr
 }
 
 func signer() (cfsigner.Signer, error) {

--- a/pkg/mtls/env.go
+++ b/pkg/mtls/env.go
@@ -7,6 +7,10 @@ const (
 	CAFileEnvName = "ROX_MTLS_CA_FILE"
 	// CAKeyFileEnvName is the env variable name for the CA key file
 	CAKeyFileEnvName = "ROX_MTLS_CA_KEY_FILE"
+	// SecondaryCAFileEnvName is the env variable name for the secondary CA file
+	SecondaryCAFileEnvName = "ROX_MTLS_SECONDARY_CA_FILE"
+	// SecondaryCAKeyEnvName is the env variable name for the secondary CA key file
+	SecondaryCAKeyEnvName = "ROX_MTLS_SECONDARY_CA_KEY_FILE"
 	// CertFilePathEnvName is the env variable name for the cert file
 	CertFilePathEnvName = "ROX_MTLS_CERT_FILE"
 	// KeyFileEnvName is the env variable name for the key file which signed the cert
@@ -14,10 +18,12 @@ const (
 )
 
 var (
-	caFilePathSetting    = env.RegisterSetting(CAFileEnvName, env.WithDefault(defaultCACertFilePath))
-	caKeyFilePathSetting = env.RegisterSetting(CAKeyFileEnvName, env.WithDefault(defaultCAKeyFilePath))
-	certFilePathSetting  = env.RegisterSetting(CertFilePathEnvName, env.WithDefault(defaultCertFilePath))
-	keyFilePathSetting   = env.RegisterSetting(KeyFileEnvName, env.WithDefault(defaultKeyFilePath))
+	caFilePathSetting             = env.RegisterSetting(CAFileEnvName, env.WithDefault(defaultCACertFilePath))
+	caKeyFilePathSetting          = env.RegisterSetting(CAKeyFileEnvName, env.WithDefault(defaultCAKeyFilePath))
+	secondaryCAFilePathSetting    = env.RegisterSetting(SecondaryCAFileEnvName, env.WithDefault(defaultSecondaryCACertFilePath))
+	secondaryCAKeyFilePathSetting = env.RegisterSetting(SecondaryCAKeyEnvName, env.WithDefault(defaultSecondaryCAKeyFilePath))
+	certFilePathSetting           = env.RegisterSetting(CertFilePathEnvName, env.WithDefault(defaultCertFilePath))
+	keyFilePathSetting            = env.RegisterSetting(KeyFileEnvName, env.WithDefault(defaultKeyFilePath))
 )
 
 // CAFilePath returns the path where the CA certificate is stored.

--- a/pkg/mtls/verifier/verify.go
+++ b/pkg/mtls/verifier/verify.go
@@ -35,6 +35,7 @@ func TrustedCertPool() (*x509.CertPool, error) {
 	}
 	certPool := x509.NewCertPool()
 	certPool.AddCert(caCert)
+	addSecondaryCACertIfExists(certPool)
 	return certPool, nil
 }
 
@@ -49,7 +50,15 @@ func SystemCertPool() (*x509.CertPool, error) {
 		return nil, err
 	}
 	certPool.AddCert(caCert)
+	addSecondaryCACertIfExists(certPool)
 	return certPool, nil
+}
+
+func addSecondaryCACertIfExists(certPool *x509.CertPool) {
+	secondaryCACert, _, err := mtls.SecondaryCACert()
+	if err == nil {
+		certPool.AddCert(secondaryCACert)
+	}
 }
 
 // TLSConfig initializes a server configuration that requires client TLS

--- a/proto/api/v1/metadata_service.proto
+++ b/proto/api/v1/metadata_service.proto
@@ -27,20 +27,25 @@ message Metadata {
 }
 
 message TrustInfo {
-  // holds the certificate chain hold by central
+  // holds the certificate chain held by Central
   repeated bytes cert_chain = 1;
-  // sensor challenge string
+  // Sensor challenge string
   string sensor_challenge = 2;
-  // central challenge string
+  // Central challenge string
   string central_challenge = 3;
-  // additional CA certs configured in central in DER format
+  // additional CA certs configured in Central in DER format
   repeated bytes additional_cas = 4;
+  // an optional certificate chain, if Central has a secondary CA
+  repeated bytes secondary_cert_chain = 5;
 }
 
 message TLSChallengeResponse {
   // signed data which is returned to the caller, is validated against the signature
   bytes trust_info_serialized = 1;
+  // signature signature (by key from TrustInfo.cert_chain[0])
   bytes signature = 2;
+  // optional signature by key from TrustInfo.secondary_cert_chain[0].
+  bytes signature_secondary_ca = 3;
 }
 
 message TLSChallengeRequest {

--- a/proto/api/v1/metadata_service.proto
+++ b/proto/api/v1/metadata_service.proto
@@ -42,7 +42,7 @@ message TrustInfo {
 message TLSChallengeResponse {
   // signed data which is returned to the caller, is validated against the signature
   bytes trust_info_serialized = 1;
-  // signature signature (by key from TrustInfo.cert_chain[0])
+  // primary signature (by key from TrustInfo.cert_chain[0])
   bytes signature = 2;
   // optional signature by key from TrustInfo.secondary_cert_chain[0].
   bytes signature_secondary_ca = 3;

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -16589,6 +16589,11 @@
                 "name": "service_certs",
                 "type": "TypedServiceCertificate",
                 "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "ca_bundle_pem",
+                "type": "bytes"
               }
             ]
           }

--- a/proto/storage/service_identity.proto
+++ b/proto/storage/service_identity.proto
@@ -51,4 +51,6 @@ message TypedServiceCertificate {
 message TypedServiceCertificateSet {
   bytes ca_pem = 1;
   repeated TypedServiceCertificate service_certs = 2;
+  // Optional: all CA certificates that Central trusts (primary + secondary)
+  bytes ca_bundle_pem = 3;
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR follows-up https://github.com/stackrox/stackrox/pull/15074 which added a CA rotation mechanism to the ACS Operator, based on [this design](https://docs.google.com/document/d/1I1r3bg3nwt96Q0dWs_mYdl5Wl4_xxVNz3NnB4UbHOCk/edit?usp=sharing). 

CA rotation will enable zero-downtime CA certificate refresh by allowing Central and Sensor to simultaneously trust certificates signed by both the current (primary) and new (secondary) CA during the transition period.

This PR introduces the following changes:
* Adds the ability of Central to load both the primary and secondary CA, and use both when authenticating clients
* Extends the TLSChallenge endpoint so that if there are two CAs in use, Central will include both certificate chains in the `TrustInfo` message, and sign it with both certificates. This will allow Sensor to trust Central even if they have leaf certificates signed by different CAs
* Adds a `ca_bundle_pem` field to the Secured Cluster certificate refresh API that contains both Central CA certificates (primary + secondary)
* The certificate generation service of Central now signs Secured Cluster certificates with the newer certificate, if such a certificate is available and Sensor has the required CA rotation capability

A feature flag in Central to gate this functionality is not needed because:
* CA rotation is not enabled in the Operator by default at the moment (the Operator does have a feature flag check)
* no current Sensor declares the `SensorCARotationSupported` capability

Note that the current implementation uses caching of certificates so that it fits with the existing code. But by the time CA rotation will be enabled in production, it's very likely that we'll be using certificate hot reloading. For more details see https://issues.redhat.com/browse/ROX-29432

#### Follow-up
Sensor will implement support for these features in a [follow-up PR](https://github.com/stackrox/stackrox/pull/16304) 

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

I'm using https://github.com/stackrox/stackrox/pull/15349 to manually validate these changes. 

That branch contains changes in this PR and https://github.com/stackrox/stackrox/pull/16304, but additionally enables the feature flags, introduces the new CA after 5 minutes (instead of 3 years) and switches the primary and secondary CAs after 10 minutes (instead of 4 years).
