### PR TITLE
ROX-28348: Cleanup results on scan config update

### DIFF
--- a/central/complianceoperator/v2/checkresults/datastore/datastore.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore.go
@@ -44,6 +44,12 @@ type DataStore interface {
 	// DeleteResultsByCluster scan results associated with cluster
 	DeleteResultsByCluster(ctx context.Context, clusterID string) error
 
+	// DeleteResultsByScanConfigAndCluster deletes scan results associated with scan config and cluster
+	DeleteResultsByScanConfigAndCluster(ctx context.Context, scanConfigName string, clusterIDs []string) error
+
+	// DeleteResultsByScanConfigAndRules deletes scan results associated with scan config and rules reference IDs
+	DeleteResultsByScanConfigAndRules(ctx context.Context, scanConfigName string, ruleRefIds []string) error
+
 	// GetComplianceCheckResult returns the instance of the result specified by ID
 	GetComplianceCheckResult(ctx context.Context, complianceResultID string) (*storage.ComplianceOperatorCheckResultV2, bool, error)
 

--- a/central/complianceoperator/v2/checkresults/datastore/datastore.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore.go
@@ -47,8 +47,8 @@ type DataStore interface {
 	// DeleteResultsByScanConfigAndCluster deletes scan results associated with scan config and cluster
 	DeleteResultsByScanConfigAndCluster(ctx context.Context, scanConfigName string, clusterIDs []string) error
 
-	// DeleteResultsByScanConfigAndRules deletes scan results associated with scan config and rules reference IDs
-	DeleteResultsByScanConfigAndRules(ctx context.Context, scanConfigName string, ruleRefIds []string) error
+	// DeleteResultsByScans deletes scan results associated with scans
+	DeleteResultsByScans(ctx context.Context, scanRefIds []string) error
 
 	// GetComplianceCheckResult returns the instance of the result specified by ID
 	GetComplianceCheckResult(ctx context.Context, complianceResultID string) (*storage.ComplianceOperatorCheckResultV2, bool, error)

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -366,6 +366,28 @@ func (d *datastoreImpl) DeleteResultsByCluster(ctx context.Context, clusterID st
 	return err
 }
 
+func (d *datastoreImpl) DeleteResultsByScanConfigAndCluster(ctx context.Context, scanConfigName string, clusterIDs []string) error {
+	if scanConfigName == "" || len(clusterIDs) == 0 {
+		return nil
+	}
+
+	query := search.NewQueryBuilder().AddExactMatches(search.ComplianceOperatorScanConfigName, scanConfigName).AddExactMatches(search.ClusterID, clusterIDs...).ProtoQuery()
+	_, err := d.store.DeleteByQuery(ctx, query)
+
+	return err
+}
+
+func (d *datastoreImpl) DeleteResultsByScanConfigAndRules(ctx context.Context, scanConfigName string, ruleRefIds []string) error {
+	if scanConfigName == "" || len(ruleRefIds) == 0 {
+		return nil
+	}
+
+	query := search.NewQueryBuilder().AddExactMatches(search.ComplianceOperatorScanConfigName, scanConfigName).AddExactMatches(search.ComplianceOperatorRuleRef, ruleRefIds...).ProtoQuery()
+	_, err := d.store.DeleteByQuery(ctx, query)
+
+	return err
+}
+
 func withCountQuery(q *v1.Query, field search.FieldLabel) *v1.Query {
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -377,12 +377,12 @@ func (d *datastoreImpl) DeleteResultsByScanConfigAndCluster(ctx context.Context,
 	return err
 }
 
-func (d *datastoreImpl) DeleteResultsByScanConfigAndRules(ctx context.Context, scanConfigName string, ruleRefIds []string) error {
-	if scanConfigName == "" || len(ruleRefIds) == 0 {
+func (d *datastoreImpl) DeleteResultsByScans(ctx context.Context, scanRefIds []string) error {
+	if len(scanRefIds) == 0 {
 		return nil
 	}
 
-	query := search.NewQueryBuilder().AddExactMatches(search.ComplianceOperatorScanConfigName, scanConfigName).AddExactMatches(search.ComplianceOperatorRuleRef, ruleRefIds...).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.ComplianceOperatorScanRef, scanRefIds...).ProtoQuery()
 	_, err := d.store.DeleteByQuery(ctx, query)
 
 	return err

--- a/central/complianceoperator/v2/checkresults/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/checkresults/datastore/mocks/datastore.go
@@ -176,18 +176,18 @@ func (mr *MockDataStoreMockRecorder) DeleteResultsByScanConfigAndCluster(ctx, sc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResultsByScanConfigAndCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteResultsByScanConfigAndCluster), ctx, scanConfigName, clusterIDs)
 }
 
-// DeleteResultsByScanConfigAndRules mocks base method.
-func (m *MockDataStore) DeleteResultsByScanConfigAndRules(ctx context.Context, scanConfigName string, ruleRefIds []string) error {
+// DeleteResultsByScans mocks base method.
+func (m *MockDataStore) DeleteResultsByScans(ctx context.Context, scanRefIds []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteResultsByScanConfigAndRules", ctx, scanConfigName, ruleRefIds)
+	ret := m.ctrl.Call(m, "DeleteResultsByScans", ctx, scanRefIds)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteResultsByScanConfigAndRules indicates an expected call of DeleteResultsByScanConfigAndRules.
-func (mr *MockDataStoreMockRecorder) DeleteResultsByScanConfigAndRules(ctx, scanConfigName, ruleRefIds any) *gomock.Call {
+// DeleteResultsByScans indicates an expected call of DeleteResultsByScans.
+func (mr *MockDataStoreMockRecorder) DeleteResultsByScans(ctx, scanRefIds any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResultsByScanConfigAndRules", reflect.TypeOf((*MockDataStore)(nil).DeleteResultsByScanConfigAndRules), ctx, scanConfigName, ruleRefIds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResultsByScans", reflect.TypeOf((*MockDataStore)(nil).DeleteResultsByScans), ctx, scanRefIds)
 }
 
 // GetComplianceCheckResult mocks base method.

--- a/central/complianceoperator/v2/checkresults/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/checkresults/datastore/mocks/datastore.go
@@ -162,6 +162,34 @@ func (mr *MockDataStoreMockRecorder) DeleteResultsByCluster(ctx, clusterID any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResultsByCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteResultsByCluster), ctx, clusterID)
 }
 
+// DeleteResultsByScanConfigAndCluster mocks base method.
+func (m *MockDataStore) DeleteResultsByScanConfigAndCluster(ctx context.Context, scanConfigName string, clusterIDs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteResultsByScanConfigAndCluster", ctx, scanConfigName, clusterIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteResultsByScanConfigAndCluster indicates an expected call of DeleteResultsByScanConfigAndCluster.
+func (mr *MockDataStoreMockRecorder) DeleteResultsByScanConfigAndCluster(ctx, scanConfigName, clusterIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResultsByScanConfigAndCluster", reflect.TypeOf((*MockDataStore)(nil).DeleteResultsByScanConfigAndCluster), ctx, scanConfigName, clusterIDs)
+}
+
+// DeleteResultsByScanConfigAndRules mocks base method.
+func (m *MockDataStore) DeleteResultsByScanConfigAndRules(ctx context.Context, scanConfigName string, ruleRefIds []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteResultsByScanConfigAndRules", ctx, scanConfigName, ruleRefIds)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteResultsByScanConfigAndRules indicates an expected call of DeleteResultsByScanConfigAndRules.
+func (mr *MockDataStoreMockRecorder) DeleteResultsByScanConfigAndRules(ctx, scanConfigName, ruleRefIds any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResultsByScanConfigAndRules", reflect.TypeOf((*MockDataStore)(nil).DeleteResultsByScanConfigAndRules), ctx, scanConfigName, ruleRefIds)
+}
+
 // GetComplianceCheckResult mocks base method.
 func (m *MockDataStore) GetComplianceCheckResult(ctx context.Context, complianceResultID string) (*storage.ComplianceOperatorCheckResultV2, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	clusterDatastoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	resultsMocks "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
 	"github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore/mocks"
 	profileMocks "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
 	scanConfigMocks "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore/mocks"
@@ -66,6 +67,7 @@ type complianceManagerTestSuite struct {
 	integrationDS    *mocks.MockDataStore
 	scanConfigDS     *scanConfigMocks.MockDataStore
 	profileDS        *profileMocks.MockDataStore
+	resultsDS        *resultsMocks.MockDataStore
 	connectionMgr    *sensorMocks.MockManager
 	clusterDatastore *clusterDatastoreMocks.MockDataStore
 	manager          Manager
@@ -94,7 +96,7 @@ func (suite *complianceManagerTestSuite) SetupTest() {
 	suite.connectionMgr = sensorMocks.NewMockManager(suite.mockCtrl)
 	suite.clusterDatastore = clusterDatastoreMocks.NewMockDataStore(suite.mockCtrl)
 	suite.profileDS = profileMocks.NewMockDataStore(suite.mockCtrl)
-	suite.manager = New(suite.connectionMgr, suite.integrationDS, suite.scanConfigDS, suite.clusterDatastore, suite.profileDS)
+	suite.manager = New(suite.connectionMgr, suite.integrationDS, suite.scanConfigDS, suite.clusterDatastore, suite.profileDS, suite.resultsDS)
 }
 
 func (suite *complianceManagerTestSuite) TearDownTest() {

--- a/central/complianceoperator/v2/compliancemanager/singleton.go
+++ b/central/complianceoperator/v2/compliancemanager/singleton.go
@@ -6,6 +6,7 @@ import (
 	compIntegration "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
 	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
+	scansDatastore "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -18,7 +19,7 @@ var (
 // Singleton returns the compliance operator manager
 func Singleton() Manager {
 	once.Do(func() {
-		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton(), profileDatastore.Singleton(), resultsDatastore.Singleton())
+		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton(), profileDatastore.Singleton(), scansDatastore.Singleton(), resultsDatastore.Singleton())
 	})
 	return manager
 }

--- a/central/complianceoperator/v2/compliancemanager/singleton.go
+++ b/central/complianceoperator/v2/compliancemanager/singleton.go
@@ -2,6 +2,7 @@ package compliancemanager
 
 import (
 	clusterDatastore "github.com/stackrox/rox/central/cluster/datastore"
+	resultsDatastore "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	compIntegration "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
 	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
@@ -17,7 +18,7 @@ var (
 // Singleton returns the compliance operator manager
 func Singleton() Manager {
 	once.Do(func() {
-		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton(), profileDatastore.Singleton())
+		manager = New(connection.ManagerSingleton(), compIntegration.Singleton(), compScanSetting.Singleton(), clusterDatastore.Singleton(), profileDatastore.Singleton(), resultsDatastore.Singleton())
 	})
 	return manager
 }


### PR DESCRIPTION
### Description

This PR is adding cleanup of scan results when scan config (schedule) is changed and clusters or profiles are removed from that schedule.

Additional changes:
- protection for changing scan config is added (we are using scan config name as a foreign key in the results table)
- smaller refactoring of tests is done because several test data creation functions could be replaced with one with additional parameters

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

- [x] unit tests
- [ ] manual tests with two clusters (after image is built with this PR)
