### PR TITLE
ROX-29313: Add conditional query to flatten CVE data

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -21,7 +21,7 @@ import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import DeploymentComponentVulnerabilitiesTable, {
     DeploymentComponentVulnerability,
     ImageMetadataContext,
-    deploymentComponentVulnerabilitiesFragment,
+    convertToFlatDeploymentComponentVulnerabilitiesFragment, // deploymentComponentVulnerabilitiesFragment
     imageMetadataContextFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
@@ -66,28 +66,35 @@ export type DeploymentForCve = {
     images: (ImageMetadataContext & { imageComponents: DeploymentComponentVulnerability[] })[];
 };
 
-export const deploymentsForCveFragment = gql`
-    ${imageMetadataContextFragment}
-    ${deploymentComponentVulnerabilitiesFragment}
-    fragment DeploymentsForCVE on Deployment {
-        id
-        name
-        namespace
-        clusterName
-        created
-        unknownImageCount: imageCount(query: $unknownImageCountQuery)
-        lowImageCount: imageCount(query: $lowImageCountQuery)
-        moderateImageCount: imageCount(query: $moderateImageCountQuery)
-        importantImageCount: imageCount(query: $importantImageCountQuery)
-        criticalImageCount: imageCount(query: $criticalImageCountQuery)
-        images(query: $query) {
-            ...ImageMetadataContext
-            imageComponents(query: $query) {
-                ...DeploymentComponentVulnerabilities
+// After release, replace temporary function
+// with deploymentsForCveFragment
+// that has unconditional deploymentComponentVulnerabilitiesFragment.
+export function convertToFlatDeploymentsForCveFragment(
+    isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
+) {
+    return gql`
+        ${imageMetadataContextFragment}
+        ${convertToFlatDeploymentComponentVulnerabilitiesFragment(isFlattenCveDataEnabled)}
+        fragment DeploymentsForCVE on Deployment {
+            id
+            name
+            namespace
+            clusterName
+            created
+            unknownImageCount: imageCount(query: $unknownImageCountQuery)
+            lowImageCount: imageCount(query: $lowImageCountQuery)
+            moderateImageCount: imageCount(query: $moderateImageCountQuery)
+            importantImageCount: imageCount(query: $importantImageCountQuery)
+            criticalImageCount: imageCount(query: $criticalImageCountQuery)
+            images(query: $query) {
+                ...ImageMetadataContext
+                imageComponents(query: $query) {
+                    ...DeploymentComponentVulnerabilities
+                }
             }
         }
-    }
-`;
+    `;
+}
 
 export type AffectedDeploymentsTableProps = {
     tableState: TableUIState<DeploymentForCve>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -31,7 +31,7 @@ import ImageNameLink from '../components/ImageNameLink';
 
 import ImageComponentVulnerabilitiesTable, {
     ImageComponentVulnerability,
-    imageComponentVulnerabilitiesFragment,
+    convertToFlatImageComponentVulnerabilitiesFragment, // imageComponentVulnerabilitiesFragment
     imageMetadataContextFragment,
 } from './ImageComponentVulnerabilitiesTable';
 import { WatchStatus } from '../../types';
@@ -97,26 +97,33 @@ export type ImageForCve = {
     })[];
 };
 
