### PR TITLE
ROX-18779: Reprocess formerly cluster local images

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -258,32 +258,45 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 			return nil, err
 		}
 
-		// If the image exists and the image name from the request matches at least one stored image name(/reference),
-		// then we returned the stored image.
-		// Otherwise, we run the enrichment pipeline using the existing image with the requests image being added to it.
 		if exists {
-			if protoutils.SliceContains(request.GetImage().GetName(), existingImg.GetNames()) {
+			// If the image is flagged as cluster local and scan has expired, clear the flag and attempt a scan.
+			// This is necessary to resume reprocessing for images after delegated scanning has been toggled on then off.
+			var clusterLocalScanExpired bool
+			if existingImg.GetIsClusterLocal() && scanExpired(existingImg) {
+				clusterLocalScanExpired = true
+				existingImg.IsClusterLocal = false
+			}
+
+			// If the image exists and the image name from the request matches at least one stored image name(/reference),
+			// then we return the stored image if it was not modified above.
+			// Otherwise, we run the enrichment pipeline using the existing image with the requests image being added to it.
+			nameFound := protoutils.SliceContains(request.GetImage().GetName(), existingImg.GetNames())
+			if nameFound && !clusterLocalScanExpired {
 				return internalScanRespFromImage(existingImg), nil
 			}
-			existingImg.Names = append(existingImg.Names, request.GetImage().GetName())
-			img = existingImg
 
 			log.Debugw("Scan cache ignored enriching image",
 				logging.FromContext(ctx),
 				logging.ImageName(existingImg.GetName().GetFullName()),
 				logging.ImageID(imgID),
 				logging.String("request_image", request.GetImage().GetName().GetFullName()),
+				logging.Bool("name_found", nameFound),
+				logging.Bool("cluster_local_scan_expired", clusterLocalScanExpired),
 			)
 
-			// We only want to force re-fetching of signatures and verification data, the additional image name has no
-			// impact on image scan data.
-			fetchOpt = enricher.ForceRefetchSignaturesOnly
-			imgExists = true
+			if !nameFound {
+				existingImg.Names = append(existingImg.Names, request.GetImage().GetName())
+				// We only want to force re-fetching of signatures and verification data, the additional image name has no
+				// impact on image scan data.
+				fetchOpt = enricher.ForceRefetchSignaturesOnly
+			}
 
-			if updateImageFromRequest(img, request.GetImage().GetName()) {
-				// Ensure that the change to Names is not overwritten by the enricher.
+			if updateImageFromRequest(existingImg, request.GetImage().GetName()) || clusterLocalScanExpired {
 				fetchOpt = enricher.IgnoreExistingImages
 			}
+
+			img = existingImg
+			imgExists = true
 		}
 	}
 
@@ -309,6 +322,13 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 	}
 
 	return internalScanRespFromImage(img), nil
+}
+
+// scanExpired returns true when the scan associated with the image
+// is considered expired.
+func scanExpired(img *storage.Image) bool {
+	scanTime := timestamp.FromProtobuf(img.GetScan().GetScanTime())
+	return !scanTime.Add(reprocessInterval).After(timestamp.Now())
 }
 
 // updateImageFromRequest will update the name of existing image with the one from the request
@@ -445,11 +465,10 @@ func (s *serviceImpl) GetImageVulnerabilitiesInternal(ctx context.Context, reque
 		if err != nil {
 			return nil, err
 		}
-		// This is safe even if img is nil.
-		scanTime := existingImg.GetScan().GetScanTime()
+
 		// If the scan exists, and reprocessing has not run since, return the scan.
 		// Otherwise, run the enrichment pipeline to ensure we do not return stale data.
-		if exists && timestamp.FromProtobuf(scanTime).Add(reprocessInterval).After(timestamp.Now()) {
+		if exists && !scanExpired(existingImg) {
 			return internalScanRespFromImage(existingImg), nil
 		}
 	}
@@ -659,11 +678,8 @@ func shouldUpdateExistingScan(imgExists bool, existingImg *storage.Image, reques
 		return true
 	}
 
-	scanTime := existingImg.GetScan().GetScanTime()
-	scanExpired := !timestamp.FromProtobuf(scanTime).Add(reprocessInterval).After(timestamp.Now())
-
 	if !features.ScannerV4.Enabled() {
-		return scanExpired
+		return scanExpired(existingImg)
 	}
 
 	v4MatchRequest := scannerTypes.ScannerV4IndexerVersion(request.GetIndexerVersion())
@@ -681,7 +697,7 @@ func shouldUpdateExistingScan(imgExists bool, existingImg *storage.Image, reques
 		return true
 	}
 
-	return scanExpired
+	return scanExpired(existingImg)
 }
 
 // buildNames returns a slice containing the known image names from the various parameters.


