### PR TITLE
ROX-22663: Add configurable Maven search

### DIFF
--- a/pkg/env/scannerv4.go
+++ b/pkg/env/scannerv4.go
@@ -34,4 +34,9 @@ var (
 	// ScannerV4ManifestDeleteDuration specifies the duration of the interval (not inclusive) in which manifests will be deleted.
 	// Default: 23 days
 	ScannerV4ManifestDeleteDuration = registerDurationSetting("ROX_SCANNER_V4_MANIFEST_DELETE_DURATION", 23*24*time.Hour)
+
+	// ScannerV4MavenSearchURL specifies the URL that Scanner V4 Indexer will use to get additional information about
+	// Java packages. The ROX_SCANNER_V4_MAVEN_SEARCH feature flag must be enabled to have any effect.
+	// Default: https://search.maven.org/solrsearch/select
+	ScannerV4MavenSearchURL = RegisterSetting("ROX_SCANNER_V4_MAVEN_SEARCH_URL", WithDefault("https://search.maven.org/solrsearch/select"))
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -159,4 +159,10 @@ var (
 
 	// ScannerV4RedHatLayers enables displaying vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers.
 	ScannerV4RedHatLayers = registerFeature("Scanner V4 will output vulnerabilities from Red Hat sources, only, for packages found in official Red Hat image layers", "ROX_SCANNER_V4_RED_HAT_LAYERS_RED_HAT_VULNS_ONLY")
+
+	// ScannerV4MavenSearch enables reaching out to a Maven Search-compatible URL for improved indexing of JARs. The
+	// URL can be adjusted via the ROX_SCANNER_V4_MAVEN_SEARCH_URL environment variable.
+	//
+	// This must be set in Scanner V4 Indexer to have any effect.
+	ScannerV4MavenSearch = registerFeature("Enables Scanner V4 to reach out to ROX_SCANNER_V4_MAVEN_SEARCH_URL for additional information about Java packages", "ROX_SCANNER_V4_MAVEN_SEARCH")
 )

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -334,6 +334,10 @@ func newLibindex(ctx context.Context, indexerCfg config.IndexerConfig, client *h
 				}),
 				"java": castToConfig(func(cfg *java.ScannerConfig) {
 					cfg.DisableAPI = true
+					if features.ScannerV4MavenSearch.Enabled() {
+						cfg.DisableAPI = false
+						cfg.API = env.ScannerV4MavenSearchURL.Setting()
+					}
 				}),
 			},
 		},


### PR DESCRIPTION
## Description

Adds a configurable feature to allow Scanner V4 indexer to reach out to a configurable URL to get additional information about JAR dependencies via the Maven search API during indexing.

This particular feature is meant to be a temporary workaround until we have a more permanent fix, e.g., resolving [CLAIRDEV-93](https://issues.redhat.com/browse/CLAIRDEV-93).

## User-facing documentation

- [ ] ~~[CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed~~
- [ ] ~~[documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed~~

N/A. This feature is meant to be a temporary workaround and will be documented in a KCS.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- ~~[ ] added unit tests~~
- ~~[ ] added e2e tests~~
- ~~[ ] added regression tests~~
- ~~[ ] added compatibility tests~~
- ~~[ ] modified existing tests~~

### How I validated my change

Container image under test: `quay.io/rhacs-eng/qa:tomcat-9.0.59`

#### Setup environment

Deploy stackrox:
```
# I have these env vars set by default
# export ROX_SCANNER_V4="true"
# export LOAD_BALANCER="route"
❯ export MAIN_IMAGE_TAG=4.8.x-875-g1a6f5ce768 # or w/e the latest PR tag is
❯ ./deploy/deploy.sh
```

#### Retrieve scan results without the feature flag

Get results from a container image that has a non-conforming JAR:
```
❯ roxctl image scan --format json --image quay.io/rhacs-eng/qa:tomcat-9.0.59 --force > qa:tomcat-9.0.59.json
```

#### Patch the Scanner V4 Indexer deployment

Patch file:
```yaml
spec:
  template:
    spec:
      containers:
      - name: indexer
        env:
        - name: ROX_SCANNER_V4_MAVEN_SEARCH
          value: "true"
```

Apply the patch:
```
❯ oc -n stackrox patch deploy scanner-v4-indexer --patch-file patch.yaml
```

#### Truncate the Scanner V4 database

Access the database:
```
❯ oc extract secret/scanner-v4-db-password -n stackrox --to=-
❯ oc -n stackrox port-forward svc/scanner-v4-db 5432:5432
```

Use your sql client of choice and truncate the necessary tables:
```sql
TRUNCATE manifest CASCADE;
TRUNCATE layer CASCADE;
```

#### Retrieve scan results with the feature flag enabled

```
❯ roxctl image scan --format json --image quay.io/rhacs-eng/qa:tomcat-9.0.59 --force > qa:tomcat-9.0.59-maven.json
```

#### Compare the results

```
❯ jq '.scan.components |= sort_by(.name) | .scan.components[].vulns |= sort_by(.cve)?' qa:tomcat-9.0.59.json
❯ jq '.scan.components |= sort_by(.name) | .scan.components[].vulns |= sort_by(.cve)?' qa:tomcat-9.0.59-maven.json
```

Vulnerabilities without Maven search:
```
❯ jq '[.scan.components[].vulns[]?.cve] | sort | .[]' qa:tomcat-9.0.59.json
"CVE-2022-29885"
"CVE-2023-28708"
"CVE-2023-3446"
"CVE-2023-3446"
"CVE-2023-3817"
"CVE-2023-3817"
"CVE-2023-5678"
"CVE-2023-5678"
"CVE-2025-24813"
```

Vulnerabilities Maven search enabled:
```
❯ jq '[.scan.components[].vulns[]?.cve] | sort | .[]' qa:tomcat-9.0.59-maven.json
"CVE-2022-42252"
"CVE-2022-45143"
"CVE-2023-24998"
"CVE-2023-3446"
"CVE-2023-3446"
"CVE-2023-3817"
"CVE-2023-3817"
"CVE-2023-41080"
"CVE-2023-42795"
"CVE-2023-44487"
"CVE-2023-45648"
"CVE-2023-46589"
"CVE-2023-5678"
"CVE-2023-5678"
"CVE-2024-24549"
"CVE-2024-34750"
"CVE-2024-50379"
"CVE-2024-56337"
"CVE-2025-24813"
"CVE-2025-46701"
```

Diff of vulnerabilities:
```
❯ diff <(jq '[.scan.components[].vulns[]?.cve] | sort | .[]' qa:tomcat-9.0.59.json) <(jq '[.scan.components[].vulns[]?.cve] | sort | .[]' qa:tomcat-9.0.59-maven.json)
1,2c1,3
< "CVE-2022-29885"
< "CVE-2023-28708"
---
> "CVE-2022-42252"
> "CVE-2022-45143"
> "CVE-2023-24998"
6a8,12
> "CVE-2023-41080"
> "CVE-2023-42795"
> "CVE-2023-44487"
> "CVE-2023-45648"
> "CVE-2023-46589"
8a15,18
> "CVE-2024-24549"
> "CVE-2024-34750"
> "CVE-2024-50379"
> "CVE-2024-56337"
9a20
> "CVE-2025-46701"
```

Feel free to DM on Slack for the full scan results.