### PR TITLE
fix(ui): Remove 'Inactive Deployment' filter from VM pages

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,6 +1,6 @@
 import { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
 import { clusterAttributes } from 'Components/CompoundSearchFilter/attributes/cluster';
-import { deploymentAttributes } from 'Components/CompoundSearchFilter/attributes/deployment';
+import { Annotation, ID, Label, Name } from 'Components/CompoundSearchFilter/attributes/deployment';
 import { imageAttributes } from 'Components/CompoundSearchFilter/attributes/image';
 import { imageCVEAttributes } from 'Components/CompoundSearchFilter/attributes/imageCVE';
 import { imageComponentAttributes } from 'Components/CompoundSearchFilter/attributes/imageComponent';
@@ -71,7 +71,7 @@ export function convertToFlatImageComponentSearchFilterConfig(
 export const deploymentSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Deployment',
     searchCategory: 'DEPLOYMENTS',
-    attributes: deploymentAttributes,
+    attributes: [ID, Name, Label, Annotation],
 };
 
 export const namespaceSearchFilterConfig: CompoundSearchFilterEntity = {


### PR DESCRIPTION
### Description

Deployment:Status (Active/Inactive) was an available search filter in VM pages, but is not relevant to VM entities. This filters is used specifically for filtering on Policy Violations.

This filter likely came along for the ride when it was added to the global deployment filters for work on the Violations page. 

Does it make more sense to include all filters per-category on pages, or explicitly opt-in to every filter as it is added? I am leaning towards the latter, as the worst case there is we miss a new filter, which should be caught with manual testing. In the former case, we risk unintentionally adding a new filter to sections that appears broken.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Check that the "Status" filter no longer exists in VM:
![image](https://github.com/user-attachments/assets/954454c7-fd4d-491a-a40e-eeedd0087f56)

