### PR TITLE
fix(ui): Remove duplicate CVE count query from VM list page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -10,7 +10,7 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { useQuery } from '@apollo/client';
+import { gql, useQuery } from '@apollo/client';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 
@@ -49,6 +49,12 @@ import SeverityCountLabels from '../../components/SeverityCountLabels';
 
 import { getImageScopeSearchValue } from '../utils';
 
+const imageCVECountQuery = gql`
+    query getImageCVECount($query: String) {
+        imageCVECount(query: $query)
+    }
+`;
+
 type RequestCVEsTableProps = {
     cves: string[];
     scope: VulnerabilityExceptionScope;
@@ -75,6 +81,10 @@ function RequestCVEsTable({
     };
 
     const query = getRequestQueryStringForSearchFilter(queryObject);
+
+    const countQuery = useQuery<{ imageCVECount: number }>(imageCVECountQuery, {
+        variables: { query },
+    });
 
     const {
         error,
@@ -103,12 +113,12 @@ function RequestCVEsTable({
                     <ToolbarContent className="pf-v5-u-justify-content-space-between">
                         <ToolbarItem variant="label">
                             <Title headingLevel="h2">
-                                {data?.imageCVECount || 0} results found
+                                {countQuery.data?.imageCVECount || 0} results found
                             </Title>
                         </ToolbarItem>
                         <ToolbarItem variant="pagination">
                             <Pagination
-                                itemCount={data?.imageCVECount}
+                                itemCount={countQuery.data?.imageCVECount}
                                 perPage={perPage}
                                 page={page}
                                 onSetPage={(_, newPage) => setPage(newPage)}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -93,7 +93,6 @@ export const cveListQuery = gql`
         $pagination: Pagination
         $statusesForExceptionCount: [String!]
     ) {
-        imageCVECount(query: $query)
         imageCVEs(query: $query, pagination: $pagination) {
             cve
             affectedImageCountBySeverity {
@@ -140,7 +139,6 @@ export const unfilteredImageCountQuery = gql`
 `;
 
 export type CVEListQueryResult = {
-    imageCVECount: number;
     imageCVEs: ImageCVE[];
 };
 


### PR DESCRIPTION
### Description

The CVE list GraphQL query is shared between the VM landing page and the Exception Management details page. It included a call to imageCVECount() that was only needed on the Exception Management page.

On the VM landing page, a separate query already handles the CVE/image/deployment counts for the entity buttons, and only re-fetches when its specific variables change. However, the shared query was also re-fetching imageCVECount() unnecessarily on unrelated changes (e.g. pagination), adding to performance issues.

This PR removes the unnecessary imageCVECount() call to improve performance.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Visit the Workload CVE list page and see that the table and counts load correctly:
![image](https://github.com/user-attachments/assets/a49d4b3c-b1e3-446f-8df3-0b591ef878c0)

Ditto with the exception management detail page:
![image](https://github.com/user-attachments/assets/25d4322d-a493-4301-b0ca-eb78bd777b11)