-export const imagesForCveFragment = gql`
-    ${imageMetadataContextFragment}
-    ${imageComponentVulnerabilitiesFragment}
-    fragment ImagesForCVE on Image {
-        ...ImageMetadataContext
+// After release, replace temporary function
+// with imagesForCveFragment
+// that has unconditional imageComponentVulnerabilitiesFragment.
+export function convertToFlatImagesForCveFragment(
+    isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
+) {
+    return gql`
+        ${imageMetadataContextFragment}
+        ${convertToFlatImageComponentVulnerabilitiesFragment(isFlattenCveDataEnabled)}
+        fragment ImagesForCVE on Image {
+            ...ImageMetadataContext
 
-        operatingSystem
-        watchStatus
-        imageComponents(query: $query) {
-            imageVulnerabilities(query: $query) {
-                discoveredAtImage
-                cvss
-                scoreVersion
-                nvdCvss
-                nvdScoreVersion
+            operatingSystem
+            watchStatus
+            imageComponents(query: $query) {
+                imageVulnerabilities(query: $query) {
+                    discoveredAtImage
+                    cvss
+                    scoreVersion
+                    nvdCvss
+                    nvdScoreVersion
+                }
+                ...ImageComponentVulnerabilities
             }
-            ...ImageComponentVulnerabilities
         }
-    }
-`;
+    `;
+}
 
 export type AffectedImagesTableProps = {
     tableState: TableUIState<ImageForCve>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -26,24 +26,32 @@ import AdvisoryLinkOrText from './AdvisoryLinkOrText';
 export { imageMetadataContextFragment };
 export type { ImageMetadataContext, DeploymentComponentVulnerability };
 
-export const deploymentComponentVulnerabilitiesFragment = gql`
-    fragment DeploymentComponentVulnerabilities on ImageComponent {
-        name
-        version
-        location
-        source
-        layerIndex
-        imageVulnerabilities(query: $query) {
-            severity
-            cvss
-            scoreVersion
-            fixedByVersion
-            discoveredAtImage
-            publishedOn
-            pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
+// After release, replace temporary function
+// with deploymentComponentVulnerabilitiesFragment
+// that has unconditional advisory property.
+export function convertToFlatDeploymentComponentVulnerabilitiesFragment(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
+) {
+    return gql`
+        fragment DeploymentComponentVulnerabilities on ImageComponent {
+            name
+            version
+            location
+            source
+            layerIndex
+            imageVulnerabilities(query: $query) {
+                severity
+                cvss
+                scoreVersion
+                fixedByVersion
+                discoveredAtImage
+                publishedOn
+                pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
+            }
         }
-    }
-`;
+    `;
+}
 
 const sortFields = ['Image', 'Component'];
 const defaultSortOption = { field: 'Image', direction: 'asc' } as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -23,7 +23,7 @@ import {
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 
 import DeploymentComponentVulnerabilitiesTable, {
-    deploymentComponentVulnerabilitiesFragment,
+    convertToFlatDeploymentComponentVulnerabilitiesFragment, // deploymentComponentVulnerabilitiesFragment
 } from './DeploymentComponentVulnerabilitiesTable';
 import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayout';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
@@ -63,34 +63,41 @@ export const defaultColumns = {
     },
 } as const;
 
-export const deploymentWithVulnerabilitiesFragment = gql`
-    ${deploymentComponentVulnerabilitiesFragment}
-    fragment DeploymentWithVulnerabilities on Deployment {
-        id
-        images(query: $query) {
-            ...ImageMetadataContext
-        }
-        imageVulnerabilities(query: $query, pagination: $pagination) {
-            vulnerabilityId: id
-            cve
-            cveBaseInfo {
-                epss {
-                    epssProbability
-                }
-            }
-            operatingSystem
-            publishedOn
-            summary
-            pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
+// After release, replace temporary function
+// with deploymentWithVulnerabilitiesFragment
+// that has unconditional deploymentComponentVulnerabilitiesFragment.
+export function convertToFlatDeploymentWithVulnerabilitiesFragment(
+    isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
+) {
+    return gql`
+        ${convertToFlatDeploymentComponentVulnerabilitiesFragment(isFlattenCveDataEnabled)}
+        fragment DeploymentWithVulnerabilities on Deployment {
+            id
             images(query: $query) {
-                imageId: id
-                imageComponents(query: $query) {
-                    ...DeploymentComponentVulnerabilities
+                ...ImageMetadataContext
+            }
+            imageVulnerabilities(query: $query, pagination: $pagination) {
+                vulnerabilityId: id
+                cve
+                cveBaseInfo {
+                    epss {
+                        epssProbability
+                    }
+                }
+                operatingSystem
+                publishedOn
+                summary
+                pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
+                images(query: $query) {
+                    imageId: id
+                    imageComponents(query: $query) {
+                        ...DeploymentComponentVulnerabilities
+                    }
                 }
             }
         }
-    }
-`;
+    `;
+}
 
 export type DeploymentVulnerabilitiesTableProps = {
     tableState: TableUIState<FormattedDeploymentVulnerability>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -21,20 +21,28 @@ import AdvisoryLinkOrText from './AdvisoryLinkOrText';
 export { imageMetadataContextFragment };
 export type { ImageMetadataContext, ImageComponentVulnerability };
 
-export const imageComponentVulnerabilitiesFragment = gql`
-    fragment ImageComponentVulnerabilities on ImageComponent {
-        name
-        version
-        location
-        source
-        layerIndex
-        imageVulnerabilities(query: $query) {
-            severity
-            fixedByVersion
-            pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
+// After release, replace temporary function
+// with imageComponentVulnerabilitiesFragment
+// that has unconditional advisory property.
+export function convertToFlatImageComponentVulnerabilitiesFragment(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
+) {
+    return gql`
+        fragment ImageComponentVulnerabilities on ImageComponent {
+            name
+            version
+            location
+            source
+            layerIndex
+            imageVulnerabilities(query: $query) {
+                severity
+                fixedByVersion
+                pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
+            }
         }
-    }
-`;
+    `;
+}
 
 const sortFields = ['Component'];
 const defaultSortOption = { field: 'Component', direction: 'asc' } as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -37,7 +37,7 @@ import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import ImageComponentVulnerabilitiesTable, {
     ImageComponentVulnerability,
     ImageMetadataContext,
-    imageComponentVulnerabilitiesFragment,
+    convertToFlatImageComponentVulnerabilitiesFragment, // imageComponentVulnerabilitiesFragment
 } from './ImageComponentVulnerabilitiesTable';
 
 import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
