### PR TITLE
chore(ci): in gha, [preamble] free only to target free space

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -15,8 +15,8 @@ runs:
       uses: 'google-github-actions/setup-gcloud@v2'
 
     - name: Shim gsutil as gcloud storage
-      shell: bash
       continue-on-error: true
+      shell: bash
       run: |
         tee -a ~/.boto <<EOF
         [GSUtil]
@@ -25,6 +25,7 @@ runs:
         gsutil version -l
 
     - name: Recover docker image cache space
+      shell: bash
       run: |
         df --si /
         printf 'Docker prune: '


### PR DESCRIPTION
Many workflows do not require more free space but deleting the un-used installed files can take minutes:
```
Thu, 05 Jun 2025 20:43:40 GMT Filesystem      Size  Used Avail Use% Mounted on
Thu, 05 Jun 2025 20:43:40 GMT overlay          77G   55G   23G  72% /
Thu, 05 Jun 2025 20:43:40 GMT Run set +e
Thu, 05 Jun 2025 20:43:40 GMT + cleanup=(/usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Ruby)
...
Thu, 05 Jun 2025 20:43:40 GMT + rm -rf /mnt/usr/local/lib/android
Thu, 05 Jun 2025 20:45:22 GMT + for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:45:22 GMT + [[ -d /mnt/opt/ghc ]]
Thu, 05 Jun 2025 20:45:22 GMT + [[ -d /opt/ghc ]]
Thu, 05 Jun 2025 20:45:22 GMT + for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:45:22 GMT + [[ -d /mnt/opt/hostedtoolcache/CodeQL ]]
Thu, 05 Jun 2025 20:45:22 GMT + rm -rf /mnt/opt/hostedtoolcache/CodeQL
Thu, 05 Jun 2025 20:45:24 GMT + for d in "${cleanup[@]}"
Thu, 05 Jun 2025 20:45:24 GMT + [[ -d /mnt/opt/hostedtoolcache/Ruby ]]
Thu, 05 Jun 2025 20:45:24 GMT + rm -rf /mnt/opt/hostedtoolcache/Ruby
Thu, 05 Jun 2025 20:45:24 GMT + df --si /
Thu, 05 Jun 2025 20:45:24 GMT Filesystem      Size  Used Avail Use% Mounted on
Thu, 05 Jun 2025 20:45:24 GMT overlay          77G   40G   37G  52% /
```

Default target of 22GB free because this covers our highest current need and is fast to reach (usually already reached, or few deletes needed):

unit-tests(go release) require >22GB, [example](https://github.com/stackrox/stackrox/actions/runs/15544313103/job/43762262260?pr=15636#step:6:35141):
```
/dev/root        77G   56G   22G  73% /__w
...
coverage: 50.0% of statements
ok  	github.com/stackrox/rox/sensor/kubernetes/enforcer/common	1.572s	coverage: 50.0% of statements
# github.com/stackrox/rox/sensor/kubernetes/fake.test
Error: /local/go/pkg/tool/linux_am2025-06-09T21:18:32.4589951Z ##[error]No space left on device : '/home/runner/runners/2.325.0/_diag/blocks/dae3505b-97f7-434a-b9d3-1f965979682d_96feb01b-a7b9-4300-92c9-3837fc133e5f.3'
```

build(build-and-push-operator) requires >21GB, [example](https://github.com/stackrox/stackrox/actions/runs/15544796863/job/43763846064?pr=15636):
```
/dev/root        77G   57G   21G  74% /__e
...
#12 [builder 13/13] RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) scripts/go-build-file.sh operator/cmd/main.go stackrox-operator
#12 sha256:9f135400a0a651bb6fa6031f0fe7387d51f1893ef85eae245d3a6bfa68dfa0f7
#12 107.0 # github.com/antlr4-go/antlr/v4
#12 107.0 compile: writing output: write $WORK/b1690/_pkg_.a: no space left on device
#12 107.0 k8s.io/kube-openapi/pkg/validation/strfmt/bson: mkdir /tmp/go-build4090117955/b1711/: no space left on device
):
```

and build-and-push-main, push-main-manifests require >20GB

Note (future):
Sometimes, there is a filesystem available at /mnt on the runner that has ~70GB free disk space. If we run out of free-able space on the root, then we may be able to use this disk:
Example (https://github.com/stackrox/stackrox/actions/runs/15542117095/job/43755117624?pr=15631#step:3:30):
```
$ df --si
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        77G   51G   27G  67% /
tmpfs           8.4G   87k  8.4G   1% /dev/shm
tmpfs           3.4G  1.2M  3.4G   1% /run
tmpfs           5.3M     0  5.3M   0% /run/lock
/dev/sdb16      924M   63M  797M   8% /boot
/dev/sdb15      110M  6.4M  103M   6% /boot/efi
/dev/sda1        79G  4.3G   71G   6% /mnt
tmpfs           1.7G   13k  1.7G   1% /run/user/1001
free= 27GB
```