### PR TITLE
chore(ci): pin gha runner image to ubuntu-22.04

### DIFF
--- a/.github/workflows/add-new-pr-to-oss-triaging.yml
+++ b/.github/workflows/add-new-pr-to-oss-triaging.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   check-pr-if-external:
     name: Add external label to pull request if outside StackRox
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ github.token }}
       BASE_REPO: ${{ github.repository }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.actor == 'dependabot[bot]' && github.event.label.name == 'auto-merge'
     steps:
     - uses: ahmadnassri/action-dependabot-auto-merge@v2.6

--- a/.github/workflows/backport-pr.yaml
+++ b/.github/workflows/backport-pr.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -9,7 +9,7 @@ concurrency: Batch load test metrics
 
 jobs:
   batch-load-test-metrics:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
   define-job-matrix:
     outputs:
       matrix: ${{ steps.define-job-matrix.outputs.matrix }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
       # For consistency with `image/rhel/konflux.Dockerfile`, see comment there.
       UI_PKG_INSTALL_EXTRA_ARGS: --ignore-scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
@@ -139,7 +139,7 @@ jobs:
             ui/apps/platform/package-lock.json
 
   pre-build-cli:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       volumes:
@@ -180,7 +180,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).pre_build_go_binaries }}
     needs: define-job-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
@@ -245,7 +245,7 @@ jobs:
           path: go-binaries-build.tgz
 
   pre-build-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
@@ -280,7 +280,7 @@ jobs:
             image/rhel/docs
 
   build-and-push-main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - define-job-matrix
       - pre-build-ui
@@ -464,7 +464,7 @@ jobs:
             push_matching_collector_scanner_images "${{ env.ROX_PRODUCT_BRANDING }}" "${{ matrix.arch }}"
 
   push-main-manifests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
     - define-job-matrix
     - build-and-push-main
@@ -573,7 +573,7 @@ jobs:
         add_build_comment_to_pr
 
   build-and-push-operator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - define-job-matrix
     container:
@@ -660,7 +660,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     needs:
@@ -720,7 +720,7 @@ jobs:
       - build-and-push-operator
       - push-main-manifests
     name: Check images for vulnerabilities
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed for stackrox/central-login to create the JWT token.
       id-token: write
@@ -783,7 +783,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'ci-test-github-action-slack-messages')
       )
     name: Post failure message to Slack
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - pre-build-ui
       - pre-build-cli

--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check-crd-compatibility:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       volumes:  # job-preamble deletes unused host runner files under /mnt

--- a/.github/workflows/check-image-vulnerabilities.yml
+++ b/.github/workflows/check-image-vulnerabilities.yml
@@ -13,7 +13,7 @@ run-name: ${{ format('Check image vulnerabilities for {0}', inputs.version) }}
 jobs:
   run-parameters:
     name: Run parameters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           {
@@ -27,7 +27,7 @@ jobs:
 
   check-image-vulnerabilities:
     name: Check ${{ matrix.image }}:${{ inputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed for stackrox/central-login to create the JWT token.
       id-token: write

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-title:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   report-e2e-failures-to-slack:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:

--- a/.github/workflows/create-clusters.yml
+++ b/.github/workflows/create-clusters.yml
@@ -42,7 +42,7 @@ concurrency: Release automation ${{ inputs.version }}
 
 jobs:
   trim-cluster-names:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       cluster-with-fake-load-name-cleaned: ${{ steps.cluster-names.outputs.cluster-with-fake-load-name-cleaned }}
       cluster-with-real-load-name-cleaned: ${{ steps.cluster-names.outputs.cluster-with-real-load-name-cleaned }}

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -60,7 +60,7 @@ concurrency: Release automation ${{ inputs.version }}
 
 jobs:
   properties:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.fetch.outputs.dry-slack-channel, steps.fetch.outputs.slack-channel))[github.event.inputs.dry-run != 'true'] }}
       jira-projects: ${{ steps.fetch.outputs.jira-projects }}
@@ -73,7 +73,7 @@ jobs:
 
   run-parameters:
     name: Run parameters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
@@ -96,7 +96,7 @@ jobs:
   check-jira:
     name: Check Jira tickets for release
     needs: [variables, properties]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Query JIRA
         # Checking unequal with "false" because closed milestones have unset input values.
