### PR TITLE
ROX-29415: Add External IPs analytics

### DIFF
--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -22,6 +22,8 @@ export const CLUSTER_LEVEL_SIMULATOR_OPENED = 'Network Graph: Cluster Level Simu
 export const GENERATE_NETWORK_POLICIES = 'Network Graph: Generate Network Policies';
 export const DOWNLOAD_NETWORK_POLICIES = 'Network Graph: Download Network Policies';
 export const CIDR_BLOCK_FORM_OPENED = 'Network Graph: CIDR Block Form Opened';
+export const EXTERNAL_IPS_SIDE_PANEL = 'External IP Side Panel Opened';
+export const DEPLOYMENT_FLOWS_TOGGLE_CLICKED = 'External Flows Toggle Clicked';
 
 // watch images
 export const WATCH_IMAGE_MODAL_OPENED = 'Watch Image Modal Opened';
@@ -161,6 +163,19 @@ export type AnalyticsEvent =
               cluster: number;
               namespaces: number;
               deployments: number;
+          };
+      }
+    | {
+          event: typeof EXTERNAL_IPS_SIDE_PANEL;
+          properties: {
+              isEmptyTable: boolean;
+              isFilteredTable: boolean;
+          };
+      }
+    | {
+          event: typeof DEPLOYMENT_FLOWS_TOGGLE_CLICKED;
+          properties: {
+              view: 'External Flows' | 'Internal Flows';
           };
       }
     /** Tracks each time the user opens the "Watched Images" modal */

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -22,7 +22,7 @@ export const CLUSTER_LEVEL_SIMULATOR_OPENED = 'Network Graph: Cluster Level Simu
 export const GENERATE_NETWORK_POLICIES = 'Network Graph: Generate Network Policies';
 export const DOWNLOAD_NETWORK_POLICIES = 'Network Graph: Download Network Policies';
 export const CIDR_BLOCK_FORM_OPENED = 'Network Graph: CIDR Block Form Opened';
-export const EXTERNAL_IPS_SIDE_PANEL = 'External IP Side Panel Opened';
+export const EXTERNAL_IPS_SIDE_PANEL = 'External IPs Side Panel Opened';
 export const DEPLOYMENT_FLOWS_TOGGLE_CLICKED = 'External Flows Toggle Clicked';
 
 // watch images


### PR DESCRIPTION
### Description

The main goal is to track whether users are interacting with External IPs and infer if the collector feature flag is enabled.

Note:

- Once side panel routing is added to the Network Graph, these tracking events can be removed. At that point, we’ll look for a more reliable way to detect if the collector feature flag `externalIps` is active.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Verified in segment:

**External IPs:**

1. Empty table with no filters
![Screenshot 2025-06-02 at 1 03 14 PM](https://github.com/user-attachments/assets/764e514b-03ae-4703-852e-5bf5e45d5a6b)

2. Empty table due to filters
![Screenshot 2025-06-02 at 1 10 43 PM](https://github.com/user-attachments/assets/65da174a-ca7f-44b5-96bf-0f63d5ff930d)

3. Table with data
![Screenshot 2025-06-02 at 1 02 32 PM](https://github.com/user-attachments/assets/0bed8e41-e8eb-4080-9515-e88406e5be44)

**External Flows:**

1. External toggle clicked:
![Screenshot 2025-06-02 at 1 01 44 PM](https://github.com/user-attachments/assets/e712c234-ee7d-4f43-a74d-62719325c013)

2. Internal toggle clicked:
![Screenshot 2025-06-02 at 1 11 27 PM](https://github.com/user-attachments/assets/d68f0770-737a-4063-a068-aa2c49fb8457)

