### PR TITLE
ROX-29675: Don't fail scanner-v4-install-tests if log collection fails

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -338,9 +338,9 @@ apply_crd_ownership_for_upgrade() {
 
 describe_pods_in_namespace() {
     local namespace="$1"
-    info "==============================="
-    info "Pods in namespace ${namespace}:"
-    info "==============================="
+    echo "==============================="
+    echo "Pods in namespace ${namespace}:"
+    echo "==============================="
     "${ORCH_CMD}" </dev/null -n "${namespace}" get pods || true
     echo
     "${ORCH_CMD}" </dev/null -n "${namespace}" get pods -o name | while read -r pod_name; do
@@ -352,12 +352,13 @@ describe_pods_in_namespace() {
       echo
     done
 }
+export -f describe_pods_in_namespace
 
 describe_deployments_in_namespace() {
     local namespace="$1"
-    info "====================================="
-    info "Deployments in namespace ${namespace}:"
-    info "====================================="
+    echo "====================================="
+    echo "Deployments in namespace ${namespace}:"
+    echo "====================================="
     "${ORCH_CMD}" </dev/null -n "${namespace}" get deployments || true
     echo
     "${ORCH_CMD}" </dev/null -n "${namespace}" get deployments -o name | while read -r name; do
@@ -365,6 +366,7 @@ describe_deployments_in_namespace() {
       "${ORCH_CMD}" </dev/null -n "${namespace}" describe "${name}" || true
     done
 }
+export -f describe_deployments_in_namespace
 
 teardown() {
     _begin "post-test-tear-down"
@@ -399,7 +401,7 @@ teardown() {
     fi
 
     # Execute this on a best-effort basis, as it sometimes encounters long delays for whatever reason.
-    timeout "$COLLECT_ANALYSIS_MAX_DURATION" bash -c "collect_analysis_data '$central_namespace' '$sensor_namespace'" || {
+    timeout "$COLLECT_ANALYSIS_MAX_DURATION" bash -c "set -euo pipefail; collect_analysis_data '$central_namespace' '$sensor_namespace'" || {
         echo "ERROR: Collecting analysis data during teardown did not finish in time."
         echo "NOTE: This failure will be ignored to not cause a test failure."
         true # Explicit.


### PR DESCRIPTION
### Description

Test failure which is caused by apparently hanging service log collection:
https://storage.googleapis.com/test-platform-results/logs/branch-ci-stackrox-stackrox-master-ocp-4-12-merge-scanner-v4-install-tests/1932054900649234432/build-log.txt

Excerpt:
```
INFO: Mon Jun  9 14:16:52 UTC 2025: [post-test-tear-down] Mon Jun  9 14:16:52 UTC 2025: >>> Collecting securedclusters from namespace stackrox-sensor <<<
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] Mon Jun  9 14:16:53 UTC 2025: Cannot get securedclusters in stackrox-sensor: error: the server doesn't have a resource type "securedclusters"
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] Mon Jun  9 14:16:53 UTC 2025: >>> Collecting nodes from namespace stackrox-sensor <<<
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] NAME                                                           STATUS   ROLES                  AGE   VERSION            INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                        KERNEL-VERSION                  CONTAINER-RUNTIME
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] rox-ci-49234432-92swz-master-0.c.acs-san-stackroxci.internal   Ready    control-plane,master   41m   v1.25.16+1eb8682   10.0.0.3      <none>        Red Hat Enterprise Linux CoreOS 412.86.202412201644-0 (Ootpa)   4.18.0-372.134.1.el8_6.x86_64   cri-o://1.25.5-30.rhaos4.12.git53dc492.el8
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] rox-ci-49234432-92swz-master-1.c.acs-san-stackroxci.internal   Ready    control-plane,master   41m   v1.25.16+1eb8682   10.0.0.5      <none>        Red Hat Enterprise Linux CoreOS 412.86.202412201644-0 (Ootpa)   4.18.0-372.134.1.el8_6.x86_64   cri-o://1.25.5-30.rhaos4.12.git53dc492.el8
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] rox-ci-49234432-92swz-master-2.c.acs-san-stackroxci.internal   Ready    control-plane,master   42m   v1.25.16+1eb8682   10.0.0.4      <none>        Red Hat Enterprise Linux CoreOS 412.86.202412201644-0 (Ootpa)   4.18.0-372.134.1.el8_6.x86_64   cri-o://1.25.5-30.rhaos4.12.git53dc492.el8
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] rox-ci-49234432-92swz-worker-a-2b4rj                           Ready    worker                 31m   v1.25.16+1eb8682   10.0.128.2    <none>        Red Hat Enterprise Linux CoreOS 412.86.202412201644-0 (Ootpa)   4.18.0-372.134.1.el8_6.x86_64   cri-o://1.25.5-30.rhaos4.12.git53dc492.el8
INFO: Mon Jun  9 14:16:53 UTC 2025: [post-test-tear-down] rox-ci-49234432-92swz-worker-b-nm9w7                           Ready    worker                 31m   v1.25.16+1eb8682   10.0.128.3    <none>        Red Hat Enterprise Linux CoreOS 412.86.202412201644-0 (Ootpa)   4.18.0-372.134.1.el8_6.x86_64   cri-o://1.25.5-30.rhaos4.12.git53dc492.el8
not ok 1 Upgrade from old Helm chart to HEAD Helm chart with Scanner v4 enabled # in 2600005 ms # timeout after 1800 s
[...]
```

Let's make it so that failures during service log collection are not treated as test failures.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
