### PR TITLE
ROX-28151: Phonehome telemetry for custom Prometheus metrics

### DIFF
--- a/central/metrics/custom/tracker/tracker_base.go
+++ b/central/metrics/custom/tracker/tracker_base.go
@@ -281,11 +281,11 @@ func (tracker *TrackerBase[Finding]) Gather(ctx context.Context) {
 	end := time.Now()
 	gatherer.lastGather = end
 
-	titCat := strings.ToTitle(tracker.category[0:1]) + tracker.category[1:]
-	centralclient.InstanceConfig().Telemeter().Track(
+	titCat := strings.ToTitle(tracker.description[0:1]) + tracker.description[1:]
+	centralclient.Singleton().Telemeter().Track(
 		titCat+" metrics gathered", nil,
 		telemeter.WithTraits(tracker.makeProps(titCat, end.Sub(begin))),
-		telemeter.WithNoDuplicates(tracker.category))
+		telemeter.WithNoDuplicates(tracker.metricPrefix))
 }
 
 func (tracker *TrackerBase[Finding]) makeProps(titCat string, duration time.Duration) map[string]any {

--- a/central/metrics/custom/tracker/tracker_base.go
+++ b/central/metrics/custom/tracker/tracker_base.go
@@ -281,18 +281,18 @@ func (tracker *TrackerBase[Finding]) Gather(ctx context.Context) {
 	end := time.Now()
 	gatherer.lastGather = end
 
-	titCat := strings.ToTitle(tracker.description[0:1]) + tracker.description[1:]
+	descriptionTitle := strings.ToTitle(tracker.description[0:1]) + tracker.description[1:]
 	centralclient.Singleton().Telemeter().Track(
-		titCat+" metrics gathered", nil,
-		telemeter.WithTraits(tracker.makeProps(titCat, end.Sub(begin))),
+		descriptionTitle+" metrics gathered", nil,
+		telemeter.WithTraits(tracker.makeProps(descriptionTitle, end.Sub(begin))),
 		telemeter.WithNoDuplicates(tracker.metricPrefix))
 }
 
-func (tracker *TrackerBase[Finding]) makeProps(titCat string, duration time.Duration) map[string]any {
+func (tracker *TrackerBase[Finding]) makeProps(descriptionTitle string, duration time.Duration) map[string]any {
 	props := make(map[string]any, 3)
-	props["Total "+titCat+" metrics"] = len(tracker.config.metrics)
-	props[titCat+" metrics labels"] = getLabels(tracker.config.metrics)
-	props[titCat+" gathering seconds"] = uint32(duration.Round(time.Second).Seconds())
+	props["Total "+descriptionTitle+" metrics"] = len(tracker.config.metrics)
+	props[descriptionTitle+" metrics labels"] = getLabels(tracker.config.metrics)
+	props[descriptionTitle+" gathering seconds"] = uint32(duration.Round(time.Second).Seconds())
 	return props
 }
 

--- a/central/metrics/custom/tracker/tracker_base_test.go
+++ b/central/metrics/custom/tracker/tracker_base_test.go
@@ -313,7 +313,7 @@ func Test_makeProps(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rf := mocks.NewMockCustomRegistry(ctrl)
 
-	tracker := MakeTrackerBase("test", "test",
+	tracker := MakeTrackerBase("test", "telemetry test",
 		testLabelGetters,
 		makeTestGatherFunc(testData))
 	tracker.registryFactory = func(string) metrics.CustomRegistry { return rf }
@@ -324,8 +324,8 @@ func Test_makeProps(t *testing.T) {
 		toAdd:   slices.Collect(maps.Keys(md)),
 		period:  time.Hour,
 	})
-	titCat := strings.ToTitle(tracker.description[0:1]) + tracker.description[1:]
-	props := tracker.makeProps(titCat, 12345*time.Millisecond)
+	descriptionTitle := strings.ToTitle(tracker.description[0:1]) + tracker.description[1:]
+	props := tracker.makeProps(descriptionTitle, 12345*time.Millisecond)
 	get := func(key string) any {
 		if v, ok := props[key]; ok {
 			return v
@@ -334,7 +334,7 @@ func Test_makeProps(t *testing.T) {
 	}
 
 	assert.Len(t, props, 3)
-	assert.ElementsMatch(t, get("Test metrics labels"), []Label{"Cluster", "Namespace", "Severity"})
-	assert.Equal(t, len(md), get("Total Test metrics"))
-	assert.Equal(t, uint32(12), get("Test gathering seconds"))
+	assert.ElementsMatch(t, get("Telemetry test metrics labels"), []Label{"Cluster", "Namespace", "Severity"})
+	assert.Equal(t, len(md), get("Total Telemetry test metrics"))
+	assert.Equal(t, uint32(12), get("Telemetry test gathering seconds"))
 }

--- a/central/metrics/custom/tracker/tracker_base_test.go
+++ b/central/metrics/custom/tracker/tracker_base_test.go
@@ -5,6 +5,7 @@ import (
 	"iter"
 	"maps"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -306,4 +307,34 @@ func makeAdminContext(t *testing.T) context.Context {
 	)
 	ctx := basic.ContextWithAdminIdentity(t, authProvider)
 	return ctx
+}
+
+func Test_makeProps(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rf := mocks.NewMockCustomRegistry(ctrl)
+
+	tracker := MakeTrackerBase("test", "test",
+		testLabelGetters,
+		makeTestGatherFunc(testData),
+		func(string) metrics.CustomRegistry { return rf })
+
+	md := makeTestMetricDescriptors(t)
+	tracker.Reconfigure(&Configuration{
+		metrics: md,
+		toAdd:   slices.Collect(maps.Keys(md)),
+		period:  time.Hour,
+	})
+	titCat := strings.ToTitle(tracker.category[0:1]) + tracker.category[1:]
+	props := tracker.makeProps(titCat, 12345*time.Millisecond)
+	get := func(key string) any {
+		if v, ok := props[key]; ok {
+			return v
+		}
+		return nil
+	}
+
+	assert.Len(t, props, 3)
+	assert.ElementsMatch(t, get("Test metrics labels"), []Label{"Cluster", "Namespace", "Severity"})
+	assert.Equal(t, len(md), get("Total Test metrics"))
+	assert.Equal(t, uint32(12), get("Test gathering seconds"))
 }

--- a/central/metrics/custom/tracker/tracker_base_test.go
+++ b/central/metrics/custom/tracker/tracker_base_test.go
@@ -315,8 +315,8 @@ func Test_makeProps(t *testing.T) {
 
 	tracker := MakeTrackerBase("test", "test",
 		testLabelGetters,
-		makeTestGatherFunc(testData),
-		func(string) metrics.CustomRegistry { return rf })
+		makeTestGatherFunc(testData))
+	tracker.registryFactory = func(string) metrics.CustomRegistry { return rf }
 
 	md := makeTestMetricDescriptors(t)
 	tracker.Reconfigure(&Configuration{
@@ -324,7 +324,7 @@ func Test_makeProps(t *testing.T) {
 		toAdd:   slices.Collect(maps.Keys(md)),
 		period:  time.Hour,
 	})
-	titCat := strings.ToTitle(tracker.category[0:1]) + tracker.category[1:]
+	titCat := strings.ToTitle(tracker.description[0:1]) + tracker.description[1:]
 	props := tracker.makeProps(titCat, 12345*time.Millisecond)
 	get := func(key string) any {
 		if v, ok := props[key]; ok {

--- a/central/metrics/custom_registry.go
+++ b/central/metrics/custom_registry.go
@@ -99,3 +99,11 @@ func (cr *customRegistry) Reset(metricName string) {
 		gauge.(*prometheus.GaugeVec).Reset()
 	}
 }
+
+// GetCustomRegistriesCount returns the total number of currently known custom
+// registries.
+func GetCustomRegistriesCount() int {
+	registriesMux.Lock()
+	defer registriesMux.Unlock()
+	return len(userRegistries)
+}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Track the event of the metrics configuration with provided related central identity properties.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Segment:
```json
{
  "anonymousId": "252d4cd4-9f59-499b-9b24-9ce485d4291f",
  "context": {
    "app": {
      "build": "development",
      "version": "4.9.x-95-g586a4a7736"
    },
    "device": {
      "id": "252d4cd4-9f59-499b-9b24-9ce485d4291f",
      "type": "Central Server",
      "version": "4.9.x-95-g586a4a7736"
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "traits": {
      "Total custom Prometheus registries": 1
    },
    "userAgent": "Rox Central/4.9.x-95-g586a4a7736 (linux; amd64)"
  },
  "event": "Served custom Prometheus metrics",
  "integrations": {},
  "messageId": "prom_registries-302d377998730586",
  "originalTimestamp": "2025-07-28T14:31:52.381788392Z",
  "receivedAt": "2025-07-28T14:31:52.474Z",
  "sentAt": "2025-07-28T14:31:52.381Z",
  "timestamp": "2025-07-28T14:31:52.474Z",
  "type": "track"
}
```

```json
{
  "anonymousId": "252d4cd4-9f59-499b-9b24-9ce485d4291f",
  "context": {
    "app": {
      "build": "development",
      "version": "4.9.x-95-g586a4a7736"
    },
    "device": {
      "id": "252d4cd4-9f59-499b-9b24-9ce485d4291f",
      "type": "Central Server",
      "version": "4.9.x-95-g586a4a7736"
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "traits": {
      "Total Vulnerabilities metrics": 1,
      "Vulnerabilities gathering seconds": 18,
      "Vulnerabilities metrics labels": [
        "Cluster",
        "Namespace",
        "Severity"
      ]
    },
    "userAgent": "Rox Central/4.9.x-95-g586a4a7736 (linux; amd64)"
  },
  "event": "Vulnerabilities metrics gathered",
  "integrations": {},
  "messageId": "vulnerabilities-59b748ba9941891",
  "originalTimestamp": "2025-07-28T14:34:53.642275995Z",
  "receivedAt": "2025-07-28T14:34:53.813Z",
  "sentAt": "2025-07-28T14:34:53.642Z",
  "timestamp": "2025-07-28T14:34:53.813Z",
  "type": "track"
}
```

Amplitude user view:
<img width="433" height="547" alt="image" src="https://github.com/user-attachments/assets/5ffbb93b-1f40-4a70-aec4-8d78d3806289" />

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #15783**
    * **PR #15784**
      * **PR #15807**
        * **PR #15796**
          * **PR #15797**
            * **PR #15809**
              * **PR #15487** 👈
              * **PR #16176**
            * **PR #15782**
<!-- GHIT dependencies end -->