### PR TITLE
ROX-29493: Render component vulnerabilities table if imageMetadata

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -271,18 +271,20 @@ function DeploymentVulnerabilitiesTable({
                                     <Td />
                                     <Td colSpan={6}>
                                         <ExpandableRowContent>
-                                            {summary && images.length > 0 ? (
-                                                <>
+                                            <>
+                                                {summary && (
                                                     <p className="pf-v5-u-mb-md">{summary}</p>
+                                                )}
+                                                {images.length > 0 ? (
                                                     <DeploymentComponentVulnerabilitiesTable
                                                         images={images}
                                                         cve={cve}
                                                         vulnerabilityState={vulnerabilityState}
                                                     />
-                                                </>
-                                            ) : (
-                                                <PartialCVEDataAlert />
-                                            )}
+                                                ) : (
+                                                    <PartialCVEDataAlert />
+                                                )}
+                                            </>
                                         </ExpandableRowContent>
                                     </Td>
                                 </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -423,17 +423,19 @@ function ImageVulnerabilitiesTable({
                                     <Td />
                                     <Td colSpan={colSpan}>
                                         <ExpandableRowContent>
-                                            {summary && imageMetadata ? (
-                                                <>
+                                            <>
+                                                {summary && (
                                                     <p className="pf-v5-u-mb-md">{summary}</p>
+                                                )}
+                                                {imageMetadata ? (
                                                     <ImageComponentVulnerabilitiesTable
                                                         imageMetadataContext={imageMetadata}
                                                         componentVulnerabilities={imageComponents}
                                                     />
-                                                </>
-                                            ) : (
-                                                <PartialCVEDataAlert />
-                                            )}
+                                                ) : (
+                                                    <PartialCVEDataAlert />
+                                                )}
+                                            </>
                                         </ExpandableRowContent>
                                     </Td>
                                 </Tr>


### PR DESCRIPTION
### Description

It might help to ignore whitespace for review.

### Problem

Thank you:
* **Ross Tannenbaum** for finding this problem.
* **David Vail** for suggesting the cause.

Component vulnerabilities tables render `PartialCVEDataAlert` element if either `summary` or `imageMetadata` are absent.

### Analysis

Other tables render `PartialCVEDataAlert` if `summary` is absent.

This seems like copy-paste-edit from one condition to two conditions.

### Solution

1. Render `summary` conditionally, else nothing.
2. Render `WhateverComponentVulnerabilitiesTable` conditionally else `PartialCVEDataAlert` element.

That is, in the context, omit secondary `summary` silently if absent, and render **Partial CVE data** only if primary `imageMetadata` is absent.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.

#### Manual testing with Advisory column

Image: registry.redhat.io/openshift-logging/logging-curator5-rhel9:v5.8.1-478

1. Visit /main/vulnerabilities/all-images search for image above, and then expand rows for GHSA and PYSEC vulnerabilities.

    * Before changes, see **Partial CVE data**
        ![ImageVulnerabilitiesTable_combined](https://github.com/user-attachments/assets/a9046650-52ef-491f-9e67-fdb8e2d87547)

    * After changes, see absence of `summary` but presence of `ImageComponentVulnerabilitiesTable` element.
        ![ImageVulnerabilitiesTable_separated](https://github.com/user-attachments/assets/e441b35b-775b-4713-b615-5997994de811)

Not sure how likely to find similar situation for deployment.
