### PR TITLE
ROX-29232: Log messages that crash grpc stream

### DIFF
--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -136,6 +136,7 @@ func (s *centralSenderImpl) send(stream central.SensorService_CommunicateClient,
 
 			if err := wrappedStream.Send(msg.MsgFromSensor); err != nil {
 				log.Errorf("unable to send to stream: %s", err)
+				log.Errorf("message that cause the problem: %+v", msg.MsgFromSensor)
 				s.stopper.Flow().StopWithError(err)
 				return
 			}

--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -135,8 +135,10 @@ func (s *centralSenderImpl) send(stream central.SensorService_CommunicateClient,
 			}
 
 			if err := wrappedStream.Send(msg.MsgFromSensor); err != nil {
-				log.Errorf("unable to send to stream: %s. "+
-					"Message that caused the problem: %+v", err, msg.MsgFromSensor)
+				log.Errorf("unable to send to stream: %s. Triggered by message type: %T"+
+					"Enable debug logging to print the entire problematic message "+
+					"(it may containt sensitive information)", msg.MsgFromSensor.GetMsg(), err)
+				log.Debugf("Message that triggered the send to stream problem: %+v", msg.MsgFromSensor)
 				s.stopper.Flow().StopWithError(err)
 				return
 			}

--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -135,8 +135,8 @@ func (s *centralSenderImpl) send(stream central.SensorService_CommunicateClient,
 			}
 
 			if err := wrappedStream.Send(msg.MsgFromSensor); err != nil {
-				log.Errorf("unable to send to stream: %s", err)
-				log.Errorf("message that cause the problem: %+v", msg.MsgFromSensor)
+				log.Errorf("unable to send to stream: %s. "+
+					"Message that caused the problem: %+v", err, msg.MsgFromSensor)
 				s.stopper.Flow().StopWithError(err)
 				return
 			}

--- a/sensor/common/sensor/central_sender_impl.go
+++ b/sensor/common/sensor/central_sender_impl.go
@@ -135,9 +135,9 @@ func (s *centralSenderImpl) send(stream central.SensorService_CommunicateClient,
 			}
 
 			if err := wrappedStream.Send(msg.MsgFromSensor); err != nil {
-				log.Errorf("unable to send to stream: %s. Triggered by message type: %T"+
+				log.Errorf("unable to send to stream: %s. Triggered by message type: %T. "+
 					"Enable debug logging to print the entire problematic message "+
-					"(it may containt sensitive information)", msg.MsgFromSensor.GetMsg(), err)
+					"(it may contain sensitive information)", err, msg.MsgFromSensor.GetMsg())
 				log.Debugf("Message that triggered the send to stream problem: %+v", msg.MsgFromSensor)
 				s.stopper.Flow().StopWithError(err)
 				return


### PR DESCRIPTION
### Description

We want to know if broken message would break the connection by not being able to be marshaled when sending from Sensor to Central. This PR prints the message to the logs for easier investigation. Otherwise, one would need to convince the customer to apply a specially-built debug image to find the root cause of the problem.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Trivial change, no need for validation
- Used it with 4.6 and a customer resolving a true issue https://github.com/stackrox/stackrox/pull/15308
