### PR TITLE
ROX-29417: reduce not pullable spam

### DIFF
--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -350,8 +350,13 @@ func (w *deploymentWrap) populateImageMetadata(localImages set.StringSet, pods .
 			// If the ID already exists populate NotPullable, IsClusterLocal, and sync the registry
 			// and remote with the container runtime.
 			if image.GetId() != "" {
-				// Use the image ID from the pod's ContainerStatus.
-				image.NotPullable = !imageUtils.IsPullable(c.ImageID)
+				if c.ImageID != "" {
+					// If the image ID is populated then determine if the image is pullable,
+					// otherwise assume the image is pullable. An Image ID may be empty when a
+					// container is not ready yet per the container runtime.
+					image.NotPullable = !imageUtils.IsPullable(c.ImageID)
+				}
+
 				image.IsClusterLocal = localImages.Contains(image.GetName().GetFullName())
 				updateImageWithNewerImageName(image, runtimeImageName, true)
 				continue

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -350,10 +350,10 @@ func (w *deploymentWrap) populateImageMetadata(localImages set.StringSet, pods .
 			// If the ID already exists populate NotPullable, IsClusterLocal, and sync the registry
 			// and remote with the container runtime.
 			if image.GetId() != "" {
+				// If the image ID is populated then determine if the image is pullable,
+				// otherwise assume the image is pullable. An Image ID may be empty when a
+				// container is not ready yet per the container runtime.
 				if c.ImageID != "" {
-					// If the image ID is populated then determine if the image is pullable,
-					// otherwise assume the image is pullable. An Image ID may be empty when a
-					// container is not ready yet per the container runtime.
 					image.NotPullable = !imageUtils.IsPullable(c.ImageID)
 				}
 

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -199,6 +199,48 @@ func TestPopulateImageMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "Image with latest tag, empty status, pullable",
+			wrap: []wrapContainer{
+				{
+					image: "stackrox.io/main:latest",
+				},
+			},
+			pods: []pod{
+				{
+					images: []string{"stackrox.io/main:latest"},
+					imageIDsInStatus: []string{
+						"",
+					},
+				},
+			},
+			expectedMetadata: []metadata{
+				{
+					expectedID: "",
+				},
+			},
+		},
+		{
+			name: "Image with ID, empty status, pullable",
+			wrap: []wrapContainer{
+				{
+					image: "stackrox.io/main@sha256:88c7e66e637f46e6bc0b95ddb1e755d616d9d76568b89af7c75c4b4aa7cfa4e3",
+				},
+			},
+			pods: []pod{
+				{
+					images: []string{"stackrox.io/main:latest"},
+					imageIDsInStatus: []string{
+						"",
+					},
+				},
+			},
+			expectedMetadata: []metadata{
+				{
+					expectedID: "sha256:88c7e66e637f46e6bc0b95ddb1e755d616d9d76568b89af7c75c4b4aa7cfa4e3",
+				},
+			},
+		},
+		{
 			name: "Explicitly pullable image with latest tag, ID in status, two pods",
 			wrap: []wrapContainer{
 				{


### PR DESCRIPTION
### Description

Images are marked `not pullable` in various scenarios, one of which is when a container is not yet 'ready' which is often inaccurate and leads to log spam and confusion. This PR reduces the log spam and at the same time attempts to make the `not pullable` designation slightly more accurate.

When a deployment is first observed, an image scan is triggered if the podspec image is a valid reference - afterwards when the associated pods are created that same image may be marked as `not pullable` if the `status.containerStatuses[].imageID` field is not populated (which will happen if the container is not ready). Since an attempt was already made to scan the image when the deployment was first observed it should also be OK to attempt to scan the image when the pod is being created.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] modified existing tests

#### How I validated my change

CI + manual testing on a OCP and GKE cluster

<details>
<summary>Setup</summary>

Create deployment that will never be ready.

By digest:
```
k apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: not-ready-deploy
  namespace: default
spec:
  replicas: 5
  selector:
    matchLabels:
      app: not-ready-deploy
  template:
    metadata:
      labels:
        app: not-ready-deploy
    spec:
      containers:
      - name: main
        image:  registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d
        command: ["sh", "-c", "while true; do sleep 30; done"]
        imagePullPolicy: Always
        readinessProbe:
          exec:
            command:
            - "false"  # This command always fails
          initialDelaySeconds: 1
          periodSeconds: 5
EOF
```

By tag:

```
k apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: not-ready-deploy-latest
  namespace: default
spec:
  replicas: 5
  selector:
    matchLabels:
      app: not-ready-deploy-latest
  template:
    metadata:
      labels:
        app: not-ready-deploy-latest
    spec:
      containers:
      - name: main
        image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013
        command: ["sh", "-c", "while true; do sleep 30; done"]
        imagePullPolicy: Always
        readinessProbe:
          exec:
            command:
            - "false"  # This command always fails
          initialDelaySeconds: 1
          periodSeconds: 5
EOF
```
</details>

### OCP: 
Sensor logs without fix:
```
common/detector: 2025/05/21 00:05:02.193706 enricher.go:214: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d"
common/detector: 2025/05/21 00:05:02.376905 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 00:05:04.782005 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 00:05:04.785197 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 00:05:04.785950 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 00:05:04.823152 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 00:05:05.332577 enricher.go:226: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d: 186 components returned by scanner
common/detector: 2025/05/21 00:05:05.348970 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 00:05:05.349189 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 00:05:21.455855 enricher.go:214: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/21 00:05:22.955108 enricher.go:226: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
common/detector: 2025/05/21 00:05:23.865352 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 00:05:23.865798 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 00:05:23.866165 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 00:05:23.892864 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 00:05:23.893112 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 00:05:23.915121 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 00:05:23.915415 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 00:05:24.142633 enricher.go:214: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/21 00:05:25.675104 enricher.go:226: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
```

Sensor logs with fix:
```
common/detector: 2025/05/20 23:59:10.330400 enricher.go:214: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d"
common/detector: 2025/05/20 23:59:10.930025 enricher.go:214: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/20 23:59:17.560339 enricher.go:226: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d: 186 components returned by scanner
common/detector: 2025/05/20 23:59:18.267406 enricher.go:214: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/20 23:59:20.135339 enricher.go:226: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
common/detector: 2025/05/20 23:59:20.564448 enricher.go:226: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
```

### GKE
Sensor logs without fix:
```
common/detector: 2025/05/21 01:02:06.320316 enricher.go:175: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d"
common/detector: 2025/05/21 01:02:06.857984 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:07.127857 enricher.go:175: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/21 01:02:13.450160 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 01:02:13.450390 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 01:02:13.450669 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 01:02:13.523689 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 01:02:13.523995 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 01:02:13.563246 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:13.563474 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:13.563727 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:13.632075 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:13.632328 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:13.632490 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:14.446859 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:14.447129 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d. Not pullable
common/detector: 2025/05/21 01:02:14.447368 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 01:02:14.447598 enricher.go:274: Warn: Skipping image scan for image: registry.access.redhat.com/ubi9/ubi:9.6-1747219013. Not pullable
common/detector: 2025/05/21 01:02:15.604915 enricher.go:175: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/21 01:02:17.188859 enricher.go:190: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
common/detector: 2025/05/21 01:02:17.417468 enricher.go:190: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d: 186 components returned by scanner
common/detector: 2025/05/21 01:02:18.074646 enricher.go:190: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
```

Sensor logs with fix:
```
common/detector: 2025/05/21 01:04:39.929342 enricher.go:175: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d"
common/detector: 2025/05/21 01:04:40.630763 enricher.go:175: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/21 01:04:42.046993 enricher.go:175: Debug: Sending scan to central for image "registry.access.redhat.com/ubi9/ubi:9.6-1747219013"
common/detector: 2025/05/21 01:04:42.068174 enricher.go:190: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi@sha256:62fb429dc6b93ab5ade55d1c8e6b08735f00224d3081d58f161eb5f55eeb3d7d: 186 components returned by scanner
common/detector: 2025/05/21 01:04:42.086769 enricher.go:190: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
common/detector: 2025/05/21 01:04:43.838767 enricher.go:190: Debug: Successful image scan for image registry.access.redhat.com/ubi9/ubi:9.6-1747219013: 186 components returned by scanner
```