@@ -115,7 +115,7 @@ jobs:
   postpone-prs:
     name: Postpone open PRs
     needs: variables
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check open PRs
         id: check
@@ -171,7 +171,7 @@ jobs:
 
   cut-rc:
     name: Tag RC for milestone ${{needs.variables.outputs.milestone}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [variables, properties, postpone-prs, check-jira]
     steps:
       - name: Check out code
@@ -300,7 +300,7 @@ jobs:
                     :arrow_right: Once all checks pass and you're ready for release, run the <${{ github.server_url }}/${{ github.repository }}/actions/workflows/finish-release.yml|Finish Release> workflow and delete the `${{ needs.variables.outputs.next-milestone }}` milestone to avoid confusion.
 
   trim-cluster-names:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       cluster-with-fake-load-name-cleaned: ${{ steps.cluster-names.outputs.cluster-with-fake-load-name-cleaned }}
       cluster-with-real-load-name-cleaned: ${{ steps.cluster-names.outputs.cluster-with-real-load-name-cleaned }}

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -21,7 +21,7 @@ jobs:
   e2e-test-on-kind:
     timeout-minutes: 60
     name: "Test on kind cluster"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ !github.event.pull_request.head.repo.fork }} # do not run for PRs from forks
     permissions:
       id-token: write

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -34,7 +34,7 @@ concurrency: Release automation ${{ inputs.version }}
 
 jobs:
   properties:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.fetch.outputs.dry-slack-channel, steps.fetch.outputs.slack-channel))[github.event.inputs.dry-run != 'true'] }}
     steps:
@@ -47,7 +47,7 @@ jobs:
   run-parameters:
     if: github.event_name == 'workflow_dispatch'
     name: Run parameters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
@@ -70,7 +70,7 @@ jobs:
 
   publish-release:
     name: Tag Release ${{ needs.variables.outputs.named-release-patch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [variables, properties]
     steps:
       - name: Check out code
@@ -166,7 +166,7 @@ jobs:
 
   update-infra-demo-version:
     name: Update infra demo default versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [publish-release]
     env:
       BRANCH: "bump-demo-versions-${{ inputs.version }}"

--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Run PR Fixxxer
     # TODO: support leading and trailing whitespace too
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/fixxx' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   label-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
     - uses: actions/labeler@v5

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -5,7 +5,7 @@ on:
   - cron: 0 0 * * 1-5
 jobs:
   create-nightly-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/notify-milestone-change.yml
+++ b/.github/workflows/notify-milestone-change.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   properties:
     name: Read repository properties
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       docs-repository: ${{ steps.properties.outputs.docs-repository }}
       slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.properties.outputs.dry-slack-channel, steps.properties.outputs.slack-channel))[github.repository == 'stackrox/stackrox'] }}
@@ -24,7 +24,7 @@ jobs:
         run: gh api -H "$ACCEPT_RAW" "$PROPERTIES_URL" >> "$GITHUB_OUTPUT"
 
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [properties]
     steps:
       - name: Determine Jira context for PR

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -10,7 +10,7 @@ concurrency: performance-tests-${{ github.ref }}
 jobs:
   wait-for-images:
     name: Wait for images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci-performance-tests') }}
     strategy:
       matrix:
@@ -34,7 +34,7 @@ jobs:
   run-k6-performance-tests:
     needs: [wait-for-images]
     name: Run k6 performance tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci-performance-tests') }}
     env:
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-parameters:
     name: Run parameters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           echo "Event: ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
 
   check-is-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       is_release: ${{ steps.is_release_check.outputs.is_release }}
     steps:
@@ -45,7 +45,7 @@ jobs:
           fi
 
   check-scanner-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
             check_scanner_version
 
   check-collector-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
   update-collector-released-versions:
     needs: [check-scanner-version, check-collector-version, check-is-release]
     if: needs.check-is-release.outputs.is_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
   publish-helm-charts:
     needs: [build, check-scanner-version, check-collector-version, check-is-release]
     if: needs.check-is-release.outputs.is_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
   publish-roxctl:
     needs: [build, check-scanner-version, check-collector-version, check-is-release]
     if: needs.check-is-release.outputs.is_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
   publish-openapispec:
     needs: [build, check-scanner-version, check-collector-version, check-is-release]
     if: needs.check-is-release.outputs.is_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/retest_periodic.yml
