### PR TITLE
chore(ci): preamble free only to target free space

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -15,7 +15,7 @@ runs:
       id: disk-check
       shell: bash
       run: |
-        df --si /
+        df --si
         free=$(df -BGB --output=avail / | tail -1)
         echo "free=${free}" | tee -a "$GITHUB_OUTPUT"
 
@@ -61,8 +61,8 @@ runs:
         done
         df --si /
         free=$(df -BGB --output=avail / | tail -1)
-        if [[ ${free%GB} -ge "${{ inputs.free-disk-space }}" ]]; then
-          printf "For container workflows, please mount the host /usr and /opt to allow deleting unused tools:\n.volumes:\n\t- /usr:/mnt/usr\n\t- /opt:/mnt/opt"
+        if [[ ${free%GB} -lt "${{ inputs.free-disk-space }}" ]]; then
+          printf "For container workflows, please mount the host /usr and /opt to allow deleting unused tools:\nvolumes:\n\t- /usr:/mnt/usr\n\t- /opt:/mnt/opt"
           exit 1
         fi
 


### PR DESCRIPTION
Many workflows do not require more free space but deleting the un-used installed files can take minutes:
```
Thu, 05 Jun 2025 20:43:40 GMT
Filesystem      Size  Used Avail Use% Mounted on
Thu, 05 Jun 2025 20:43:40 GMT
overlay          77G   55G   23G  72% /
Thu, 05 Jun 2025 20:43:40 GMT
Run set +e
Thu, 05 Jun 2025 20:43:40 GMT
+ cleanup=(/usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Ruby)
Thu, 05 Jun 2025 20:43:40 GMT
+ for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:43:40 GMT
+ [[ -d /mnt/usr/share/dotnet ]]
Thu, 05 Jun 2025 20:43:40 GMT
+ [[ -d /usr/share/dotnet ]]
Thu, 05 Jun 2025 20:43:40 GMT
+ for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:43:40 GMT
+ [[ -d /mnt/usr/local/lib/android ]]
Thu, 05 Jun 2025 20:43:40 GMT
+ rm -rf /mnt/usr/local/lib/android
Thu, 05 Jun 2025 20:45:22 GMT
+ for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:45:22 GMT
+ [[ -d /mnt/opt/ghc ]]
Thu, 05 Jun 2025 20:45:22 GMT
+ [[ -d /opt/ghc ]]
Thu, 05 Jun 2025 20:45:22 GMT
+ for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:45:22 GMT
+ [[ -d /mnt/opt/hostedtoolcache/CodeQL ]]
Thu, 05 Jun 2025 20:45:22 GMT
+ rm -rf /mnt/opt/hostedtoolcache/CodeQL
Thu, 05 Jun 2025 20:45:24 GMT
+ for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:45:24 GMT
+ [[ -d /mnt/opt/hostedtoolcache/Ruby ]]
Thu, 05 Jun 2025 20:45:24 GMT
+ rm -rf /mnt/opt/hostedtoolcache/Ruby
Thu, 05 Jun 2025 20:45:24 GMT
+ df --si /
Thu, 05 Jun 2025 20:45:24 GMT
Filesystem      Size  Used Avail Use% Mounted on
Thu, 05 Jun 2025 20:45:24 GMT
overlay          77G   40G   37G  52% /
```

Note (future):
Sometimes, there is a filesystem available at /mnt on the runner that has ~70GB free disk space. If we run out of free-able space on the root, then we may be able to use this disk:
Example (https://github.com/stackrox/stackrox/actions/runs/15542117095/job/43755117624?pr=15631#step:3:30):
```
$ df --si
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        77G   51G   27G  67% /
tmpfs           8.4G   87k  8.4G   1% /dev/shm
tmpfs           3.4G  1.2M  3.4G   1% /run
tmpfs           5.3M     0  5.3M   0% /run/lock
/dev/sdb16      924M   63M  797M   8% /boot
/dev/sdb15      110M  6.4M  103M   6% /boot/efi
/dev/sda1        79G  4.3G   71G   6% /mnt
tmpfs           1.7G   13k  1.7G   1% /run/user/1001
free= 27GB
```