### PR TITLE
chore(ui): Disables Risk Priority test temporarily

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -33,7 +33,8 @@ describe('Vulnerability Management Image Components', () => {
         ]);
     });
 
-    it('should sort the Risk Priority column', () => {
+    // TODO - re-enable this test once the 4.8 release has been cut https://issues.redhat.com/browse/ROX-29614
+    it.skip('should sort the Risk Priority column', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("Risk Priority")';


### PR DESCRIPTION
### Description

Disables this frequently failing test due to a sorting regression to reduce noise signal during the 4.8 release and subsequent patch releases.

This will be re-enabled as a follow up once the release is cut. https://issues.redhat.com/browse/ROX-29614

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Self-evident.