### PR TITLE
fix(tests): moves GetDefaultNetworkTree mock out of concurrent setup

### DIFF
--- a/central/networkbaseline/manager/manager_impl_test.go
+++ b/central/networkbaseline/manager/manager_impl_test.go
@@ -126,8 +126,12 @@ func (suite *ManagerTestSuite) mustInitManager(initialBaselines ...*storage.Netw
 		baseline.ObservationPeriodEnd = protoconv.ConvertMicroTSToProtobufTS(getNewObservationPeriodEnd())
 		suite.ds.baselines[baseline.GetDeploymentId()] = baseline
 	}
+
 	var err error
+
 	suite.networkPolicyDS.EXPECT().GetNetworkPolicies(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	suite.treeManager.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil).AnyTimes()
+
 	suite.m, err = New(suite.ds, suite.networkEntities, suite.deploymentDS, suite.networkPolicyDS, suite.clusterFlows, suite.connectionManager, suite.treeManager)
 	suite.Require().NoError(err)
 }
@@ -169,7 +173,6 @@ func (suite *ManagerTestSuite) mustGetObserationPeriod(baselineID int) timestamp
 }
 
 func (suite *ManagerTestSuite) initBaselinesForDeployments(ids ...int) {
-	suite.treeManager.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil).AnyTimes()
 	for _, id := range ids {
 		suite.deploymentDS.EXPECT().GetDeployment(gomock.Any(), depID(id)).Return(
 			&storage.Deployment{
@@ -184,7 +187,6 @@ func (suite *ManagerTestSuite) initBaselinesForDeployments(ids ...int) {
 		suite.treeManager.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), clusterID(id)).Return(nil).AnyTimes()
 		suite.Require().NoError(suite.m.ProcessDeploymentCreate(depID(id), depName(id), clusterID(id), ns(id)))
 		suite.Require().NoError(suite.m.CreateNetworkBaseline(depID(id)))
-
 	}
 }
 


### PR DESCRIPTION
### Description

Fixes https://issues.redhat.com/browse/ROX-29380

The race is not in the tested code, but in the mock set up of the tree manager. Moving the offending mock setup outside the concurrent code solves the issue.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI should be enough. 