### PR TITLE
ROX-29320: support RHEL 10 CPEs

### DIFF
--- a/scanner/datastore/postgres/distributions.go
+++ b/scanner/datastore/postgres/distributions.go
@@ -11,7 +11,7 @@ import (
 
 // rhelCPE represents the expected pattern to identify a CPE which indicates a RHEL major version.
 // The purpose of this is to identify the major version represented by this CPE.
-var rhelCPE = regexp.MustCompile(`cpe:2\.3:o:redhat:enterprise_linux:(\d+)(?:\.\d+)*:\*:\*:\*:\*:\*:\*:\*`)
+var rhelCPE = regexp.MustCompile(`^cpe:2\.3:o:redhat:enterprise_linux:(\d+)(?:\.\d+)*:\*:\*:\*:\*:\*:\*:\*$`)
 
 // Distributions retrieves the currently known distributions from the database.
 //

--- a/scanner/datastore/postgres/distributions.go
+++ b/scanner/datastore/postgres/distributions.go
@@ -11,7 +11,7 @@ import (
 
 // rhelCPE represents the expected pattern to identify a CPE which indicates a RHEL major version.
 // The purpose of this is to identify the major version represented by this CPE.
-var rhelCPE = regexp.MustCompile(`cpe:2\.3:o:redhat:enterprise_linux:(\d+):\*:\*:\*:\*:\*:\*:\*`)
+var rhelCPE = regexp.MustCompile(`cpe:2\.3:o:redhat:enterprise_linux:(\d+)(?:\.\d+)*:\*:\*:\*:\*:\*:\*:\*`)
 
 // Distributions retrieves the currently known distributions from the database.
 //
@@ -30,7 +30,7 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 	}
 	defer rows.Close()
 
-	var dists []claircore.Distribution
+	uniqueDists := make(map[claircore.Distribution]struct{})
 	for rows.Next() {
 		var (
 			dID       string
@@ -41,24 +41,29 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 		if err := rows.Scan(&dID, &versionID, &version, &repoName); err != nil {
 			return nil, err
 		}
+
+		dist := claircore.Distribution{
+			DID:       dID,
+			VersionID: versionID,
+			Version:   version,
+		}
 		if repoName != "" {
-			dist, err := rhelDist(repoName)
+			dist, err = rhelDist(repoName)
 			if err != nil {
 				zlog.Warn(ctx).Err(err).Msg("failed to parse repo_name; skipping...")
 				continue
 			}
-			dists = append(dists, dist)
-			continue
 		}
 
-		dists = append(dists, claircore.Distribution{
-			DID:       dID,
-			VersionID: versionID,
-			Version:   version,
-		})
+		uniqueDists[dist] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+
+	dists := make([]claircore.Distribution, 0, len(uniqueDists))
+	for dist := range uniqueDists {
+		dists = append(dists, dist)
 	}
 
 	return dists, nil

--- a/scanner/datastore/postgres/distributions_test.go
+++ b/scanner/datastore/postgres/distributions_test.go
@@ -52,12 +52,13 @@ func TestDistributions(t *testing.T) {
 	const insertDists = `
 INSERT INTO vuln (hash_kind, hash, dist_id, dist_version_id, dist_version, repo_name) VALUES
     ('md5', 'fake1', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:9:*:*:*:*:*:*:*'),
-    ('md5', 'fake2', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:10:*:*:*:*:*:*:*'),
+    ('md5', 'fake2', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:10.0:*:*:*:*:*:*:*'),
     ('md5', 'fake3', 'ubuntu', '22.04', '22.04 (Jammy)', ''),
     ('md5', 'fake4', 'alpine', '',      '3.17',          ''),
     ('md5', 'fake5', 'alpine', '',      '3.18',          ''),
     ('md5', 'fake6', 'debian', '10',    '10 (buster)',   ''),
-    ('md5', 'fake7', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*')`
+    ('md5', 'fake7', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*'),
+    ('md5', 'fake8', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:10.1:*:*:*:*:*:*:*')`
 	_, err = pool.Exec(ctx, insertDists)
 	require.NoError(t, err)
 
@@ -82,7 +83,16 @@ func TestRHELDist(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			repoName: "cpe:2.3:o:redhat:enterprise_linux:10:*:*:*:*:*:*:*",
+			repoName: "cpe:2.3:o:redhat:enterprise_linux:10.0:*:*:*:*:*:*:*",
+			expected: claircore.Distribution{
+				DID:       "rhel",
+				VersionID: "10",
+				Version:   "10",
+			},
+			wantErr: false,
+		},
+		{
+			repoName: "cpe:2.3:o:redhat:enterprise_linux:10.1:*:*:*:*:*:*:*",
 			expected: claircore.Distribution{
 				DID:       "rhel",
 				VersionID: "10",


### PR DESCRIPTION
### Description

RHEL 10 uses different CPEs from previous versions. It lists the Major.Minor version instead of just the Major version.

This change updates the regex we use to determine which OSes we support, so we can capture RHEL 10.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI + installed `4.8.x-750-g5bc923da93` in a cluster and ran `roxctl -e <central endpoint> image scan -i registry.access.redhat.com/ubi10:latest` (same again for `registry.access.redhat.com/ubi10:10.0-1745487123`). Found not only did we get results, but also the note indicating we do not support the OS is not present