@@ -95,29 +95,36 @@ export const defaultColumns = {
     },
 } as const;
 
-export const imageVulnerabilitiesFragment = gql`
-    ${imageComponentVulnerabilitiesFragment}
-    fragment ImageVulnerabilityFields on ImageVulnerability {
-        severity
-        cve
-        summary
-        cvss
-        scoreVersion
-        nvdCvss
-        nvdScoreVersion
-        cveBaseInfo {
-            epss {
-                epssProbability
+// After release, replace temporary function
+// with imageVulnerabilitiesFragment
+// that has unconditional imageComponentVulnerabilitiesFragment.
+export function convertToFlatImageVulnerabilitiesFragment(
+    isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
+) {
+    return gql`
+        ${convertToFlatImageComponentVulnerabilitiesFragment(isFlattenCveDataEnabled)}
+        fragment ImageVulnerabilityFields on ImageVulnerability {
+            severity
+            cve
+            summary
+            cvss
+            scoreVersion
+            nvdCvss
+            nvdScoreVersion
+            cveBaseInfo {
+                epss {
+                    epssProbability
+                }
+            }
+            discoveredAtImage
+            publishedOn
+            pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
+            imageComponents(query: $query) {
+                ...ImageComponentVulnerabilities
             }
         }
-        discoveredAtImage
-        publishedOn
-        pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
-        imageComponents(query: $query) {
-            ...ImageComponentVulnerabilities
-        }
-    }
-`;
+    `;
+}
 
 export type ImageVulnerability = {
     severity: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useInvalidateVulnerabilityQueries.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useInvalidateVulnerabilityQueries.ts
@@ -5,11 +5,15 @@ import uniq from 'lodash/uniq';
 import { imageListQuery } from '../WorkloadCves/Tables/ImageOverviewTable';
 import { cveListQuery } from '../WorkloadCves/Tables/WorkloadCVEOverviewTable';
 import { deploymentListQuery } from '../WorkloadCves/Tables/DeploymentOverviewTable';
-import { deploymentVulnerabilitiesQuery } from '../WorkloadCves/Deployment/DeploymentPageVulnerabilities';
-import { imageVulnerabilitiesQuery } from '../WorkloadCves/Image/ImagePageVulnerabilities';
 import {
-    imageCveAffectedDeploymentsQuery,
-    imageCveAffectedImagesQuery,
+    convertToFlatDeploymentVulnerabilitiesQuery, // deploymentVulnerabilitiesQuery
+} from '../WorkloadCves/Deployment/DeploymentPageVulnerabilities';
+import {
+    convertToFlatImageVulnerabilitiesQuery, // imageVulnerabilitiesQuery
+} from '../WorkloadCves/Image/ImagePageVulnerabilities';
+import {
+    convertToFlatImageCveAffectedDeploymentsQuery, // imageCveAffectedDeploymentsQuery
+    convertToFlatImageCveAffectedImagesQuery, // imageCveAffectedImagesQuery
 } from '../WorkloadCves/ImageCve/ImageCvePage';
 
 /**
@@ -37,12 +41,12 @@ const queryFieldNames = uniq(
         cveListQuery,
         deploymentListQuery,
         // Queries for the Workload CVE detail page
-        imageCveAffectedDeploymentsQuery,
-        imageCveAffectedImagesQuery,
+        convertToFlatImageCveAffectedDeploymentsQuery(true), // imageCveAffectedDeploymentsQuery
+        convertToFlatImageCveAffectedImagesQuery(true), // imageCveAffectedImagesQuery
         // Query for the Workload CVE image detail page
-        imageVulnerabilitiesQuery,
+        convertToFlatImageVulnerabilitiesQuery(true), // imageVulnerabilitiesQuery
         // Query for the Workload CVE deployment detail page
-        deploymentVulnerabilitiesQuery,
+        convertToFlatDeploymentVulnerabilitiesQuery(true), //deploymentVulnerabilitiesQuery
     ].flatMap(extractTopLevelFieldNames)
 );
 


### PR DESCRIPTION
### Description

Review with ignore whitespace setting.

### Problem

GraphQL queries for deployment and image component vulnerabilities support `advisory` property **only if** backend `'ROX_FLATTEN_CVE_DATA'` feature flag is enabled.

### Analysis

Three levels of GraphQL queries and 2 pairs of components that request the data.

Bottom up for **deployment** components:

`deploymentComponentVulnerabilitiesFragment` in DeploymentComponentVulnerabilitiesTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx#L29-L46

first `deploymentsForCveFragment` in AffectedDeploymentsTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx#L68-L88

parent `imageCveAffectedDeploymentsQuery` in ImageCvePage.tsx file (see image)
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx#L136-L152

second `deploymentWithVulnerabilitiesFragment` in DeploymentVulnerabilitiesTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx#L66-L93

parent `deploymentVulnerabilitiesQuery` in DeploymentPageVulnerabilities.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx#L79-L93

Bottom up for **image** component:

`imageComponentVulnerabilitiesFragment` in imageComponentVulnerabilitiesTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx#L31-L35

first `imagesForCve` in AffectedImagesTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx#L100-L119

parent `imageCveAffectedImagesQuery` in ImageCvePage.tsx file (see deployment)
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx#L122-L134

second `imageVulnerabilitiesFragment` in ImageVulnerabilitiesTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx#L98-L120

parent `imageVulnerabilitiesQuery` in ImagePageVulnerabilities.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx#L71-L92

### Solution

Thank you, **David Vail** for brainstorming which changes to make where and how (including how to delete conditional query after release.)

Apply similar pattern as for search autocomplete in #15317

1. Add `convertToFlatWhatever` helper functions to encapsulate `Whatever` queries at module scope, where feature flag disabled/enabled is not available.
    Unlike some of the changes for search autocomplete, do **not** move code from module scope to component scope to minimize churn.
2. Call `convertToFlatWhatever` helper functions with `isFlattenCveDataEnabled` argument in component files, where feature flag enabled/disabled is available via `usePermissions` hook.
3. Call  `convertToFlatWhatever` helper functions with `true` argument in `useInvalidateVulnerabilities` hook (because only top-level queries matter).

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsx` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.

#### Manual testing

Thank you, **Surabhi** for central with backend and scanner feature flags enabled.

For first test pass, temporarily add `advisory` following `fixedByVersion` in fragments.
For second test pass, remove `advisory` in fragments and add `console.log` in components to gain some confidence that functions calls do not cause problem for `useQuery` hooks. Anywhere from 2 to 4 calls, but only one request.

1. Visit /main/vulnerabilities/platform and then click a link to visit vulnerability page.

    See `getImagesForCVE` request with `advisory: ""` property in reponse.
    ![cves_image](https://github.com/user-attachments/assets/c9a29ce1-d4e9-4a83-88ea-524ff94b3a84)

2. Click link to open image page.

    See `getCVEsForImage` request with `advisory: ""` property in response.
    ![image](https://github.com/user-attachments/assets/acc71892-2b33-4c85-8615-4919f2ab7419)

3. Click **Deployments** toggle.

    See `getDeploymentsForCVE` request with `advisory: ""` property in response.
    ![cves_deployment](https://github.com/user-attachments/assets/577af2a0-f0d9-4d30-9972-6efe4f2e3b40)

4. Click link to open deployment page.

    See `getCvesForDeployment` request with `advisory: ""` property in response.
    ![deployment](https://github.com/user-attachments/assets/04e46533-7234-42ae-ac0b-1e2fcf76810e)
