### PR TITLE
ROX-27598: Replace deprecated CLI menu component

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
@@ -69,7 +69,7 @@ function CLIDownloadMenu({ addToast, removeToast }: CLIDownloadMenuProps): React
                         spaceItems={{ default: 'spaceItemsSm' }}
                     >
                         <FlexItem>
-                            <DownloadIcon alt="Download roxctl" />
+                            <DownloadIcon />
                         </FlexItem>
                         <FlexItem>CLI</FlexItem>
                     </Flex>
@@ -78,12 +78,7 @@ function CLIDownloadMenu({ addToast, removeToast }: CLIDownloadMenuProps): React
         >
             <DropdownList>
                 {cliDownloadOptions.map(({ os, display }) => (
-                    <DropdownItem
-                        id={`app-launcher-item-cli-${os}`}
-                        value={`app-launcher-item-cli-${os}`}
-                        key={os}
-                        onClick={handleDownloadCLI(os)}
-                    >
+                    <DropdownItem key={os} onClick={handleDownloadCLI(os)}>
                         {display}
                     </DropdownItem>
                 ))}


### PR DESCRIPTION
### Description

Two for one change:
1. Remove one of the two deprecated instances of `<ApplicationLauncher>` in preparation for PF 6
2. Fix the issue with the CLI download dropdown that does not give an indication to the user that a download has started

### Follow ups

1. Replace `react-toastify` notification implementation with PatternFly alerts

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Open the CLI dropdown from the top masthead. The presentation of this list should be unchanged:
![image](https://github.com/user-attachments/assets/815049d7-3ecb-4d4e-98e8-2e06b7e60fc1)

Clicking an item closes the dropdown and presents a toast using the pre-wired toast notification system:
![image](https://github.com/user-attachments/assets/6f1bc8ca-c1b3-4f7f-9c55-c1d8a6f2e6f9)


