### PR TITLE
ROX-29492: Compute conditional colSpan according to Advisory column

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -122,7 +122,9 @@ function AffectedDeploymentsTable({
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
 
-    const colSpan = 8 + -hiddenColumnCount;
+    const colSpan = 7 + -hiddenColumnCount;
+    const colSpanForComponentVulnerabilitiesTable = colSpan - 1; // minus ExpandRowTh
+
     return (
         <Table variant="compact">
             <Thead noWrap>
@@ -248,7 +250,7 @@ function AffectedDeploymentsTable({
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>
                                     <Td />
-                                    <Td colSpan={6}>
+                                    <Td colSpan={colSpanForComponentVulnerabilitiesTable}>
                                         <ExpandableRowContent>
                                             <DeploymentComponentVulnerabilitiesTable
                                                 images={imageComponentVulns}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -152,6 +152,7 @@ function AffectedImagesTable({
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const colSpan = 8 + (isNvdCvssColumnEnabled ? 1 : 0) + -hiddenColumnCount;
+    const colSpanForComponentVulnerabilitiesTable = colSpan - 1; // minus ExpandRowTh
 
     return (
         <Table variant="compact">
@@ -298,7 +299,7 @@ function AffectedImagesTable({
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>
                                     <Td />
-                                    <Td colSpan={7}>
+                                    <Td colSpan={colSpanForComponentVulnerabilitiesTable}>
                                         <ExpandableRowContent>
                                             <ImageComponentVulnerabilitiesTable
                                                 imageMetadataContext={image}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -77,6 +77,8 @@ function DeploymentComponentVulnerabilitiesTable({
         isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA') &&
         isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
 
+    const colSpanForDockerfileLayer = 8 + (isAdvisoryColumnEnabled ? 1 : 0);
+
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = images.flatMap(({ imageMetadataContext, componentVulnerabilities }) =>
         flattenDeploymentComponentVulns(imageMetadataContext, componentVulnerabilities)
@@ -164,7 +166,7 @@ function DeploymentComponentVulnerabilitiesTable({
                             </Td>
                         </Tr>
                         <Tr>
-                            <Td colSpan={8} className="pf-v5-u-pt-0">
+                            <Td colSpan={colSpanForDockerfileLayer} className="pf-v5-u-pt-0">
                                 <DockerfileLayer layer={layer} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -63,6 +63,8 @@ function ImageComponentVulnerabilitiesTable({
         isFeatureFlagEnabled('ROX_FLATTEN_CVE_DATA') &&
         isFeatureFlagEnabled('ROX_CVE_ADVISORY_SEPARATION');
 
+    const colSpanForDockerfileLayer = 5 + (isAdvisoryColumnEnabled ? 1 : 0);
+
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = flattenImageComponentVulns(
         imageMetadataContext,
@@ -115,7 +117,7 @@ function ImageComponentVulnerabilitiesTable({
                             </Td>
                         </Tr>
                         <Tr>
-                            <Td colSpan={5} className="pf-v5-u-pt-0">
+                            <Td colSpan={colSpanForDockerfileLayer} className="pf-v5-u-pt-0">
                                 <DockerfileLayer layer={layer} />
                             </Td>
                         </Tr>


### PR DESCRIPTION
### Description
### Problems

1. Thank you, **David Vail** for finding inconsistent `colspan="5"` attribute of `td` element when presence of **Advisory** column increases total to 6.
    Therefore layer has less than available width.
2. When I expanded the wrong `td` element, I also found inconsistent `colspan` attribute for component table itself.
    * Images: `colspan={7}` attribute is out-of-date and too small.
    * Deployments: `colspan={6}` attribute is up-to-date, becamebut incorrect when I substituted inline value with computed value, because `colspan={8}` attribute of `TbodyUnified` for filtered empty state is incorrect. Maybe copy-paste from images?

### Solution

Follow conditional `colSpan` pattern from elsewhere.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.

#### Manual testing with Advisory column

Temporarily edit code to simulate `ROX_FLATTEN_CVE_DATA` feature flag enabled, because it is not yet enabled for staging demo.

1. Visit /main/vulnerabilities/user-workloads/cves/id with and expand vulnerability row to see `ImageComponentVulnerabilitiesTable` element.

    * Before changes, with constant `colSpan={5}` prop, see inconsistent `colspan="5"` attribute of `td` element, therefore layer has less than available width.
        ![ImageComponentVulnerabilitiesTable_inconsistent](https://github.com/user-attachments/assets/6f8589c8-a45d-4b6c-bca1-8f0f74043903)

    * After changes, with conditional `colSpan={colSpanForDockerfileLayer}` prop, consistent `colspan="6"` attribute of `td` element, therefore layer has available width.
        ![ImageComponentVulnerabilitiesTable_consistent](https://github.com/user-attachments/assets/11b6a3a4-4f41-4ea3-a287-a6e81b47f941)

2. Click **Deployments** and then expand vulnerability row to see `DeploymentComponentVulnerabilitiesTable` element.

    * Before changes, with constant `colSpan={8}` prop, see inconsistent `colspan="8"` attribute of `td` element, therefore layer has less than available width.
        ![DeploymentComponentVulnerabilitiesTable_inconsistent](https://github.com/user-attachments/assets/9c6c01d7-8221-4530-836c-03b233650a95)

    * After changes, with conditional `colSpan={colSpanForDockerfileLayer}` prop, consistent `colspan="9"` attribute of `td` element, therefore layer has available width.
    ![DeploymentComponentVulnerabilitiesTable_consistent](https://github.com/user-attachments/assets/7c1d6867-2dea-45c2-9872-558fd4f7fdfd)

#### Manual testing without Advisory column

1. Visit /main/vulnerabilities/user-workloads/cves/id with and expand vulnerability row to see `ImageComponentVulnerabilitiesTable` element.

    * Before and after changes, with conditional `colSpan={colSpanForDockerfileLayer}` prop, see consistent `colspan="5"` attribute of `td` element, therefore layer has available width.

2. Click **Deployments** and then expand vulnerability row to see `DeploymentComponentVulnerabilitiesTable` element.

    * Before and after changes, with conditional `colSpan={colSpanForDockerfileLayer}` prop, see consistent `colspan="8"` attribute of `td` element, therefore layer has available width.

#### Bonus

1. Visit /main/vulnerabilities/user-workloads/cves/id with and expand vulnerability row to see `ImageComponentVulnerabilitiesTable` element.

    * Before changes, with constant `colSpan={7}` prop, see inconsistent `colspan="7"` attribute of `td` element, therefore component table has less than available width.
        ![AffectedImagesTable_inconsistent](https://github.com/user-attachments/assets/092bed7d-7005-4bc7-92ed-0bbb9405c3f2)

    * After changes, with conditional `colSpan={colSpanForComponentVulnerabilitiesTable}` prop, consistent `colspan="8"` attribute of `td` element, therefore component table has available width.
        ![AffectedImagesTable_consistent](https://github.com/user-attachments/assets/a56c8865-5a37-45e9-82ba-9340e5c17732)

2. Click **Deployments** filter for no matches, and then expand vulnerability row to see `DeploymentComponentVulnerabilitiesTable` element.

    * Before changes, with incorrect `8 + -hiddenColumnCount` prop, see inconsistent `colspan="8"` attribute of `td` element, although `TbodyFilteredEmpty` has available width.
        ![AffectedDeploymentsTable_inconsistent](https://github.com/user-attachments/assets/69f63c9b-548e-45e9-a654-743e12829ff3)

    * After changes, with conditional `7 + -hiddenColumnCount` prop, see consistent `colspan="7"` attribute of `td` element, therefore `TbodyFilteredEmpty` has available width.
        ![AffectedDeploymentsTable_consistent](https://github.com/user-attachments/assets/07ee9281-a83f-4396-9b6b-75b6446038aa)
