### PR TITLE
fix(networkbaseline): anonymize external entities in baseline update

### DIFF
--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -73,13 +73,6 @@ func getNewObservationPeriodEnd() timestamp.MicroTS {
 	return timestamp.Now().Add(observationDuration)
 }
 
-func anonymizeDiscoveredExternal(entity networkgraph.Entity) networkgraph.Entity {
-	if entity.Type == storage.NetworkEntityInfo_EXTERNAL_SOURCE && entity.Discovered {
-		return networkgraph.InternetEntity()
-	}
-	return entity
-}
-
 // shouldUpdate -- looks at the baselines and flows to determine if the flow should be added to the baseline.
 func (m *manager) shouldUpdate(conn *networkgraph.NetworkConnIndicator, updateTS timestamp.MicroTS, initialLoad bool) bool {
 	var atLeastOneBaselineInObservationPeriod bool
@@ -263,7 +256,7 @@ func (m *manager) processFlowUpdate(flows map[networkgraph.NetworkConnIndicator]
 			continue
 		}
 		if conn.SrcEntity.Type == storage.NetworkEntityInfo_DEPLOYMENT {
-			anonymizedDst := anonymizeDiscoveredExternal(conn.DstEntity)
+			anonymizedDst := networkbaseline.AnonymizeExternalDiscoveredEntity(conn.DstEntity)
 			peer := m.lookUpPeerInfo(anonymizedDst)
 			if peer.name != "" {
 				m.maybeAddPeer(conn.SrcEntity.ID, &networkbaseline.Peer{
@@ -277,7 +270,7 @@ func (m *manager) processFlowUpdate(flows map[networkgraph.NetworkConnIndicator]
 			}
 		}
 		if conn.DstEntity.Type == storage.NetworkEntityInfo_DEPLOYMENT {
-			anonymizedSrc := anonymizeDiscoveredExternal(conn.SrcEntity)
+			anonymizedSrc := networkbaseline.AnonymizeExternalDiscoveredEntity(conn.SrcEntity)
 			peer := m.lookUpPeerInfo(anonymizedSrc)
 			if peer.name != "" {
 				m.maybeAddPeer(conn.DstEntity.ID, &networkbaseline.Peer{
@@ -477,12 +470,7 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 	for _, peerAndStatus := range modifyRequest.GetPeers() {
 		v1Peer := peerAndStatus.GetPeer()
 
-		entity := anonymizeDiscoveredExternal(networkgraph.Entity{
-			ID:         v1Peer.GetEntity().GetId(),
-			Type:       v1Peer.GetEntity().GetType(),
-			Discovered: v1Peer.GetEntity().GetDiscovered(),
-		})
-
+		entity := networkbaseline.AnonymizeExternalDiscoveredPeer(v1Peer.GetEntity())
 		info := m.lookUpPeerInfo(entity)
 		peer := networkbaseline.PeerFromV1Peer(v1Peer, info.name, info.cidrBlock)
 

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -476,11 +476,14 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 	modifiedDeploymentIDs := set.NewStringSet()
 	for _, peerAndStatus := range modifyRequest.GetPeers() {
 		v1Peer := peerAndStatus.GetPeer()
-		info := m.lookUpPeerInfo(
-			networkgraph.Entity{
-				Type: v1Peer.GetEntity().GetType(),
-				ID:   v1Peer.GetEntity().GetId(),
-			})
+
+		entity := anonymizeDiscoveredExternal(networkgraph.Entity{
+			ID:         v1Peer.GetEntity().GetId(),
+			Type:       v1Peer.GetEntity().GetType(),
+			Discovered: v1Peer.GetEntity().GetDiscovered(),
+		})
+
+		info := m.lookUpPeerInfo(entity)
 		peer := networkbaseline.PeerFromV1Peer(v1Peer, info.name, info.cidrBlock)
 		_, inBaseline := baseline.BaselinePeers[peer]
 		_, inForbidden := baseline.ForbiddenPeers[peer]

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -485,6 +485,7 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 
 		info := m.lookUpPeerInfo(entity)
 		peer := networkbaseline.PeerFromV1Peer(v1Peer, info.name, info.cidrBlock)
+
 		_, inBaseline := baseline.BaselinePeers[peer]
 		_, inForbidden := baseline.ForbiddenPeers[peer]
 		switch peerAndStatus.GetStatus() {

--- a/pkg/networkgraph/networkbaseline/peer.go
+++ b/pkg/networkgraph/networkbaseline/peer.go
@@ -180,12 +180,22 @@ func ConvertPeersToProto(peerSet map[Peer]struct{}) ([]*storage.NetworkBaselineP
 
 // PeerFromV1Peer converts peer within v1 request to in-memory representation form
 func PeerFromV1Peer(v1Peer *v1.NetworkBaselineStatusPeer, peerName, cidrBlock string) Peer {
+	var entity networkgraph.Entity
+
+	if v1Peer.GetEntity().GetType() == storage.NetworkEntityInfo_EXTERNAL_SOURCE &&
+		v1Peer.GetEntity().GetDiscovered() {
+		entity = networkgraph.InternetEntity()
+	} else {
+		entity = networkgraph.Entity{
+			Type:       v1Peer.GetEntity().GetType(),
+			ID:         v1Peer.GetEntity().GetId(),
+			Discovered: v1Peer.GetEntity().GetDiscovered(),
+		}
+	}
+
 	return Peer{
 		IsIngress: v1Peer.GetIngress(),
-		Entity: networkgraph.Entity{
-			Type: v1Peer.GetEntity().GetType(),
-			ID:   v1Peer.GetEntity().GetId(),
-		},
+		Entity:    entity,
 		Name:      peerName,
 		DstPort:   v1Peer.GetPort(),
 		Protocol:  v1Peer.GetProtocol(),


### PR DESCRIPTION
### Description

Final missed anonymization location, when the baseline is updated via the UI. e.g. a customer wants an entity to be added/removed from the baseline.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests

- [x] modified existing tests

#### How I validated my change

Provided unit test should be enough.
