### PR TITLE
chore(CI): build binaries at once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,10 +485,16 @@ main-build-dockerized: build-volumes
 	docker run $(DOCKER_OPTS) -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make main-build-nodeps
 
 .PHONY: main-build-nodeps
-main-build-nodeps: central-build-nodeps migrator-build-nodeps config-controller-build-nodeps
-	$(GOBUILD) sensor/kubernetes sensor/admission-control compliance/cmd/compliance
-	$(GOBUILD) sensor/upgrader
-	$(GOBUILD) sensor/init-tls-certs
+main-build-nodeps:
+	$(GOBUILD) \
+ 		central \
+ 		compliance/cmd/compliance \
+ 		config-controller \
+ 		migrator \
+ 		sensor/admission-control \
+ 		sensor/init-tls-certs \
+ 		sensor/kubernetes \
+ 		sensor/upgrader
 ifndef CI
 	CGO_ENABLED=0 $(GOBUILD) roxctl
 endif

--- a/scripts/go-tool.sh
+++ b/scripts/go-tool.sh
@@ -76,19 +76,19 @@ function go_build() (
   [[ -n "$GOOS" ]] || die "GOOS must be set"
   [[ -n "$GOARCH" ]] || die "GOARCH must be set"
 
+  dirs=()
   for main_srcdir in "$@"; do
-    if ! [[ "${main_srcdir}" =~ ^\.?/ ]]; then
-      main_srcdir="./${main_srcdir}"
+    if ! [[ "$main_srcdir" =~ ^\.?/ ]]; then
+      main_srcdir="./$main_srcdir"
     fi
-    bin_name="$(basename "$main_srcdir")"
-    output_file="bin/${GOOS}_${GOARCH}/${bin_name}"
-    if [[ "$GOOS" == "windows" ]]; then
-      output_file="${output_file}.exe"
-    fi
-    mkdir -p "$(dirname "$output_file")"
-    echo >&2 "Compiling Go source in ${main_srcdir} to ${output_file}"
-    invoke_go_build -o "$output_file" "$main_srcdir"
+    dirs+=("$main_srcdir")
   done
+
+  output="bin/${GOOS}_${GOARCH}"
+  mkdir -p "$output"
+
+  echo >&2 "Compiling Go source in ${dirs[@]} to ${output}"
+  invoke_go_build -o "$output" ${dirs[@]}
 )
 
 function go_build_file() {


### PR DESCRIPTION
### Description

This PR changes `main-build-nodeps` and go build script to build binaries in a single call instead of building them one by one. This speeds up the build process.

See:
- https://blog.howardjohn.info/posts/go-build-times/#building-multiple-binaries
- https://github.com/ko-build/ko/issues/314
- https://github.com/orgs/goreleaser/discussions/4886
