### PR TITLE
fix: add user defined volumes to make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ else
 GOPATH_VOLUME_SRC := $(GOPATH_VOLUME_NAME)
 endif
 
-LOCAL_VOLUME_ARGS := -v $(CURDIR):/src:delegated -v $(GOCACHE_VOLUME_SRC):/linux-gocache:delegated -v $(GOPATH_VOLUME_SRC):/go:delegated
+LOCAL_VOLUME_ARGS := -v $(CURDIR):/src:delegated -v $(GOCACHE_VOLUME_SRC):/linux-gocache:delegated -v $(GOPATH_VOLUME_SRC):/go:delegated$(if $(ADDITIONAL_LOCAL_VOLUME_ARGS), $(ADDITIONAL_LOCAL_VOLUME_ARGS))
 GOPATH_WD_OVERRIDES := -w /src -e GOPATH=/go -e GOCACHE=/linux-gocache -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='/src'
 
 null :=


### PR DESCRIPTION
### Description

The `*-dockerized` make targets will map, among other volumes, the current working directory to `/src`. Some scripts used by these make targets will run git commands against `/src`. However, a developer will be met with an error if the current working directory is a git worktree that references a git directory outside of the current directory.

These changes allow developers to set a new variable, `ADDITIONAL_LOCAL_VOLUME_ARGS`, that will be appended to `LOCAL_VOLUME_ARGS`.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- ~~[ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)~~
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

Current automated testing should be sufficient.

#### How I validated my change

Before:
```
❯ make main-build-dockerized
+ main-build-dockerized
docker run --user "501" -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm -w /src -e GOPATH=/go -e GOCACHE=/linux-gocache -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='/src' -v ~/dev/stackrox/stackrox/work:/src:delegated -v ~/dev/stackrox/stackrox/work/linux-gocache:/linux-gocache:delegated -v ~/go:/go:delegated docker.io/library/golang:1.23 make main-build-nodeps
fatal: not a git repository: ~/dev/stackrox/stackrox/.bare/worktrees/work
fatal: not a git repository: ~/dev/stackrox/stackrox/.bare/worktrees/work
+ central-build-nodeps
/src/scripts/go-build.sh central
fatal: not a git repository: ~/dev/stackrox/stackrox/.bare/worktrees/work
fatal: not a git repository: ~/dev/stackrox/stackrox/.bare/worktrees/work
fatal: not a git repository: ~/dev/stackrox/stackrox/.bare/worktrees/work
Malformed status.sh output line STABLE_MAIN_VERSION
make: *** [Makefile:244: central-build-nodeps] Error 1
make: *** [Makefile:484: main-build-dockerized] Error 2
```

After (note the variable export at the start):
```
❯ export ADDITIONAL_LOCAL_VOLUME_ARGS="-v $PWD/..:$PWD/.."
❯ make main-build-dockerized
+ main-build-dockerized
docker run --user "501" -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm -w /src -e GOPATH=/go -e GOCACHE=/linux-gocache -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='/src' -v ~/dev/stackrox/stackrox/work:/src:delegated -v ~/dev/stackrox/stackrox/work/linux-gocache:/linux-gocache:delegated -v ~/go:/go:delegated -v ~/dev/stackrox/stackrox/work/..:~/dev/stackrox/stackrox/work/.. docker.io/library/golang:1.23 make main-build-nodeps
+ central-build-nodeps
/src/scripts/go-build.sh central
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./central to bin/linux_arm64/central
+ migrator-build-nodeps
/src/scripts/go-build.sh migrator
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./migrator to bin/linux_arm64/migrator
+ config-controller-build-nodeps
/src/scripts/go-build.sh config-controller
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./config-controller to bin/linux_arm64/config-controller
/src/scripts/go-build.sh sensor/kubernetes sensor/admission-control compliance/cmd/compliance
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./sensor/kubernetes to bin/linux_arm64/kubernetes
Compiling Go source in ./sensor/admission-control to bin/linux_arm64/admission-control
Compiling Go source in ./compliance/cmd/compliance to bin/linux_arm64/compliance
/src/scripts/go-build.sh sensor/upgrader
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./sensor/upgrader to bin/linux_arm64/upgrader
/src/scripts/go-build.sh sensor/init-tls-certs
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./sensor/init-tls-certs to bin/linux_arm64/init-tls-certs
CGO_ENABLED=0 /src/scripts/go-build.sh roxctl
Compiling Go source in ./roxctl to bin/linux_arm64/roxctl
```
