### PR TITLE
ROX-29427: Add image id to sensor scan logs

### DIFF
--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -170,9 +170,9 @@ func (c *cacheValue) scanAndSet(ctx context.Context, svc v1.ImageServiceClient, 
 	scanImageFn := scanImage
 	if c.regStore.IsLocal(req.containerImage.GetName()) {
 		scanImageFn = scanImageLocal
-		log.Debugf("Sending scan to local scanner for image %q", req.containerImage.GetName().GetFullName())
+		log.Debugf("Sending scan to local scanner for image %q (ID %q)", req.containerImage.GetName().GetFullName(), req.containerImage.GetId())
 	} else {
-		log.Debugf("Sending scan to central for image %q", req.containerImage.GetName().GetFullName())
+		log.Debugf("Sending scan to central for image %q (ID %q)", req.containerImage.GetName().GetFullName(), req.containerImage.GetId())
 	}
 
 	scannedImage, err := c.scanWithRetries(ctx, svc, req, scanImageFn)
@@ -182,12 +182,12 @@ func (c *cacheValue) scanAndSet(ctx context.Context, svc v1.ImageServiceClient, 
 	if err != nil {
 		// Ignore the error and set the image to something basic,
 		// so alerting can progress.
-		log.Errorf("Scan request failed for image %q: %s", req.containerImage.GetName().GetFullName(), err)
+		log.Errorf("Scan request failed for image %q (ID %q): %s", req.containerImage.GetName().GetFullName(), req.containerImage.GetId(), err)
 		c.image = types.ToImage(req.containerImage)
 		return
 	}
 
-	log.Debugf("Successful image scan for image %s: %d components returned by scanner", req.containerImage.GetName().GetFullName(), len(scannedImage.GetImage().GetScan().GetComponents()))
+	log.Debugf("Successful image scan for image %q (ID %q): %d components returned by scanner", req.containerImage.GetName().GetFullName(), req.containerImage.GetId(), len(scannedImage.GetImage().GetScan().GetComponents()))
 	c.image = scannedImage.GetImage()
 }
 
@@ -201,7 +201,7 @@ func (c *cacheValue) scanAndSetWithLock(ctx context.Context, svc v1.ImageService
 
 	// Check to see if another routine already enriched this name, if so, short circuit.
 	if protoutils.SliceContains(req.containerImage.GetName(), c.image.GetNames()) {
-		log.Debugf("Image scan loaded from cache: %s: Components: (%d) - short circuit", req.containerImage.GetName().GetFullName(), len(c.image.GetScan().GetComponents()))
+		log.Debugf("Image scan loaded from cache %q (ID %q): Components: (%d) - short circuit", req.containerImage.GetName().GetFullName(), req.containerImage.GetId(), len(c.image.GetScan().GetComponents()))
 		return
 	}
 
@@ -209,21 +209,21 @@ func (c *cacheValue) scanAndSetWithLock(ctx context.Context, svc v1.ImageService
 	scanImageFn := scanImage
 	if c.regStore.IsLocal(req.containerImage.GetName()) {
 		scanImageFn = scanImageLocal
-		log.Debugf("Sending scan to local scanner for image %q", req.containerImage.GetName().GetFullName())
+		log.Debugf("Sending scan to local scanner for image %q (ID %q)", req.containerImage.GetName().GetFullName(), req.containerImage.GetId())
 	} else {
-		log.Debugf("Sending scan to central for image %q", req.containerImage.GetName().GetFullName())
+		log.Debugf("Sending scan to central for image %q (ID %q)", req.containerImage.GetName().GetFullName(), req.containerImage.GetId())
 	}
 
 	scannedImage, err := c.scanWithRetries(ctx, svc, req, scanImageFn)
 	if err != nil {
 		// Ignore the error and set the image to something basic,
 		// so alerting can progress.
-		log.Errorf("Scan request failed for image %q: %s", req.containerImage.GetName().GetFullName(), err)
+		log.Errorf("Scan request failed for image %q (ID %q): %s", req.containerImage.GetName().GetFullName(), req.containerImage.GetId(), err)
 		c.updateImageNoLock(types.ToImage(req.containerImage))
 		return
 	}
 
-	log.Debugf("Successful image scan for image %s: %d components returned by scanner", req.containerImage.GetName().GetFullName(), len(scannedImage.GetImage().GetScan().GetComponents()))
+	log.Debugf("Successful image scan for image %q (ID %q): %d components returned by scanner", req.containerImage.GetName().GetFullName(), req.containerImage.GetId(), len(scannedImage.GetImage().GetScan().GetComponents()))
 	c.updateImageNoLock(scannedImage.GetImage())
 }
 


### PR DESCRIPTION
### Description

Adds the image ID to various sensor scan logs to assist troubleshooting.

### User-facing documentation

- [X] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [X] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

No tests added

#### How I validated my change

CI / manual

```
$ k set image deploy/sensor sensor=quay.io/rhacs-eng/main:4.8.x-749-gd200c515ca
$ k apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: nginx-a
spec:
  containers:
  - name: main
    image: nginx:1.27.5-bookworm
  restartPolicy: Always
EOF
```
```
common/detector: 2025/05/20 15:15:04.639524 enricher.go:175: Debug: Sending scan to central for image "docker.io/library/nginx:1.27.5-bookworm" (ID "")
common/detector: 2025/05/20 15:15:09.514598 enricher.go:190: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5-bookworm" (ID ""): 150 components returned by scanner
common/detector: 2025/05/20 15:15:11.314442 enricher.go:175: Debug: Sending scan to central for image "docker.io/library/nginx:1.27.5-bookworm" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440")
common/detector: 2025/05/20 15:15:12.166342 enricher.go:190: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5-bookworm" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440"): 150 components returned by scanner
```
Same after enabling delegated scanning
```
common/detector: 2025/05/20 15:23:13.493495 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm" (ID "")
common/detector: 2025/05/20 15:23:14.452520 enricher.go:173: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440")
common/detector: 2025/05/20 15:23:15.160303 enricher.go:190: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5-bookworm" (ID ""): 150 components returned by scanner
common/detector: 2025/05/20 15:23:15.803323 enricher.go:190: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5-bookworm" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440"): 150 components returned by scanner
```
After enabling unqualified search registries feature and creating multiple deployments with different images same ID (unqualified search registries feature will trigger the alternate branch of code)

```
$ k set env deploy/sensor ROX_UNQUALIFIED_SEARCH_REGISTRIES=true
```
```
common/detector: 2025/05/20 15:30:34.581865 enricher.go:212: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5" (ID "")
common/detector: 2025/05/20 15:30:34.988589 enricher.go:212: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm" (ID "")
common/detector: 2025/05/20 15:30:35.728805 enricher.go:212: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440")
common/detector: 2025/05/20 15:30:36.400106 enricher.go:226: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5" (ID ""): 150 components returned by scanner
common/detector: 2025/05/20 15:30:36.410289 enricher.go:226: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5-bookworm" (ID ""): 150 components returned by scanner
common/detector: 2025/05/20 15:30:36.952845 enricher.go:226: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440"): 150 components returned by scanner
common/detector: 2025/05/20 15:30:36.954946 enricher.go:212: Debug: Sending scan to local scanner for image "docker.io/library/nginx:1.27.5-bookworm" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440")
common/detector: 2025/05/20 15:30:37.570033 enricher.go:226: Debug: Successful image scan for image "docker.io/library/nginx:1.27.5-bookworm" (ID "sha256:88b3388ea06c7262e410a3ab5c05dc4088b7b39dea569addd8c30766f4f47440"): 150 components returned by scanner
```
Repeating the same for an image that doesn't exist to trigger error:
```
$ k apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: nginx-no
spec:
  containers:
  - name: main
    image: nginx:noexist
  restartPolicy: Never
EOF

$ k apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: nginx-no-with-dig
spec:
  containers:
  - name: main
    image: nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000
  restartPolicy: Never
EOF
```
```
common/detector: 2025/05/20 15:33:38.798259 enricher.go:221: Error: Scan request failed for image "docker.io/library/nginx:noexist" (ID ""): image enrichment error: for pull source "docker.io/library/nginx:noexist" error: with integration "Public DockerHub" (insecure: false): failed to get the manifest digest: Head "https://registry-1.docker.io/v2/library/nginx/manifests/noexist": http: non-successful response (status=404 body="")

common/detector: 2025/05/20 15:34:48.202023 enricher.go:221: Error: Scan request failed for image "docker.io/library/nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000" (ID "sha256:0000000000000000000000000000000000000000000000000000000000000000"): image enrichment error: for pull source "docker.io/library/nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000" error: with integration "Public DockerHub" (insecure: false): failed to get the manifest digest: Head "https://registry-1.docker.io/v2/library/nginx/manifests/sha256:0000000000000000000000000000000000000000000000000000000000000000": http: non-successful response (status=404 body="")
```
