### PR TITLE
ROX-29574: Add external flows confirmation modal

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -389,7 +389,7 @@ function ExternalFlows({
             <ConfirmationModal
                 title="Apply status change to multiple flows?"
                 ariaLabel="Confirm status change"
-                confirmText="Yes"
+                confirmText="Apply"
                 isOpen={isConfirmingStatusChange}
                 onConfirm={onConfirmStatusChange}
                 onCancel={onCancelStatusChange}


### PR DESCRIPTION
### Description

Adds a confirmation modal to status updates in Network Graph External Flows.

Because flow status is determined by the combination of direction, port, and protocol (**not** by individual flows) we want to clarify for users what updates will be applied and that related flows will also be affected.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

![Screenshot 2025-06-02 at 2 49 49 PM](https://github.com/user-attachments/assets/cb140c2b-4718-4059-85d2-be45911d2cae)
![Screenshot 2025-06-02 at 2 50 00 PM](https://github.com/user-attachments/assets/250bddea-0c96-4f0b-ab22-1359a9e305d2)

Error state:
![Screenshot 2025-06-03 at 2 21 34 PM](https://github.com/user-attachments/assets/aa46c365-625d-49f7-9881-d26b745ec629)

