### PR TITLE
ROX-29596: Fix duplicate images returned when expanding CVEs with different severities in different images

### DIFF
--- a/central/views/images/view_impl.go
+++ b/central/views/images/view_impl.go
@@ -69,6 +69,9 @@ func withSelectQuery(query *v1.Query) *v1.Query {
 		Fields: []string{search.ImageSHA.String()},
 	}
 
+	// This is to minimize UI change and hide an implementation detail that the query groups images by their SHA.
+	// Because of this, for a field that is not in images table, there can be multiple values of that field per SHA.
+	// So in order to sort by that field, we need some kind of aggregate applied to it.
 	for _, sortOption := range cloned.GetPagination().GetSortOptions() {
 		if sortOption.Field == search.Severity.String() {
 			sortOption.Field = search.SeverityMax.String()
@@ -78,6 +81,11 @@ func withSelectQuery(query *v1.Query) *v1.Query {
 		}
 		if sortOption.Field == search.NVDCVSS.String() {
 			sortOption.Field = search.NVDCVSSMax.String()
+		}
+		if sortOption.Field == search.OperatingSystem.String() {
+			// Both 'Operating System' in CVE and 'Image OS' in an image containing that CVE have the same value.
+			// Don't need an aggregate here since 'Image OS' is in images schema
+			sortOption.Field = search.ImageOS.String()
 		}
 	}
 

--- a/central/views/images/view_impl.go
+++ b/central/views/images/view_impl.go
@@ -69,5 +69,17 @@ func withSelectQuery(query *v1.Query) *v1.Query {
 		Fields: []string{search.ImageSHA.String()},
 	}
 
+	for _, sortOption := range cloned.GetPagination().GetSortOptions() {
+		if sortOption.Field == search.Severity.String() {
+			sortOption.Field = search.SeverityMax.String()
+		}
+		if sortOption.Field == search.CVSS.String() {
+			sortOption.Field = search.CVSSMax.String()
+		}
+		if sortOption.Field == search.NVDCVSS.String() {
+			sortOption.Field = search.NVDCVSSMax.String()
+		}
+	}
+
 	return cloned
 }

--- a/central/views/images/view_impl.go
+++ b/central/views/images/view_impl.go
@@ -54,7 +54,7 @@ func (v *imageCoreViewImpl) Get(ctx context.Context, query *v1.Query) ([]ImageCo
 func withSelectQuery(query *v1.Query) *v1.Query {
 	cloned := query.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{
-		search.NewQuerySelect(search.ImageSHA).Distinct().Proto(),
+		search.NewQuerySelect(search.ImageSHA).Proto(),
 	}
 
 	if common.IsSortBySeverityCounts(cloned) {
@@ -64,6 +64,9 @@ func withSelectQuery(query *v1.Query) *v1.Query {
 		cloned.Selects = append(cloned.Selects,
 			common.WithCountBySeverityAndFixabilityQuery(query, search.CVE).Selects...,
 		)
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{search.ImageSHA.String()},
 	}
 
 	return cloned


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The image view chooses distinct image SHAs for a given query. However, if the sort option in the query is a field that is not part of image schema, it is added to the distinct clause by search framework. This could result in duplicate images being returned from the view.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [X] documentation is not needed

### Testing and quality

- [X] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual testing
