### PR TITLE
ROX-20769: Add DatabaseIsExternal to the status

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/version"
 	"google.golang.org/grpc"
 )
@@ -184,6 +185,7 @@ func (s *serviceImpl) GetDatabaseStatus(ctx context.Context, _ *v1.Empty) (*v1.D
 		dbStatus.DatabaseType = dbType
 	}
 
+	dbStatus.DatabaseIsExternal = pgconfig.IsExternalDatabase()
 	return dbStatus, nil
 }
 

--- a/generated/api/v1/metadata_service.pb.go
+++ b/generated/api/v1/metadata_service.pb.go
@@ -432,9 +432,10 @@ type DatabaseStatus struct {
 	// type of database serving central
 	DatabaseType DatabaseStatus_DatabaseType `protobuf:"varint,2,opt,name=database_type,json=databaseType,proto3,enum=v1.DatabaseStatus_DatabaseType" json:"database_type,omitempty"`
 	// version of the database
-	DatabaseVersion string `protobuf:"bytes,3,opt,name=database_version,json=databaseVersion,proto3" json:"database_version,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	DatabaseVersion    string `protobuf:"bytes,3,opt,name=database_version,json=databaseVersion,proto3" json:"database_version,omitempty"`
+	DatabaseIsExternal bool   `protobuf:"varint,4,opt,name=database_is_external,json=databaseIsExternal,proto3" json:"database_is_external,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *DatabaseStatus) Reset() {
@@ -486,6 +487,13 @@ func (x *DatabaseStatus) GetDatabaseVersion() string {
 		return x.DatabaseVersion
 	}
 	return ""
+}
+
+func (x *DatabaseStatus) GetDatabaseIsExternal() bool {
+	if x != nil {
+		return x.DatabaseIsExternal
+	}
+	return false
 }
 
 type DatabaseBackupStatus struct {
@@ -648,11 +656,12 @@ const file_api_v1_metadata_service_proto_rawDesc = "" +
 	"\x15trust_info_serialized\x18\x01 \x01(\fR\x13trustInfoSerialized\x12\x1c\n" +
 	"\tsignature\x18\x02 \x01(\fR\tsignature\">\n" +
 	"\x13TLSChallengeRequest\x12'\n" +
-	"\x0fchallenge_token\x18\x01 \x01(\tR\x0echallengeToken\"\xe9\x01\n" +
+	"\x0fchallenge_token\x18\x01 \x01(\tR\x0echallengeToken\"\x9b\x02\n" +
 	"\x0eDatabaseStatus\x12-\n" +
 	"\x12database_available\x18\x01 \x01(\bR\x11databaseAvailable\x12D\n" +
 	"\rdatabase_type\x18\x02 \x01(\x0e2\x1f.v1.DatabaseStatus.DatabaseTypeR\fdatabaseType\x12)\n" +
-	"\x10database_version\x18\x03 \x01(\tR\x0fdatabaseVersion\"7\n" +
+	"\x10database_version\x18\x03 \x01(\tR\x0fdatabaseVersion\x120\n" +
+	"\x14database_is_external\x18\x04 \x01(\bR\x12databaseIsExternal\"7\n" +
 	"\fDatabaseType\x12\n" +
 	"\n" +
 	"\x06Hidden\x10\x00\x12\v\n" +

--- a/generated/api/v1/metadata_service.swagger.json
+++ b/generated/api/v1/metadata_service.swagger.json
@@ -280,6 +280,9 @@
         "databaseVersion": {
           "type": "string",
           "title": "version of the database"
+        },
+        "databaseIsExternal": {
+          "type": "boolean"
         }
       }
     },

--- a/generated/api/v1/metadata_service_vtproto.pb.go
+++ b/generated/api/v1/metadata_service_vtproto.pb.go
@@ -128,6 +128,7 @@ func (m *DatabaseStatus) CloneVT() *DatabaseStatus {
 	r.DatabaseAvailable = m.DatabaseAvailable
 	r.DatabaseType = m.DatabaseType
 	r.DatabaseVersion = m.DatabaseVersion
+	r.DatabaseIsExternal = m.DatabaseIsExternal
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -305,6 +306,9 @@ func (this *DatabaseStatus) EqualVT(that *DatabaseStatus) bool {
 		return false
 	}
 	if this.DatabaseVersion != that.DatabaseVersion {
+		return false
+	}
+	if this.DatabaseIsExternal != that.DatabaseIsExternal {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -617,6 +621,16 @@ func (m *DatabaseStatus) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.DatabaseIsExternal {
+		i--
+		if m.DatabaseIsExternal {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if len(m.DatabaseVersion) > 0 {
 		i -= len(m.DatabaseVersion)
 		copy(dAtA[i:], m.DatabaseVersion)
@@ -856,6 +870,9 @@ func (m *DatabaseStatus) SizeVT() (n int) {
 	l = len(m.DatabaseVersion)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.DatabaseIsExternal {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1541,6 +1558,26 @@ func (m *DatabaseStatus) UnmarshalVT(dAtA []byte) error {
 			}
 			m.DatabaseVersion = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DatabaseIsExternal", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.DatabaseIsExternal = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2455,6 +2492,26 @@ func (m *DatabaseStatus) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.DatabaseVersion = stringValue
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DatabaseIsExternal", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.DatabaseIsExternal = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/api/v1/metadata_service.proto
+++ b/proto/api/v1/metadata_service.proto
@@ -61,6 +61,7 @@ message DatabaseStatus {
   DatabaseType database_type = 2;
   // version of the database
   string database_version = 3;
+  bool database_is_external = 4;
 }
 
 message DatabaseBackupStatus {


### PR DESCRIPTION
### Description

Due to switching to PG15 UI would need to display a warning when Central is still running with PG13 as an internal database (it's possible to abuse troubleshooting mechanisms for that). The issue is that the same warning will be displayed for ACSCS, which has different timeline for upgrading the database.

To display the warning only on installations with an internal database, add the corresponding field into the database status API.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Not validated yet.