### PR TITLE
chore(ci): cancel ci if new commits

### DIFF
--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -13,7 +13,7 @@ on:
     - synchronize
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -15,7 +15,7 @@ env:
   ROX_PRODUCT_BRANDING: RHACS_BRANDING
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,7 +13,7 @@ on:
     - synchronize
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Let's cancel running test jobs when new commits are pushed to a branch (exclude master and release-* branches where we want to build and test every commit).

why?
* We already do this by default for e2e tests (default behavior in prow).
* ~Do we ever use the built+pushed images for old commits? (this can reduce the wasted github-actions time, and registry tags/space)~
    * There is a use case for building a series of commits from a single push for dev comparison testing.
* Do we need to see the results of tests for old commits? (if so, can we just cancel running builds for outdated commits?)
* I think we can optimize our GHA usage (more than 4million minutes in 90 days, and 2+ million are on the unit tests):
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/ef1f5263-24b8-4909-adff-41c5c4cc93a2" />

Tested on test-gh-actions repo with release-* branch and unittests triggers: https://github.com/stackrox/test-gh-actions/commits/refs/tags/release-test-concurrency/