### PR TITLE
ROX-29199: Treat "Default" vals in CRs the same as not-specified

### DIFF
--- a/operator/api/v1alpha1/central_defaults.go
+++ b/operator/api/v1alpha1/central_defaults.go
@@ -63,6 +63,14 @@ func AddUnstructuredDefaultsToCentral(central *Central, u *unstructured.Unstruct
 // MergeCentralDefaultsIntoSpec merges the defaults from Central.Defaults into Central.Spec.
 // Modifies content of central.
 func MergeCentralDefaultsIntoSpec(central *Central) error {
+	// Delete old "Default" values, which were previously injected into CRs via CRD defaults.
+	// Necessary for the below merging to be effectful in the sense that spec paths in the custom resource
+	// with explicit "Default" values are actually filled in with our runtime defaults.
+	if scannerV4 := central.Spec.ScannerV4; scannerV4 != nil {
+		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == "Default" {
+			scannerV4.ScannerComponent = nil
+		}
+	}
 	if err := mergo.Merge(&central.Spec, central.Defaults); err != nil {
 		return errors.Wrap(err, "merging Central Defaults into Spec")
 	}

--- a/operator/api/v1alpha1/central_types.go
+++ b/operator/api/v1alpha1/central_types.go
@@ -739,6 +739,7 @@ var (
 	// CentralGVK is the GVK for the Central type.
 	CentralGVK = GroupVersion.WithKind("Central")
 
+	ScannerV4Default  = ScannerV4ComponentDefault
 	ScannerV4Enabled  = ScannerV4ComponentEnabled
 	ScannerV4Disabled = ScannerV4ComponentDisabled
 )

--- a/operator/api/v1alpha1/securedcluster_defaults.go
+++ b/operator/api/v1alpha1/securedcluster_defaults.go
@@ -63,6 +63,14 @@ func AddUnstructuredDefaultsToSecuredCluster(securedCluster *SecuredCluster, u *
 // MergeSecuredClusterDefaultsIntoSpec merges the defaults from SecuredCluster.Defaults into SecuredCluster.Spec.
 // Modifies content of securedCluster.
 func MergeSecuredClusterDefaultsIntoSpec(securedCluster *SecuredCluster) error {
+	// Delete old "Default" values, which were previously injected into CRs via CRD defaults.
+	// Necessary for the below merging to be effectful in the situation that spec paths in the custom resource
+	// with explicit "Defaults" values are actually filled in with our computed defaults.
+	if scannerV4 := securedCluster.Spec.ScannerV4; scannerV4 != nil {
+		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == "Default" {
+			scannerV4.ScannerComponent = nil
+		}
+	}
 	if err := mergo.Merge(&securedCluster.Spec, securedCluster.Defaults); err != nil {
 		return errors.Wrap(err, "merging SecuredCluster Defaults into Spec")
 	}

--- a/operator/internal/central/values/translation/translation_test.go
+++ b/operator/internal/central/values/translation/translation_test.go
@@ -42,7 +42,6 @@ func TestTranslate(t *testing.T) {
 	connectivityPolicy := platform.ConnectivityOffline
 	scannerComponentPolicy := platform.ScannerComponentEnabled
 	scannerAutoScalingPolicy := platform.ScannerAutoScalingEnabled
-	scannerV4ComponentDefault := platform.ScannerV4ComponentDefault
 	scannerV4ComponentEnabled := platform.ScannerV4ComponentEnabled
 	scannerV4ComponentDisabled := platform.ScannerV4ComponentDisabled
 	monitoringExposeEndpointEnabled := platform.ExposeEndpointEnabled
@@ -421,7 +420,7 @@ func TestTranslate(t *testing.T) {
 							},
 						},
 						ScannerV4: &platform.ScannerV4Spec{
-							ScannerComponent: &scannerV4ComponentDefault,
+							ScannerComponent: &scannerV4ComponentEnabled,
 							Indexer: &platform.ScannerV4Component{
 								Scaling: &platform.ScannerComponentScaling{
 									AutoScaling: &scannerAutoScalingPolicy,
@@ -715,7 +714,7 @@ func TestTranslate(t *testing.T) {
 					"exposeMonitoring": true,
 				},
 				"scannerV4": map[string]interface{}{
-					"disable": true,
+					"disable": false,
 					"indexer": map[string]interface{}{
 						"autoscaling": map[string]interface{}{
 							"disable":     false,

--- a/operator/internal/central/values/translation/translation_test.go
+++ b/operator/internal/central/values/translation/translation_test.go
@@ -74,6 +74,34 @@ func TestTranslate(t *testing.T) {
 		args args
 		want chartutil.Values
 	}{
+		"minimal spec": {
+			args: args{
+				c: platform.Central{
+					Spec: platform.CentralSpec{},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{defaultPvc},
+			},
+			want: chartutil.Values{
+				"monitoring": map[string]interface{}{
+					"openshift": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
 		"scannerV4 with explicit Default value is treated as not-specified": {
 			args: args{
 				c: platform.Central{

--- a/operator/internal/central/values/translation/translation_test.go
+++ b/operator/internal/central/values/translation/translation_test.go
@@ -75,6 +75,46 @@ func TestTranslate(t *testing.T) {
 		args args
 		want chartutil.Values
 	}{
+		"scannerV4 with explicit Default value is treated as not-specified": {
+			args: args{
+				c: platform.Central{
+					Spec: platform.CentralSpec{
+						ScannerV4: &platform.ScannerV4Spec{
+							ScannerComponent: &platform.ScannerV4Default,
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+					Defaults: platform.CentralSpec{
+						ScannerV4: &platform.ScannerV4Spec{
+							ScannerComponent: &platform.ScannerV4Enabled,
+						},
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{defaultPvc},
+			},
+			want: chartutil.Values{
+				"monitoring": map[string]interface{}{
+					"openshift": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+				"scannerV4": map[string]interface{}{
+					"disable": false,
+				},
+			},
+		},
 		"defaults are being used for enabling Scanner V4": {
 			args: args{
 				c: platform.Central{

--- a/operator/internal/securedcluster/scanner/auto_sense.go
+++ b/operator/internal/securedcluster/scanner/auto_sense.go
@@ -32,7 +32,12 @@ func AutoSenseLocalScannerConfig(ctx context.Context, client ctrlClient.Client, 
 // Takes into account the setting in provided SecuredCluster CR as well as the presence of a Central instance in the same namespace.
 // Modifies the provided SecuredCluster object to set a default Spec.ScannerV4 if missing.
 func AutoSenseLocalScannerV4Config(ctx context.Context, client ctrlClient.Client, s platform.SecuredCluster) (AutoSenseResult, error) {
-	SetScannerV4Defaults(&s.Spec)
+	if s.Spec.ScannerV4 == nil {
+		s.Spec.ScannerV4 = &platform.LocalScannerV4ComponentSpec{}
+	}
+	if s.Spec.ScannerV4.ScannerComponent == nil {
+		return AutoSenseResult{}, nil
+	}
 	scannerV4ComponentPolicy := *s.Spec.ScannerV4.ScannerComponent
 
 	return autoSenseScannerV4(ctx, client, scannerV4ComponentPolicy, s.GetNamespace())
@@ -54,7 +59,7 @@ func autoSenseScannerV4(ctx context.Context, client ctrlClient.Client, deploymen
 	switch deploymentPolicy {
 	case platform.LocalScannerV4ComponentAutoSense:
 		return autoSense(ctx, client, namespace)
-	case platform.LocalScannerV4ComponentDisabled, platform.LocalScannerV4ComponentDefault:
+	case platform.LocalScannerV4ComponentDisabled, platform.LocalScannerV4ComponentDefault: // LocalScannerV4ComponentDefault shouldn't happen at this point anymore.
 		return AutoSenseResult{}, nil
 	}
 

--- a/operator/internal/securedcluster/scanner/defaults.go
+++ b/operator/internal/securedcluster/scanner/defaults.go
@@ -17,7 +17,4 @@ func SetScannerV4Defaults(spec *platform.SecuredClusterSpec) {
 	if spec.ScannerV4 == nil {
 		spec.ScannerV4 = &platform.LocalScannerV4ComponentSpec{}
 	}
-	if spec.ScannerV4.ScannerComponent == nil {
-		spec.ScannerV4.ScannerComponent = platform.LocalScannerV4ComponentDisabled.Pointer()
-	}
 }

--- a/operator/internal/securedcluster/scanner/defaults.go
+++ b/operator/internal/securedcluster/scanner/defaults.go
@@ -11,10 +11,3 @@ func SetScannerDefaults(spec *platform.SecuredClusterSpec) {
 		spec.Scanner.ScannerComponent = platform.LocalScannerComponentAutoSense.Pointer()
 	}
 }
-
-// SetScannerV4Defaults makes sure that spec.ScannerV4 and spec.ScannerV4.Deployment are not nil.
-func SetScannerV4Defaults(spec *platform.SecuredClusterSpec) {
-	if spec.ScannerV4 == nil {
-		spec.ScannerV4 = &platform.LocalScannerV4ComponentSpec{}
-	}
-}

--- a/operator/internal/securedcluster/values/translation/translation.go
+++ b/operator/internal/securedcluster/values/translation/translation.go
@@ -444,7 +444,6 @@ func (t Translator) getLocalScannerV4ComponentValues(ctx context.Context, secure
 // Only defaults that result in behaviour different from the Helm chart defaults should be included here.
 func (t Translator) setDefaults(sc *platform.SecuredCluster) {
 	scanner.SetScannerDefaults(&sc.Spec)
-	scanner.SetScannerV4Defaults(&sc.Spec)
 	if sc.Spec.AdmissionControl == nil {
 		sc.Spec.AdmissionControl = &platform.AdmissionControlComponentSpec{}
 	}

--- a/operator/internal/securedcluster/values/translation/translation_test.go
+++ b/operator/internal/securedcluster/values/translation/translation_test.go
@@ -305,9 +305,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
-				"scannerV4": map[string]interface{}{
-					"disable": true,
-				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]string{
 						"enabled": "true",
@@ -370,6 +367,11 @@ func (s *TranslationTestSuite) TestTranslate() {
 					Spec: platform.SecuredClusterSpec{
 						ClusterName: "test-cluster",
 					},
+					Defaults: platform.SecuredClusterSpec{
+						ScannerV4: &platform.LocalScannerV4ComponentSpec{
+							ScannerComponent: platform.LocalScannerV4AutoSense.Pointer(),
+						},
+					},
 				},
 			},
 			want: chartutil.Values{
@@ -387,6 +389,14 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
+				"scannerV4": map[string]interface{}{
+					"disable": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"none": true,
+						},
+					},
+				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]interface{}{
 						"enabled": "true",
@@ -396,9 +406,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 					"openshift": map[string]interface{}{
 						"enabled": true,
 					},
-				},
-				"scannerV4": map[string]interface{}{
-					"disable": true,
 				},
 			},
 		},
@@ -426,9 +433,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"scanner": map[string]interface{}{
 					"disable": false,
-				},
-				"scannerV4": map[string]interface{}{
-					"disable": true,
 				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]string{
@@ -1023,9 +1027,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"scanner": map[string]interface{}{
 					"disable": false,
-				},
-				"scannerV4": map[string]interface{}{
-					"disable": true,
 				},
 				"sensor": map[string]interface{}{
 					"localImageScanning": map[string]string{

--- a/operator/internal/securedcluster/values/translation/translation_test.go
+++ b/operator/internal/securedcluster/values/translation/translation_test.go
@@ -121,6 +121,63 @@ func (s *TranslationTestSuite) TestTranslate() {
 		args args
 		want chartutil.Values
 	}{
+		"scannerV4 with explicit Default value is treated as not-specified": {
+			args: args{
+				client: newDefaultFakeClient(t),
+				sc: platform.SecuredCluster{
+					Spec: platform.SecuredClusterSpec{
+						ClusterName: "test-cluster",
+						ScannerV4: &platform.LocalScannerV4ComponentSpec{
+							ScannerComponent: platform.LocalScannerV4ComponentDefault.Pointer(),
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+					Defaults: platform.SecuredClusterSpec{
+						ScannerV4: &platform.LocalScannerV4ComponentSpec{
+							ScannerComponent: platform.LocalScannerV4ComponentAutoSense.Pointer(),
+						},
+					},
+				},
+			},
+			want: chartutil.Values{
+				"clusterName":   "test-cluster",
+				"ca":            map[string]string{"cert": "ca central content"},
+				"createSecrets": false,
+				"admissionControl": map[string]interface{}{
+					"dynamic": map[string]interface{}{
+						"enforceOnCreates": true,
+						"enforceOnUpdates": true,
+					},
+					"listenOnCreates": true,
+					"listenOnUpdates": true,
+				},
+				"scanner": map[string]interface{}{
+					"disable": false,
+				},
+				"scannerV4": map[string]interface{}{
+					"disable": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": true,
+							},
+						},
+					},
+				},
+				"sensor": map[string]interface{}{
+					"localImageScanning": map[string]string{
+						"enabled": "true",
+					},
+				},
+				"monitoring": map[string]interface{}{
+					"openshift": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+		},
 		"defaults are being used for enabling Scanner V4": {
 			args: args{
 				client: newDefaultFakeClient(t),


### PR DESCRIPTION
### Description

Literal `"Default"` values (e.g. injected by the previous version of the CRD) need to be treated in a sane manner in our new defaulting setting, ideally causing little or no surprises for the user. My proposal: Treat them the same as "not specified".


### User-facing documentation

- [x] CHANGELOG.md update is not needed, this will be documented as part of separate tickets.
- [x] The same applies to documentation changes.

### Testing and quality

- [x] the change is production ready(https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are inspected

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

Manual tests conducted:

```
make -C operator olm-install
make -C operator deploy-previous-via-olm

kubectl -n stackrox-operator patch --type=merge catalogsources.operators.coreos.com stackrox-operator-test-index -p "{\"spec\":{\"image\": \"$(kubectl -n stackrox-operator get catalogsources.operators.coreos.com stackrox-operator-test-index -o jsonpath='{.spec.image}' | sed -e 's/stackrox-io/rhacs-eng/;')\"}}"

kubectl create ns stackrox
kubens stackrox
./deploy/common/pull-secret.sh stackrox quay.io | kubectl -n stackrox apply -f -

kubectl apply -f setup.yaml
kubectl apply -f central-cr-0.yaml

[NO SCANNER V4]

kubectl create ns stackrox-sc
 ./deploy/common/pull-secret.sh stackrox quay.io | kubectl -n stackrox-sc apply -f -
 
 NS=stackrox; for i in $(seq 30); do ip="$(kubectl -n $NS get service central-loadbalancer -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"; if [[ "${ip}" != "" ]]; then CENTRAL_ENDPOINT="https://${ip}:443"; break; else sleep 1; fi; done; echo "export CENTRAL_ENDPOINT='$CENTRAL_ENDPOINT'"

 export ROX_ADMIN_PASSWORD=letmein
 roxctl --insecure-skip-tls-verify -e "$CENTRAL_ENDPOINT" central init-bundles generate sc1 --output-secrets=ini
t-bundle-sc1.yaml

kubectl -n stackrox-sc apply -f init-bundle-sc1.yaml
kubectl -n stackrox-sc apply -f secured-cluster-cr-0.yaml

[NO SCANNER V4]

[BOTH CRs CONTAIN "scannerComponent: Default"]

make -C operator upgrade-via-olm

[NO SCANNER V4]

kubectl -n stackrox annotate --overwrite centrals.platform.stackrox.io stackrox-central-services feature-defaults.platform.stackrox.io/scannerV4=Enabled

[SCANNER V4 DEPLOYED IN stackrox]

kubectl -n stackrox-sc annotate --overwrite securedclusters.platform.stackrox.io stackrox-secured-cluster-services feature-defaults.platform.stackrox.io/scannerV4=AutoSense

[SCANNER V4 DEPLOYED IN stackrox-sc]

kubectl -n stackrox annotate --overwrite centrals.platform.stackrox.io stackrox-central-services feature-defaults.platform.stackrox.io/scannerV4=Disabled

[NO SCANNER V4 IN stackrox]

kubectl -n stackrox-sc annotate --overwrite securedclusters.platform.stackrox.io stackrox-secured-cluster-services feature-defaults.platform.stackrox.io/scannerV4=Disabled

[NO SCANNER V4 IN stackrox-sc]

kubectl -n stackrox patch centrals.platform.stackrox.io stackrox-central-services --type='json' -p='[{"op": "remove", "path": "/spec/scannerV4"}]'

[UNCHANGED: NO SCANNER V4 IN stackrox]


kubectl -n stackrox-sc patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type='json' -p='[{"op": "remove", "path": "/spec/scannerV4"}]'

[UNCHANGED: NO SCANNER V4 IN stackrox-sc]

kubectl -n stackrox delete centrals.platform.stackrox.io stackrox-central-services
kubectl -n stackrox-sc delete securedclusters.platform.stackrox.io stackrox-secured-cluster-services
kubectl -n stackrox delete pvc central-db

kubectl -n stackrox apply -f central-cr-0.yaml

[SCANNER V4 IN stackrox]

NS=stackrox; for i in $(seq 30); do ip="$(kubectl -n $NS get service central-loadbalancer -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"; if [[ "${ip}" != "" ]]; then CENTRAL_ENDPOINT="https://${ip}:443"; break; else sleep 1; fi; done; echo "export CENTRAL_ENDPOINT='$CENTRAL_ENDPOINT'"

roxctl --insecure-skip-tls-verify -e "$CENTRAL_ENDPOINT" central init-bundles generate sc2 --output-secrets=init-bundle-sc2.yaml

kubectl -n stackrox-sc apply -f init-bundle-sc2.yaml

kubectl -n stackrox-sc apply -f secured-cluster-cr-0.yaml

[SCANNER V4 DEFPLOYED IN BOTH NAMESPACES]
[SPEC OF BOTH CRs DOES NOT CONTAIN "Default" VALUE]
```