### PR DESCRIPTION
### Description

When scans are delegated/handled by Sensor the image is [flagged as cluster local](https://github.com/stackrox/stackrox/blob/8aa699b3a1fb1998e8750432a22cbbb76f30957c/central/image/service/service_impl.go#L591)

Cluster local images will [not be reprocessed by Central](https://github.com/stackrox/stackrox/blob/e09eea9d3eb55bae5bd3b7625a03ad2f698e423a/central/reprocessor/reprocessor.go#L324) (Sensor handles the reprocessing instead) - images can get stuck in a state where they are never reprocessed.

This can occur, for example, when delegated scanning is enabled and then subsequently disabled - or `roxctl` scans are executed with the `--cluster` flag for active images while delegated scanning is disabled.

This PR adds a reset / 'self-heal' capability - when Sensor requests a scan from Central for an image previously flagged as cluster local with an expired scan (per reprocessing interval), the cluster local flag will be cleared and a scan attempted. If the scan is successful normal reprocessing will resume going forward.

In the future the usage of the cluster local flag should be reverted back to its original intent (to represent images that can only be scanned via a secured cluster) - at which point the delegated scanning config will dynamically determine what to do with an image during reprocessing: ROX-26334

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

Set a very short reprocessing interval on Central and Sensor:

```
k set env deploy/central ROX_REPROCESSING_INTERVAL=30s
k set env deploy/sensor ROX_REPROCESSING_INTERVAL=30s
```

Create a deployment (distinct for easy grepping):

```
k apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: nginx-b
spec:
  containers:
  - name: main
    image: nginx:1.27.5
  restartPolicy: Never
EOF
```

And Ensure delegated scanning disabled


### Without Fix
Notice that Central never recovers and image is not reprocessed

Start - Central logs:
```
pkg/images/enricher: 2025/05/22 21:59:07.091846 enricher_impl.go:604: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 21:59:37.119029 enricher_impl.go:604: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 22:00:08.328078 enricher_impl.go:604: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
```

`rctl image scan --image=nginx:1.27.5 --cluster=remote` executed:

```
delegatedregistryconfig/delegator: 2025/05/22 22:00:16.093346 delegator.go:112: Info: Sent scan request "085220d8-2382-483b-99a6-88b1a49a5d0b" to cluster "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49" for "docker.io/library/nginx:1.27.5" with inferred namespace ""
delegatedregistryconfig/delegator: 2025/05/22 22:00:17.842294 delegator.go:119: Debug: Scan response received for "085220d8-2382-483b-99a6-88b1a49a5d0b" and image "docker.io/library/nginx:1.27.5"

### No scan occured after waiting 2+ mins

```

Delegated scanning enabled:
```
delegatedregistryconfig/service: 2025/05/22 22:02:07.462442 service.go:146: Info: Delegated registry config updated: "enabled_for:ALL"
delegatedregistryconfig/service: 2025/05/22 22:02:07.462627 service.go:148: Debug: Sending updated delegated registry config to cluster "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49"

image/service: 2025/05/22 22:02:42.391996 service_impl.go:534: Debug: Scan cache ignored enriching image with vulnerabilities {"image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "force_scan_update": true, "force_sig_verification_update": true}
image/service: 2025/05/22 22:03:13.287785 service_impl.go:534: Debug: Scan cache ignored enriching image with vulnerabilities {"image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "force_scan_update": true, "force_sig_verification_update": true}
image/service: 2025/05/22 22:04:12.542316 service_impl.go:534: Debug: Scan cache ignored enriching image with vulnerabilities {"image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "force_scan_update": true, "force_sig_verification_update": true}
image/service: 2025/05/22 22:05:12.701306 service_impl.go:534: Debug: Scan cache ignored enriching image with vulnerabilities {"image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "force_scan_update": true, "force_sig_verification_update": true}
```

Delegated scanning disabled:
```
delegatedregistryconfig/service: 2025/05/22 22:05:39.386682 service.go:146: Info: Delegated registry config updated: ""
delegatedregistryconfig/service: 2025/05/22 22:05:39.387256 service.go:148: Debug: Sending updated delegated registry config to cluster "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49"

### No scan occured after waiting 2+ mins
```

### With fix

Notice how in each scenario Central recovers with `Scan cache ignored enriching image` ... `"cluster_local_scan_expired": true`

Start - Central logs:
```
pkg/images/enricher: 2025/05/22 21:46:38.987840 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 21:47:09.830930 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 21:47:39.885056 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
```

`rctl image scan --image=nginx:1.27.5 --cluster=remote` executed:

```
delegatedregistryconfig/delegator: 2025/05/22 21:47:42.003885 delegator.go:112: Info: Sent scan request "e3907469-24bb-4f83-b520-2afe37b62270" to cluster "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49" for "docker.io/library/nginx:1.27.5" with inferred namespace ""
delegatedregistryconfig/delegator: 2025/05/22 21:47:45.180265 delegator.go:119: Debug: Scan response received for "e3907469-24bb-4f83-b520-2afe37b62270" and image "docker.io/library/nginx:1.27.5"

image/service: 2025/05/22 21:48:23.840549 service_impl.go:279: Debug: Scan cache ignored enriching image {"cluster_id": "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49", "image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "name_found": true, "cluster_local_scan_expired": true}

pkg/images/enricher: 2025/05/22 21:48:23.840831 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 21:48:52.496168 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 21:49:22.935283 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
```

Delegated scanning enabled:

```
image/service: 2025/05/22 21:52:08.070275 service_impl.go:591: Debug: Scan cache ignored enriching image with vulnerabilities {"cluster_id": "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49", "image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "force_scan_update": true, "force_sig_verification_update": true}
image/service: 2025/05/22 21:52:40.590447 service_impl.go:591: Debug: Scan cache ignored enriching image with vulnerabilities {"cluster_id": "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49", "image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "force_scan_update": true, "force_sig_verification_update": true}
image/service: 2025/05/22 21:53:40.396044 service_impl.go:591: Debug: Scan cache ignored enriching image with vulnerabilities {"cluster_id": "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49", "image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "force_scan_update": true, "force_sig_verification_update": true}
```

Delegated scanning disabled:

```
delegatedregistryconfig/service: 2025/05/22 21:53:44.999365 service.go:146: Info: Delegated registry config updated: ""
delegatedregistryconfig/service: 2025/05/22 21:53:44.999450 service.go:148: Debug: Sending updated delegated registry config to cluster "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49

image/service: 2025/05/22 21:54:44.951540 service_impl.go:279: Debug: Scan cache ignored enriching image {"cluster_id": "a2e26d3e-2ad9-4d26-ae32-e00a1b052c49", "image": "docker.io/library/nginx:1.27.5", "image_id": "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85", "request_image": "docker.io/library/nginx:1.27.5", "name_found": true, "cluster_local_scan_expired": true}

pkg/images/enricher: 2025/05/22 21:54:44.951729 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 21:55:20.614015 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
pkg/images/enricher: 2025/05/22 21:55:50.416061 enricher_impl.go:615: Debug: Scanning image "docker.io/library/nginx:1.27.5" (ID "sha256:ccbbc30b4057f9364bf31e27e25c773f5f83cb3ed908bb2994cd2993fcbbad85")
```
