### PR TITLE
chore(ui): Update nth-check dependency

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -16354,8 +16354,9 @@
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-            "integrity": "sha1-yeq0KO/842zWuSySS9sADvHx7R0= sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0"
             },
@@ -22170,15 +22171,6 @@
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
             "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs= sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
             "dev": true
-        },
-        "node_modules/svgo/node_modules/nth-check": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-            "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw= sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-            "dev": true,
-            "dependencies": {
-                "boolbase": "~1.0.0"
-            }
         },
         "node_modules/svgo/node_modules/source-map": {
             "version": "0.5.7",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -188,6 +188,7 @@
         "jest": "^29.7.0",
         "jest-resolve": "^29.7.0",
         "jest-watch-typeahead": "^2.2.2",
+        "nth-check": "^2.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": {


### PR DESCRIPTION
### Description

As titled. This needs an override as the <2.x version dependency comes from a transitive dependency of `react-scripts`, which will not be getting updates.

The breaking changes from 1.x to 2.x are:
- The main export is now a default export.
- The module now throws regular Errors on invalid selectors instead of SyntaxErrors.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Manual testing of UI and verification the SVGs in Network Graph, old VM are loaded correctly into the UI.

CI.
