### PR TITLE
ROX-29418: Refactoring system config pt.1

### DIFF
--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
@@ -11,57 +11,22 @@ import {
     Text,
 } from '@patternfly/react-core';
 
-import { PlatformComponentRule, PlatformComponentsConfig } from 'types/config.proto';
+import { PlatformComponentsConfig } from 'types/config.proto';
 
 import './PlatformComponentsConfigDetails.css';
 import RedHatLayeredProductsCard from './components/RedHatLayeredProductsCard';
 import CustomPlatformComponentsCard from './components/CustomPlatformComponentsCard';
+import { getPlatformComponentsConfigRules } from '../configUtils';
 
-// @TODO: Remove hardcoded value and add platformComponentsConfig as a prop
-const platformComponentsConfig: PlatformComponentsConfig = {
-    needsReevaluation: false,
-    rules: [
-        {
-            name: 'system rule',
-            namespaceRule: {
-                regex: '^kube-.*|^openshift-.*',
-            },
-        },
-        {
-            name: 'red hat layered products',
-            namespaceRule: {
-                regex: '^stackrox$|^rhacs-operator$|^open-cluster-management$|^multicluster-engine$|^aap$|^hive$`',
-            },
-        },
-        {
-            name: 'custom platform component 1',
-            namespaceRule: {
-                regex: '^my-application$|^custom-test$|^something-else$',
-            },
-        },
-        {
-            name: 'custom platform component 2',
-            namespaceRule: {
-                regex: '^nvidia$',
-            },
-        },
-    ],
+export type PlatformComponentsConfigDetailsProps = {
+    platformComponentsConfig: PlatformComponentsConfig;
 };
 
-const PlatformComponentsConfigDetails = (): ReactElement => {
-    let coreSystemRule: PlatformComponentRule | undefined;
-    let redHatLayeredProductsRule: PlatformComponentRule | undefined;
-    const customRules: PlatformComponentRule[] = [];
-
-    platformComponentsConfig.rules.forEach((rule) => {
-        if (rule.name === 'system rule') {
-            coreSystemRule = rule;
-        } else if (rule.name === 'red hat layered products') {
-            redHatLayeredProductsRule = rule;
-        } else {
-            customRules.push(rule);
-        }
-    });
+const PlatformComponentsConfigDetails = ({
+    platformComponentsConfig,
+}: PlatformComponentsConfigDetailsProps): ReactElement => {
+    const { coreSystemRule, redHatLayeredProductsRule, customRules } =
+        getPlatformComponentsConfigRules(platformComponentsConfig);
 
     return (
         <Grid hasGutter>
@@ -78,7 +43,7 @@ const PlatformComponentsConfigDetails = (): ReactElement => {
                             <Text component="small" className="pf-v5-u-color-200">
                                 Namespaces match (Regex)
                             </Text>
-                            <CodeBlock>{coreSystemRule?.namespaceRule.regex}</CodeBlock>
+                            <CodeBlock>{coreSystemRule?.namespaceRule?.regex || 'None'}</CodeBlock>
                         </Stack>
                     </CardBody>
                 </Card>

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
@@ -14,7 +14,6 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import { SystemConfig } from 'types/config.proto';
 import { selectors } from 'reducers';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 import PrivateConfigDataRetentionDetails from './PrivateConfigDataRetentionDetails';
@@ -24,20 +23,17 @@ import PublicConfigTelemetryDetails from './PublicConfigTelemetryDetails';
 import PlatformComponentsConfigDetails from './PlatformComponentsConfigDetails';
 
 export type SystemConfigDetailsProps = {
-    isClustersRoutePathRendered: boolean;
     systemConfig: SystemConfig;
+    isClustersRoutePathRendered: boolean;
+    isCustomizingPlatformComponentsEnabled: boolean;
 };
 
 function SystemConfigDetails({
-    isClustersRoutePathRendered,
     systemConfig,
+    isClustersRoutePathRendered,
+    isCustomizingPlatformComponentsEnabled,
 }: SystemConfigDetailsProps): ReactElement {
     const isTelemetryConfigured = useSelector(selectors.getIsTelemetryConfigured);
-
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isCustomizingPlatformComponentsEnabled = isFeatureFlagEnabled(
-        'ROX_CUSTOMIZABLE_PLATFORM_COMPONENTS'
-    );
 
     return (
         <>
@@ -71,7 +67,9 @@ function SystemConfigDetails({
                         findings from user workloads
                     </Text>
                     <div className="pf-v5-u-mt-lg">
-                        <PlatformComponentsConfigDetails />
+                        <PlatformComponentsConfigDetails
+                            platformComponentsConfig={systemConfig.platformComponentsConfig}
+                        />
                     </div>
                 </PageSection>
             )}

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
@@ -40,13 +40,17 @@ function RedHatLayeredProductsCard({ rule }: RedHatLayeredProductsCardProps) {
                             Namespaces match (Regex)
                         </Text>
                         <CodeBlock>
-                            <div className="truncate-multiline">{rule?.namespaceRule.regex}</div>
+                            <div className="truncate-multiline">
+                                {rule?.namespaceRule?.regex || 'None'}
+                            </div>
                         </CodeBlock>
-                        <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
-                            <Button variant="link" isInline onClick={toggleModal}>
-                                View more
-                            </Button>
-                        </StackItem>
+                        {rule?.namespaceRule.regex !== '' && (
+                            <StackItem className="pf-v5-u-text-align-center pf-v5-u-mt-sm">
+                                <Button variant="link" isInline onClick={toggleModal}>
+                                    View more
+                                </Button>
+                            </StackItem>
+                        )}
                     </Stack>
                 </CardBody>
             </Card>

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -101,6 +101,8 @@ const SystemConfigForm = ({
 
     const { privateConfig } = systemConfig;
     const publicConfig = getCompletePublicConfig(systemConfig);
+    // @TODO: Use "getPlatformComponentsConfigRules" to convert the config into a structure compatible with Formik
+    const { platformComponentsConfig } = systemConfig;
     const {
         dirty,
         errors,
@@ -118,6 +120,8 @@ const SystemConfigForm = ({
             saveSystemConfig({
                 privateConfig: values.privateConfig,
                 publicConfig: values.publicConfig,
+                // @TODO: Pass the form values instead
+                platformComponentsConfig,
             })
                 .then((data) => {
                     // Simulate fetchPublicConfig response to update Redux state.

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
@@ -14,6 +14,7 @@ import {
 import { clustersBasePath, getIsRoutePathRendered } from 'routePaths';
 */
 import usePermissions from 'hooks/usePermissions';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { fetchSystemConfig } from 'services/SystemConfigService';
 import { SystemConfig } from 'types/config.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -34,6 +35,11 @@ const SystemConfigPage = (): ReactElement => {
     })(clustersBasePath);
     */
     const isClustersRoutePathRendered = true; // TODO replace with the preceding after #2105 has been merged
+
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isCustomizingPlatformComponentsEnabled = !isFeatureFlagEnabled(
+        'ROX_CUSTOMIZABLE_PLATFORM_COMPONENTS'
+    );
 
     const [isEditing, setIsEditing] = useState(false);
 
@@ -84,8 +90,9 @@ const SystemConfigPage = (): ReactElement => {
             </PageSection>
         ) : (
             <SystemConfigDetails
-                isClustersRoutePathRendered={isClustersRoutePathRendered}
                 systemConfig={systemConfig}
+                isClustersRoutePathRendered={isClustersRoutePathRendered}
+                isCustomizingPlatformComponentsEnabled={isCustomizingPlatformComponentsEnabled}
             />
         );
     } else {

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
@@ -37,7 +37,7 @@ const SystemConfigPage = (): ReactElement => {
     const isClustersRoutePathRendered = true; // TODO replace with the preceding after #2105 has been merged
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isCustomizingPlatformComponentsEnabled = !isFeatureFlagEnabled(
+    const isCustomizingPlatformComponentsEnabled = isFeatureFlagEnabled(
         'ROX_CUSTOMIZABLE_PLATFORM_COMPONENTS'
     );
 

--- a/ui/apps/platform/src/Containers/SystemConfig/configUtils.ts
+++ b/ui/apps/platform/src/Containers/SystemConfig/configUtils.ts
@@ -15,7 +15,7 @@ const defaultSystemRule = {
 };
 
 // This rule should theoretically always be set. This is to safeguard against any issues with the API
-const defaultRedHayLayeredProductsRule = {
+const defaultRedHatLayeredProductsRule = {
     name: 'red hat layered products',
     namespaceRule: {
         regex: '',
@@ -33,7 +33,7 @@ export function getPlatformComponentsConfigRules(
 ): PlatformComponentsConfigRules {
     const platformComponentsConfigRules: PlatformComponentsConfigRules = {
         coreSystemRule: defaultSystemRule,
-        redHatLayeredProductsRule: defaultRedHayLayeredProductsRule,
+        redHatLayeredProductsRule: defaultRedHatLayeredProductsRule,
         customRules: [],
     };
 

--- a/ui/apps/platform/src/Containers/SystemConfig/configUtils.ts
+++ b/ui/apps/platform/src/Containers/SystemConfig/configUtils.ts
@@ -1,0 +1,51 @@
+import { PlatformComponentRule, PlatformComponentsConfig } from 'types/config.proto';
+
+export type PlatformComponentsConfigRules = {
+    coreSystemRule: PlatformComponentRule;
+    redHatLayeredProductsRule: PlatformComponentRule;
+    customRules: PlatformComponentRule[];
+};
+
+// This rule should theoretically always be set. This is to safeguard against any issues with the API
+const defaultSystemRule = {
+    name: 'system rule',
+    namespaceRule: {
+        regex: '',
+    },
+};
+
+// This rule should theoretically always be set. This is to safeguard against any issues with the API
+const defaultRedHayLayeredProductsRule = {
+    name: 'red hat layered products',
+    namespaceRule: {
+        regex: '',
+    },
+};
+
+/**
+ * Transforms the platform components configuration into a structure compatible with Formik.
+ *
+ * @param platformComponentsConfig - This reprsents the platform components config retrieved from the API
+ * @returns - A structured set of rules organized for use in Formik
+ */
+export function getPlatformComponentsConfigRules(
+    platformComponentsConfig: PlatformComponentsConfig | undefined
+): PlatformComponentsConfigRules {
+    const platformComponentsConfigRules: PlatformComponentsConfigRules = {
+        coreSystemRule: defaultSystemRule,
+        redHatLayeredProductsRule: defaultRedHayLayeredProductsRule,
+        customRules: [],
+    };
+
+    platformComponentsConfig?.rules.forEach((rule) => {
+        if (rule.name === 'system rule') {
+            platformComponentsConfigRules.coreSystemRule = rule;
+        } else if (rule.name === 'red hat layered products') {
+            platformComponentsConfigRules.redHatLayeredProductsRule = rule;
+        } else {
+            platformComponentsConfigRules.customRules.push(rule);
+        }
+    });
+
+    return platformComponentsConfigRules;
+}

--- a/ui/apps/platform/src/types/config.proto.ts
+++ b/ui/apps/platform/src/types/config.proto.ts
@@ -79,5 +79,5 @@ export type SystemConfig = {
      */
     publicConfig: PublicConfig | null;
     privateConfig: PrivateConfig;
-    // @TODO: Add platform components config here
+    platformComponentsConfig: PlatformComponentsConfig;
 };


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR refactors a few things in preparation for the changes in the System Config Form. Some changes that were made:
1.  **General changes**
    1. Falling back to displaying `None` when the regex is not present.
    2. Hiding the `View more` button if there is nothing to show.
3. **PlatformComponentsConfigDetails**
    1. We now accept a prop for the `platformComponentsConfig` instead of the hardcoded value.
    2. We are utilizing a `getPlatformComponentsConfigRules` function to extract the rules in a more structured way to be used in both the details view and the form.
4. **SystemConfigDetails**
    1. We will move the feature flag hook up the parent and pass `isCustomizingPlatformComponentsEnabled` as a prop.
5. **SystemConfigForm**
    1. Fixing a Typescript issue related to having `platformComponentsConfig` in our `SystemConfig` type.
6. **SystemConfigPage**
    1. We will use the feature flag hook here and pass it to both `SystemConfigDetails` and `SystemConfigForm`.
7. **configUtils**
    1. Created a `getPlatformComponentsConfigRules` function to extract the rules in a more structured way to be used in both the details view and the form.
8. **config.proto**
    1. Adding `PlatformComponentsConfig` to the `SystemConfig` type.

### Screenshots

When there are no rules or the regexes are empty (The Core system rule and Red Hat layered products rules should always be set, but this is in case they aren't)
<img width="1411" alt="Screenshot 2025-05-20 at 3 41 19 PM" src="https://github.com/user-attachments/assets/8e9b200d-a558-41bf-816a-5788729ea13b" />

When there are rules set
<img width="1417" alt="Screenshot 2025-05-20 at 3 43 17 PM" src="https://github.com/user-attachments/assets/9838bf00-0fd8-4d71-9bd8-c779d0ee306d" />


### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [x] added regression tests
- [x] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
