### PR TITLE
ROX-28348: Skip compliance operator version check for empty versions

### DIFF
--- a/central/complianceoperator/v2/pipelines/complianceoperatorinfo/pipeline.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorinfo/pipeline.go
@@ -80,13 +80,15 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		operatorErrors = append(operatorErrors, fmt.Sprintf("Compliance operator is not ready. Only %d pods out of desired %d are ready.", readyPods, desiredPods))
 	}
 
-	// we support only newer versions of compliance operator
-	complianceOperatorVersion, err := semver.NewVersion(operatorInfo.GetVersion())
-	if complianceOperatorVersion == nil || err != nil {
-		log.Error(errors.Wrapf(err, "parsing compliance operator version: %q", operatorInfo.GetVersion()))
-		operatorErrors = append(operatorErrors, fmt.Sprintf("The installed compliance operator version %q is invalid.", operatorInfo.GetVersion()))
-	} else if complianceOperatorVersion.LessThan(env.ComplianceMinimalSupportedVersion.VersionSetting()) {
-		operatorErrors = append(operatorErrors, fmt.Sprintf("The installed compliance operator version %q is unsupported. The minimum required version is %q.", complianceOperatorVersion.String(), env.ComplianceMinimalSupportedVersion.VersionSetting().String()))
+	if msg.GetComplianceOperatorInfo().GetIsInstalled() {
+		// we support only newer versions of compliance operator
+		complianceOperatorVersion, err := semver.NewVersion(operatorInfo.GetVersion())
+		if complianceOperatorVersion == nil || err != nil {
+			log.Error(errors.Wrapf(err, "parsing compliance operator version: %q", operatorInfo.GetVersion()))
+			operatorErrors = append(operatorErrors, fmt.Sprintf("The installed compliance operator version %q is invalid.", operatorInfo.GetVersion()))
+		} else if complianceOperatorVersion.LessThan(env.ComplianceMinimalSupportedVersion.VersionSetting()) {
+			operatorErrors = append(operatorErrors, fmt.Sprintf("The installed compliance operator version %q is unsupported. The minimum required version is %q.", complianceOperatorVersion.String(), env.ComplianceMinimalSupportedVersion.VersionSetting().String()))
+		}
 	}
 
 	operatorInfo.StatusErrors = operatorErrors


### PR DESCRIPTION
### Description

We are getting empty versions for clusters where compliance is not installed (or there is no integration).
For example: GKE cluster

This PR is changing the logic for checking the supported compliance operator version. It will ignore compliance operator information if the compliance operator is not installed.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] added a unit test
