### PR TITLE
ROX-28036: Display temporarily hidden EPSS probability columns

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -189,9 +189,8 @@ function DeploymentPageVulnerabilities({
         },
     });
 
-    // Omit for 4.7 release until CVE/advisory separation is available in 4.8 release.
-    // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled = false;
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA');
     const filteredColumns = filterManagedColumns(
         defaultColumns,
         (key) => key !== 'epssProbability' || isEpssProbabilityColumnEnabled
@@ -209,7 +208,8 @@ function DeploymentPageVulnerabilities({
         {
             ...imageCVESearchFilterConfig,
             attributes: imageCVESearchFilterConfig.attributes.filter(
-                ({ searchTerm }) => searchTerm !== 'EPSS Probability'
+                ({ searchTerm }) =>
+                    searchTerm !== 'EPSS Probability' || isEpssProbabilityColumnEnabled
             ),
         },
         convertToFlatImageComponentSearchFilterConfig(isFlattenCveDataEnabled),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -193,9 +193,8 @@ function ImagePageVulnerabilities({
     });
 
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    // Omit for 4.7 release until CVE/advisory separation is available in 4.8 release.
-    // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled = false;
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA');
     // totalAdvisories out of scope for MVP
     /*
     const isAdvisoryColumnEnabled =
@@ -227,7 +226,8 @@ function ImagePageVulnerabilities({
         {
             ...imageCVESearchFilterConfig,
             attributes: imageCVESearchFilterConfig.attributes.filter(
-                ({ searchTerm }) => searchTerm !== 'EPSS Probability'
+                ({ searchTerm }) =>
+                    searchTerm !== 'EPSS Probability' || isEpssProbabilityColumnEnabled
             ),
         },
         convertToFlatImageComponentSearchFilterConfig(isFlattenCveDataEnabled),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -3,8 +3,7 @@ import { Link } from 'react-router-dom';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-// Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
-// import useFeatureFlags from 'hooks/useFeatureFlags';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -120,10 +119,9 @@ function DeploymentVulnerabilitiesTable({
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
-    // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
-    // const { isFeatureFlagEnabled } = useFeatureFlags();
-    // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled = false;
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA');
 
     const colSpan = 7 + (isEpssProbabilityColumnEnabled ? 1 : 0) - hiddenColumnCount;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -178,9 +178,8 @@ function ImageVulnerabilitiesTable({
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    // Omit for 4.7 release until CVE/advisory separatipn is available in 4.8 release.
-    // const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled = false;
+    const isEpssProbabilityColumnEnabled =
+        isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA');
     // totalAdvisories out of scope for MVP
     /*
     const isAdvisoryColumnEnabled =


### PR DESCRIPTION
### Description

Be prepared to merge when cross-team say the time is right.

### Problem

Without CVE/advisory separaration in 4.7, **EPSS probability** for RHSA/RHBA/RHEA might differ between WorkloadCVEOverviewTable and the other tables:
* DeploymentVulnerabilitiesTable
* ImageVulnerabilitiesTable

### Analysis

Scanner team reports that even with mitigations, customers might notice differences depending on which CVE are associated with an advisory in a context.

### Solution

Conditional display depends on `'ROX_SCANNER_V4'` for data and `'ROX_FLATTEN_CVE_DATA'` for data model, but let it be independent of `'ROX_CVE_ADVISORY_SEPARATION'` for **Advisory** column.

Make changes according to:
* Changed files in #14201
* Find in Files `epssProbability`

By the way, conditional search filter was moved and updated in #15317

### Residue

1. Absence of spacing between second and third label in `CvePageHeader` element.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.

#### Manual testing

To test with staging demo as backend, verify absence with `'ROX_FLATTEN_CVE_DATA'` disabled and verify presence with temporary `!` to simulate enabled.

1. Visit /main/vulnerabilities/user-workloads

    As baseline, see `epssProbability` property in response and presence of **EPSS probability** column.
    ![user-workloads](https://github.com/user-attachments/assets/57ac4cf3-bee0-44c1-b717-e41f8ac3ff90)

2. Click link to visit vulnerability page.

    As baseline, see `epssProbability` property in response and presence of **EPSS probability** label.
    ![cves_id](https://github.com/user-attachments/assets/a7a07d21-b164-4ea0-8239-6e42a57de542)

3. Click link to visit image vulnerabilities page.

    Before changes, see `epssProbability` property in response but absence of **EPSS probability** search filter and table column.
    ![images_id_absence](https://github.com/user-attachments/assets/10e313f3-626b-4bcf-a5e2-2fe8d093eeba)

    After changes, see `epssProbability` property in response and presence of **EPSS probability** search filter and table column.
    ![images_id_presence](https://github.com/user-attachments/assets/4e7edb71-666b-438b-9b81-4f396bbf38ff)

4. Go back, click **Deployments**, and then click link to visit deployment vulnerabilities page.

    Before changes, see `epssProbability` property in response but absence of **EPSS probability** search filter and table column.
    ![deployments_id_absence](https://github.com/user-attachments/assets/e8a90110-a9cb-4e5e-ad81-90e3d12d5231)

    After changes, see `epssProbability` property in response and presence of **EPSS probability** search filter and table column.
    ![deployments_id_presence](https://github.com/user-attachments/assets/1d923790-5f37-42eb-b462-2414ac9f060a)
