### PR TITLE
chore(ui): Remove initial telemetry page event, redact sidePanel

### DIFF
--- a/ui/apps/platform/src/global/initializeAnalytics.js
+++ b/ui/apps/platform/src/global/initializeAnalytics.js
@@ -80,7 +80,6 @@ export function initializeAnalytics(writeKey, proxyApiEndpoint, userId) {
             }
 
             analytics.load(writeKey, analyticsLoadConfig);
-            analytics.page();
             analytics.identify(userId);
         }
     }

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -506,7 +506,7 @@ function redactParsedQs(value: RawQueryStringValue, key: string): RawQueryString
 function redactSearchParams(location: string): string {
     // Top level URL parameters that can contain user or installation-specific information. Any
     // key that should have its value redacted should be added to this list.
-    const topLevelSearchKeys = ['s', 's2'];
+    const topLevelSearchKeys = ['s', 's2', 'sidePanel'];
 
     try {
         const url = new URL(location);


### PR DESCRIPTION
### Description

Goals:

1. Eliminate the initial `analytics.page()` event that bypassed our redaction logic when analytics is initialized
    - This was also causing duplicate `page` events on initial app load, since we already trigger our own `page` event when `Body` mounts
2. Ensure `sidePanel` query parameters are redacted since they may contain sensitive data



### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

**Duplicate Page Events (Before):**
When first visiting the app, both of the following `analytics.page()` events were triggered, one from the default segment snippet and one from our `Body` component:
![Screenshot 2025-06-03 at 11 56 03 AM](https://github.com/user-attachments/assets/baeed388-6a15-4e13-b93c-0ad279537256)
![Screenshot 2025-06-03 at 11 56 09 AM](https://github.com/user-attachments/assets/dbc6050d-f0d6-4da6-aff8-9c424997060e)
After Fix: Once the default `analytics.page()` call was removed, only our intended page event (2nd) is sent.

**Redacted `sidePanel`**
![Screenshot 2025-06-03 at 11 58 37 AM](https://github.com/user-attachments/assets/dbed4d90-e1d1-45ca-a690-2fe66daf4b9d)

