### PR TITLE
ROX-29495: Add time window to external ip flows service

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/external/EntityDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/EntityDetails.tsx
@@ -18,6 +18,7 @@ import {
 import { InnerScrollContainer, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import { TimeWindow } from 'constants/timeWindows';
 import useRestQuery from 'hooks/useRestQuery';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { UseUrlSearchReturn } from 'hooks/useURLSearch';
@@ -25,15 +26,17 @@ import { getExternalNetworkFlows } from 'services/NetworkService';
 import { getTableUIState } from 'utils/getTableUIState';
 import { ExternalNetworkFlowsResponse } from 'types/networkFlow.proto';
 
-import { getDeploymentInfoForExternalEntity, protocolLabel } from '../utils/flowUtils';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import { getDeploymentInfoForExternalEntity, protocolLabel } from '../utils/flowUtils';
+import { timeWindowToISO } from '../utils/timeWindow';
 
 export type EntityDetailsProps = {
     labelledById: string;
     entityName: string;
     entityId: string;
     scopeHierarchy: NetworkScopeHierarchy;
+    timeWindow: TimeWindow;
     urlPagination: UseURLPaginationResult;
     urlSearchFiltering: UseUrlSearchReturn;
     onNodeSelect: (id: string) => void;
@@ -53,6 +56,7 @@ function EntityDetails({
     entityName,
     entityId,
     scopeHierarchy,
+    timeWindow,
     urlPagination,
     urlSearchFiltering,
     onNodeSelect,
@@ -63,13 +67,21 @@ function EntityDetails({
     const clusterId = scopeHierarchy.cluster.id;
     const { deployments, namespaces } = scopeHierarchy;
     const fetchExternalNetworkFlows = useCallback((): Promise<ExternalNetworkFlowsResponse> => {
-        return getExternalNetworkFlows(clusterId, entityId, namespaces, deployments, {
-            sortOption: {},
-            page,
-            perPage,
-            advancedFilters: searchFilter,
-        });
-    }, [page, perPage, clusterId, deployments, entityId, namespaces, searchFilter]);
+        const fromTimestamp = timeWindowToISO(timeWindow);
+        return getExternalNetworkFlows(
+            clusterId,
+            entityId,
+            namespaces,
+            deployments,
+            fromTimestamp,
+            {
+                sortOption: {},
+                page,
+                perPage,
+                advancedFilters: searchFilter,
+            }
+        );
+    }, [page, perPage, clusterId, deployments, entityId, namespaces, searchFilter, timeWindow]);
 
     const {
         data: externalNetworkFlows,

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
@@ -80,6 +80,7 @@ function ExternalEntitiesSideBar({
                 scopeHierarchy={scopeHierarchy}
                 onNodeSelect={onNodeSelect}
                 onExternalIPSelect={onExternalIPSelect}
+                timeWindow={timeWindow}
                 urlPagination={urlPagination}
                 urlSearchFiltering={urlSearchFiltering}
             />

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -467,6 +467,7 @@ export function getExternalNetworkFlows(
     entityId,
     namespaces,
     deployments,
+    sinceTimestamp,
     { sortOption, page, perPage, advancedFilters }
 ) {
     const searchFilter = {
@@ -481,7 +482,7 @@ export function getExternalNetworkFlows(
     const params = getListQueryParams({ searchFilter, sortOption, page, perPage });
     return axios
         .get(
-            `${networkFlowBaseUrl}/cluster/${clusterId}/externalentities/${entityId}/flows?${params}`
+            `${networkFlowBaseUrl}/cluster/${clusterId}/externalentities/${entityId}/flows?since=${sinceTimestamp}&${params}`
         )
         .then((response) => response.data);
 }


### PR DESCRIPTION
### Description

Update the existing `/v1/networkgraph/cluster/{clusterId}/externalentities/{entityId}/flows` call to include a `since` query parameter set to the network graph `timeWindow` variable.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manually tested instance.

Before:
Defaults to last 5min – `/v1/networkgraph/cluster/d4368447-c8f3-4e64-9e07-00b8a5ed226c/externalentities/d4368447-c8f3-4e64-9e07-00b8a5ed226c__MTQyLjI1MC4xNTIuODIvMzI/flows?since=2025-05-27T19:46:08.048Z`

After:`/v1/networkgraph/cluster/d4368447-c8f3-4e64-9e07-00b8a5ed226c/externalentities/d4368447-c8f3-4e64-9e07-00b8a5ed226c__MTQyLjI1MC4xNTIuODIvMzI/flows?since=2025-05-27T19:46:08.048Z`