### PR TITLE
ROX-29529: Remove external flows from internal flows table

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -11,6 +11,7 @@ import { EdgeState } from '../components/EdgeStateSelect';
 import { Flow } from '../types/flow.type';
 import InternalFlows from './InternalFlows';
 import ExternalFlows from './ExternalFlows';
+import { isInternalFlow } from '../utils/networkGraphUtils';
 
 export type DeploymentFlowsView = 'external-flows' | 'internal-flows';
 
@@ -56,6 +57,8 @@ function DeploymentFlows({
         setPageBaseline(1);
         setSearchFilter({});
     }, [selectedView, setPageAnomalous, setPageBaseline, setSearchFilter]);
+
+    const internalFlowsOnly = networkFlows.filter((flow) => isInternalFlow(flow));
 
     if (!isNetworkGraphExternalIpsEnabled) {
         return (
@@ -104,7 +107,7 @@ function DeploymentFlows({
                                 onNodeSelect={onNodeSelect}
                                 isLoadingNetworkFlows={isLoadingNetworkFlows}
                                 networkFlowsError={networkFlowsError}
-                                networkFlows={networkFlows}
+                                networkFlows={internalFlowsOnly}
                                 refetchFlows={refetchFlows}
                             />
                         ) : (

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -58,8 +58,6 @@ function DeploymentFlows({
         setSearchFilter({});
     }, [selectedView, setPageAnomalous, setPageBaseline, setSearchFilter]);
 
-    const internalFlowsOnly = networkFlows.filter((flow) => isInternalFlow(flow));
-
     if (!isNetworkGraphExternalIpsEnabled) {
         return (
             <div className="pf-v5-u-h-100 pf-v5-u-p-md">
@@ -107,7 +105,7 @@ function DeploymentFlows({
                                 onNodeSelect={onNodeSelect}
                                 isLoadingNetworkFlows={isLoadingNetworkFlows}
                                 networkFlowsError={networkFlowsError}
-                                networkFlows={internalFlowsOnly}
+                                networkFlows={networkFlows.filter((flow) => isInternalFlow(flow))}
                                 refetchFlows={refetchFlows}
                             />
                         ) : (

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
@@ -36,11 +36,7 @@ export function getExternalEntitiesNode(
 export function getNumAnomalousInternalFlows(networkFlows: Flow[]) {
     const numAnomalousInternalFlows =
         networkFlows.reduce((acc, flow) => {
-            if (
-                flow.isAnomalous &&
-                flow.type !== 'CIDR_BLOCK' &&
-                flow.type !== 'EXTERNAL_ENTITIES'
-            ) {
+            if (flow.isAnomalous && isInternalFlow(flow)) {
                 return acc + 1;
             }
             return acc;
@@ -51,10 +47,7 @@ export function getNumAnomalousInternalFlows(networkFlows: Flow[]) {
 export function getNumAnomalousExternalFlows(networkFlows: Flow[]) {
     const numAnomalousExternalFlows =
         networkFlows.reduce((acc, flow) => {
-            if (
-                flow.isAnomalous &&
-                (flow.type === 'CIDR_BLOCK' || flow.type === 'EXTERNAL_ENTITIES')
-            ) {
+            if (flow.isAnomalous && isExternalFlow(flow)) {
                 return acc + 1;
             }
             return acc;
@@ -77,6 +70,14 @@ export function getNumDeploymentFlows(edges: CustomEdgeModel[], deploymentId: st
             return acc;
         }, 0) || 0;
     return numFlows;
+}
+
+function isExternalFlow(flow: Flow) {
+    return flow.type === 'CIDR_BLOCK' || flow.type === 'EXTERNAL_ENTITIES';
+}
+
+export function isInternalFlow(flow: Flow) {
+    return !isExternalFlow(flow);
 }
 
 /* deployment helper functions */


### PR DESCRIPTION
### Description

Previously, all flows (internal and external) were displayed in the Deployment → Flows table. Now that external flows are shown in a separate table when the feature flag is enabled, we need to exclude External Entities and CIDR Blocks from the deployment flows to avoid duplication.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Feature flag disabled:
![Screenshot 2025-05-29 at 11 59 37 AM](https://github.com/user-attachments/assets/cc0405ac-ff26-4d69-ace1-b51afabbc514)

Feature flag enabled:
![Screenshot 2025-05-29 at 11 58 05 AM](https://github.com/user-attachments/assets/abb1a79c-21a1-433b-bdc6-890a2c39f4a0)

