### PR TITLE
fix: change metadata log severity to debug

### DIFF
--- a/pkg/cloudproviders/aws/metadata.go
+++ b/pkg/cloudproviders/aws/metadata.go
@@ -30,14 +30,10 @@ const (
 	instanceTagsPath    = "/tags/instance"
 )
 
-var (
-	log = logging.LoggerForModule()
-
-	httpClient = &http.Client{
-		Timeout:   timeout,
-		Transport: proxy.Without(),
-	}
-)
+var httpClient = &http.Client{
+	Timeout:   timeout,
+	Transport: proxy.Without(),
+}
 
 // GetMetadata tries to obtain the AWS instance metadata.
 // If not on AWS, returns nil, nil.
@@ -52,7 +48,6 @@ func GetMetadata(ctx context.Context) (*storage.ProviderMetadata, error) {
 	verified := true
 	doc, err := signedIdentityDoc(ctx, mdClient)
 	if err != nil {
-		log.Warnf("Could not verify AWS public certificate: %v", err)
 		errs.AddError(err)
 		verified = false
 

--- a/pkg/providers/metadata.go
+++ b/pkg/providers/metadata.go
@@ -37,7 +37,7 @@ func GetMetadata(ctx context.Context) *storage.ProviderMetadata {
 	errors.AddWrap(err, "Azure")
 
 	if err := errors.ToError(); err != nil {
-		log.Warn(err.Error())
+		log.Debug(err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

ACS attempts to get metadata from cloud providers' internal metadata services. This is used to set metadata fields in the cluster status. These calls are expected to fail in various scenarios (access to internal metadata endpoint is blocked, unknown cloud provider, bare metal deployment, ...). Therefore, failing metadata calls do not necessarily indicate a problem.

Unfortunately we frequently see users getting confused by these logs (recent example is https://issues.redhat.com/browse/ROX-29550), which may provide a red herring during debugging. Hence, let's remove redundant logs and reduce severity to `debug`.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
