### PR TITLE
fix(access): Use proper access in the convert functions

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -260,7 +261,9 @@ func (s *ComplianceScanConfigServiceTestSuite) TestDeleteComplianceScanConfigura
 	}
 	s.manager.EXPECT().DeleteScan(gomock.Any(), validID).Return(nil).Times(1)
 	s.snapshotDS.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).Times(1).Return(snapshots, nil)
-	s.blobDS.EXPECT().Delete(gomock.Any(), common.GetComplianceReportBlobPath(validID, snapshotID)).Times(1).Return(nil)
+	s.blobDS.EXPECT().Delete(gomock.Cond[context.Context](func(ctx context.Context) bool {
+		return validateBlobContext(ctx, storage.Access_READ_WRITE_ACCESS)
+	}), common.GetComplianceReportBlobPath(validID, snapshotID)).Times(1).Return(nil)
 
 	_, err := s.service.DeleteComplianceScanConfiguration(allAccessContext, &v2.ResourceByID{Id: validID})
 	s.Require().NoError(err)
@@ -790,6 +793,72 @@ func (s *ComplianceScanConfigServiceTestSuite) TestGetReportHistory() {
 		}, res)
 	})
 
+	s.Run("Success for download", func() {
+		scanConfigID := "scan-config-1"
+		now := protocompat.TimestampNow()
+		snapshots := []*storage.ComplianceOperatorReportSnapshotV2{
+			{
+				ReportId:            "snapshot-1",
+				ScanConfigurationId: scanConfigID,
+				ReportStatus: &storage.ComplianceOperatorReportStatus{
+					ReportRequestType:        storage.ComplianceOperatorReportStatus_ON_DEMAND,
+					ReportNotificationMethod: storage.ComplianceOperatorReportStatus_DOWNLOAD,
+					StartedAt:                now,
+					CompletedAt:              now,
+					RunState:                 storage.ComplianceOperatorReportStatus_GENERATED,
+				},
+			},
+		}
+		sc := &storage.ComplianceOperatorScanConfigurationV2{
+			Id:             scanConfigID,
+			ScanConfigName: scanConfigID,
+		}
+
+		s.snapshotDS.EXPECT().SearchSnapshots(allAccessContext, gomock.Any()).Return(snapshots, nil)
+		s.scanConfigDatastore.EXPECT().GetScanConfiguration(allAccessContext, scanConfigID).Return(sc, true, nil)
+		s.scanConfigDatastore.EXPECT().GetScanConfigClusterStatus(allAccessContext, scanConfigID).Return(nil, nil)
+		s.suiteDataStore.EXPECT().GetSuites(allAccessContext, gomock.Any()).Return(nil, nil)
+		s.blobDS.EXPECT().Search(gomock.Cond[context.Context](func(ctx context.Context) bool {
+			return validateBlobContext(ctx, storage.Access_READ_ACCESS)
+		}), gomock.Any()).Times(1).Return([]search.Result{
+			{
+				ID: common.GetComplianceReportBlobPath(scanConfigID, "snapshot-1"),
+			},
+		}, nil)
+
+		res, err := s.service.GetReportHistory(allAccessContext, &v2.ComplianceReportHistoryRequest{Id: scanConfigID})
+		s.Require().NoError(err)
+		protoassert.Equal(s.T(), &v2.ComplianceReportHistoryResponse{
+			ComplianceReportSnapshots: []*v2.ComplianceReportSnapshot{
+				{
+					ReportJobId:  "snapshot-1",
+					ScanConfigId: scanConfigID,
+					ReportStatus: &v2.ComplianceReportStatus{
+						ReportRequestType:        v2.ComplianceReportStatus_ON_DEMAND,
+						ReportNotificationMethod: v2.NotificationMethod_DOWNLOAD,
+						StartedAt:                now,
+						CompletedAt:              now,
+						FailedClusters:           []*v2.FailedCluster{},
+						RunState:                 v2.ComplianceReportStatus_GENERATED,
+					},
+					ReportData: &v2.ComplianceScanConfigurationStatus{
+						Id:       scanConfigID,
+						ScanName: scanConfigID,
+						ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
+							OneTimeScan: false,
+							Profiles:    []string{},
+							Notifiers:   []*v2.NotifierConfiguration{},
+						},
+						ClusterStatus: []*v2.ClusterScanStatus{},
+						ModifiedBy:    &v2.SlimUser{},
+					},
+					User:                &v2.SlimUser{},
+					IsDownloadAvailable: true,
+				},
+			},
+		}, res)
+	})
+
 	s.Run("Success with failed cluster and multiple errors", func() {
 		scanConfigID := "scan-config-1"
 		now := protocompat.TimestampNow()
@@ -1088,7 +1157,9 @@ func (s *ComplianceScanConfigServiceTestSuite) TestDeleteReport() {
 
 		ctx := getContextForUser(s.T(), s.mockCtrl, allAccessContext, storageRequester)
 		s.snapshotDS.EXPECT().GetSnapshot(gomock.Any(), snapshotID).Return(snapshot, true, nil)
-		s.blobDS.EXPECT().Delete(gomock.Any(), common.GetComplianceReportBlobPath(snapshot.GetScanConfigurationId(), snapshotID)).Return(errors.New("some error"))
+		s.blobDS.EXPECT().Delete(gomock.Cond[context.Context](func(ctx context.Context) bool {
+			return validateBlobContext(ctx, storage.Access_READ_WRITE_ACCESS)
+		}), common.GetComplianceReportBlobPath(snapshot.GetScanConfigurationId(), snapshotID)).Return(errors.New("some error"))
 
 		_, err := s.service.DeleteReport(ctx, &v2.ResourceByID{Id: snapshotID})
 		s.Require().Error(err)
@@ -1100,7 +1171,9 @@ func (s *ComplianceScanConfigServiceTestSuite) TestDeleteReport() {
 
 		ctx := getContextForUser(s.T(), s.mockCtrl, allAccessContext, storageRequester)
 		s.snapshotDS.EXPECT().GetSnapshot(gomock.Any(), snapshotID).Return(snapshot, true, nil)
-		s.blobDS.EXPECT().Delete(gomock.Any(), common.GetComplianceReportBlobPath(snapshot.GetScanConfigurationId(), snapshotID)).Return(nil)
+		s.blobDS.EXPECT().Delete(gomock.Cond[context.Context](func(ctx context.Context) bool {
+			return validateBlobContext(ctx, storage.Access_READ_WRITE_ACCESS)
+		}), common.GetComplianceReportBlobPath(snapshot.GetScanConfigurationId(), snapshotID)).Return(nil)
 
 		_, err := s.service.DeleteReport(ctx, &v2.ResourceByID{Id: snapshotID})
 		s.Require().NoError(err)
@@ -1156,4 +1229,9 @@ func getContextForUser(t *testing.T, ctrl *gomock.Controller, ctx context.Contex
 	mockID.EXPECT().FullName().Return(user.Name).AnyTimes()
 	mockID.EXPECT().FriendlyName().Return(user.Name).AnyTimes()
 	return authn.ContextWithIdentity(ctx, mockID, t)
+}
+
+func validateBlobContext(ctx context.Context, access storage.Access) bool {
+	scopeChecker := sac.ForResource(resources.Administration)
+	return scopeChecker.ScopeChecker(ctx, access).IsAllowed()
 }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The Blob store uses a different access scope than Compliance. We need to use the correct context to Search in the Blob store.

Problem:

1. Create a user with the following permissions:
    - Cluster Read
    - Compliance Read/Write
    - Integration Read
2. Create a Schedule with that user
3. Generate a Download
4. Observe in the logs/db that the download is generated correctly
5. Observe that cannot be downloaded through the UI and we see error messages in the logs in the convert function

After these changes the steps (4) and (5) should be fixed and we should be able to download the report from the UI.

- Follow-up on #15513

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit tests added
- [x] Manual test. Follow the steps described in the `Description` section
