### PR TITLE
ROX-28348: Disable changing of scan config name

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -70,6 +70,7 @@ function ScanConfigOptions(): ReactElement {
                                         id="parameters.name"
                                         name="parameters.name"
                                         value={formik.values.parameters.name}
+                                        isDisabled={!!formik.initialValues.parameters.name}
                                         validated={
                                             formik.errors?.parameters?.name &&
                                             formik.touched?.parameters?.name

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -18,14 +18,18 @@ import DayPickerDropdown from 'Components/PatternFly/DayPickerDropdown';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import RepeatScheduleDropdown from 'Components/PatternFly/RepeatScheduleDropdown';
 
-import { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
+import usePageAction from 'hooks/usePageAction';
+import { PageActions, ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
-import { helperTextForName, helperTextForTime } from './useFormikScanConfig';
+import { helperTextForName, helperTextForNameEdit, helperTextForTime } from './useFormikScanConfig';
 
 import './ScanConfigOptions.css';
 
 function ScanConfigOptions(): ReactElement {
     const formik: FormikContextType<ScanConfigFormValues> = useFormikContext();
+    const { pageAction } = usePageAction<PageActions>();
+    const isEditAction = pageAction === 'edit';
+
     function handleSelectChange(id: string, value: string): void {
         formik.setFieldValue('parameters.daysOfWeek', []);
         formik.setFieldValue('parameters.daysOfMonth', []);
@@ -62,7 +66,9 @@ function ScanConfigOptions(): ReactElement {
                                     fieldId="parameters.name"
                                     errors={formik.errors}
                                     touched={formik.touched}
-                                    helperText={helperTextForName}
+                                    helperText={
+                                        isEditAction ? helperTextForNameEdit : helperTextForName
+                                    }
                                 >
                                     <TextInput
                                         isRequired
@@ -70,7 +76,7 @@ function ScanConfigOptions(): ReactElement {
                                         id="parameters.name"
                                         name="parameters.name"
                                         value={formik.values.parameters.name}
-                                        isDisabled={!!formik.initialValues.parameters.name}
+                                        isDisabled={isEditAction}
                                         validated={
                                             formik.errors?.parameters?.name &&
                                             formik.touched?.parameters?.name

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
@@ -26,6 +26,8 @@ export const defaultScanConfigFormValues: ScanConfigFormValues = {
 
 export const helperTextForName =
     "Name can contain only lowercase alphanumeric characters, hyphen '-' or period '.', and start and end with an alphanumeric character.";
+export const helperTextForNameEdit =
+    "Scan config name cannot be changed because it's linked to existing scan results.";
 export const helperTextForTime = 'Select or enter scan time between 00:00 and 23:59 UTC';
 
 const timeRegExp = /\d\d:\d\d/;


### PR DESCRIPTION
### Description

The scan config name is used as a foreign key in the results table. Changing the name would cause scan results to lose association with the scan config.

Backend change to block scan config name change is added in: https://github.com/stackrox/stackrox/pull/15333

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no test changes

#### How I validated my change

- [x] tested locally with demo stage as backend
