### PR TITLE
ROX-29093: Show disabled save as CR option when default policy

### DIFF
--- a/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.jsx
+++ b/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.jsx
@@ -38,7 +38,7 @@ test('can press the next button when on the first page', async () => {
     expect(button).toBeEnabled();
 });
 
-test('can not press the next button when on the last page', async () => {
+test('cannot press the next button when on the last page', async () => {
     render(<MockPagination defaultPage={5} />);
     const button = screen.getByRole('button', options);
 

--- a/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.test.jsx
+++ b/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.test.jsx
@@ -17,7 +17,7 @@ const MockPaginationInput = ({ defaultPage = 1 }) => {
     );
 };
 
-test('can not set page to a higher value than the total pages count', async () => {
+test('cannot set page to a higher value than the total pages count', async () => {
     render(<MockPaginationInput />);
     const input = screen.getByTestId('pagination-input');
 
@@ -26,7 +26,7 @@ test('can not set page to a higher value than the total pages count', async () =
     expect(input.value).toBe('5');
 });
 
-test('can not set page to a lower value than 1', async () => {
+test('cannot set page to a lower value than 1', async () => {
     render(<MockPaginationInput />);
     const input = screen.getByTestId('pagination-input');
 

--- a/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.jsx
+++ b/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.jsx
@@ -30,7 +30,7 @@ const options = {
     name: 'Go to previous page', // aria-label attribute
 };
 
-test('can not press the previous button when on the first page', async () => {
+test('cannot press the previous button when on the first page', async () => {
     render(<MockPagination defaultPage={1} />);
     const button = screen.getByRole('button', options);
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -114,7 +114,7 @@ function yupLabelRuleObject({ field }: ByLabelResourceSelector) {
                         yup.object().shape({
                             value: yup
                                 .string()
-                                .required('This field can not be empty')
+                                .required('This field cannot be empty')
                                 .test(
                                     'label-value-k8s-format',
                                     'Labels must be valid k8s labels in the form: key=value',
@@ -150,7 +150,7 @@ function yupNameRuleObject({ field }: ByNameResourceSelector) {
                 .of(
                     yup.object().shape({
                         // TODO Add validation for k8s cluster, namespace, and deployment name characters
-                        value: yup.string().trim().required('This field can not be empty'),
+                        value: yup.string().trim().required('This field cannot be empty'),
                         matchType: yup
                             .string()
                             .required()

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ApiTokenIntegrationForm/ApiTokenIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ApiTokenIntegrationForm/ApiTokenIntegrationForm.tsx
@@ -99,7 +99,7 @@ function ApiTokenIntegrationForm({
     if (isEditing) {
         return (
             <NotFoundMessage
-                title="This API Token can not be edited"
+                title="This API Token cannot be edited"
                 message="Create a new API Token or delete an existing one"
             />
         );

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -74,7 +74,7 @@ export function clearStoredCredentials<I extends IntegrationBase>(
 
 export function getEditDisabledMessage(type) {
     if (type === 'apitoken') {
-        return 'This API Token can not be edited. Create a new API Token or delete an existing one.';
+        return 'This API Token cannot be edited. Create a new API Token or delete an existing one.';
     }
     return '';
 }

--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement, useState } from 'react';
-import { Link, LinkProps, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
 import {
+    ApplicationLauncher,
     ApplicationLauncherGroup,
     ApplicationLauncherItem,
     ApplicationLauncherSeparator,
@@ -19,55 +19,67 @@ function HelpMenu(): ReactElement {
     const [isHelpMenuOpen, setIsHelpMenuOpen] = useState(false);
     const dispatch = useDispatch();
 
-    return (
-        <Dropdown
-            isOpen={isHelpMenuOpen}
-            onOpenChange={(isOpen) => setIsHelpMenuOpen(isOpen)}
-            onOpenChangeKeys={['Escape', 'Tab']}
-            popperProps={{ position: 'right' }}
-            toggle={(toggleRef) => (
-                <MenuToggle
-                    aria-label="Help Menu"
-                    ref={toggleRef}
-                    variant="plain"
-                    onClick={() => setIsHelpMenuOpen((wasOpen) => !wasOpen)}
-                    isExpanded={isHelpMenuOpen}
-                >
-                    <QuestionCircleIcon />
-                </MenuToggle>
+    function onToggleHelpMenu() {
+        setIsHelpMenuOpen(!isHelpMenuOpen);
+    }
+
+    // React requires key to render an item in an array of elements.
+    const appLauncherItems = [
+        <ApplicationLauncherGroup key="">
+            <ApplicationLauncherItem
+                component={
+                    <Link className="pf-v5-c-app-launcher__menu-item" to={apidocsPath}>
+                        API Reference (v1)
+                    </Link>
+                }
+            />
+            <ApplicationLauncherItem
+                component={
+                    <Link className="pf-v5-c-app-launcher__menu-item" to={apidocsPathV2}>
+                        API Reference (v2)
+                    </Link>
+                }
+            />
+            <ApplicationLauncherItem
+                component="button"
+                onClick={() => {
+                    dispatch(actions.setFeedbackModalVisibility(true));
+                }}
+            >
+                Share feedback
+            </ApplicationLauncherItem>
+            {version && (
+                <>
+                    <ApplicationLauncherItem
+                        href={getVersionedDocs(version)}
+                        isExternal
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Help Center
+                    </ApplicationLauncherItem>
+                    <ApplicationLauncherSeparator />
+                    <ApplicationLauncherItem isDisabled>
+                        {`v${version}${releaseBuild ? '' : ' [DEV BUILD]'}`}
+                    </ApplicationLauncherItem>
+                </>
             )}
-        >
-            <DropdownList>
-                <DropdownItem>
-                    <Link to={apidocsPath}>API Reference (v1)</Link>
-                </DropdownItem>
-                <DropdownItem>
-                    <Link to={apidocsPathV2}>API Reference (v2)</Link>
-                </DropdownItem>
-                <DropdownItem
-                    component="button"
-                    onClick={() => dispatch(actions.setFeedbackModalVisibility(true))}
-                >
-                    Share feedback
-                </DropdownItem>
-                {version && (
-                    <>
-                        <DropdownItem
-                            to={getVersionedDocs(version)}
-                            isExternalLink
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Help Center
-                        </DropdownItem>
-                        <Divider component="li" />
-                        <DropdownItem isDisabled>
-                            {`v${version}${releaseBuild ? '' : ' [DEV BUILD]'}`}
-                        </DropdownItem>
-                    </>
-                )}
-            </DropdownList>
-        </Dropdown>
+        </ApplicationLauncherGroup>,
+    ];
+
+    return (
+        <ApplicationLauncher
+            aria-label="Help menu"
+            isGrouped
+            isOpen={isHelpMenuOpen}
+            items={appLauncherItems}
+            onToggle={onToggleHelpMenu}
+            onSelect={onToggleHelpMenu}
+            position="right"
+            toggleIcon={<QuestionCircleIcon alt="" />}
+            className="co-app-launcher"
+            data-quickstart-id="qs-masthead-utilitymenu"
+        />
     );
 }
 

--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, LinkProps, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
 import {
-    ApplicationLauncher,
     ApplicationLauncherGroup,
     ApplicationLauncherItem,
     ApplicationLauncherSeparator,
@@ -19,67 +19,55 @@ function HelpMenu(): ReactElement {
     const [isHelpMenuOpen, setIsHelpMenuOpen] = useState(false);
     const dispatch = useDispatch();
 
-    function onToggleHelpMenu() {
-        setIsHelpMenuOpen(!isHelpMenuOpen);
-    }
-
-    // React requires key to render an item in an array of elements.
-    const appLauncherItems = [
-        <ApplicationLauncherGroup key="">
-            <ApplicationLauncherItem
-                component={
-                    <Link className="pf-v5-c-app-launcher__menu-item" to={apidocsPath}>
-                        API Reference (v1)
-                    </Link>
-                }
-            />
-            <ApplicationLauncherItem
-                component={
-                    <Link className="pf-v5-c-app-launcher__menu-item" to={apidocsPathV2}>
-                        API Reference (v2)
-                    </Link>
-                }
-            />
-            <ApplicationLauncherItem
-                component="button"
-                onClick={() => {
-                    dispatch(actions.setFeedbackModalVisibility(true));
-                }}
-            >
-                Share feedback
-            </ApplicationLauncherItem>
-            {version && (
-                <>
-                    <ApplicationLauncherItem
-                        href={getVersionedDocs(version)}
-                        isExternal
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Help Center
-                    </ApplicationLauncherItem>
-                    <ApplicationLauncherSeparator />
-                    <ApplicationLauncherItem isDisabled>
-                        {`v${version}${releaseBuild ? '' : ' [DEV BUILD]'}`}
-                    </ApplicationLauncherItem>
-                </>
-            )}
-        </ApplicationLauncherGroup>,
-    ];
-
     return (
-        <ApplicationLauncher
-            aria-label="Help menu"
-            isGrouped
+        <Dropdown
             isOpen={isHelpMenuOpen}
-            items={appLauncherItems}
-            onToggle={onToggleHelpMenu}
-            onSelect={onToggleHelpMenu}
-            position="right"
-            toggleIcon={<QuestionCircleIcon alt="" />}
-            className="co-app-launcher"
-            data-quickstart-id="qs-masthead-utilitymenu"
-        />
+            onOpenChange={(isOpen) => setIsHelpMenuOpen(isOpen)}
+            onOpenChangeKeys={['Escape', 'Tab']}
+            popperProps={{ position: 'right' }}
+            toggle={(toggleRef) => (
+                <MenuToggle
+                    aria-label="Help Menu"
+                    ref={toggleRef}
+                    variant="plain"
+                    onClick={() => setIsHelpMenuOpen((wasOpen) => !wasOpen)}
+                    isExpanded={isHelpMenuOpen}
+                >
+                    <QuestionCircleIcon />
+                </MenuToggle>
+            )}
+        >
+            <DropdownList>
+                <DropdownItem>
+                    <Link to={apidocsPath}>API Reference (v1)</Link>
+                </DropdownItem>
+                <DropdownItem>
+                    <Link to={apidocsPathV2}>API Reference (v2)</Link>
+                </DropdownItem>
+                <DropdownItem
+                    component="button"
+                    onClick={() => dispatch(actions.setFeedbackModalVisibility(true))}
+                >
+                    Share feedback
+                </DropdownItem>
+                {version && (
+                    <>
+                        <DropdownItem
+                            to={getVersionedDocs(version)}
+                            isExternalLink
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Help Center
+                        </DropdownItem>
+                        <Divider component="li" />
+                        <DropdownItem isDisabled>
+                            {`v${version}${releaseBuild ? '' : ' [DEV BUILD]'}`}
+                        </DropdownItem>
+                    </>
+                )}
+            </DropdownList>
+        </Dropdown>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -230,19 +230,23 @@ function PolicyDetail({
                                               >
                                                   Export policy to JSON
                                               </DropdownItem>,
-                                              !isDefault ? (
-                                                  <DropdownItem
-                                                      key="Save as Custom Resource"
-                                                      component="button"
-                                                      onClick={() =>
-                                                          setIsSaveAsCustomResourceOpen(true)
-                                                      }
-                                                  >
-                                                      Save as Custom Resource
-                                                  </DropdownItem>
-                                              ) : (
-                                                  <React.Fragment key="Save as Custom Resource"></React.Fragment>
-                                              ),
+                                              <DropdownItem
+                                                  key="Save as Custom Resource"
+                                                  component="button"
+                                                  isDisabled={isDefault}
+                                                  description={
+                                                      isDefault
+                                                          ? 'Default policies can not be saved as Custom Resource'
+                                                          : ''
+                                                  }
+                                                  onClick={() =>
+                                                      setIsSaveAsCustomResourceOpen(true)
+                                                  }
+                                              >
+                                                  {isDefault
+                                                      ? 'Cannot save as Custom Resource'
+                                                      : 'Save as Custom Resource'}
+                                              </DropdownItem>,
                                               <DropdownItem
                                                   key="Enable/Disable policy"
                                                   component="button"
@@ -270,19 +274,23 @@ function PolicyDetail({
                                               >
                                                   Export policy to JSON
                                               </DropdownItem>,
-                                              !isDefault ? (
-                                                  <DropdownItem
-                                                      key="Save as Custom Resource"
-                                                      component="button"
-                                                      onClick={() =>
-                                                          setIsSaveAsCustomResourceOpen(true)
-                                                      }
-                                                  >
-                                                      Save as Custom Resource
-                                                  </DropdownItem>
-                                              ) : (
-                                                  <React.Fragment key="Save as Custom Resource"></React.Fragment>
-                                              ),
+                                              <DropdownItem
+                                                  key="Save as Custom Resource"
+                                                  component="button"
+                                                  isDisabled={isDefault}
+                                                  description={
+                                                      isDefault
+                                                          ? 'Default policies can not be saved as Custom Resource'
+                                                          : ''
+                                                  }
+                                                  onClick={() =>
+                                                      setIsSaveAsCustomResourceOpen(true)
+                                                  }
+                                              >
+                                                  {isDefault
+                                                      ? 'Cannot save as Custom Resource'
+                                                      : 'Save as Custom Resource'}
+                                              </DropdownItem>,
                                           ]
                                 }
                             />

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -236,7 +236,7 @@ function PolicyDetail({
                                                   isDisabled={isDefault}
                                                   description={
                                                       isDefault
-                                                          ? 'Default policies can not be saved as Custom Resource'
+                                                          ? 'Default policies cannot be saved as Custom Resource'
                                                           : ''
                                                   }
                                                   onClick={() =>
@@ -280,7 +280,7 @@ function PolicyDetail({
                                                   isDisabled={isDefault}
                                                   description={
                                                       isDefault
-                                                          ? 'Default policies can not be saved as Custom Resource'
+                                                          ? 'Default policies cannot be saved as Custom Resource'
                                                           : ''
                                                   }
                                                   onClick={() =>

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -434,7 +434,7 @@ function PoliciesTable({
                                 ? 'Cannot save as Custom Resource'
                                 : 'Save as Custom Resource',
                             description: isDefault
-                                ? 'Default policies can not be saved as Custom Resource'
+                                ? 'Default policies cannot be saved as Custom Resource'
                                 : '',
                             onClick: () => setSavingIds([id]),
                             isDisabled: isDefault,

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -21,6 +21,7 @@ import {
 import {
     ActionsColumn,
     ExpandableRowContent,
+    IAction,
     Table,
     Tbody,
     Td,
@@ -35,7 +36,6 @@ import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import PolicyDisabledIconText from 'Components/PatternFly/IconText/PolicyDisabledIconText';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
 import SearchFilterInput from 'Components/SearchFilterInput';
-import { ActionItem } from 'Containers/Violations/ViolationsTablePanel';
 import EnableDisableNotificationModal, {
     EnableDisableType,
 } from 'Containers/Policies/Modal/EnableDisableNotificationModal';
@@ -423,20 +423,22 @@ function PoliciesTable({
                             labelAndNotifierIdsForTypes,
                             notifierIds
                         );
-                        const exportPolicyAction: ActionItem = {
+                        const exportPolicyAction: IAction = {
                             title: 'Export policy to JSON',
                             onClick: () => exportPoliciesHandler([id]),
                         };
                         // Store as an array so that we can conditionally spread into actionItems
                         // based on feature flag without having to deal with nulls
-                        const saveAsCustomResourceActionItems: ActionItem[] = !isDefault
-                            ? [
-                                  {
-                                      title: 'Save as Custom Resource',
-                                      onClick: () => setSavingIds([id]),
-                                  },
-                              ]
-                            : [];
+                        const saveAsCustomResourceActionItem: IAction = {
+                            title: isDefault
+                                ? 'Cannot save as Custom Resource'
+                                : 'Save as Custom Resource',
+                            description: isDefault
+                                ? 'Default policies can not be saved as Custom Resource'
+                                : '',
+                            onClick: () => setSavingIds([id]),
+                            isDisabled: isDefault,
+                        };
                         const actionItems = hasWriteAccessForPolicy
                             ? [
                                   {
@@ -457,7 +459,7 @@ function PoliciesTable({
                                             onClick: () => disablePoliciesHandler([id]),
                                         },
                                   exportPolicyAction,
-                                  ...saveAsCustomResourceActionItems,
+                                  saveAsCustomResourceActionItem,
                                   {
                                       isSeparator: true,
                                   },
@@ -469,7 +471,7 @@ function PoliciesTable({
                                       isDisabled: isDefault,
                                   },
                               ]
-                            : [exportPolicyAction, ...saveAsCustomResourceActionItems];
+                            : [exportPolicyAction, saveAsCustomResourceActionItem];
                         const rowIndex = rowIdToIndex[id];
                         return (
                             <Tbody

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.css
@@ -1,8 +1,8 @@
 /*
   Each child label is wrapped in a Tooltip, which as of PF5 has the style `display: contents;` applied
-  in a way that can not be overridden via props. This prevents us from rendering the children with
+  in a way that cannot be overridden via props. This prevents us from rendering the children with
   any sort of layout, so we need to override the display property here.
 */
-.severity-count-labels > div {
+.severity-count-labels>div {
   display: inline !important;
 }


### PR DESCRIPTION
### Description

Instead of omitting the "Save as CR" option from the policy menu when a selected policy is a default policy, instead we keep the option in the menu, disabled, with a brief description why. This is consistent with how we handle the policy delete action, and can help prevent confusion for users who see that the option is missing from the menu with no indication why.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Open a default policy row menu:
![image](https://github.com/user-attachments/assets/0d5d8ad2-af26-4b52-8dd3-f11ba60577cf)

Open a non-default policy row menu:
![image](https://github.com/user-attachments/assets/91cf1861-9bbb-494c-8e0c-60b50fc381b7)

Open the top menu on a default policy page:
![image](https://github.com/user-attachments/assets/72451539-7d3a-4566-875a-1f1c3779f097)

Open the top menu on a non-default policy page:
![image](https://github.com/user-attachments/assets/bb6d6115-06c0-4e37-af5e-5bb80fd42be1)

