### PR TITLE
perf(signatures): break early on successful verification

### DIFF
--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -191,14 +191,14 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 	// Find the union of all image references from verified signatures. The resulting status
 	// is verified if at least one verification was successful.
 	//
-	// verifier_1(sig_1) OR ... OR verifier_1(sig_N)
+	// verifier_1(sig_1) OR ... OR verifier_N(sig_1)
 	// OR
 	// ...
 	// OR
-	// verifier_N(sig_1) OR ... OR verifier_N(sig_N)
+	// verifier_1(sig_N) OR ... OR verifier_N(sig_N)
 	verifiedImageReferences := set.NewStringSet()
-	for _, opts := range c.verifierOpts {
-		for _, sig := range sigs {
+	for _, sig := range sigs {
+		for _, opts := range c.verifierOpts {
 			verifierRefs, err := verifyImageSignature(ctx, sig, hash, image, opts)
 			if err != nil {
 				allVerifyErrs = multierror.Append(allVerifyErrs, err)
@@ -206,6 +206,9 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 			}
 			// Successful verification. Keep the image references.
 			verifiedImageReferences.AddAll(verifierRefs...)
+			// We can exit the inner loop early here because the verified references
+			// do not depend on the verifier.
+			break
 		}
 	}
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

I realized that we can skip the remaining verifiers if we already found a match for a particular signature. Hence, invert the loop order and break on successful match. This will lead to a speed up in cases where multiple verifiers are added to integration that all match the same signature.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI