### PR TITLE
ROX-29392: Add conditional search categories to ExceptionManagement

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
@@ -25,7 +26,9 @@ import {
 import { getTableUIState } from '../../../utils/getTableUIState';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
-import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
+import {
+    convertToFlatVulnRequestSearchFilterConfig, // vulnRequestSearchFilterConfig
+} from './searchFilterConfig';
 
 const sortFields = [
     'Request Name',
@@ -40,6 +43,11 @@ const defaultSortOption = {
 } as const;
 
 function ApprovedDeferrals() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const vulnRequestSearchFilterConfig = convertToFlatVulnRequestSearchFilterConfig(
+        isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA')
+    );
+
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 
@@ -24,7 +25,9 @@ import {
 import { getTableUIState } from '../../../utils/getTableUIState';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
-import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
+import {
+    convertToFlatVulnRequestSearchFilterConfig, // vulnRequestSearchFilterConfig
+} from './searchFilterConfig';
 
 const sortFields = ['Request Name', 'Requester User Name', 'Created Time', 'Image Registry Scope'];
 const defaultSortOption = {
@@ -33,6 +36,11 @@ const defaultSortOption = {
 } as const;
 
 function ApprovedFalsePositives() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const vulnRequestSearchFilterConfig = convertToFlatVulnRequestSearchFilterConfig(
+        isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA')
+    );
+
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useRestQuery from 'hooks/useRestQuery';
@@ -24,7 +25,9 @@ import {
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import { getTableUIState } from '../../../utils/getTableUIState';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
-import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
+import {
+    convertToFlatVulnRequestSearchFilterConfig, // vulnRequestSearchFilterConfig
+} from './searchFilterConfig';
 
 const sortFields = [
     'Request Name',
@@ -39,6 +42,11 @@ const defaultSortOption = {
 } as const;
 
 function DeniedRequests() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const vulnRequestSearchFilterConfig = convertToFlatVulnRequestSearchFilterConfig(
+        isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA')
+    );
+
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useRestQuery from 'hooks/useRestQuery';
@@ -24,7 +25,9 @@ import {
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import { getTableUIState } from '../../../utils/getTableUIState';
-import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
+import {
+    convertToFlatVulnRequestSearchFilterConfig, // vulnRequestSearchFilterConfig
+} from './searchFilterConfig';
 
 const sortFields = [
     'Request Name',
@@ -38,7 +41,12 @@ const defaultSortOption = {
     direction: 'desc',
 } as const;
 
-function PendingApprovals() {
+function PendingRequests() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const vulnRequestSearchFilterConfig = convertToFlatVulnRequestSearchFilterConfig(
+        isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA')
+    );
+
     const { searchFilter, setSearchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { sortOption, getSortParams } = useURLSort({
@@ -188,4 +196,4 @@ function PendingApprovals() {
     );
 }
 
-export default PendingApprovals;
+export default PendingRequests;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/searchFilterConfig.ts
@@ -9,9 +9,16 @@ const imageSearchFilterConfig: CompoundSearchFilterEntity = {
     attributes: [ImageName],
 };
 
-const imageCVESearchFilterConfig: CompoundSearchFilterEntity = {
+// After release, delete.
+const imageCVESearchFilterConfigV1: CompoundSearchFilterEntity = {
     displayName: 'CVE',
     searchCategory: 'IMAGE_VULNERABILITIES',
+    attributes: [ImageCveName],
+};
+
+const imageCVESearchFilterConfig: CompoundSearchFilterEntity = {
+    displayName: 'CVE',
+    searchCategory: 'IMAGE_VULNERABILITIES_V2',
     attributes: [ImageCveName],
 };
 
@@ -21,8 +28,26 @@ const vulnerabilityRequestSearchFilterConfig: CompoundSearchFilterEntity = {
     attributes: vulnerabilityRequestAttributes,
 };
 
-export const vulnRequestSearchFilterConfig = [
+// After release, delete.
+const vulnRequestSearchFilterConfigV1 = [
+    vulnerabilityRequestSearchFilterConfig,
+    imageCVESearchFilterConfigV1,
+    imageSearchFilterConfig,
+];
+
+const vulnRequestSearchFilterConfig = [
     vulnerabilityRequestSearchFilterConfig,
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,
 ];
+
+// After release, replace temporary function
+// with export of vulnRequestSearchFilterConfig (above)
+// that has unconditional updated imageCVESearchFilterConfig.
+export function convertToFlatVulnRequestSearchFilterConfig(
+    isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
+): CompoundSearchFilterEntity[] {
+    return isFlattenCveDataEnabled
+        ? vulnRequestSearchFilterConfig
+        : vulnRequestSearchFilterConfigV1;
+}


### PR DESCRIPTION
### Description

Follow up with changes that I forgot in #15317

Vulnerabilities Exception Management:
https://github.com/stackrox/stackrox/commit/99c8b7ce745c73e1096eae23c7e6353c293e9fdf#diff-8dbd18bd8635ab21e0396fb96bf259c6ff033f36041f571b6481f27841f8fe7bL14-L16

### Changes

1. Edit ApprovedDeferrals.tsx, ApprovedFalsePositives.tsx, DeniedRequests.tsx, and PendingRequests.tsx files.
    * Call `convertToFlatVulnRequestSearchFilterConfig` function.
2. Edit searchFilterConfig.ts file.
    * Add `convertToFlatVulnRequestSearchFilterConfig` function.

### Observation

1. Although search filter is below tabs, they share the same filter settings (bravo) therefore the same configuration (and comment by bot about boilerplate).
    * Therefore, it could make sense to lift configuration up to ExceptionRequestsPage.tsx file.
    * Of course, if we followed policy about where shared configuration is on page, we might lift up `AdvancedFiltersToolbar` element.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
3. `npm run lint` in ui/apps/platform folder.

#### Manual testing

Thank you, **Surabhi** for central with backend and scanner feature flags enabled.

1. Visit /main/vulnerabilities/exception-management/pending-requests and then select **CVE** in search filter.

    With `'ROX_FLATTEN_CVE_DATA'` disabled on staging demo, see /api/graphql?opname=autocomplete request with `categories: "IMAGE_VULNERABILITIES"` in payload and presence of search autocomplete results.
    ![PendingRequests_disabled](https://github.com/user-attachments/assets/217e8707-219d-45a1-9988-4cc58842322d)

    Before changes and with `'ROX_FLATTEN_CVE_DATA'` enabled, see /api/graphql?opname=autocomplete request with `categories: "IMAGE_VULNERABILITIES"` in payload but absence of search autocomplete results.
    ![PendingRequests_enabled_without_V2](https://github.com/user-attachments/assets/2fddf01a-0b08-45ea-9de6-97977cd1e12b)

    After changes and with `'ROX_FLATTEN_CVE_DATA'` enabled, see /api/graphql?opname=autocomplete request with `categories: "IMAGE_VULNERABILITIES_V2"` in payload and presence of search autocomplete results.
    ![PendingRequests_enabled_with_V2](https://github.com/user-attachments/assets/91d451bd-9278-421e-ac51-d5b5228fffd9)

2. Click **Approved deferrals** and then select **CVE** in search filter.

    Ditto.

4. Click **Approved false positives** and then select **CVE** in search filter.

    Ditto.

5. Click **Denied requests** and then select **CVE** in search filter.

    Ditto.

By the way, for default **Exception** in search filter, /api/graphql?opname=autocomplete request with `/api/graphql?opname=autocomplete request` with `{categories: "VULN_REQUEST", query: "Request Name:"}` in payload has error:
> Search category "VULN_REQUEST" is not implemented: invalid arguments