+++ b/.github/workflows/retest_periodic.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   retest:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -23,7 +23,7 @@ jobs:
   define-scanner-job-matrix:
     outputs:
       matrix: ${{ steps.define-scanner-job-matrix.outputs.matrix }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
 
   pre-build-scanner-go-binary:
     needs: define-scanner-job-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       # Supports three go binary builds:
       # default              - built with environment defaults (see handle-tagged-build & env.mk)
@@ -135,7 +135,7 @@ jobs:
 
   scan-scanner-go-binary:
     needs: pre-build-scanner-go-binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
@@ -182,7 +182,7 @@ jobs:
     needs:
     - define-scanner-job-matrix
     - pre-build-scanner-go-binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       # Supports three go binary and image builds:
@@ -254,7 +254,7 @@ jobs:
     needs:
     - define-scanner-job-matrix
     - build-and-push-scanner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       # Supports three image builds:
@@ -317,7 +317,7 @@ jobs:
     - build-and-push-scanner
     - push-scanner-manifests
     name: Check images for vulnerabilities
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed for stackrox/central-login to create the JWT token.
       id-token: write

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   db-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
     steps:

--- a/.github/workflows/scanner-e2e-test.yaml
+++ b/.github/workflows/scanner-e2e-test.yaml
@@ -14,7 +14,7 @@ jobs:
     if: >
       github.event_name != 'pull_request'
       || contains(github.event.pull_request.labels.*.name, 'scanner-functional-tests')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image:
@@ -39,7 +39,7 @@ jobs:
     name: Deploy and run
     needs:
       - scanner-ft-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       SCANNER_E2E_QUAY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
       SCANNER_E2E_QUAY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}

--- a/.github/workflows/scanner-mapping-update.yaml
+++ b/.github/workflows/scanner-mapping-update.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-scanner-mappings:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       REPOMAPPING_DIR: repomapping
     steps:

--- a/.github/workflows/scanner-nvd-update.yaml
+++ b/.github/workflows/scanner-nvd-update.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   fetch-nvd-feeds:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -53,7 +53,7 @@ jobs:
         if-no-files-found: error
 
   fetch-nvd-api:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -96,7 +96,7 @@ jobs:
   upload-nvd-feeds:
     needs:
     - fetch-nvd-feeds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request'
     steps:
     - name: Checkout repository
@@ -125,7 +125,7 @@ jobs:
   upload-nvd-api:
     needs:
     - fetch-nvd-api
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request'
     steps:
     - name: Checkout repository
@@ -155,7 +155,7 @@ jobs:
     needs:
       - upload-nvd-feeds
       - upload-nvd-api
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: failure()
     steps:
     - name: Send Slack notification on workflow failure

--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   offline-bundle-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'schedule' ||
       (github.event_name == 'pull_request' &&
@@ -35,7 +35,7 @@ jobs:
 
   offline-bundle-generate:
     needs: offline-bundle-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
         if-no-files-found: error
 
   offline-bundle-upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
     - offline-bundle-generate
     steps:
@@ -124,7 +124,7 @@ jobs:
     - offline-bundle-matrix
     - offline-bundle-generate
     - offline-bundle-upload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'schedule' && failure()
     steps:
     - name: Send Slack notification on workflow failure

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   parse-versions:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       versions: ${{ steps.set-versions.outputs.versions }}
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   prepare-environment:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       manual_url: ${{ steps.set-manual-url.outputs.manual_url }}
     steps:
@@ -106,7 +106,7 @@ jobs:
     needs:
     - parse-versions
     - prepare-environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
       volumes:
@@ -181,7 +181,7 @@ jobs:
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
     needs:
     - prepare-environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.4.8
       volumes:
@@ -261,7 +261,7 @@ jobs:
     needs:
     - build-and-run
     if: ${{ (failure() || success()) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     # Checkout to run ./.github/actions/download-artifact-with-retry
     - uses: actions/checkout@v4
@@ -337,7 +337,7 @@ jobs:
     needs:
     - build-and-run
     - upload-definitions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ failure() && github.ref_name == 'master' }}
     steps:
     - name: Send Slack notification on workflow failure

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -42,7 +42,7 @@ concurrency: Release automation ${{ inputs.version }}
 jobs:
   start-sha:
     name: Find commit for release branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       start-sha: ${{ fromJSON(format('["{0}","{1}"]', env.USER_REF, steps.find.outputs.merge_base))[env.USER_REF == ''] }}
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   properties:
     name: Read repository properties
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       docs-repository: ${{ steps.properties.outputs.docs-repository }}
       slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.properties.outputs.dry-slack-channel, steps.properties.outputs.slack-channel))[github.event.inputs.dry-run != 'true'] }}
