### PR TITLE
ROX-19095: Ensure image names are not lost

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -583,7 +583,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 		Id:   imgID,
 		Name: request.GetImageName(),
 		// 'Names' must be populated to enable cache hits in central AND sensor.
-		Names:          buildNames(request.GetImageName(), request.GetMetadata()),
+		Names:          buildNames(request.GetImageName(), existingImg.GetNames(), request.GetMetadata()),
 		Signature:      request.GetImageSignature(),
 		Metadata:       request.GetMetadata(),
 		Notes:          request.GetImageNotes(),
@@ -685,8 +685,9 @@ func shouldUpdateExistingScan(imgExists bool, existingImg *storage.Image, reques
 }
 
 // buildNames returns a slice containing the known image names from the various parameters.
-func buildNames(srcImage *storage.ImageName, metadata *storage.ImageMetadata) []*storage.ImageName {
-	names := []*storage.ImageName{srcImage}
+func buildNames(srcImageName *storage.ImageName, existingNames []*storage.ImageName, metadata *storage.ImageMetadata) []*storage.ImageName {
+	names := []*storage.ImageName{srcImageName}
+	names = append(names, existingNames...)
 
 	// Add a mirror name if exists.
 	if mirror := metadata.GetDataSource().GetMirror(); mirror != "" {
@@ -699,6 +700,7 @@ func buildNames(srcImage *storage.ImageName, metadata *storage.ImageMetadata) []
 		}
 	}
 
+	names = protoutils.SliceUnique(names)
 	return names
 }
 

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -685,9 +685,9 @@ func shouldUpdateExistingScan(imgExists bool, existingImg *storage.Image, reques
 }
 
 // buildNames returns a slice containing the known image names from the various parameters.
