### PR TITLE
fix: Remove nested logger name

### DIFF
--- a/operator/internal/common/defaulting/secured_cluster_scanner_v4_enabling.go
+++ b/operator/internal/common/defaulting/secured_cluster_scanner_v4_enabling.go
@@ -22,7 +22,6 @@ var (
 func SecuredClusterScannerV4ComponentPolicy(logger logr.Logger, status *platform.SecuredClusterStatus, annotations map[string]string, spec *platform.LocalScannerV4ComponentSpec) (platform.LocalScannerV4ComponentPolicy, bool) {
 	defaultForUpgrades := platform.LocalScannerV4Disabled
 	defaultForNewInstallations := platform.LocalScannerV4AutoSense
-	logger = logger.WithName("scanner-v4-defaulting")
 
 	if spec != nil && spec.ScannerComponent != nil {
 		comp := *spec.ScannerComponent


### PR DESCRIPTION
### Description

Currently some of the log messages for the Scanner V4 defaulting look like this:

```
2025-06-03T09:21:37Z    INFO    controllers.SecuredCluster.extension-feature-defaults.defaulting-flow-scanner-V4.scanner-v4-defaulting   using componentPolicy set in CR {"componentPolicy": "Disabled"}
```

There is a superfluous level of nesting in the logger name. This PR removes the final nesting layer `scanner-v4-defaulting`, which doesn't add any value.


### User-facing documentation

No changes required.

### Testing and quality

Production ready.

#### Automated testing

No tests added or modified.

#### How I validated my change

Just CI.
