### PR TITLE
tests: Add unit tests to ping service

### DIFF
--- a/central/ping/service/service_impl_test.go
+++ b/central/ping/service/service_impl_test.go
@@ -17,7 +17,7 @@ func TestAuthz(t *testing.T) {
 
 func TestPing(t *testing.T) {
 	service := &serviceImpl{}
-	response, err := service.Ping(sac.WithAllAccess(context.Background()), &v1.Empty{})
+	response, err := service.Ping(sac.WithNoAccess(context.Background()), &v1.Empty{})
 	assert.NoError(t, err)
 	protoassert.Equal(t, &v1.PongMessage{Status: "ok"}, response)
 }


### PR DESCRIPTION
### Description

While working with [pull/15430](https://github.com/stackrox/stackrox/pull/15430) I noticed that the Ping service lacks unit tests. Even if it's a simple service, it can benefit from basic checks that verify that the contract is not broken.

This PR adds unit tests that check that the response is what's expected ("ok") and that the right level of access (anonymous in this case) is allowed.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI, manual verification.
