### PR TITLE
ROX-29548: Add Prometheus metrics for Compliance Operator reporting

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -354,6 +354,7 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 		}
 		return err
 	}
+	log.Debugf("Searching for ScanWatcher %s to PushScan", id)
 	return m.getWatcher(sensorCtx, id).PushScan(scan)
 }
 
@@ -412,6 +413,9 @@ func (m *managerImpl) getWatcher(sensorCtx context.Context, id string) watcher.S
 			m.watchingScans[id] = scanWatcher
 			m.watchingScansStartTime[id] = time.Now()
 			m.updateMaxNumScansRunningInParallelNoLock()
+			log.Debugf("ScanWatcher with %s NOT found", id)
+		} else {
+			log.Debugf("ScanWatcher with %s found", id)
 		}
 	})
 	return scanWatcher
@@ -438,6 +442,7 @@ func (m *managerImpl) HandleResult(sensorCtx context.Context, result *storage.Co
 		}
 		return err
 	}
+	log.Debugf("Searching for ScanWatcher %s to PushCheckResult", id)
 	return m.getWatcher(sensorCtx, id).PushCheckResult(result)
 }
 

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -455,7 +455,7 @@ func (m *managerImpl) handleReadyScan() {
 				concurrency.WithLock(&m.watchingScansLock, func() {
 					delete(m.watchingScans, scanWatcherResult.WatcherID)
 					m.maxScansInParallel.Store(int32(len(m.watchingScans)))
-					scanWatcherActiveTime.Observe(float64(time.Since(m.watchingScansStartTime[scanWatcherResult.WatcherID])))
+					scanWatcherActiveTime.Observe(time.Since(m.watchingScansStartTime[scanWatcherResult.WatcherID]).Seconds())
 					delete(m.watchingScansStartTime, scanWatcherResult.WatcherID)
 				})
 				if err := watcher.DeleteOldResults(m.automaticReportingCtx, scanWatcherResult, m.checkResultDataStore); err != nil {

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -351,7 +351,6 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 		}
 		return err
 	}
-	log.Debugf("Searching for ScanWatcher %s to PushScan", id)
 	numChecks, err := watcher.GetExpectedNumChecks(scan)
 	if err != nil {
 		log.Warnf("Failed to get expected number of checks from annotations for %s: %v", scan.GetScanName(), err)
@@ -360,6 +359,7 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 	if w != nil {
 		return w.PushScan(scan)
 	}
+	log.Debugf("Received scan update after removing the watcher %+v", scan)
 	return nil
 }
 
@@ -453,6 +453,7 @@ func (m *managerImpl) HandleResult(sensorCtx context.Context, result *storage.Co
 	if w != nil {
 		return w.PushCheckResult(result)
 	}
+	log.Debugf("Received check result update after removing the watcher %+v", result)
 	return nil
 }
 

--- a/central/complianceoperator/v2/report/manager/metrics.go
+++ b/central/complianceoperator/v2/report/manager/metrics.go
@@ -1,0 +1,39 @@
+package manager
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func init() {
+	prometheus.MustRegister(
+		scansRunningInParallel,
+		numWatchers,
+	)
+}
+
+const (
+	coPrefix = "complianceoperator_"
+)
+
+var (
+	numWatchers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      coPrefix + "scan_watchers_current",
+		Help:      "Current number of scan watchers in central's memory",
+	})
+	scansRunningInParallel = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		// Num of scans: 0-10 with resolution of 1, 10-200 with resolution of 10.
+		Buckets: append(
+			prometheus.LinearBuckets(1, 1, 9),
+			prometheus.LinearBuckets(10, 10, 20)...,
+		),
+		Name: coPrefix + "num_scans_running_in_parallel",
+		Help: "Number of observations with a given number of watchers being in unfinished state (still running). " +
+			"If the metrics are updated every hour, then the value means how many time-blocks of 1 hour had the given " +
+			"(or less) number of scans running in parallel.",
+	})
+)

--- a/central/complianceoperator/v2/report/manager/metrics.go
+++ b/central/complianceoperator/v2/report/manager/metrics.go
@@ -8,7 +8,7 @@ import (
 func init() {
 	prometheus.MustRegister(
 		scansRunningInParallel,
-		scanWatcherActiveTime,
+		scanWatcherActiveTimeMinutes,
 		numWatchers,
 	)
 }
@@ -37,16 +37,11 @@ var (
 			"If the metrics are updated every hour, then the value means how many time-blocks of 1 hour had the given " +
 			"(or less) number of scans running in parallel.",
 	})
-	scanWatcherActiveTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+	scanWatcherActiveTimeMinutes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Buckets: append(
-			// First 2 minutes every 10s
-			prometheus.LinearBuckets(1, 10, 12),
-			// Rest every minute until the 40m timeout is covered
-			prometheus.LinearBuckets(120, 60, 45)...,
-		),
-		Name: coPrefix + "scan_watchers_active_time_seconds",
-		Help: "How long a scan watcher was active",
-	})
+		Buckets:   []float64{0.5, 1, 1.5, 2, 3, 4, 5, 10, 20, 30, 40, 45},
+		Name:      coPrefix + "scan_watchers_active_time_minutes",
+		Help:      "How long (in minutes) a scan watcher was active. Value of 40m is the default timeout.",
+	}, []string{"name"})
 )

--- a/central/complianceoperator/v2/report/manager/metrics.go
+++ b/central/complianceoperator/v2/report/manager/metrics.go
@@ -8,6 +8,7 @@ import (
 func init() {
 	prometheus.MustRegister(
 		scansRunningInParallel,
+		scanWatcherActiveTime,
 		numWatchers,
 	)
 }
@@ -35,5 +36,17 @@ var (
 		Help: "Number of observations with a given number of watchers being in unfinished state (still running). " +
 			"If the metrics are updated every hour, then the value means how many time-blocks of 1 hour had the given " +
 			"(or less) number of scans running in parallel.",
+	})
+	scanWatcherActiveTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Buckets: append(
+			// First 2 minutes every 10s
+			prometheus.LinearBuckets(1, 10, 12),
+			// Rest every minute until the 40m timeout is covered
+			prometheus.LinearBuckets(120, 60, 45)...,
+		),
+		Name: coPrefix + "scan_watchers_active_time_seconds",
+		Help: "How long a scan watcher was active",
 	})
 )

--- a/central/complianceoperator/v2/report/manager/watcher/metrics.go
+++ b/central/complianceoperator/v2/report/manager/watcher/metrics.go
@@ -1,0 +1,25 @@
+package watcher
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func init() {
+	prometheus.MustRegister(
+		watcherFinishType,
+	)
+}
+
+const (
+	coPrefix = "complianceoperator_"
+)
+
+var (
+	watcherFinishType = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      coPrefix + "scan_watchers_finish_type_total",
+		Help:      "How a watcher run has ended",
+	}, []string{"name", "type"})
+)

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -312,7 +312,7 @@ func (s *scanWatcherImpl) run() {
 
 func GetExpectedNumChecks(scan *storage.ComplianceOperatorScanV2) (int, error) {
 	annotationsMap := scan.GetAnnotations()
-	if annotationsMap == nil || len(annotationsMap) == 0 {
+	if len(annotationsMap) == 0 {
 		return 0, nil // It can happen that the annotation is not available and this is okay.
 	}
 	checkCountAnnotation, found := annotationsMap[CheckCountAnnotationKey]

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -298,6 +298,8 @@ func (s *scanWatcherImpl) run() {
 		concurrency.WithLock(&s.resultsLock, func() {
 			numCheckResults = len(s.scanResults.CheckResults)
 		})
+		log.Debugf("Checking whether %s is finished. TotalChecks=%d, numCheckResults=%d",
+			s.scanResults.Scan.GetScanName(), s.totalChecks, numCheckResults)
 		if s.totalChecks != 0 && s.totalChecks == numCheckResults {
 			s.readyQueue.Push(s.scanResults)
 			return

--- a/pkg/env/compliance_operator.go
+++ b/pkg/env/compliance_operator.go
@@ -30,4 +30,18 @@ var (
 	// This value can be customized via the ROX_COMPLIANCE_MINIMAL_SUPPORTED_OPERATOR_VERSION environment variable.
 	// If the environment variable is unset, contains an invalid version, or is lower than the default value, the default value "v1.6.0" will be used.
 	ComplianceMinimalSupportedVersion = RegisterVersionSetting("ROX_COMPLIANCE_MINIMAL_SUPPORTED_OPERATOR_VERSION", "v1.6.0", "v1.6.0")
+	// ComplianceScansRunningInParallelMetricObservationPeriod defines an observation window for the compliance operator metrics in Central.
+	// For example, a metric output like this:
+	// rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="0"} 0
+	// rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="1"} 6
+	// rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="2"} 16
+	// rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="3"} 20
+	// rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="4"} 36
+	// with setting of 1 hour, should be interpreted as follows:
+	// - The line with `le="0"` should be always empty, as we never have a negative number of scans running
+	// - There were six 1-hour-long time-windows with not a single scan was running
+	// - There were ten (16-6) 1-hour-long time-windows with a single scan was running
+	// - There were four (20-16) 1-hour-long time-windows with two scans were running in parallel
+	// - There were fourteen (34-20) 1-hour-long time-windows with three scans were running in parallel
+	ComplianceScansRunningInParallelMetricObservationPeriod = registerDurationSetting("ROX_COMPLIANCE_METRIC_OBSERVATION_PERIOD", 15*time.Minute)
 )

--- a/sensor/kubernetes/complianceoperator/metrics.go
+++ b/sensor/kubernetes/complianceoperator/metrics.go
@@ -1,0 +1,32 @@
+package complianceoperator
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func init() {
+	prometheus.MustRegister(
+		commandsFromCentral,
+		applyScanConfigCommands,
+	)
+}
+
+const (
+	coPrefix = "complianceoperator_"
+)
+
+var (
+	commandsFromCentral = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      coPrefix + "commands_from_central_total",
+		Help:      "Total number of messages from Central instructing Sensor to execute a compliance operator related operation",
+	}, []string{"operation", "processed"})
+	applyScanConfigCommands = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      coPrefix + "apply_scan_config_commands_from_central_total",
+		Help:      "Total number of messages from Central instructing Sensor to apply a particular scan config",
+	}, []string{"operation"})
+)


### PR DESCRIPTION
### Description

This PR adds the following metrics:

1. Number of scans running in parallel. The goal was to capture the temporal aspects, so we divide the time into time-windows, and count what was the max number of scan watchers active in a given time window. Default window is 15 minutes.
2. How long a scan would take - i.e., what is the lifetime of a scan watcher in Central. This maybe skewed if Central frequently restarts, but that should be rare.
3. What kind of CO-related messages Central sends to Sensor.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

I validated the metrics on a cluster.

#### Sensor

```
# HELP rox_sensor_complianceoperator_apply_scan_config_commands_from_central_total Total number of messages from Central instructing Sensor to apply a particular scan config
# TYPE rox_sensor_complianceoperator_apply_scan_config_commands_from_central_total counter
rox_sensor_complianceoperator_apply_scan_config_commands_from_central_total{operation="*central.ApplyComplianceScanConfigRequest_ScheduledScan_"} 3
# HELP rox_sensor_complianceoperator_commands_from_central_total Total number of messages from Central instructing Sensor to execute a compliance operator related operation
# TYPE rox_sensor_complianceoperator_commands_from_central_total counter
rox_sensor_complianceoperator_commands_from_central_total{operation="*central.ComplianceRequest_ApplyScanConfig",processed="true"} 3
```

#### Central

Number of active scan watchers = number of active scans - 1 per profile

```
# HELP rox_central_complianceoperator_num_scans_running_in_parallel Number of observations with a given number of watchers being in unfinished state (still running). If the metrics are updated every hour, then the value means how many time-blocks of 1 hour had the given (or less) number of scans running in parallel.
# TYPE rox_central_complianceoperator_num_scans_running_in_parallel histogram
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="1"} 4
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="2"} 5
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="3"} 5
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="4"} 5
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="5"} 5
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="6"} 5
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="7"} 18
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="8"} 18
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="9"} 18
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="10"} 18
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="20"} 30
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="30"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="40"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="50"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="60"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="70"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="80"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="90"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="100"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="110"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="120"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="130"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="140"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="150"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="160"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="170"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="180"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="190"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="200"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_bucket{le="+Inf"} 58
rox_central_complianceoperator_num_scans_running_in_parallel_sum 890
rox_central_complianceoperator_num_scans_running_in_parallel_count 58
```

Duration of a scan (for each profile)

```
# HELP rox_central_complianceoperator_scan_watchers_active_time_minutes How long (in minutes) a scan watcher was active. Value of 40m is the default timeout.
# TYPE rox_central_complianceoperator_scan_watchers_active_time_minutes histogram
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="0.5"} 1
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="1"} 1
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="1.5"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="2"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="3"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="4"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="5"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="10"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="20"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="30"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="40"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="45"} 3
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi",le="+Inf"} 3
rox_central_complianceoperator_scan_watchers_active_time_minutes_sum{name="ocp4-bsi"} 41.08969301571666
rox_central_complianceoperator_scan_watchers_active_time_minutes_count{name="ocp4-bsi"} 3
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="0.5"} 1
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="1"} 1
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="1.5"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="2"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="3"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="4"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="5"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="10"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="20"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="30"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="40"} 2
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="45"} 3
rox_central_complianceoperator_scan_watchers_active_time_minutes_bucket{name="ocp4-bsi-2022",le="+Inf"} 3
rox_central_complianceoperator_scan_watchers_active_time_minutes_sum{name="ocp4-bsi-2022"} 41.483600666983335
rox_central_complianceoperator_scan_watchers_active_time_minutes_count{name="ocp4-bsi-2022"} 3
```

Possible visualisation in Grafana

![Screenshot 2025-06-04 at 10 27 34](https://github.com/user-attachments/assets/c0ea95f6-4d4a-457b-82ff-544ae81341b4)

Zoom-in on the explanation how to read the first histogram

![Screenshot 2025-06-04 at 10 37 05](https://github.com/user-attachments/assets/97275d94-b296-472b-959b-3c9c9c3251c4)

### Discovering a bug

Note, that there are some scan watchers being active for over 40 minutes, although the UI reports that all scans finish within few minutes. 

![Screenshot 2025-06-04 at 10 38 39](https://github.com/user-attachments/assets/6edd63e9-ef97-463a-959d-f39b05583f91)
 
