### PR TITLE
ROX-29031: Add pagination to external flows tables

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -104,9 +104,9 @@ const TopologyComponent = ({
     const urlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
     const { setPage, setPerPage } = urlPagination;
     const anomalousUrlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'anomalous');
-    const { setPage: anomalousSetPage, setPerPage: anomalousSetPerPage } = anomalousUrlPagination;
+    const { setPage: setPageAnomalous, setPerPage: setPerPageAnomalous } = anomalousUrlPagination;
     const baselineUrlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'baseline');
-    const { setPage: baselineSetPage, setPerPage: baselineSetPerPage } = baselineUrlPagination;
+    const { setPage: setPageBaseline, setPerPage: setPerPageBaseline } = baselineUrlPagination;
 
     const urlSearchFiltering = useURLSearch('sidePanel');
     const { setSearchFilter } = urlSearchFiltering;
@@ -204,19 +204,19 @@ const TopologyComponent = ({
     useEffect(() => {
         setPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
         setPage(1);
-        anomalousSetPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-        anomalousSetPage(1);
-        baselineSetPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-        baselineSetPage(1);
+        setPerPageAnomalous(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
+        setPageAnomalous(1);
+        setPerPageBaseline(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
+        setPageBaseline(1);
         setSearchFilter({});
     }, [
         setPage,
         setPerPage,
         setSearchFilter,
-        anomalousSetPage,
-        anomalousSetPerPage,
-        baselineSetPage,
-        baselineSetPerPage,
+        setPageAnomalous,
+        setPerPageAnomalous,
+        setPageBaseline,
+        setPerPageBaseline,
         selectedNode,
     ]);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -97,10 +97,19 @@ const TopologyComponent = ({
     const hasReadAccessForNetworkPolicy = hasReadAccess('NetworkPolicy');
 
     const { detailID: selectedExternalIP } = useParams();
+
+    // three paginations (default + two flows tables: anomalous & baseline)
+    // deployment flows section has 2 tables instead of 1 which is why we need anomalous+baseline.
+    // set at the topology level so we can reset every table when switching nodes.
     const urlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
     const { setPage, setPerPage } = urlPagination;
+    const anomalousUrlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'anomalous');
+    const { setPage: anomalousSetPage, setPerPage: anomalousSetPerPage } = anomalousUrlPagination;
+    const baselineUrlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'baseline');
+    const { setPage: baselineSetPage, setPerPage: baselineSetPerPage } = baselineUrlPagination;
+
     const urlSearchFiltering = useURLSearch('sidePanel');
-    const { searchFilter, setSearchFilter } = urlSearchFiltering;
+    const { setSearchFilter } = urlSearchFiltering;
 
     const firstRenderRef = useRef(true);
     const location = useLocation();
@@ -193,14 +202,23 @@ const TopologyComponent = ({
     });
 
     useEffect(() => {
-        setPage(1);
         setPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-        setSearchFilter({});
-    }, [setPage, setPerPage, setSearchFilter, selectedNode]);
-
-    useEffect(() => {
         setPage(1);
-    }, [setPage, setPerPage, searchFilter]);
+        anomalousSetPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
+        anomalousSetPage(1);
+        baselineSetPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
+        baselineSetPage(1);
+        setSearchFilter({});
+    }, [
+        setPage,
+        setPerPage,
+        setSearchFilter,
+        anomalousSetPage,
+        anomalousSetPerPage,
+        baselineSetPage,
+        baselineSetPerPage,
+        selectedNode,
+    ]);
 
     useEffect(() => {
         // we don't want to reset view on init
@@ -265,7 +283,8 @@ const TopologyComponent = ({
                             edgeState={edgeState}
                             onNodeSelect={onNodeSelect}
                             defaultDeploymentTab={defaultDeploymentTab}
-                            urlPagination={urlPagination}
+                            anomalousUrlPagination={anomalousUrlPagination}
+                            baselineUrlPagination={baselineUrlPagination}
                             urlSearchFiltering={urlSearchFiltering}
                             timeWindow={timeWindow}
                         />

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
@@ -1,20 +1,42 @@
 import React from 'react';
+import { Pagination, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { NetworkBaselinePeerStatus } from 'types/networkBaseline.proto';
 import { TableUIState } from 'utils/getTableUIState';
 
 import { getFlowKey } from '../utils/flowUtils';
 
 type FlowTableProps = {
+    pagination: UseURLPaginationResult;
+    flowCount: number;
     emptyStateMessage: string;
     tableState: TableUIState<NetworkBaselinePeerStatus>;
 };
 
-export function FlowTable({ emptyStateMessage, tableState }: FlowTableProps) {
+export function FlowTable({
+    pagination,
+    flowCount,
+    emptyStateMessage,
+    tableState,
+}: FlowTableProps) {
+    const { page, perPage, setPage, setPerPage } = pagination;
     return (
         <>
+            <ToolbarContent>
+                <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+                    <Pagination
+                        itemCount={flowCount}
+                        page={page}
+                        perPage={perPage}
+                        onSetPage={(_, newPage) => setPage(newPage)}
+                        onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                        isCompact
+                    />
+                </ToolbarItem>
+            </ToolbarContent>
             <Table variant="compact">
                 <Thead>
                     <Tr>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -23,7 +23,8 @@ type DeploymentFlowsProps = {
     networkFlowsError: string;
     networkFlows: Flow[];
     refetchFlows: () => void;
-    urlPagination: UseURLPaginationResult;
+    anomalousUrlPagination: UseURLPaginationResult;
+    baselineUrlPagination: UseURLPaginationResult;
     urlSearchFiltering: UseUrlSearchReturn;
     timeWindow: TimeWindow;
 };
@@ -37,7 +38,8 @@ function DeploymentFlows({
     networkFlowsError,
     networkFlows,
     refetchFlows,
-    urlPagination,
+    anomalousUrlPagination,
+    baselineUrlPagination,
     urlSearchFiltering,
     timeWindow,
 }: DeploymentFlowsProps) {
@@ -45,13 +47,15 @@ function DeploymentFlows({
     const isNetworkGraphExternalIpsEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_EXTERNAL_IPS');
     const [selectedView, setSelectedView] = useState<DeploymentFlowsView>('internal-flows');
 
-    const { setPage } = urlPagination;
+    const { setPage: anomalousSetPage } = anomalousUrlPagination;
+    const { setPage: baselineSetPage } = baselineUrlPagination;
     const { setSearchFilter } = urlSearchFiltering;
 
     useEffect(() => {
-        setPage(1);
+        anomalousSetPage(1);
+        baselineSetPage(1);
         setSearchFilter({});
-    }, [selectedView, setPage, setSearchFilter]);
+    }, [selectedView, anomalousSetPage, baselineSetPage, setSearchFilter]);
 
     if (!isNetworkGraphExternalIpsEnabled) {
         return (
@@ -104,7 +108,12 @@ function DeploymentFlows({
                                 refetchFlows={refetchFlows}
                             />
                         ) : (
-                            <ExternalFlows deploymentId={deploymentId} timeWindow={timeWindow} />
+                            <ExternalFlows
+                                deploymentId={deploymentId}
+                                timeWindow={timeWindow}
+                                anomalousUrlPagination={anomalousUrlPagination}
+                                baselineUrlPagination={baselineUrlPagination}
+                            />
                         )}
                     </Stack>
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -47,15 +47,15 @@ function DeploymentFlows({
     const isNetworkGraphExternalIpsEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_EXTERNAL_IPS');
     const [selectedView, setSelectedView] = useState<DeploymentFlowsView>('internal-flows');
 
-    const { setPage: anomalousSetPage } = anomalousUrlPagination;
-    const { setPage: baselineSetPage } = baselineUrlPagination;
+    const { setPage: setPageAnomalous } = anomalousUrlPagination;
+    const { setPage: setPageBaseline } = baselineUrlPagination;
     const { setSearchFilter } = urlSearchFiltering;
 
     useEffect(() => {
-        anomalousSetPage(1);
-        baselineSetPage(1);
+        setPageAnomalous(1);
+        setPageBaseline(1);
         setSearchFilter({});
-    }, [selectedView, anomalousSetPage, baselineSetPage, setSearchFilter]);
+    }, [selectedView, setPageAnomalous, setPageBaseline, setSearchFilter]);
 
     if (!isNetworkGraphExternalIpsEnabled) {
         return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -51,7 +51,8 @@ type DeploymentSideBarProps = {
     edgeState: EdgeState;
     onNodeSelect: (id: string) => void;
     defaultDeploymentTab: string;
-    urlPagination: UseURLPaginationResult;
+    anomalousUrlPagination: UseURLPaginationResult;
+    baselineUrlPagination: UseURLPaginationResult;
     urlSearchFiltering: UseUrlSearchReturn;
     timeWindow: TimeWindow;
 };
@@ -64,7 +65,8 @@ function DeploymentSideBar({
     edgeState,
     onNodeSelect,
     defaultDeploymentTab,
-    urlPagination,
+    anomalousUrlPagination,
+    baselineUrlPagination,
     urlSearchFiltering,
     timeWindow,
 }: DeploymentSideBarProps) {
@@ -237,7 +239,8 @@ function DeploymentSideBar({
                                     networkFlowsError={networkFlowsError}
                                     networkFlows={networkFlows}
                                     refetchFlows={refetchFlows}
-                                    urlPagination={urlPagination}
+                                    anomalousUrlPagination={anomalousUrlPagination}
+                                    baselineUrlPagination={baselineUrlPagination}
                                     urlSearchFiltering={urlSearchFiltering}
                                     timeWindow={timeWindow}
                                 />

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -67,6 +67,8 @@ function ExternalFlows({ deploymentId, timeWindow }: ExternalFlowsProps) {
                             contentId={'anomalous-expandable-content'}
                         >
                             <FlowTable
+                                pagination={anomalous.pagination}
+                                flowCount={totalAnomalous}
                                 emptyStateMessage="No anomalous flows."
                                 tableState={anomalous.tableState}
                             />
@@ -88,6 +90,8 @@ function ExternalFlows({ deploymentId, timeWindow }: ExternalFlowsProps) {
                             isExpanded={isBaselineFlowsExpanded}
                         >
                             <FlowTable
+                                pagination={baseline.pagination}
+                                flowCount={totalBaseline}
                                 emptyStateMessage="No baseline flows."
                                 tableState={baseline.tableState}
                             />

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -13,6 +13,7 @@ import pluralize from 'pluralize';
 
 import { TimeWindow } from 'constants/timeWindows';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 
 import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
 import { FlowTable } from '../components/FlowTable';
@@ -21,11 +22,28 @@ import { useNetworkBaselineStatus } from '../hooks/useNetworkBaselineStatus';
 type ExternalFlowsProps = {
     deploymentId: string;
     timeWindow: TimeWindow;
+    anomalousUrlPagination: UseURLPaginationResult;
+    baselineUrlPagination: UseURLPaginationResult;
 };
 
-function ExternalFlows({ deploymentId, timeWindow }: ExternalFlowsProps) {
-    const anomalous = useNetworkBaselineStatus(deploymentId, timeWindow, 'ANOMALOUS');
-    const baseline = useNetworkBaselineStatus(deploymentId, timeWindow, 'BASELINE');
+function ExternalFlows({
+    deploymentId,
+    timeWindow,
+    anomalousUrlPagination,
+    baselineUrlPagination,
+}: ExternalFlowsProps) {
+    const anomalous = useNetworkBaselineStatus(
+        deploymentId,
+        timeWindow,
+        anomalousUrlPagination,
+        'ANOMALOUS'
+    );
+    const baseline = useNetworkBaselineStatus(
+        deploymentId,
+        timeWindow,
+        baselineUrlPagination,
+        'BASELINE'
+    );
 
     const { isOpen: isAnomalousFlowsExpanded, onToggle: toggleAnomalousFlowsExpandable } =
         useSelectToggle(true);
@@ -67,7 +85,7 @@ function ExternalFlows({ deploymentId, timeWindow }: ExternalFlowsProps) {
                             contentId={'anomalous-expandable-content'}
                         >
                             <FlowTable
-                                pagination={anomalous.pagination}
+                                pagination={anomalous.urlPagination}
                                 flowCount={totalAnomalous}
                                 emptyStateMessage="No anomalous flows."
                                 tableState={anomalous.tableState}
@@ -90,7 +108,7 @@ function ExternalFlows({ deploymentId, timeWindow }: ExternalFlowsProps) {
                             isExpanded={isBaselineFlowsExpanded}
                         >
                             <FlowTable
-                                pagination={baseline.pagination}
+                                pagination={baseline.urlPagination}
                                 flowCount={totalBaseline}
                                 emptyStateMessage="No baseline flows."
                                 tableState={baseline.tableState}

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     Button,
     Divider,
@@ -41,6 +41,10 @@ function ExternalIpsTable({
     const { version } = useMetadata();
     const { page, perPage, setPage, setPerPage } = urlPagination;
     const { searchFilter, setSearchFilter } = urlSearchFiltering;
+
+    useEffect(() => {
+        setPage(1);
+    }, [searchFilter, setPage]);
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
@@ -2,10 +2,12 @@ import { useCallback } from 'react';
 
 import { TimeWindow } from 'constants/timeWindows';
 import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
 import { getNetworkBaselineExternalStatus } from 'services/NetworkService';
 import { NetworkBaselineExternalStatusResponse } from 'types/networkBaseline.proto';
 import { getTableUIState } from 'utils/getTableUIState';
 
+import { DEFAULT_NETWORK_GRAPH_PAGE_SIZE } from '../NetworkGraph.constants';
 import { timeWindowToISO } from '../utils/timeWindow';
 
 export function useNetworkBaselineStatus(
@@ -13,15 +15,18 @@ export function useNetworkBaselineStatus(
     timeWindow: TimeWindow,
     status: 'ANOMALOUS' | 'BASELINE'
 ) {
+    const pagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, status.toLowerCase());
+    const { page, perPage } = pagination;
+
     const fetch = useCallback((): Promise<NetworkBaselineExternalStatusResponse> => {
         const fromTimestamp = timeWindowToISO(timeWindow);
         return getNetworkBaselineExternalStatus(deploymentId, fromTimestamp, {
-            page: 1,
-            perPage: 1000,
+            page,
+            perPage,
             sortOption: {},
             searchFilter: {},
         });
-    }, [deploymentId, timeWindow]);
+    }, [deploymentId, page, perPage, timeWindow]);
 
     const { data, isLoading, error, refetch } = useRestQuery(fetch);
 
@@ -35,5 +40,5 @@ export function useNetworkBaselineStatus(
     const flows = status === 'ANOMALOUS' ? (data?.anomalous ?? []) : (data?.baseline ?? []);
     const total = status === 'ANOMALOUS' ? (data?.totalAnomalous ?? 0) : (data?.totalBaseline ?? 0);
 
-    return { flows, total, tableState, refetch };
+    return { flows, total, tableState, pagination, refetch };
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
@@ -1,22 +1,21 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 
 import { TimeWindow } from 'constants/timeWindows';
 import useRestQuery from 'hooks/useRestQuery';
-import useURLPagination from 'hooks/useURLPagination';
+import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { getNetworkBaselineExternalStatus } from 'services/NetworkService';
 import { NetworkBaselineExternalStatusResponse } from 'types/networkBaseline.proto';
 import { getTableUIState } from 'utils/getTableUIState';
 
-import { DEFAULT_NETWORK_GRAPH_PAGE_SIZE } from '../NetworkGraph.constants';
 import { timeWindowToISO } from '../utils/timeWindow';
 
 export function useNetworkBaselineStatus(
     deploymentId: string,
     timeWindow: TimeWindow,
+    urlPagination: UseURLPaginationResult,
     status: 'ANOMALOUS' | 'BASELINE'
 ) {
-    const pagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, status.toLowerCase());
-    const { page, perPage, setPage } = pagination;
+    const { page, perPage } = urlPagination;
 
     const fetch = useCallback((): Promise<NetworkBaselineExternalStatusResponse> => {
         const fromTimestamp = timeWindowToISO(timeWindow);
@@ -30,10 +29,6 @@ export function useNetworkBaselineStatus(
 
     const { data, isLoading, error, refetch } = useRestQuery(fetch);
 
-    useEffect(() => {
-        setPage(1);
-    }, [deploymentId, timeWindow, setPage]);
-
     const tableState = getTableUIState({
         isLoading,
         data: status === 'ANOMALOUS' ? data?.anomalous : data?.baseline,
@@ -44,5 +39,5 @@ export function useNetworkBaselineStatus(
     const flows = status === 'ANOMALOUS' ? (data?.anomalous ?? []) : (data?.baseline ?? []);
     const total = status === 'ANOMALOUS' ? (data?.totalAnomalous ?? 0) : (data?.totalBaseline ?? 0);
 
-    return { flows, total, tableState, pagination, refetch };
+    return { flows, total, tableState, urlPagination, refetch };
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { TimeWindow } from 'constants/timeWindows';
 import useRestQuery from 'hooks/useRestQuery';
@@ -16,7 +16,7 @@ export function useNetworkBaselineStatus(
     status: 'ANOMALOUS' | 'BASELINE'
 ) {
     const pagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, status.toLowerCase());
-    const { page, perPage } = pagination;
+    const { page, perPage, setPage } = pagination;
 
     const fetch = useCallback((): Promise<NetworkBaselineExternalStatusResponse> => {
         const fromTimestamp = timeWindowToISO(timeWindow);
@@ -29,6 +29,10 @@ export function useNetworkBaselineStatus(
     }, [deploymentId, page, perPage, timeWindow]);
 
     const { data, isLoading, error, refetch } = useRestQuery(fetch);
+
+    useEffect(() => {
+        setPage(1);
+    }, [deploymentId, timeWindow, setPage]);
 
     const tableState = getTableUIState({
         isLoading,

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -14,9 +14,12 @@ function safeNumber(val: unknown, defaultVal: number) {
     return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : defaultVal;
 }
 
-function useURLPagination(defaultPerPage: number): UseURLPaginationResult {
-    const [page, setPageString] = useURLParameter('page', '1');
-    const [perPage, setPerPageString] = useURLParameter('perPage', `${defaultPerPage}`);
+function useURLPagination(defaultPerPage: number, keyPrefix?: string): UseURLPaginationResult {
+    const pageParam = keyPrefix ? `${keyPrefix}Page` : 'page';
+    const perPageParam = keyPrefix ? `${keyPrefix}PerPage` : 'perPage';
+
+    const [page, setPageString] = useURLParameter(pageParam, '1');
+    const [perPage, setPerPageString] = useURLParameter(perPageParam, `${defaultPerPage}`);
     const setPage = useCallback(
         (num: number, historyAction?: HistoryAction) =>
             setPageString(num > 1 ? String(num) : undefined, historyAction),


### PR DESCRIPTION
### Description

Add pagination to the "External Flows" in the deployment-level Network Graph side panel.

**Why:**

- Large clusters may easily dump hundred of external flows into one table.

**Challenges:**

1. Two independent pagers
    - The side panel shows anomalous and baseline flows side-by-side, so each table now owns its own `?anomalousPage=` / `?baselinePage=` and matching `PerPage` keys.
    - `useURLPagination(perPage, keyPrefix)` now supports an optional `keyPrefix`, same pattern as `useURLParameter`.
2. Pagination clean up
    - When the user closes the side panel or clicks a different node we `setPage(1)` and `setPerPage(10)`, clearing out any stray `?anomalousPage` / `?baselinePage` params.


### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
![Screenshot 2025-05-19 at 2 49 42 PM](https://github.com/user-attachments/assets/f01008e5-d6ae-42f0-802a-39635c8ec107)

![Screenshot 2025-05-19 at 2 49 52 PM](https://github.com/user-attachments/assets/4e5662cb-7c89-49aa-98cc-f6a7f22143fd)

