### PR TITLE
ROX-29032: Add ability to switch external flow status

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/FlowBulkDropdown.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/FlowBulkDropdown.tsx
@@ -1,0 +1,45 @@
+import React, { ReactElement } from 'react';
+import {
+    Badge,
+    Divider,
+    Dropdown,
+    DropdownItem,
+    DropdownList,
+    MenuToggle,
+    MenuToggleElement,
+} from '@patternfly/react-core';
+
+type Props = {
+    selectedCount: number;
+    isOpen: boolean;
+    setOpen: (o: boolean) => void;
+    onClear: () => void;
+    children: ReactElement<typeof DropdownItem> | ReactElement<typeof DropdownItem>[];
+};
+
+export function FlowBulkDropdown({ selectedCount, isOpen, setOpen, onClear, children }: Props) {
+    return (
+        <Dropdown
+            isOpen={isOpen}
+            onOpenChange={setOpen}
+            toggle={(ref: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                    ref={ref}
+                    isExpanded={isOpen}
+                    badge={selectedCount > 0 ? <Badge isRead>{selectedCount}</Badge> : undefined}
+                    isDisabled={selectedCount === 0}
+                    onClick={() => setOpen(!isOpen)}
+                >
+                    Bulk actions
+                </MenuToggle>
+            )}
+            onSelect={() => setOpen(false)}
+        >
+            <DropdownList>
+                {children}
+                <Divider component="li" />
+                <DropdownItem onClick={onClear}>Clear selections</DropdownItem>
+            </DropdownList>
+        </Dropdown>
+    );
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
-
+import React, { useState } from 'react';
 import {
+    Alert,
+    DropdownItem,
     ExpandableSection,
     ExpandableSectionToggle,
+    Flex,
     Stack,
     StackItem,
     Toolbar,
@@ -14,10 +16,15 @@ import pluralize from 'pluralize';
 import { TimeWindow } from 'constants/timeWindows';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import { markNetworkBaselineStatuses } from 'services/NetworkService';
+import { NetworkBaselinePeerStatus, PeerStatus } from 'types/networkBaseline.proto';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
+import { FlowBulkDropdown } from '../components/FlowBulkDropdown';
 import { FlowTable } from '../components/FlowTable';
 import { useNetworkBaselineStatus } from '../hooks/useNetworkBaselineStatus';
+import { getFlowKey } from '../utils/flowUtils';
 
 type ExternalFlowsProps = {
     deploymentId: string;
@@ -45,16 +52,120 @@ function ExternalFlows({
         'BASELINE'
     );
 
+    const [selectedAnomalous, setSelectedAnomalous] = useState<NetworkBaselinePeerStatus[]>([]);
+    const [selectedBaseline, setSelectedBaseline] = useState<NetworkBaselinePeerStatus[]>([]);
+
+    const [isAnomalousBulkActionOpen, setIsAnomalousBulkActionOpen] = useState(false);
+    const [isBaselineBulkActionOpen, setIsBaselineBulkActionOpen] = useState(false);
+
+    const [networkFlowError, setNetworkFlowError] = useState('');
+
     const { isOpen: isAnomalousFlowsExpanded, onToggle: toggleAnomalousFlowsExpandable } =
         useSelectToggle(true);
     const { isOpen: isBaselineFlowsExpanded, onToggle: toggleBaselineFlowsExpandable } =
         useSelectToggle(true);
 
+    function setFlowSelected(flow: NetworkBaselinePeerStatus, isSelecting = true) {
+        const key = getFlowKey(flow);
+        const setter = flow.status === 'ANOMALOUS' ? setSelectedAnomalous : setSelectedBaseline;
+
+        setter((prev) => {
+            const without = prev.filter((f) => getFlowKey(f) !== key);
+            return isSelecting ? [...without, flow] : without;
+        });
+    }
+
     const totalAnomalous = anomalous.total;
     const totalBaseline = baseline.total;
 
+    const anomalousFlows = anomalous.flows;
+    const baselineFlows = baseline.flows;
+
+    const areAllPageAnomalousSelected =
+        anomalousFlows.length > 0 && anomalousFlows.every(isFlowSelected);
+    const areAllPageBaselineSelected =
+        baselineFlows.length > 0 && baselineFlows.every(isFlowSelected);
+
+    function selectAllBaselineFlows(isSelecting = true) {
+        togglePageFlows(baselineFlows, isSelecting);
+    }
+
+    function selectAllAnomalousFlows(isSelecting = true) {
+        togglePageFlows(anomalousFlows, isSelecting);
+    }
+
+    function isFlowSelected(flow: NetworkBaselinePeerStatus) {
+        const key = getFlowKey(flow);
+        return (flow.status === 'ANOMALOUS' ? selectedAnomalous : selectedBaseline).some(
+            (f) => getFlowKey(f) === key
+        );
+    }
+
+    function onSelectFlow(
+        flow: NetworkBaselinePeerStatus,
+        _rowIndex: number,
+        isSelecting: boolean
+    ) {
+        setFlowSelected(flow, isSelecting);
+    }
+
+    function togglePageFlows(flows: NetworkBaselinePeerStatus[], isSelecting = true) {
+        if (!flows.length) {
+            return;
+        }
+
+        const setter = flows[0].status === 'ANOMALOUS' ? setSelectedAnomalous : setSelectedBaseline;
+
+        setter((prev) => {
+            const pageKeys = new Set(flows.map(getFlowKey));
+            const withoutPage = prev.filter((f) => !pageKeys.has(getFlowKey(f)));
+            return isSelecting ? [...withoutPage, ...flows] : withoutPage;
+        });
+    }
+
+    async function updateFlowsStatus(
+        flows: NetworkBaselinePeerStatus | NetworkBaselinePeerStatus[],
+        targetStatus: PeerStatus
+    ) {
+        const selected = Array.isArray(flows) ? flows : [flows];
+        if (!selected.length) {
+            return;
+        }
+
+        const payload = selected.map((f) => ({ ...f, status: targetStatus }));
+
+        try {
+            await markNetworkBaselineStatuses({ deploymentId, networkBaselines: payload });
+            await Promise.all([anomalous.refetch(), baseline.refetch()]);
+            setSelectedAnomalous([]);
+            setSelectedBaseline([]);
+            setNetworkFlowError('');
+        } catch (err) {
+            setNetworkFlowError(getAxiosErrorMessage(err));
+        }
+    }
+
+    async function markSelectedAsAnomalous() {
+        await updateFlowsStatus(selectedBaseline, 'ANOMALOUS');
+    }
+
+    async function addSelectedToBaseline() {
+        await updateFlowsStatus(selectedAnomalous, 'BASELINE');
+    }
+
     return (
         <Stack>
+            {networkFlowError && (
+                <StackItem>
+                    <Alert
+                        isInline
+                        variant="danger"
+                        title={networkFlowError}
+                        component="p"
+                        className="pf-v5-u-mb-sm"
+                    />
+                </StackItem>
+            )}
             <StackItem>
                 <Toolbar className="pf-v5-u-p-0">
                     <ToolbarContent className="pf-v5-u-px-0">
@@ -70,14 +181,28 @@ function ExternalFlows({
             <StackItem>
                 <Stack hasGutter>
                     <StackItem>
-                        <ExpandableSectionToggle
-                            isExpanded={isAnomalousFlowsExpanded}
-                            onToggle={(isExpanded) => toggleAnomalousFlowsExpandable(isExpanded)}
-                            toggleId={'anomalous-expandable-toggle'}
-                            contentId={'anomalous-expandable-content'}
-                        >
-                            {`${totalAnomalous} anomalous ${pluralize('flow', totalAnomalous)}`}
-                        </ExpandableSectionToggle>
+                        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+                            <ExpandableSectionToggle
+                                isExpanded={isAnomalousFlowsExpanded}
+                                onToggle={(isExpanded) =>
+                                    toggleAnomalousFlowsExpandable(isExpanded)
+                                }
+                                toggleId={'anomalous-expandable-toggle'}
+                                contentId={'anomalous-expandable-content'}
+                            >
+                                {`${totalAnomalous} anomalous ${pluralize('flow', totalAnomalous)}`}
+                            </ExpandableSectionToggle>
+                            <FlowBulkDropdown
+                                selectedCount={selectedAnomalous.length}
+                                isOpen={isAnomalousBulkActionOpen}
+                                setOpen={setIsAnomalousBulkActionOpen}
+                                onClear={() => setSelectedAnomalous([])}
+                            >
+                                <DropdownItem onClick={addSelectedToBaseline}>
+                                    Add to baseline
+                                </DropdownItem>
+                            </FlowBulkDropdown>
+                        </Flex>
                         <ExpandableSection
                             isExpanded={isAnomalousFlowsExpanded}
                             isDetached
@@ -89,18 +214,43 @@ function ExternalFlows({
                                 flowCount={totalAnomalous}
                                 emptyStateMessage="No anomalous flows."
                                 tableState={anomalous.tableState}
+                                selectedPageAll={areAllPageAnomalousSelected}
+                                onSelectAll={selectAllAnomalousFlows}
+                                isFlowSelected={isFlowSelected}
+                                onRowSelect={onSelectFlow}
+                                rowActions={(flow) => [
+                                    {
+                                        title: <span>Add to baseline</span>,
+                                        onClick: async (e) => {
+                                            e.preventDefault();
+                                            await updateFlowsStatus(flow, 'BASELINE');
+                                        },
+                                    },
+                                ]}
                             />
                         </ExpandableSection>
                     </StackItem>
                     <StackItem>
-                        <ExpandableSectionToggle
-                            isExpanded={isBaselineFlowsExpanded}
-                            onToggle={(isExpanded) => toggleBaselineFlowsExpandable(isExpanded)}
-                            toggleId={'baseline-expandable-toggle'}
-                            contentId={'baseline-expandable-content'}
-                        >
-                            {`${totalBaseline} baseline ${pluralize('flow', totalBaseline)}`}
-                        </ExpandableSectionToggle>
+                        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+                            <ExpandableSectionToggle
+                                isExpanded={isBaselineFlowsExpanded}
+                                onToggle={(isExpanded) => toggleBaselineFlowsExpandable(isExpanded)}
+                                toggleId={'baseline-expandable-toggle'}
+                                contentId={'baseline-expandable-content'}
+                            >
+                                {`${totalBaseline} baseline ${pluralize('flow', totalBaseline)}`}
+                            </ExpandableSectionToggle>
+                            <FlowBulkDropdown
+                                selectedCount={selectedBaseline.length}
+                                isOpen={isBaselineBulkActionOpen}
+                                setOpen={setIsBaselineBulkActionOpen}
+                                onClear={() => setSelectedBaseline([])}
+                            >
+                                <DropdownItem onClick={markSelectedAsAnomalous}>
+                                    Mark as anomalous
+                                </DropdownItem>
+                            </FlowBulkDropdown>
+                        </Flex>
                         <ExpandableSection
                             isDetached
                             toggleId={'baseline-expandable-toggle'}
@@ -112,6 +262,19 @@ function ExternalFlows({
                                 flowCount={totalBaseline}
                                 emptyStateMessage="No baseline flows."
                                 tableState={baseline.tableState}
+                                selectedPageAll={areAllPageBaselineSelected}
+                                onSelectAll={selectAllBaselineFlows}
+                                isFlowSelected={isFlowSelected}
+                                onRowSelect={onSelectFlow}
+                                rowActions={(flow) => [
+                                    {
+                                        title: <span>Mark as anomalous</span>,
+                                        onClick: async (e) => {
+                                            e.preventDefault();
+                                            await updateFlowsStatus(flow, 'ANOMALOUS');
+                                        },
+                                    },
+                                ]}
                             />
                         </ExpandableSection>
                     </StackItem>


### PR DESCRIPTION
### Description

Enable status updates for external flows (baseline ↔ anomalous) in Network Graph

Bulk-action improvement:

- Per-table dropdown: each table (baseline, anomalous) now has its own Bulk actions dropdown, so actions are always relevant to that list.
- Selection badge: the dropdown shows the "count" of selected flows, including those picked on other pages.



### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![Screenshot 2025-05-19 at 1 50 30 PM](https://github.com/user-attachments/assets/d18fe538-94de-4cc6-80e6-3f678bf4af58)
![Screenshot 2025-05-19 at 1 50 55 PM](https://github.com/user-attachments/assets/e1954a10-6af9-4dbf-8467-292864e4f735)
![Screenshot 2025-05-19 at 1 51 06 PM](https://github.com/user-attachments/assets/6ab9bbbd-c444-4055-8b5d-8fe8b7d3976a)

