### PR TITLE
fix(multiarch): use centos9 for central-db image

### DIFF
--- a/image/postgres/Dockerfile
+++ b/image/postgres/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_VERSION=15
-FROM quay.io/sclorg/postgresql-${PG_VERSION}-c8s:latest AS final
+FROM quay.io/sclorg/postgresql-${PG_VERSION}-c9s:latest AS final
 
 USER root
 


### PR DESCRIPTION
### Description

The central-db image build target silently pulls an amd64 base image for all architectures (the current image isn't multi-arch), the end result being that 
non-x86 versions of the central-db image are not runnable on their respective architectures. These images are not directly tested.

```
docker run -it --entrypoint /bin/bash quay.io/rhacs-eng/central-db:latest-arm64 -c "readelf -h /usr/bin/postgres" | grep Machine
  Machine: Advanced Micro Devices X86-64
docker run -it --entrypoint /bin/bash quay.io/rhacs-eng/central-db:latest-s390x -c "readelf -h /usr/bin/postgres" | grep Machine
  Machine:  Advanced Micro Devices X86-64
```


### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Images built by CI now have the correct layer for amd64 and arm64
```
$ docker run -it --entrypoint /bin/bash quay.io/stackrox-io/central-db:4.8.x-844-g5676d45c2d-amd64 -c "head /usr/bin/postgres | grep -ao x86-64"
x86-64
$ docker run -it --entrypoint /bin/bash quay.io/stackrox-io/central-db:4.8.x-844-g5676d45c2d-arm64 -c "head /usr/bin/postgres | grep -ao aarch64"
aarch64
```

And I was able to successfully deploy on a local arm64, from central-db logs:
```
2025-05-29 18:07:50.001 UTC [15] LOG:  starting PostgreSQL 15.12 on aarch64-redhat-linux-gnu, compiled by gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-5), 64-bit
```