### PR TITLE
ROX-29399: Directional external-IPs

### DIFF
--- a/proto/internalapi/sensor/collector.proto
+++ b/proto/internalapi/sensor/collector.proto
@@ -21,6 +21,13 @@ enum ExternalIpsEnabled {
   ENABLED = 1;
 }
 
+enum ExternalIpsDirection {
+  UNSPECIFIED = 0;
+  BOTH = 1;
+  INGRESS = 2;
+  EGRESS = 3;
+}
+
 // CollectorConfig controls which type of data is reported by collector
 // and how it is processed by collector. These configurations are used
 // to fine-tune collector's performance on large scale clusters.
@@ -30,6 +37,7 @@ enum ExternalIpsEnabled {
 message CollectorConfig {
   message ExternalIPs {
     ExternalIpsEnabled enabled = 1;
+    ExternalIpsDirection direction = 2;
   }
 
   message Networking {


### PR DESCRIPTION
### Description

Add an attribute to the runtime-configuration to set in which direction the external-IPs are enabled.

The possible options for the new direction attribute are INGRESS, EGRESS and BOTH.

### Scope

This PR is only for adding an attribute to the proto files. No code.