-func buildNames(srcImageName *storage.ImageName, existingNames []*storage.ImageName, metadata *storage.ImageMetadata) []*storage.ImageName {
-	names := []*storage.ImageName{srcImageName}
-	names = append(names, existingNames...)
+func buildNames(requestImageName *storage.ImageName, existingImageNames []*storage.ImageName, metadata *storage.ImageMetadata) []*storage.ImageName {
+	names := []*storage.ImageName{requestImageName}
+	names = append(names, existingImageNames...)
 
 	// Add a mirror name if exists.
 	if mirror := metadata.GetDataSource().GetMirror(); mirror != "" {

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -183,12 +183,12 @@ func (c *cacheValue) scanAndSet(ctx context.Context, svc v1.ImageServiceClient, 
 		// Ignore the error and set the image to something basic,
 		// so alerting can progress.
 		log.Errorf("Scan request failed for image %q (ID %q): %s", req.containerImage.GetName().GetFullName(), req.containerImage.GetId(), err)
-		c.image = types.ToImage(req.containerImage)
+		c.updateImageNoLock(types.ToImage(req.containerImage))
 		return
 	}
 
 	log.Debugf("Successful image scan for image %q (ID %q): %d components returned by scanner", req.containerImage.GetName().GetFullName(), req.containerImage.GetId(), len(scannedImage.GetImage().GetScan().GetComponents()))
-	c.image = scannedImage.GetImage()
+	c.updateImageNoLock(scannedImage.GetImage())
 }
 
 func (c *cacheValue) scanAndSetWithLock(ctx context.Context, svc v1.ImageServiceClient, req *scanImageRequest) {


### PR DESCRIPTION
### Description

The observed 'names' for an image are used to determine if a cached scan should be used (amongst other things). When these names are 'lost' cache misses will occur and potentially lead to excessive registry traffic (observed in the wild).

This PR enhances both Central's and Sensor's handling of image names to ensure names are not lost, increasing chances of cache hits.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

Unit tests + manual testing

<details>
<summary>Setup Commands</summary>

To deploy nginx-a:
```
$ k apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: nginx-a
spec:
  containers:
  - name: main
    image: nginx:1.27.5-bookworm
  restartPolicy: Always
EOF
```

To deploy nginx-b
```
$ k apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: nginx-b
spec:
  containers:
  - name: main
    image: nginx:1.27.5
  restartPolicy: Never
  imagePullSecrets:
  - name: arti
EOF
```

The `names.sh` script:

```sh
#!/bin/bash

json=$(curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440)



echo "   id: $(echo $json | jq -r '.id')"
echo " name: $(echo $json | jq -r '.name.fullName')"
echo "names:"
names=$(echo $json | jq -r '.names[].fullName')
i=0
for name in $names
do
    echo "  [$i]: $name"
    ((i++))
done
```
</details>

### Test 1: Current state (no fix)
Observe that scans are repeated when deploys updated and names are lost

```
# deploy nginx-a
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5-bookworm
names:
  [0]: docker.io/library/nginx:1.27.5-bookworm

# deploy nginx-b
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5

# update pod a
$ k label pod nginx-a --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5-bookworm
names:
  [0]: docker.io/library/nginx:1.27.5-bookworm

# update pod b
$ k label pod nginx-b --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
```
Sensor logs
```
common/detector: 2025/05/20 01:21:13.350891 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:21:14.452198 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:21:45.147262 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:21:46.622187 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:21:46.622947 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:22:10.877420 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:22:23.753082 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
```

### Test 2: With Central fix but not Sensor
Observe that the names are not lost, and scans are not repeated when deploy updated
```
$ k set image deploy/central central=quay.io/rhacs-eng/main:4.8.x-713-g95ab4918b7

# deploy nginx-a
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5-bookworm
names:
  [0]: docker.io/library/nginx:1.27.5-bookworm

# deploy nginx-b
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
  [1]: docker.io/library/nginx:1.27.5-bookworm

# update pod a
$ k label pod nginx-a --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
  [1]: docker.io/library/nginx:1.27.5-bookworm

# update pod b
$ k label pod nginx-b --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
  [1]: docker.io/library/nginx:1.27.5-bookworm
```

Sensor logs
```
common/detector: 2025/05/20 01:25:06.268523 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:25:07.653920 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:25:23.738836 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:25:24.660876 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:25:24.661473 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
```

###  Test 3: With Sensor fix but not Central
Observe that the names are lost, but scans are not repeated when deploy updated (sensor cache hit)
```
$ k set image deploy/sensor sensor=quay.io/rhacs-eng/main:4.8.x-713-g95ab4918b7

# deploy nginx-a
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5-bookworm
names:
  [0]: docker.io/library/nginx:1.27.5-bookworm

# deploy nginx-b
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5

# update pod a
$ k label pod nginx-a --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5

# update pod b
$ k label pod nginx-b --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
```

Sensor logs
```
common/detector: 2025/05/20 01:28:59.944742 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:29:00.736183 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:29:27.062793 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:29:27.847332 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:29:27.847847 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
```

###  Test 4: With fix in both Central and Sensor
Observe that the names are not lost, and scans are not repeated when deploy updated
```
$ k set image deploy/sensor sensor=quay.io/rhacs-eng/main:4.8.x-713-g95ab4918b7
$ k set image deploy/central central=quay.io/rhacs-eng/main:4.8.x-713-g95ab4918b7


# deploy nginx-a
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5


# deploy nginx-b
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
  [1]: docker.io/library/nginx:1.27.5-bookworm

# update pod a
$ k label pod nginx-a --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
  [1]: docker.io/library/nginx:1.27.5-bookworm


# update pod b
$ k label pod nginx-b --overwrite dave=1
$ ./names.sh
   id: sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440
 name: docker.io/library/nginx:1.27.5
names:
  [0]: docker.io/library/nginx:1.27.5
  [1]: docker.io/library/nginx:1.27.5-bookworm
```

Sensor logs
```
common/detector: 2025/05/20 01:32:15.651194 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:32:16.664107 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm"
common/detector: 2025/05/20 01:32:24.296390 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:32:25.706875 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
common/detector: 2025/05/20 01:32:25.707362 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5"
```
