### PR TITLE
ROX-28038: Render Advisory columns with GraphQL data

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AdvisoryLinkOrText.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AdvisoryLinkOrText.tsx
@@ -18,7 +18,7 @@ export type AdvisoryLinkOrTextProps = {
 
 function AdvisoryLinkOrText({ advisory }: AdvisoryLinkOrTextProps): ReactNode {
     if (advisory) {
-        const { advisoryId, advisoryLink } = advisory;
+        const { name: advisoryId, link: advisoryLink } = advisory;
         return (
             <ExternalLink>
                 <a href={advisoryLink} target="_blank" rel="noopener noreferrer">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -30,7 +30,6 @@ export type { ImageMetadataContext, DeploymentComponentVulnerability };
 // with deploymentComponentVulnerabilitiesFragment
 // that has unconditional advisory property.
 export function convertToFlatDeploymentComponentVulnerabilitiesFragment(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
 ) {
     return gql`
@@ -45,6 +44,7 @@ export function convertToFlatDeploymentComponentVulnerabilitiesFragment(
                 cvss
                 scoreVersion
                 fixedByVersion
+                ${isFlattenCveDataEnabled ? 'advisory { name, link }' : ''}
                 discoveredAtImage
                 publishedOn
                 pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
@@ -74,6 +74,7 @@ function DeploymentComponentVulnerabilitiesTable({
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled =
         isFeatureFlagEnabled('ROX_SCANNER_V4') &&
+        isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA') &&
         isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
@@ -111,11 +112,11 @@ function DeploymentComponentVulnerabilitiesTable({
                     cvss,
                     scoreVersion,
                     fixedByVersion,
+                    advisory,
                     location,
                     source,
                     layer,
                 } = componentVuln;
-                const advisory = undefined; // placeholder until response includes property
                 // No border on the last row
                 const style =
                     index !== componentVulns.length - 1

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -25,7 +25,6 @@ export type { ImageMetadataContext, ImageComponentVulnerability };
 // with imageComponentVulnerabilitiesFragment
 // that has unconditional advisory property.
 export function convertToFlatImageComponentVulnerabilitiesFragment(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     isFlattenCveDataEnabled: boolean // ROX_FLATTEN_CVE_DATA
 ) {
     return gql`
@@ -38,6 +37,7 @@ export function convertToFlatImageComponentVulnerabilitiesFragment(
             imageVulnerabilities(query: $query) {
                 severity
                 fixedByVersion
+                ${isFlattenCveDataEnabled ? 'advisory { name, link }' : ''}
                 pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
             }
         }
@@ -60,6 +60,7 @@ function ImageComponentVulnerabilitiesTable({
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled =
         isFeatureFlagEnabled('ROX_SCANNER_V4') &&
+        isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA') &&
         isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
@@ -87,9 +88,8 @@ function ImageComponentVulnerabilitiesTable({
                 </Tr>
             </Thead>
             {sortedComponentVulns.map((componentVuln, index) => {
-                const { image, name, version, fixedByVersion, location, source, layer } =
+                const { image, name, version, fixedByVersion, advisory, location, source, layer } =
                     componentVuln;
-                const advisory = undefined; // placeholder until response includes property
                 // No border on the last row
                 const style =
                     index !== componentVulns.length - 1

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -4,7 +4,12 @@ import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
 import pluralize from 'pluralize';
 
-import { CveBaseInfo, VulnerabilitySeverity, isVulnerabilitySeverity } from 'types/cve.proto';
+import {
+    Advisory,
+    CveBaseInfo,
+    VulnerabilitySeverity,
+    isVulnerabilitySeverity,
+} from 'types/cve.proto';
 import { SourceType } from 'types/image.proto';
 import { ApiSortOptionSingle } from 'types/search';
 
@@ -60,6 +65,7 @@ export type ComponentVulnerabilityBase = {
     imageVulnerabilities: {
         severity: string;
         fixedByVersion: string;
+        advisory?: Advisory | null;
         pendingExceptionCount: number;
     }[];
 };
@@ -75,6 +81,7 @@ export type DeploymentComponentVulnerability = Omit<
         cvss: number;
         scoreVersion: string;
         fixedByVersion: string;
+        advisory?: Advisory | null;
         discoveredAtImage: string | null;
         publishedOn: string | null;
         pendingExceptionCount: number;
@@ -92,6 +99,7 @@ export type TableDataRow = {
     };
     name: string;
     fixedByVersion: string;
+    advisory?: Advisory | null;
     severity: VulnerabilitySeverity;
     version: string;
     location: string;
@@ -176,6 +184,7 @@ function extractCommonComponentFields(
             ? vulnerability.severity
             : 'UNKNOWN_VULNERABILITY_SEVERITY';
     const fixedByVersion = vulnerability?.fixedByVersion ?? 'N/A';
+    const advisory = vulnerability?.advisory;
     const pendingExceptionCount = vulnerability?.pendingExceptionCount ?? 0;
 
     return {
@@ -187,6 +196,7 @@ function extractCommonComponentFields(
         layer,
         severity,
         fixedByVersion,
+        advisory,
         pendingExceptionCount,
     };
 }

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -22,8 +22,8 @@ export function isVulnerabilityState(value: unknown): value is VulnerabilityStat
 
 // advisory property is null if not available or not applicable
 export type Advisory = {
-    advisoryId: string; // for example, RHSA-yyyy:nnnn
-    advisoryLink: string; // for example, https://access.redhat.com/errata/RHSA-yyyy:nnnn
+    name: string; // for example, RHSA-yyyy:nnnn
+    link: string; // for example, https://access.redhat.com/errata/RHSA-yyyy:nnnn
 };
 
 // epss property is null if not available


### PR DESCRIPTION
### Description

Frontend counterpart to #15286

### Prerequisites

1. Scanner: `'ROX_SCANNER_V4'` and `ROX_SCANNER_V4_RED_HAT_CVES`
2. Backend: `'ROX_FLATTEN_CVE_DATA'`
3. Frontend: `'ROX_CVE_ADVISORY_SEPARATION'`

### Problem

GraphQL queries for deployment and image component vulnerabilities support `advisory` property **only if** backend `'ROX_FLATTEN_CVE_DATA'` feature flag is enabled.

### Analysis

`deploymentComponentVulnerabilitiesFragment` in DeploymentComponentVulnerabilitiesTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx#L29-L46

`imageComponentVulnerabilitiesFragment` in imageComponentVulnerabilitiesTable.tsx file
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx#L31-L35

### Changes

1. Edit AdvisoryLinkOrText.tsx and cve.proto.ts files.
    Too bad, so sad: update property names from #15284
    * Replace `advisoryId` with `name`
    * Replace `advisoryLink` with `link`
2. Edit DeploymentComponentVulnerabilitiesTable.tsx and ImageComponentVulnerabilitiesTable.tsx file.
    * Add conditional `advisory` following `fixedByVersion` in GraphQL query.
    * Add `'ROX_FLATTEN_CVE_DATA'` backend feature flag to `isAdvisoryColumnEnabled` condition.
    * Replace placeholder `advisory = undefined` with `advisory` following `fixedByVersion` in destructured properties.
3. Edit table.utils.ts file.
    Add optional `advisory` property:
    * `ComponentVulnerabilityBase` for `ImageComponentVulnerability` type
    * `DeploymentComponentVulnerability` type
    * `TableDataRow` type
    * `extractCommonComponentFields` function

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.

#### Manual testing

Thank you, **Surabhi** for central with backend and scanner feature flags enabled.

Initial CI while I wait for test central to finish scanning images

1. Visit /main/vulnerabilities/platform click a link to visit vulnerability page, and then expand a sub-table.

    See `getImagesForCVE` request with `advisory: null` property in reponse.
    See presence of **Advisory** column.

2. Click link to open image page, and then expand a sub-table.

    See `getCVEsForImage` request with `advisory: null` property in response.
    See presence of **Advisory** column.

3. Go back, click **Deployments** toggle, and then expand a sub-table.

    See `getDeploymentsForCVE` request with `advisory: null` property in response.
    See presence of **Advisory** column.

4. Click link to open deployment page, and then expand a sub-table.

    See `getCvesForDeployment` request with `advisory: null` property in response.
    See presence of **Advisory** column.
