### PR TITLE
ROX-27696: Enable external-IPs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Scanner V4 claims the images contain vulnerabilities which the official Red Hat 
 - ROX-25570: The data model for image based CVEs has been denormalized
   - This will result in far more consistent results as 1 image scan will no longer overwrite CVE data of a previous image scan.
   - `ROX_FLATTEN_CVE_DATA` can be set to false to use the old normalized data model
+- ROX-27696: ROX_EXTERNAL_IPS feature flag enabled by default. Note: Collector will still need to be configured for external IPs for this to have an effect.
 
 ### Removed Features
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -96,10 +96,10 @@ var (
 	SensorPullSecretsByName = registerFeature("Sensor will capture pull secrets by name and registry host instead of just registry host", "ROX_SENSOR_PULL_SECRETS_BY_NAME", enabled)
 
 	// ExternalIPs enables storing detailed discovered external IPs
-	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS")
+	ExternalIPs = registerFeature("Central will work with discovered external IPs", "ROX_EXTERNAL_IPS", enabled)
 
 	// NetworkGraphExternalIPs enables displaying external IPs in the network graph
-	NetworkGraphExternalIPs = registerFeature("Display external ips in the UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
+	NetworkGraphExternalIPs = registerFeature("Display external ips in the UI", "ROX_NETWORK_GRAPH_EXTERNAL_IPS", enabled)
 
 	// Display RHSA/RHBA/RHEA advisory separately from associated CVE.
 	CVEAdvisorySeparation = registerFeature("Display RHSA/RHBA/RHEA advisory separately from associated CVE", "ROX_CVE_ADVISORY_SEPARATION", enabled)


### PR DESCRIPTION
### Description

We want external-IPs to be as seamless as possible and turning it on by default contributes to this.

The feature still requires that external-IPs is enabled for each cluster, which should prevent scaling issues after upgrade.

The feature-flag was already being enabled in tests, so the coverage is already there.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed
