### PR TITLE
ROX-26453: Remove Integration from RBAC for Network policy generator

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -79,8 +79,7 @@ function NetworkGraphPage() {
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForBlocks =
         hasReadAccess('Administration') && hasReadWriteAccess('NetworkGraph');
-    const hasReadAccessForGenerator =
-        hasReadAccess('Integration') && hasReadAccess('NetworkPolicy');
+    const hasReadAccessForGenerator = hasReadAccess('NetworkPolicy');
 
     const [edgeState, setEdgeState] = useState<EdgeState>('active');
     const [displayOptions, setDisplayOptions] = useState<DisplayOption[]>([

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -24,6 +24,7 @@ import { HelpIcon } from '@patternfly/react-icons';
 import sortBy from 'lodash/sortBy';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
+import usePermissions from 'hooks/usePermissions';
 import useRestQuery from 'hooks/useRestQuery';
 import useAnalytics, { GENERATE_NETWORK_POLICIES } from 'hooks/useAnalytics';
 import useURLSearch from 'hooks/useURLSearch';
@@ -82,6 +83,9 @@ function NetworkPolicySimulatorSidePanel({
 }: NetworkPolicySimulatorSidePanelProps) {
     const { analyticsTrack } = useAnalytics();
     const { searchFilter } = useURLSearch();
+
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForNotifiers = hasReadAccess('Integration');
 
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
@@ -253,16 +257,20 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
-                            openNotifyYAMLModal={openNotifyYAMLModal}
+                            openNotifyYAMLModal={
+                                hasReadAccessForNotifiers ? openNotifyYAMLModal : undefined
+                            }
                         />
                     </FlexItem>
                 </Flex>
-                <NotifyYAMLModal
-                    isModalOpen={isNotifyModalOpen}
-                    setIsModalOpen={setIsNotifyModalOpen}
-                    clusterId={scopeHierarchy.cluster.id}
-                    modification={simulator.modification}
-                />
+                {hasReadAccessForNotifiers && (
+                    <NotifyYAMLModal
+                        isModalOpen={isNotifyModalOpen}
+                        setIsModalOpen={setIsNotifyModalOpen}
+                        clusterId={scopeHierarchy.cluster.id}
+                        modification={simulator.modification}
+                    />
+                )}
                 {compareModalYAMLs && (
                     <CompareYAMLModal
                         generated={compareModalYAMLs.generated}
@@ -315,16 +323,20 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
-                            openNotifyYAMLModal={openNotifyYAMLModal}
+                            openNotifyYAMLModal={
+                                hasReadAccessForNotifiers ? openNotifyYAMLModal : undefined
+                            }
                         />
                     </StackItem>
                 </Stack>
-                <NotifyYAMLModal
-                    isModalOpen={isNotifyModalOpen}
-                    setIsModalOpen={setIsNotifyModalOpen}
-                    clusterId={scopeHierarchy.cluster.id}
-                    modification={simulator.modification}
-                />
+                {hasReadAccessForNotifiers && (
+                    <NotifyYAMLModal
+                        isModalOpen={isNotifyModalOpen}
+                        setIsModalOpen={setIsNotifyModalOpen}
+                        clusterId={scopeHierarchy.cluster.id}
+                        modification={simulator.modification}
+                    />
+                )}
             </div>
         );
     }
@@ -365,16 +377,20 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
-                            openNotifyYAMLModal={openNotifyYAMLModal}
+                            openNotifyYAMLModal={
+                                hasReadAccessForNotifiers ? openNotifyYAMLModal : undefined
+                            }
                         />
                     </StackItem>
                 </Stack>
-                <NotifyYAMLModal
-                    isModalOpen={isNotifyModalOpen}
-                    setIsModalOpen={setIsNotifyModalOpen}
-                    clusterId={scopeHierarchy.cluster.id}
-                    modification={simulator.modification}
-                />
+                {hasReadAccessForNotifiers && (
+                    <NotifyYAMLModal
+                        isModalOpen={isNotifyModalOpen}
+                        setIsModalOpen={setIsNotifyModalOpen}
+                        clusterId={scopeHierarchy.cluster.id}
+                        modification={simulator.modification}
+                    />
+                )}
             </div>
         );
     }

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { Alert, Bullseye, Button, Modal, Spinner } from '@patternfly/react-core';
 
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
-import useFetchNotifiers from 'hooks/useFetchNotifiers';
 import useTableSelection from 'hooks/useTableSelection';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { notifyNetworkPolicyModification } from 'services/NetworkService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import useFetchNotifiers from './useFetchNotifiers';
 
 type NotifyYAMLModalProps = {
     isModalOpen: boolean;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/useFetchNotifiers.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/useFetchNotifiers.ts
@@ -12,7 +12,7 @@ const defaultResultState = { notifiers: [], error: null, isLoading: true };
 /*
  * This hook does an API call to the notifiers API to get the list of notifiers
  */
-function useFetchScopes(): Result {
+function useFetchNotifiers(): Result {
     const [result, setResult] = useState<Result>(defaultResultState);
 
     useEffect(() => {
@@ -30,4 +30,4 @@ function useFetchScopes(): Result {
     return result;
 }
 
-export default useFetchScopes;
+export default useFetchNotifiers;


### PR DESCRIPTION
### Description

### Problem

User role has minimum resources `'Deployment'` and `'NetworkGraph'` plus optional `'NetworkPolicy'` but does not have need for optional `'Integration'` resource.

That is, administration does not want user to see **Integrations** under **Platform Configuration** in navigation sidebar.

But without `'Integration'` resource, user does not see **Network policy generator** button.

### Analysis

1. NetworkGraphPage.tsx file requires `'NetworkPolicy'` and `'Integration'` resources for conditional rendering of `SimulateNetworkPolicyButton` element.
    Why? Because `NotifyYAMLModal` component has `useFetchNotifiers` hook. During my previous RBAC tour of duty, I observed:
    GET /v1/notifiers has 403 Forbidden status

    This is **Residue** in #8218
    > Investigate conditional rendering for absence of Integration resource in NetworkPolicySimulatorSidePanel component.

2. What I see now, but did not have brain nor time to see then.
    Conditional rendering:
    * not only for **Share YAML with notifiers** in NetworkSimulatorActions.tsx file.
        But it already has conditional rendering according to `openNotifyYAMLModal` prop, so buy-one-get-one (three times) in the same file as next item.
    * but also for (three occurrences of) `NotifyYAMLModal` element in NetworkPolicySimulatorSidePanel.tsx file.
        That is, unconditionally rendered modal makes request, even if user never opens it.

### Solution

1. Edit NetworkGraphPage.tsx file.
    * Delete `'Integration'` resource requirement.
2. Edit NetworkPolicySimulatorSidePanel.tsx file.
    * Add `hasReadAccessForNotifiers` as conditional rendering for `openNotifyYAMLModal` prop and `NotifyYAMLModal` element.
        Although the bot might comment about the repetition, I decided on parallel conditional rendering for both.
3. Move useNotifiers.ts file adjacent to its only use and rename `useScopes` as `useNotifiers` because inconsistency foiled Find in Files (pardon pun).

### Residue

1. See 403 Forbidden status for request from **Flows** tab:
    GET /v1/networkbaseline/id/status
    As discovered and discussed with **Brad** recently, both **Flows** and **Baseline** require `'DeploymentExtension'` resource.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed, but Release Notes in Jira bug instead

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

#### Manual testing

Thank you **David Vail** for recipe to test user role permissions.

See **Dashboard**, **Network Graph**, and **Risk** in navigation sidebar.

1. Visit /main/network-graph select cluster and namespace.

    Before changes, see absence of **Network policy generator** button.
    ![SimulateNetworkPolicyButton_absence](https://github.com/user-attachments/assets/4eb12744-a5ff-4413-9aaf-5f2a9ee2c2fc)

    With partial changes, see presence of **Network policy generator**.
    Click it, and then **Generate and simulate network policies** button.
    GET /v1/notifiers request 403 Forbidden status
    ![SimulateNetworkPolicyButton_presence_with_403](https://github.com/user-attachments/assets/4e161e92-05bb-468e-93c0-22e6920cff89)

    After changes, see presence of **Network policy generator**, absence of **Share YAML with notifiers** item in **Actions** dropdown, and absence of request.
    ![SimulateNetworkPolicyButton_presence_without_403](https://github.com/user-attachments/assets/d80c0707-bd97-4a60-8539-dd0c8b4fa4bd)
