### PR TITLE
fix: source deploy scripts

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 source "${DIR}/detect.sh"
 
 if is_openshift; then
-    "${DIR}/openshift/deploy.sh"
+    source "${DIR}/openshift/deploy.sh"
 else
-    "${DIR}/k8s/deploy.sh"
+    source "${DIR}/k8s/deploy.sh"
 fi


### PR DESCRIPTION
### Description

IntelliJ seems to have trouble following/GOTOing scripts that are called without `.` or `source`.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is  is not needed

### Testing and quality

- ~~[ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)~~
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

N/A

#### How I validated my change

Before:
In IntelliJ (or an IntelliJ-based IDE such as GoLand), right click > Go To > Declaration or Usages returns an error `Cannot find declaration to go to`.

After:
IntelliJ jumps to the correct file.