### PR TITLE
ROX-29634: disable scannerV2 NodeInventory test

### DIFF
--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Tag
 // skip if executed in a test environment with just secured-cluster deployed in the test cluster
 // i.e. central is deployed elsewhere
 @IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
-@IgnoreIf({ true })  // legacy: scanner-v2 test failing with rhcos layers change
+@IgnoreIf({ true })  // ROX-29634: address legacy scanner-v2 test failing with rhcos layers change
 @Tag("PZ")
 class NodeInventoryTest extends BaseSpecification {
     @Shared


### PR DESCRIPTION
Disabling test because it is using legacy scanner-v2 node scanning and fails on ocp4.19 (fails with new coreos node base images).

example failure in ocp-next-candidate-qa-e2e (https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/14774/pull-ci-stackrox-stackrox-master-ocp-next-candidate-qa-e2e-tests/1929962151737298944):
```
node.getScan().getComponentsList().size() >= 4
|    |         |                   |      |
|    |         []                  0      false
|    io.stackrox.proto.storage.NodeOuterClass.NodeScan@7913d38f
id: "67b4cc3d-2c75-4ba7-b78b-f6402575914b"
name: "rox-ci-37298944-67z5w-worker-b-wzxv6"
cluster_id: "b4521497-d7a3-4eb6-8f32-00027c7c1e61"
cluster_name: "remote"
...
labels {
  key: "node.openshift.io/os_id"
  value: "rhel"
}
```
node-inventory log:
```
{"Event":"Running Scanner version 2.36.x-77-gbbd29cb742-dirty in Node Inventory mode","Level":"info","Location":"main.go:279","Time":"2025-06-03 20:50:13.425441"}
{"Event":"Launching backend GRPC listener on 127.0.0.1:8444","Level":"info","Location":"grpc.go:56","Time":"2025-06-03 20:50:13.426143"}
{"Event":"Unable to start node scanning for this namespace","Level":"warning","Location":"detection.go:49","Time":"2025-06-03 20:50:29.676477","detected namespace":"rhel:9","layer":"rox-ci-37298944-67z5w-worker-b-wzxv6"}
{"Event":"Error scanning node /host inventory: Node scanning is unsupported for this node","Level":"error","Location":"inventorizer.go:58","Time":"2025-06-03 20:50:29.676694"}
{"Event":"error analyzing node \"rox-ci-37298944-67z5w-worker-b-wzxv6\": Node scanning is unsupported for this node","Level":"error","Location":"service.go:49","Time":"2025-06-03 20:50:29.676745"}
```
