### PR TITLE
ROX-29602: Use updated `determine-image-tag` task

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -212,8 +212,6 @@ spec:
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
     taskRef:
       params:
       - name: name

--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
         - name: kind
           value: task
       resolver: bundles
@@ -201,7 +201,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -217,7 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -212,8 +212,6 @@ spec:
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
     taskRef:
       params:
       - name: name

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
         - name: kind
           value: task
       resolver: bundles
@@ -201,7 +201,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -217,7 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -237,7 +237,7 @@ spec:
       - name: name
         value: fetch-external-networks
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
         - name: kind
           value: task
       resolver: bundles
@@ -303,7 +303,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -319,7 +319,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -356,7 +356,7 @@ spec:
       - name: name
         value: wait-for-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -827,7 +827,7 @@ spec:
       - name: name
         value: create-snapshot
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -314,8 +314,6 @@ spec:
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
     taskRef:
       params:
       - name: name

--- a/.tekton/retag-pipeline.yaml
+++ b/.tekton/retag-pipeline.yaml
@@ -131,8 +131,6 @@ spec:
       value: $(params.image-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
     taskRef:
       params:
       - name: name

--- a/.tekton/retag-pipeline.yaml
+++ b/.tekton/retag-pipeline.yaml
@@ -35,7 +35,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
         - name: kind
           value: task
       resolver: bundles
@@ -136,7 +136,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -154,7 +154,7 @@ spec:
         - name: name
           value: determine-dependency-image-tag
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
         - name: kind
           value: task
       resolver: bundles
@@ -174,7 +174,7 @@ spec:
       - name: name
         value: retag-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -212,8 +212,6 @@ spec:
       value: $(params.output-tag-suffix)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: SOURCE_BRANCH
-      value: '{{source_branch}}'
     taskRef:
       params:
       - name: name

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
         - name: name
           value: post-bigquery-metrics
         - name: bundle
-          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+          value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
         - name: kind
           value: task
       resolver: bundles
@@ -201,7 +201,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -217,7 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -237,7 +237,7 @@ spec:
       - name: name
         value: fetch-scanner-v4-vuln-mappings
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:a430d9d1be902a11cb55e25db21570da8922887bda1b9cb10c7d986166d57961
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
### Description

From https://github.com/stackrox/konflux-tasks/pull/66.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

No change.

#### How I validated my change

Only CI here.