### PR TITLE
fix: set GOPATH from go env

### DIFF
--- a/make/env.mk
+++ b/make/env.mk
@@ -5,9 +5,15 @@ SHELL := /bin/bash
 colon := :
 comma := ,
 
-# GOPATH might actually be a colon-separated list of paths. For the purposes of this makefile,
-# work with the first element only.
+# GOPATH might not be exported in the current shell but is available in the
+# Go environment.
+ifndef $(GOPATH)
+    GOPATH=$(shell go env GOPATH)
+    export GOPATH
+endif
 
+# GOPATH might actually be a colon-separated list of paths. For the purposes of
+# this makefile, work with the first element only.
 ifeq ($(findstring :, $(GOPATH)), $(colon))
 GOPATH := $(firstword $(subst :, ,$(GOPATH)))
 endif


### PR DESCRIPTION
### Description

The `*-dockerized` make targets assume that the shell variable `GOPATH` is set; however, Go will default to variables configured in `go env` if one is not set, meaning that developers might not have the shell variable explicitly set.

These changes will allow any Makefiles that include `make/env.mk` to have `GOPATH` be inferred by `go env GOPATH`.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- [ ] ~~the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)~~
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

Current automated testing should be sufficient.

#### How I validated my change

Before:
```
❯ make main-build-dockerized
+ main-build-dockerized
docker run --user "501" -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm -w /src -e GOPATH=/go -e GOCACHE=/linux-gocache -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='/src' -v ~/dev/stackrox/stackrox/master:/src:delegated -v ~/dev/stackrox/stackrox/master/linux-gocache:/linux-gocache:delegated -v :/go:delegated -v ~/dev/stackrox/stackrox/..:~/dev/stackrox/stackrox/.. docker.io/library/golang:1.23 make main-build-nodeps
docker: invalid spec: :/go:delegated: empty section between colons.
See 'docker run --help'.
make: *** [Makefile:484: main-build-dockerized] Error 125
```

After:
```
❯ make main-build-dockerized
+ main-build-dockerized
docker run --user "501" -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMITsafe.directory -e GIT_CONFIG_VALUE_0='/src' -v ~/dev/stackrox/stackrox/master:/src:delegated -v ~/dev/stackrox/stackrox/master/linux-gocache:/linux-gocache:delegated -v ~/go:/go:delegated -v ~/dev/stackrox/stackrox/..:~/dev/stackrox/stackrox/.. docker.io/library/golang:1.23 make main-build-nodeps
+ central-build-nodeps
/src/scripts/go-build.sh central
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./central to bin/linux_arm64/central
+ migrator-build-nodeps
/src/scripts/go-build.sh migrator
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./migrator to bin/linux_arm64/migrator
+ config-controller-build-nodeps
/src/scripts/go-build.sh config-controller
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./config-controller to bin/linux_arm64/config-controller
/src/scripts/go-build.sh sensor/kubernetes sensor/admission-control compliance/cmd/compliance
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./sensor/kubernetes to bin/linux_arm64/kubernetes
Compiling Go source in ./sensor/admission-control to bin/linux_arm64/admission-control
Compiling Go source in ./compliance/cmd/compliance to bin/linux_arm64/compliance
/src/scripts/go-build.sh sensor/upgrader
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./sensor/upgrader to bin/linux_arm64/upgrader
/src/scripts/go-build.sh sensor/init-tls-certs
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./sensor/init-tls-certs to bin/linux_arm64/init-tls-certs
CGO_ENABLED=0 /src/scripts/go-build.sh roxctl
Compiling Go source in ./roxctl to bin/linux_arm64/roxctl
```