@@ -81,7 +81,7 @@ jobs:
 
   run-parameters:
     name: Run parameters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
@@ -102,7 +102,7 @@ jobs:
   check-jira:
     name: Check Jira release
     needs: [variables, properties]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       release-date: ${{steps.check-jira-release.outputs.date}}
     steps:
@@ -120,7 +120,7 @@ jobs:
   branch:
     name: Prepare release branch
     needs: [variables, start-sha]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code (normal release)
         if: needs.variables.outputs.patch == 0
@@ -192,7 +192,7 @@ jobs:
     name: Configure OpenShift CI jobs
     needs: [variables, branch]
     if: needs.variables.outputs.patch == 0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RELEASE: "${{needs.variables.outputs.release}}"
       BRANCH: "stackrox-release-${{needs.variables.outputs.release}}"
@@ -261,7 +261,7 @@ jobs:
     name: Patch CHANGELOG.md
     needs: [variables, branch, start-sha]
     if: needs.variables.outputs.patch == 0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -287,7 +287,7 @@ jobs:
   patch-scanner-versions:
     name: Patch Scanner updater configuration
     needs: [variables, branch]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -309,7 +309,7 @@ jobs:
   milestone:
     name: Create milestone
     needs: [variables]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Create ${{needs.variables.outputs.next-milestone}} milestone
         if: env.DRY_RUN == 'false'
@@ -335,7 +335,7 @@ jobs:
   notify:
     name: Notify everybody
     needs: [variables, properties, branch, milestone]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Post to Slack (normal release)
         if: needs.variables.outputs.patch == 0

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -18,7 +18,7 @@ jobs:
   check-generated-files:
     env:
       ARTIFACT_DIR: junit-reports/
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
@@ -44,7 +44,7 @@ jobs:
   misc-checks:
     env:
       ARTIFACT_DIR: junit-reports/
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
@@ -82,7 +82,7 @@ jobs:
       run: scripts/ci/jobs/check-image-version.sh
 
   style-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       volumes:
@@ -116,7 +116,7 @@ jobs:
 
   golangci-lint:
     timeout-minutes: 240
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       volumes:
@@ -165,7 +165,7 @@ jobs:
     # This job ensures that COLLECTOR_VERSION or SCANNER_VERSION files cannot be updated to a version for which the
     # image was not successfully built on Konflux (suffix "-fast"). It also verifies that GHA-built image is there (no
     # suffix) so that the failure also happens in this job.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image: ["collector", "scanner", "scanner-slim", "scanner-db", "scanner-db-slim"]
@@ -202,7 +202,7 @@ jobs:
           limit: 300
 
   github-actions-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/job-preamble
@@ -217,7 +217,7 @@ jobs:
         shell: bash
 
   github-actions-shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/job-preamble
