### PR TITLE
fix(ui): Reference navigator under the globalThis object

### DIFF
--- a/ui/apps/platform/src/utils/dateUtils.ts
+++ b/ui/apps/platform/src/utils/dateUtils.ts
@@ -1,7 +1,7 @@
 import Raven from 'raven-js';
 import { distanceInWordsStrict } from 'date-fns';
 
-const userLanguages = navigator.languages;
+const userLanguages: readonly string[] | undefined = globalThis.navigator?.languages;
 
 export type DateLike = string | number | Date;
 


### PR DESCRIPTION
### Description

References `navigator` under `globalThis` to prevent errors in tests.

### Follow up

Figure out why this wasn't failing in CI.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Local `npm run test`.

Verify CI
