### PR TITLE
ROX-29641: Fix k6 tests

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -120,6 +120,9 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
         run: |
           source ./workflow/env.sh
+
+          # ROX-29641: We are facing issues with workload generation on GKE when Scanner v4 is enabled.
+          export ROX_SCANNER_V4=false
           ./scale/dev/launch_central.sh
 
           # Required for k6 tests to run.

--- a/scale/dev/launch_sensor.sh
+++ b/scale/dev/launch_sensor.sh
@@ -38,4 +38,4 @@ if [[ $(kubectl get nodes -o json | jq '.items | length') == 1 ]]; then
   exit 0
 fi
 
-kubectl -n "${namespace}" patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","resources":{"requests":{"memory":"8Gi","cpu":"4"},"limits":{"memory":"20Gi","cpu":"8"}}}]}}}}'
+kubectl -n "${namespace}" patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","resources":{"requests":{"memory":"20Gi","cpu":"4"},"limits":{"memory":"20Gi","cpu":"8"}}}]}}}}'


### PR DESCRIPTION
### Description

Initial investigation showed that sensors were properly scheduled and working, but after some additional testing, it turned out that this is not true. It appears that the sensors are not running, which is why the workload is not being created.

**Further findings**

It looks like the specific node becomes unstable, and sensors scheduled on that node never reach the `running` state. It's not clear what causes node instability. After additional testing, the most stable solution option is to deploy central without scanner V4 and set sensor memory request higher.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no changes on test

#### How I validated my change

- [x] tested locally (partially true, because I had problems with a cluster)
- [x] test in CI pipeline - a few executions: https://github.com/stackrox/stackrox/actions/workflows/performance-tests.yml?query=is%3Asuccess
