### PR TITLE
ROX-29400: prune also in network trees

### DIFF
--- a/central/networkgraph/flow/datastore/internal/store/postgres/cluster_impl.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/cluster_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/sync"
@@ -30,7 +31,7 @@ func (s *clusterStoreImpl) GetFlowStore(clusterID string) store.FlowStore {
 
 	flowStore, found := s.flowStore[clusterID]
 	if !found || flowStore == nil {
-		flowStore = New(s.db, clusterID)
+		flowStore = New(s.db, clusterID, networktree.Singleton())
 		s.flowStore[clusterID] = flowStore
 	}
 	return flowStore

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
@@ -125,7 +126,8 @@ const (
 		AND
 		NOT EXISTS
 		(SELECT 1 FROM %s flow WHERE
-			flow.Props_DstEntity_Type = 4 AND flow.Props_DstEntity_Id = entity.Info_Id);`
+			flow.Props_DstEntity_Type = 4 AND flow.Props_DstEntity_Id = entity.Info_Id)
+			RETURNING entity.Info_Id;`
 )
 
 var (
@@ -166,10 +168,11 @@ type FlowStore interface {
 }
 
 type flowStoreImpl struct {
-	db            postgres.DB
-	mutex         sync.Mutex
-	clusterID     uuid.UUID
-	partitionName string
+	db             postgres.DB
+	mutex          sync.Mutex
+	clusterID      uuid.UUID
+	partitionName  string
+	networktreeMgr networktree.Manager
 }
 
 func (s *flowStoreImpl) insertIntoNetworkflow(ctx context.Context, tx *postgres.Tx, clusterID uuid.UUID, obj *storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error {
@@ -249,7 +252,7 @@ func (s *flowStoreImpl) copyFromNetworkflow(ctx context.Context, tx *postgres.Tx
 }
 
 // New returns a new Store instance using the provided sql instance.
-func New(db postgres.DB, clusterID string) FlowStore {
+func New(db postgres.DB, clusterID string, networktreeMgr networktree.Manager) FlowStore {
 	clusterUUID, err := uuid.FromString(clusterID)
 	if err != nil {
 		log.Errorf("cluster ID is not valid.  %v", err)
@@ -271,9 +274,10 @@ func New(db postgres.DB, clusterID string) FlowStore {
 	}
 
 	return &flowStoreImpl{
-		db:            db,
-		clusterID:     clusterUUID,
-		partitionName: partitionName,
+		db:             db,
+		clusterID:      clusterUUID,
+		partitionName:  partitionName,
+		networktreeMgr: networktreeMgr,
 	}
 }
 
@@ -409,6 +413,23 @@ func (s *flowStoreImpl) readRows(rows pgx.Rows, pred func(*storage.NetworkFlowPr
 
 	log.Debugf("Read returned %d flows", len(flows))
 	return flows, rows.Err()
+}
+
+func (s *flowStoreImpl) readIdFromRows(rows pgx.Rows) ([]string, error) {
+	var entityIds []string
+
+	for rows.Next() {
+		var id string
+
+		if err := rows.Scan(&id); err != nil {
+			return nil, pgutils.ErrNilIfNoRows(err)
+		}
+
+		entityIds = append(entityIds, id)
+	}
+
+	log.Debugf("Read returned %d entity IDs", len(entityIds))
+	return entityIds, rows.Err()
 }
 
 // RemoveFlowsForDeployment removes all flows where the source OR destination match the deployment id
@@ -789,8 +810,24 @@ func (s *flowStoreImpl) pruneEntities(ctx context.Context, deleteStmt string, en
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 
-	if _, err := conn.Exec(ctx, deleteStmt, entityIds); err != nil {
+	rows, err := conn.Query(ctx, deleteStmt, entityIds)
+	if err != nil {
 		return err
+	}
+
+	deletedIDs, err := s.readIdFromRows(rows)
+	if err != nil {
+		return err
+	}
+
+	// The networktree still has the pruned entities,
+	// so we need to propagate the removal.
+	// TODO: ROX-29450 will make this unnecessary
+	// and we can remove this logic.
+	if networktree := s.networktreeMgr.GetNetworkTree(ctx, s.clusterID.String()); networktree != nil {
+		for _, id := range deletedIDs {
+			networktree.Remove(id)
+		}
 	}
 
 	return nil
@@ -832,7 +869,7 @@ func Destroy(ctx context.Context, db postgres.DB) {
 }
 
 // CreateTableAndNewStore returns a new Store instance for testing
-func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB, clusterID string) FlowStore {
+func CreateTableAndNewStore(ctx context.Context, db postgres.DB, gormDB *gorm.DB, clusterID string, networktreeMgr networktree.Manager) FlowStore {
 	pkgSchema.ApplySchemaForTable(ctx, gormDB, networkFlowsTable)
-	return New(db, clusterID)
+	return New(db, clusterID, networktreeMgr)
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -127,7 +127,7 @@ const (
 		NOT EXISTS
 		(SELECT 1 FROM %s flow WHERE
 			flow.Props_DstEntity_Type = 4 AND flow.Props_DstEntity_Id = entity.Info_Id)
-			RETURNING entity.Info_Id;`
+		RETURNING entity.Info_Id;`
 )
 
 var (

--- a/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/tests/store_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	entityStore "github.com/stackrox/rox/central/networkgraph/entity/datastore"
+	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	postgresFlowStore "github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/networkgraph/testhelper"
 	"github.com/stackrox/rox/generated/storage"
@@ -50,12 +51,16 @@ func (s *NetworkflowStoreSuite) SetupSuite() {
 
 	source := pgtest.GetConnectionString(s.T())
 	s.gormDB = pgtest.OpenGormDB(s.T(), source)
+
+	entitiesByCluster := map[string][]*storage.NetworkEntityInfo{}
+	err := networktree.Singleton().Initialize(entitiesByCluster)
+	s.NoError(err)
 }
 
 func (s *NetworkflowStoreSuite) SetupTest() {
 	s.pgDB = pgtest.ForT(s.T())
 
-	s.flowStore = postgresFlowStore.CreateTableAndNewStore(s.ctx, s.pgDB.DB, s.gormDB, clusterID)
+	s.flowStore = postgresFlowStore.CreateTableAndNewStore(s.ctx, s.pgDB.DB, s.gormDB, clusterID, networktree.Singleton())
 	s.entityStore = entityStore.GetTestPostgresDataStore(s.T(), s.pgDB.DB)
 	s.entityStore.RegisterCluster(s.ctx, clusterID)
 }
@@ -73,7 +78,7 @@ func (s *NetworkflowStoreSuite) TearDownSuite() {
 
 func (s *NetworkflowStoreSuite) TestStore() {
 	secondCluster := fixtureconsts.Cluster2
-	store2 := postgresFlowStore.New(s.pgDB.DB, secondCluster)
+	store2 := postgresFlowStore.New(s.pgDB.DB, secondCluster, networktree.Singleton())
 
 	networkFlow := &storage.NetworkFlow{
 		Props: &storage.NetworkFlowProperties{
@@ -540,6 +545,12 @@ func (s *NetworkflowStoreSuite) TestRemoveDeplExternalEntitiesOrphaned() {
 	err = s.entityStore.UpdateExternalNetworkEntity(s.ctx, extEntity2, false)
 	s.Nil(err)
 
+	nt := networktree.Singleton().CreateNetworkTree(s.ctx, clusterID)
+	err = nt.Insert(extEntity1.Info)
+	s.Nil(err)
+	err = nt.Insert(extEntity2.Info)
+	s.Nil(err)
+
 	flows := []*storage.NetworkFlow{
 		{
 			Props: &storage.NetworkFlowProperties{
@@ -601,21 +612,29 @@ func (s *NetworkflowStoreSuite) TestRemoveDeplExternalEntitiesOrphaned() {
 	s.Nil(err)
 	s.Equal(2, count)
 
+	// entities initially in the networktree
+	s.NotNil(nt.Get(extEntity1.GetInfo().Id))
+	s.NotNil(nt.Get(extEntity2.GetInfo().Id))
+
 	// Delete deployment2
 	err = s.flowStore.RemoveFlowsForDeployment(s.ctx, fixtureconsts.Deployment2)
 	s.Nil(err)
 
-	// flows after pruning
+	// flows after pruning in the DB
 	row = s.pgDB.DB.QueryRow(s.ctx, flowsCountStmt)
 	err = row.Scan(&count)
 	s.Nil(err)
 	s.Equal(1, count)
 
-	// entities after pruning
+	// entities after pruning in the DB
 	row = s.pgDB.DB.QueryRow(s.ctx, entitiesCountStmt)
 	err = row.Scan(&count)
 	s.Nil(err)
 	s.Equal(1, count)
+
+	// entities after pruning in the networktree
+	s.NotNil(nt.Get(extEntity1.GetInfo().Id))
+	s.Nil(nt.Get(extEntity2.GetInfo().Id))
 }
 
 func deploymentIngressFlowsPredicate(props *storage.NetworkFlowProperties) bool {

--- a/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	"github.com/stackrox/rox/central/networkgraph/flow/datastore/internal/store"
 	"github.com/stackrox/rox/central/networkgraph/testhelper"
 	"github.com/stackrox/rox/generated/storage"
@@ -37,6 +38,11 @@ type FlowStoreTestSuite struct {
 // SetupSuite runs before any tests
 func (suite *FlowStoreTestSuite) SetupSuite() {
 	var err error
+
+	entitiesByCluster := map[string][]*storage.NetworkEntityInfo{}
+	err = networktree.Singleton().Initialize(entitiesByCluster)
+	suite.Require().NoError(err)
+
 	suite.tested, err = suite.store.CreateFlowStore(context.Background(), fixtureconsts.Cluster1)
 	suite.Require().NoError(err)
 }


### PR DESCRIPTION
### Description

This PR is a duplicate of https://github.com/stackrox/stackrox/pull/15445. The difference is that this is based on master, whereas the other PR is based on a another PR.

The "discovered" entities pruner is located in the FlowStore component to benefit from an interesting optimization : we use the result of the procedure deleting flows to get a list of the entities 'potentially' orphaned. The verification that an entity is no longer in use (orphaned) is then executed on a much smaller set.

Unfortunately, the EntityStore keeps a "in-memory" copy of all the entities : this is done by the Network-Trees.

The [initial implementation](https://github.com/stackrox/stackrox/pull/14769) of the discovered-entities pruner forgot to delete the entities in the Network-Trees after they are deleted from the database.

#### FIX

Ideally, we could prevent discovered-entities from being kept in memory and the problem just doesn't exists anymore. This is currently being attempted. (ref. https://issues.redhat.com/browse/ROX-29450)

As a short-term solution, we can retrieve the list of entities deleted when pruning and forward it to the Network-Trees component to remove them.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### Scalability

Removing elements from the networktree is a local task and has a low resource cost.

External entities are considered for removal in batches of 100; as a consequence, the number of actually deleted entities per iteration is at most 100. The computation time introduced by this PR is negligible in comparison with the database query time.

#### How I validated my change