@@ -227,7 +227,7 @@ jobs:
         run: shellcheck -P SCRIPTDIR -x ./.github/workflows/scripts/*.sh
 
   openshift-ci-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
     steps:
@@ -255,7 +255,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'ci-test-github-action-slack-messages')
       )
     name: Post failure message to Slack
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - check-generated-files
       - misc-checks

--- a/.github/workflows/tagged-ci.yaml
+++ b/.github/workflows/tagged-ci.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   slack-tagged-notice:
     name: Slack Tagged Notice
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/triage-report_periodic.yml
+++ b/.github/workflows/triage-report_periodic.yml
@@ -5,7 +5,7 @@ on:
   - cron: 0 15 * * 3,5
 jobs:
   triage-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
@@ -88,7 +88,7 @@ jobs:
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
         pg: [ '13', '15' ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
@@ -150,7 +150,7 @@ jobs:
         directory: 'junit-reports'
 
   go-bench:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       volumes:  # job-preamble deletes unused host runner files under /mnt
@@ -198,7 +198,7 @@ jobs:
     # https://github.com/jstemmer/go-junit-report/issues/174
 
   ui:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
@@ -237,7 +237,7 @@ jobs:
         directory: 'ui/apps/platform/test-results/reports'
 
   ui-component:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
@@ -283,7 +283,7 @@ jobs:
         directory: 'ui/apps/platform/cypress/test-results/reports'
 
   local-roxctl-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
@@ -327,7 +327,7 @@ jobs:
         directory: 'roxctl-test-output'
 
   shell-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
@@ -366,7 +366,7 @@ jobs:
         directory: 'shell-test-output'
 
   openshift-ci-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.8
       volumes:  # job-preamble deletes unused host runner files under /mnt
@@ -397,7 +397,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'ci-test-github-action-slack-messages')
       )
     name: Post failure message to Slack
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - go
       - go-bench

--- a/.github/workflows/update_collector_periodic.yaml
+++ b/.github/workflows/update_collector_periodic.yaml
@@ -5,7 +5,7 @@ on:
     - cron: 0 5 * * 1-5
 jobs:
   update-collector:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/update_scanner_periodic.yaml
+++ b/.github/workflows/update_scanner_periodic.yaml
@@ -5,7 +5,7 @@ on:
   - cron: 0 5 * * 1
 jobs:
   update-scanner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -40,7 +40,7 @@ concurrency: Release automation ${{ inputs.milestone }}
 jobs:
   properties:
     name: Read repository properties
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       slack-channel: ${{ fromJSON(format('["{0}","{1}"]', steps.properties.outputs.dry-slack-channel, steps.properties.outputs.slack-channel))[inputs.dry-run != 'true'] }}
     steps:
@@ -52,7 +52,7 @@ jobs:
 
   run-parameters:
     name: Run parameters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           [ "$DRY_RUN" = "true" ] && echo "::warning::This is a dry run"
@@ -66,7 +66,7 @@ jobs:
   create-clusters:
     needs: [properties]
     if: github.event.inputs.dry-run != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         name: [test1, test2]
@@ -83,7 +83,7 @@ jobs:
 
   prepare-clusters:
     needs: [properties, create-clusters]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -136,7 +136,7 @@ jobs:
     name: Notify about failed cluster creation
     needs: [properties, prepare-clusters]
     if: always() && needs.prepare-clusters.result == 'failure'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Post to Slack
         uses: slackapi/slack-github-action@v2.1.0

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -56,7 +56,7 @@ on:
 jobs:
   parse:
     name: Parse ${{inputs.version}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       release: ${{steps.parse.outputs.release}}
       major: ${{steps.parse.outputs.major}}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -32,7 +32,7 @@ concurrency: Release automation ${{ inputs.version }}
 jobs:
   run-parameters:
     name: Run parameters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           {
@@ -52,7 +52,7 @@ jobs:
 
   properties:
     name: Read repository properties
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       jira-project: ${{ steps.properties.outputs.jira-project }}
     steps:
@@ -64,7 +64,7 @@ jobs:
 
   verify-release:
     name: Verify all artifacts for release ${{ needs.variables.outputs.named-release-patch }} are published
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [variables, properties]
     env:
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}


### PR DESCRIPTION
Pin to old(stable) GHA runner version.

? Should we pin to ubuntu-24.04 instead?
? What does a change like this risk breaking? (non-pr jobs? .. should I just remove those from this change?)

My ideas right now of for/against pinning the GHA runner image version:

For:
1. Control _when_ we see runner changes and need to update our CI jobs/scripts to work in a new runner environment because of resource changes or tooling changes (tool versions are updated weekly). We see few tooling changes now that most of our jobs run in our rox-ci-image, but it still may affect us.
2. Avoid bugs with the latest runner image that are not exposed yet. We have seen few cases where the runner image was broken, but it can block our work in PR's or the release process.

Against:
Is there a reason to stay on latest. Are we benefiting from something?
1. We do not use tooling in the runner image; we do not need to know/care when it changes.
2. We can benefit from any environment improvements without any change needed by us (latest runner may be configured to work better with github itself or in the hosting environment).
3. It is a version we will then have to maintain and update in the future. How will we track when the pinned version is deprecated, and removed?



This PR was originally created to test working-around CI gha failures like:
```
The hosted runner: GitHub Actions 497 lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```
(https://github.com/stackrox/stackrox/actions/runs/15181841057/job/42692834095)
However, that incident was an outage from the host and not fixed by changing the runner image (it is unknown if the older runner image encountered the problem less frequently during the time of the problem).