### PR TITLE
ROX-29569: CVE and component single pages should use same unique identifiers as their list pages

### DIFF
--- a/central/graphql/resolvers/image_vulnerabilities_v2_test.go
+++ b/central/graphql/resolvers/image_vulnerabilities_v2_test.go
@@ -360,9 +360,9 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityImages() {
 
 	images, err := vuln.Images(ctx, PaginatedQuery{})
 	s.NoError(err)
-	s.Equal(1, len(images))
+	s.Equal(2, len(images))
 	idList := getIDList(ctx, images)
-	s.ElementsMatch([]string{"sha1"}, idList)
+	s.ElementsMatch([]string{"sha1", "sha2"}, idList)
 
 	count, err := vuln.ImageCount(ctx, RawQuery{})
 	s.NoError(err)
@@ -388,9 +388,9 @@ func (s *GraphQLImageVulnerabilityV2TestSuite) TestImageVulnerabilityImageCompon
 
 	comps, err := vuln.ImageComponents(ctx, PaginatedQuery{})
 	s.NoError(err)
-	s.Equal(1, len(comps))
+	s.Equal(2, len(comps))
 	idList := getIDList(ctx, comps)
-	s.ElementsMatch([]string{s.componentIDMap[comp11]}, idList)
+	s.ElementsMatch([]string{s.componentIDMap[comp11], s.componentIDMap[comp21]}, idList)
 
 	count, err := vuln.ImageComponentCount(ctx, RawQuery{})
 	s.NoError(err)


### PR DESCRIPTION


### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In VM 1.0, CVE list page groups CVEV2 results by CVE names. In other words, the resolver produces one row for each CVE name and aggregates data from multiple CVEV2s in each group. So, CVE detail page (opened by clicking a single CVE) should also aggregate results from all CVEV2s matching that CVE name.

Similarly, component list page groups ComponentV2 results by component name + version + OS and aggregates the data in each group. So, component detail page should also aggregate data from all ComponentV2s matching the clicked component (name + version + OS).

### User-facing documentation

- [X] CHANGELOG update is not needed
- [X] documentation is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [X] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit and manual testing
