### PR TITLE
ROX-29631: Remove ROX_PLATFORM_CVE_SPLIT from cypress tests

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -1,4 +1,3 @@
-import { hasFeatureFlag } from '../../helpers/features';
 import withAuth from '../../helpers/basicAuth';
 import {
     assertSortedItems,
@@ -144,11 +143,7 @@ describe('Risk', () => {
             clickTab('Deployment Details');
             cy.get(RiskPageSelectors.imageLink).first().click();
 
-            const expectedPath = hasFeatureFlag('ROX_PLATFORM_CVE_SPLIT')
-                ? '/main/vulnerabilities/platform/image'
-                : '/main/vulnerabilities/workload-cves/image';
-
-            cy.location('pathname').should('contain', expectedPath);
+            cy.location('pathname').should('contain', '/main/vulnerabilities/platform/image');
         });
     });
 

--- a/ui/apps/platform/cypress/integration/violations/filteredWorkflowViews.test.ts
+++ b/ui/apps/platform/cypress/integration/violations/filteredWorkflowViews.test.ts
@@ -1,18 +1,8 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import { selectFilteredWorkflowView, visitViolations } from './Violations.helpers';
 
 describe('Violations - Filtered Workflow Views', () => {
     withAuth();
-
-    before(function () {
-        if (
-            !hasFeatureFlag('ROX_PLATFORM_COMPONENTS') ||
-            !hasFeatureFlag('ROX_PLATFORM_CVE_SPLIT')
-        ) {
-            this.skip();
-        }
-    });
 
     it('should filter the violations table when the "Applications view" is selected', () => {
         visitViolations();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -1,5 +1,4 @@
 import { addDays, format } from 'date-fns';
-import { hasFeatureFlag } from '../../../helpers/features';
 import { getDescriptionListGroup } from '../../../helpers/formHelpers';
 import {
     interactAndWaitForResponses,
@@ -25,15 +24,10 @@ export function getFutureDateByDays(days) {
 export function visitWorkloadCveOverview({ clearFiltersOnVisit = true, urlSearch = '' } = {}) {
     // With Workload CVEs split between User and Platform components, we can only reliably expect
     // CVEs to be present for the built-in (Platform) components during CI
-    const basePath = hasFeatureFlag('ROX_PLATFORM_CVE_SPLIT')
-        ? '/main/vulnerabilities/platform/'
-        : '/main/vulnerabilities/workload-cves/';
+    const basePath = '/main/vulnerabilities/platform/';
     visit(basePath + urlSearch);
 
-    const pageTitle = hasFeatureFlag('ROX_PLATFORM_CVE_SPLIT')
-        ? 'Platform vulnerabilities'
-        : 'Workload CVEs';
-    cy.get(`h1:contains("${pageTitle}")`);
+    cy.get(`h1:contains("Platform vulnerabilities")`);
     cy.location('pathname').should('eq', basePath);
 
     // Wait for the initial table load to begin and complete

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -1,4 +1,3 @@
-import { hasFeatureFlag } from '../../../helpers/features';
 import withAuth from '../../../helpers/basicAuth';
 
 import {
@@ -24,10 +23,7 @@ describe('Workload CVE Namespace View', () => {
 
             cy.wrap($row.find('td[data-label="Deployments"] a')).click();
 
-            const pageTitle = hasFeatureFlag('ROX_PLATFORM_CVE_SPLIT')
-                ? 'Platform vulnerabilities'
-                : 'Workload CVEs';
-            cy.get(`h1:contains("${pageTitle}")`);
+            cy.get(`h1:contains("Platform vulnerabilities")`);
 
             cy.get(selectors.filterChipGroupItem('Namespace', `^${namespace}$`));
             cy.get(selectors.filterChipGroupItem('Cluster', `^${cluster}$`));

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -95,11 +95,7 @@ describe('Workload CVE overview page tests', () => {
         });
     });
 
-    it('should apply the correct baseline filters when switching between built in views using the user-workload based template', function () {
-        if (!hasFeatureFlag('ROX_PLATFORM_CVE_SPLIT')) {
-            this.skip();
-        }
-
+    it('should apply the correct baseline filters when switching between built in views using the user-workload based template', () => {
         interceptAndWatchRequests(
             getRouteMatcherMapForGraphQL(['getImageCVEList', 'getImageList'])
         ).then(({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
@@ -228,11 +224,7 @@ describe('Workload CVE overview page tests', () => {
     });
 
     describe('Images without CVEs view tests', () => {
-        it('should remove cve-related UI elements when viewing the "without cves" view', function () {
-            if (!hasFeatureFlag('ROX_PLATFORM_CVE_SPLIT')) {
-                this.skip();
-            }
-
+        it('should remove cve-related UI elements when viewing the "without cves" view', () => {
             visitWorkloadCveOverview();
 
             const cvesBySeverityHeader = 'th:contains("CVEs by severity")';


### PR DESCRIPTION
### Description

### Problem

Local cypress testing requires `export CYPRESS_ROX_WHATEVER=true` even after enabled

### Analysis

* `ROX_PLATFORM_CVE_SPLIT` enabled on 2025-02-06 in #14133
* `ROX_PLATFORM_COMPONENTS` enabled on 2024-10-22 #13090

### Solution

1. Delete conditional assertions and skip.

### Residue

1. Add lint rule to report `function` (versus arrow function) as error after we delete `this.skip` to prevent inconsistency.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [x] updated e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI