### PR TITLE
chore(refactor): Unify receiver var name in compliance datastore

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -295,7 +295,7 @@ type distinctProfileName struct {
 }
 
 // GetProfilesNames gets the list of distinct profile names for the query
-func (d *datastoreImpl) GetProfilesNames(ctx context.Context, q *v1.Query) ([]string, error) {
+func (ds *datastoreImpl) GetProfilesNames(ctx context.Context, q *v1.Query) ([]string, error) {
 	var err error
 	q, err = withSACFilter(ctx, resources.Compliance, q)
 	if err != nil {
@@ -317,7 +317,7 @@ func (d *datastoreImpl) GetProfilesNames(ctx context.Context, q *v1.Query) ([]st
 	clonedQuery.Pagination = q.GetPagination()
 
 	var results []*distinctProfileName
-	results, err = pgSearch.RunSelectRequestForSchema[distinctProfileName](ctx, d.db, schema.ComplianceOperatorScanConfigurationV2Schema, clonedQuery)
+	results, err = pgSearch.RunSelectRequestForSchema[distinctProfileName](ctx, ds.db, schema.ComplianceOperatorScanConfigurationV2Schema, clonedQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ type distinctProfileCount struct {
 }
 
 // CountDistinctProfiles returns count of distinct profiles matching query
-func (d *datastoreImpl) CountDistinctProfiles(ctx context.Context, q *v1.Query) (int, error) {
+func (ds *datastoreImpl) CountDistinctProfiles(ctx context.Context, q *v1.Query) (int, error) {
 	var err error
 	q, err = withSACFilter(ctx, resources.Compliance, q)
 	if err != nil {
@@ -354,7 +354,7 @@ func (d *datastoreImpl) CountDistinctProfiles(ctx context.Context, q *v1.Query) 
 	}
 
 	var results []*distinctProfileCount
-	results, err = pgSearch.RunSelectRequestForSchema[distinctProfileCount](ctx, d.db, schema.ComplianceOperatorScanConfigurationV2Schema, withCountQuery(query, search.ComplianceOperatorConfigProfileName))
+	results, err = pgSearch.RunSelectRequestForSchema[distinctProfileCount](ctx, ds.db, schema.ComplianceOperatorScanConfigurationV2Schema, withCountQuery(query, search.ComplianceOperatorConfigProfileName))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -57,10 +57,10 @@ var (
 	// SensorAggregateDeploymentReferenceOptimization enables a performance improvement by aggregating deployment references when the same reference is queued for processing
 	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION")
 
-	// ACSCSEmailNotifier enables support for the ACSCS email notifier integratioon
+	// ACSCSEmailNotifier enables support for the ACSCS email notifier integration
 	ACSCSEmailNotifier = registerFeature("Enable support for ACSCS Email notifier type", "ROX_ACSCS_EMAIL_NOTIFIER", enabled)
 
-	// AttemptManifestDigest enables attempting to pull manifest digests from registres that historically did not
+	// AttemptManifestDigest enables attempting to pull manifest digests from registries that historically did not
 	// support it but now appear to (ie: Nexus and RHEL).
 	AttemptManifestDigest = registerFeature("Enables attempts to pull manifest digests for all registry integrations", "ROX_ATTEMPT_MANIFEST_DIGEST", enabled)
 


### PR DESCRIPTION
### Description

There were two ways of naming the receiver var in this file:
- `func (ds *datastoreImpl)`
- `func (d *datastoreImpl)`

as the first one was more popular, I changed all occurrences of the second one to get rid of the IDE style warning.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- in CI we trust
