### PR TITLE
ROX-29304: add retry to alert service

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/AlertService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/AlertService.groovy
@@ -2,6 +2,7 @@ package services
 
 import groovy.transform.CompileStatic
 
+import io.stackrox.annotations.Retry
 import io.stackrox.proto.api.v1.AlertServiceGrpc
 import io.stackrox.proto.api.v1.AlertServiceOuterClass.GetAlertTimeseriesResponse
 import io.stackrox.proto.api.v1.AlertServiceOuterClass.GetAlertsCountsRequest
@@ -18,28 +19,34 @@ class AlertService extends BaseService {
         return AlertServiceGrpc.newBlockingStub(getChannel())
     }
 
+    @Retry
     static List<ListAlert> getViolations(ListAlertsRequest request = ListAlertsRequest.newBuilder().build()) {
         return getAlertClient().listAlerts(request).alertsList
     }
 
+    @Retry
     static GetAlertsCountsResponse getAlertCounts(
             GetAlertsCountsRequest request = GetAlertsCountsRequest.newBuilder().build()) {
         return getAlertClient().getAlertsCounts(request)
     }
 
+    @Retry
     static GetAlertsGroupResponse getAlertGroups(ListAlertsRequest request = ListAlertsRequest.newBuilder().build()) {
         return getAlertClient().getAlertsGroup(request)
     }
 
+    @Retry
     static GetAlertTimeseriesResponse getAlertTimeseries(
             ListAlertsRequest request = ListAlertsRequest.newBuilder().build()) {
         return getAlertClient().getAlertTimeseries(request)
     }
 
+    @Retry
     static Alert getViolation(String alertId) {
         return getAlertClient().getAlert(getResourceByID(alertId))
     }
 
+    @Retry
     static resolveAlert(String alertID, boolean addToBaseline = false) {
         return getAlertClient().resolveAlert(
                 ResolveAlertRequest.newBuilder().setId(alertID).setAddToBaseline(addToBaseline).build())


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In ROX-29304, an `UNAVAILABLE` response gRPC code from the alert service caused a flake in the image signature integration tests. Hence, add the `Retry` annotation to the alert service to make sure we retry in such cases.

```
waitForViolation(deployment.name, policyName)
|                |          |     |
|                |          |     BOYPKI-Wildcard+Tekton
|                |          with-signature-unverifiable
|                <objects.Deployment@11c4b34d name=with-signature-unverifiable namespace=qa-signature-tests image=quay.io/rhacs-eng/qa-signatures:centos9-multiarch@sha256:743cf31b5c29c227aa1371eddd9f9313b2a0487f39ccfc03ec5c89a692c4a0c7 labels=[name:with-signature-unverifiable, app:image-with-unverifiable-signature-test] ports=[:] targetport=null volumes=[] volumeMounts=[] secretNames=[:] imagePullSecret=[] annotation=[:] command=[/bin/sh, -c, /bin/sleep 600] args=[] replicas=1 env=[:] envFromSecrets=[] envFromConfigMaps=[] envValueFromSecretKeyRef=[:] envValueFromConfigMapKeyRef=[:] envValueFromFieldRef=[:] envValueFromResourceFieldRef=[:] isPrivileged=false readOnlyRootFilesystem=false limits=[:] request=[:] hostNetwork=false addCapabilities=[] dropCapabilities=[] loadBalancerIP=null routeHost=null deploymentUid=396d3d83-95d3-40ee-8276-90c3e522e761 pods=[objects.Pod@427c703b] containerName=null skipReplicaWait=false exposeAsService=false createLoadBalancer=false createRoute=false automountServiceAccountToken=true livenessProbeDefined=false readinessProbeDefined=false serviceName=null serviceAccountName=null>
io.grpc.StatusRuntimeException: UNAVAILABLE: Keepalive failed. The connection is likely gone
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:268)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:249)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:167)
	at io.stackrox.proto.api.v1.AlertServiceGrpc$AlertServiceBlockingStub.listAlerts(AlertServiceGrpc.java:614)
	at services.AlertService.getViolations(AlertService.groovy:22)
	at Services.getViolationsHelper(Services.groovy:190)
	at Services.getViolationsWithTimeout(Services.groovy:204)
	at Services.waitForViolation(Services.groovy:166)
	at ImageSignatureVerificationTest.$spock_feature_1_0(ImageSignatureVerificationTest.groovy:548)
```

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI