### PR TITLE
chore(ui): Refactor VM report forms to use a shared wizard

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
@@ -108,7 +108,7 @@ describe('Vulnerability Reporting form', () => {
     });
 
     it('creates a report configuration via the wizard', () => {
-        const expectedReportParameters = [
+        const expectedReportParameters: [string, string][] = [
             ['Report name', testReportName],
             ['Report description', ''],
             ['CVE severity', 'Critical'],

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -11,8 +11,6 @@ import {
     Bullseye,
     Spinner,
 } from '@patternfly/react-core';
-import { Wizard } from '@patternfly/react-core/deprecated';
-import isEmpty from 'lodash/isEmpty';
 
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import useReportFormValues from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
@@ -21,13 +19,10 @@ import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm';
-import DeliveryDestinationsForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm';
-import ReportReviewForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm';
 import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
 import { getReportFormValuesFromConfiguration } from '../utils';
 import ReportFormErrorAlert from './ReportFormErrorAlert';
-import ReportFormWizardFooter from './ReportFormWizardFooter';
+import ReportFormWizard from './ReportFormWizard';
 
 const wizardStepNames = [
     'Configure report parameters',
@@ -61,52 +56,11 @@ function CloneVulnReportPage() {
             reportFormValues.reportParameters.reportName = `${reportFormValues.reportParameters.reportName} (copy)`;
             formik.setValues(reportFormValues);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [reportConfiguration, formik.setValues]);
 
     function onCreate() {
         createReport(formik.values);
     }
-
-    // @TODO: This is reused in the Edit and Clone components so we can try to refactor this soon
-    function isStepDisabled(stepName: string | undefined): boolean {
-        if (stepName === wizardStepNames[0]) {
-            return false;
-        }
-        if (stepName === wizardStepNames[1]) {
-            return !isEmpty(formik.errors.reportParameters);
-        }
-        if (stepName === wizardStepNames[2]) {
-            return (
-                !isEmpty(formik.errors.reportParameters) ||
-                !isEmpty(formik.errors.deliveryDestinations) ||
-                !isEmpty(formik.errors.schedule)
-            );
-        }
-        return false;
-    }
-
-    function onClose() {
-        navigate(vulnerabilityConfigurationReportsPath);
-    }
-
-    const wizardSteps = [
-        {
-            name: wizardStepNames[0],
-            component: <ReportParametersForm title={wizardStepNames[0]} formik={formik} />,
-        },
-        {
-            name: wizardStepNames[1],
-            component: <DeliveryDestinationsForm title={wizardStepNames[1]} formik={formik} />,
-            isDisabled: isStepDisabled(wizardStepNames[1]),
-        },
-        {
-            name: wizardStepNames[2],
-            component: <ReportReviewForm title={wizardStepNames[2]} formValues={formik.values} />,
-            nextButtonText: 'Create',
-            isDisabled: isStepDisabled(wizardStepNames[2]),
-        },
-    ];
 
     if (error) {
         return (
@@ -153,22 +107,14 @@ function CloneVulnReportPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
-                <Wizard
+                <ReportFormWizard
+                    formik={formik}
                     navAriaLabel="Report clone steps"
                     mainAriaLabel="Report clone content"
-                    hasNoBodyPadding
-                    steps={wizardSteps}
+                    wizardStepNames={wizardStepNames}
+                    finalStepNextButtonText={'Create'}
                     onSave={onCreate}
-                    onClose={onClose}
-                    footer={
-                        <ReportFormWizardFooter
-                            wizardSteps={wizardSteps}
-                            saveText="Create"
-                            onSave={onCreate}
-                            isSaving={isCreating}
-                            isStepDisabled={isStepDisabled}
-                        />
-                    }
+                    isSaving={isCreating}
                 />
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
@@ -9,20 +9,15 @@ import {
     Breadcrumb,
     BreadcrumbItem,
 } from '@patternfly/react-core';
-import { Wizard, WizardStep } from '@patternfly/react-core/deprecated';
-import isEmpty from 'lodash/isEmpty';
 
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import useReportFormValues from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm';
-import DeliveryDestinationsForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm';
-import ReportReviewForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm';
 import useCreateReport from '../api/useCreateReport';
-import ReportFormWizardFooter from './ReportFormWizardFooter';
 import ReportFormErrorAlert from './ReportFormErrorAlert';
+import ReportFormWizard from './ReportFormWizard';
 
 const wizardStepNames = [
     'Configure report parameters',
@@ -44,46 +39,6 @@ function CreateVulnReportPage() {
     function onCreate() {
         createReport(formik.values);
     }
-
-    function onClose() {
-        navigate(vulnerabilityConfigurationReportsPath);
-    }
-
-    // @TODO: This is reused in the Edit and Clone components so we can try to refactor this soon
-    function isStepDisabled(stepName: string | undefined): boolean {
-        if (stepName === wizardStepNames[0]) {
-            return false;
-        }
-        if (stepName === wizardStepNames[1]) {
-            return !isEmpty(formik.errors.reportParameters);
-        }
-        if (stepName === wizardStepNames[2]) {
-            return (
-                !isEmpty(formik.errors.reportParameters) ||
-                !isEmpty(formik.errors.deliveryDestinations) ||
-                !isEmpty(formik.errors.schedule)
-            );
-        }
-        return false;
-    }
-
-    const wizardSteps: WizardStep[] = [
-        {
-            name: wizardStepNames[0],
-            component: <ReportParametersForm title={wizardStepNames[0]} formik={formik} />,
-        },
-        {
-            name: wizardStepNames[1],
-            component: <DeliveryDestinationsForm title={wizardStepNames[1]} formik={formik} />,
-            isDisabled: isStepDisabled(wizardStepNames[1]),
-        },
-        {
-            name: wizardStepNames[2],
-            component: <ReportReviewForm title={wizardStepNames[2]} formValues={formik.values} />,
-            nextButtonText: 'Create',
-            isDisabled: isStepDisabled(wizardStepNames[2]),
-        },
-    ];
 
     return (
         <>
@@ -111,22 +66,14 @@ function CreateVulnReportPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
-                <Wizard
+                <ReportFormWizard
+                    formik={formik}
                     navAriaLabel="Report creation steps"
                     mainAriaLabel="Report creation content"
-                    hasNoBodyPadding
-                    steps={wizardSteps}
+                    wizardStepNames={wizardStepNames}
                     onSave={onCreate}
-                    onClose={onClose}
-                    footer={
-                        <ReportFormWizardFooter
-                            wizardSteps={wizardSteps}
-                            saveText="Create"
-                            onSave={onCreate}
-                            isSaving={isLoading}
-                            isStepDisabled={isStepDisabled}
-                        />
-                    }
+                    finalStepNextButtonText={'Create'}
+                    isSaving={isLoading}
                 />
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -11,8 +11,6 @@ import {
     Bullseye,
     Spinner,
 } from '@patternfly/react-core';
-import { Wizard } from '@patternfly/react-core/deprecated';
-import isEmpty from 'lodash/isEmpty';
 
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 import useReportFormValues from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
@@ -21,18 +19,15 @@ import useFetchReport from 'Containers/Vulnerabilities/VulnerablityReporting/api
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import ReportParametersForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm';
-import DeliveryDestinationsForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm';
-import ReportReviewForm from 'Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm';
 import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
 import { getReportFormValuesFromConfiguration } from '../utils';
 import ReportFormErrorAlert from './ReportFormErrorAlert';
-import ReportFormWizardFooter from './ReportFormWizardFooter';
+import ReportFormWizard from './ReportFormWizard';
 
 const wizardStepNames = [
     'Configure report parameters',
     'Configure delivery destinations',
-    'Review and save',
+    'Review and save', // diff
 ];
 
 function EditVulnReportPage() {
@@ -54,52 +49,11 @@ function EditVulnReportPage() {
             const reportFormValues = getReportFormValuesFromConfiguration(reportConfiguration);
             formik.setValues(reportFormValues);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [reportConfiguration, formik.setValues]);
 
     function onSave() {
         saveReport(reportId, formik.values);
     }
-
-    // @TODO: This is reused in the Edit and Clone components so we can try to refactor this soon
-    function isStepDisabled(stepName: string | undefined): boolean {
-        if (stepName === wizardStepNames[0]) {
-            return false;
-        }
-        if (stepName === wizardStepNames[1]) {
-            return !isEmpty(formik.errors.reportParameters);
-        }
-        if (stepName === wizardStepNames[2]) {
-            return (
-                !isEmpty(formik.errors.reportParameters) ||
-                !isEmpty(formik.errors.deliveryDestinations) ||
-                !isEmpty(formik.errors.schedule)
-            );
-        }
-        return false;
-    }
-
-    function onClose() {
-        navigate(vulnerabilityConfigurationReportsPath);
-    }
-
-    const wizardSteps = [
-        {
-            name: wizardStepNames[0],
-            component: <ReportParametersForm title={wizardStepNames[0]} formik={formik} />,
-        },
-        {
-            name: wizardStepNames[1],
-            component: <DeliveryDestinationsForm title={wizardStepNames[1]} formik={formik} />,
-            isDisabled: isStepDisabled(wizardStepNames[1]),
-        },
-        {
-            name: wizardStepNames[2],
-            component: <ReportReviewForm title={wizardStepNames[2]} formValues={formik.values} />,
-            nextButtonText: 'Save',
-            isDisabled: isStepDisabled(wizardStepNames[2]),
-        },
-    ];
 
     if (error) {
         return (
@@ -146,22 +100,14 @@ function EditVulnReportPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
-                <Wizard
+                <ReportFormWizard
+                    formik={formik}
                     navAriaLabel="Report edit steps"
                     mainAriaLabel="Report edit content"
-                    hasNoBodyPadding
-                    steps={wizardSteps}
+                    wizardStepNames={wizardStepNames}
                     onSave={onSave}
-                    onClose={onClose}
-                    footer={
-                        <ReportFormWizardFooter
-                            wizardSteps={wizardSteps}
-                            saveText="Save"
-                            onSave={onSave}
-                            isSaving={isSaving}
-                            isStepDisabled={isStepDisabled}
-                        />
-                    }
+                    finalStepNextButtonText={'Save'}
+                    isSaving={isSaving}
                 />
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Wizard, WizardStep } from '@patternfly/react-core/deprecated';
+import { FormikProps } from 'formik';
+import isEmpty from 'lodash/isEmpty';
+
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
+
+import DeliveryDestinationsForm from '../forms/DeliveryDestinationsForm';
+import ReportParametersForm from '../forms/ReportParametersForm';
+import ReportReviewForm from '../forms/ReportReviewForm';
+import ReportFormWizardFooter from './ReportFormWizardFooter';
+import { ReportFormValues } from '../forms/useReportFormValues';
+
+export type ReportFormWizardProps = {
+    formik: FormikProps<ReportFormValues>;
+    navAriaLabel: string;
+    mainAriaLabel: string;
+    wizardStepNames: string[];
+    finalStepNextButtonText: string;
+    onSave: () => void;
+    isSaving: boolean;
+};
+
+function ReportFormWizard({
+    formik,
+    navAriaLabel,
+    mainAriaLabel,
+    wizardStepNames,
+    finalStepNextButtonText,
+    onSave,
+    isSaving,
+}: ReportFormWizardProps) {
+    const navigate = useNavigate();
+    function onClose() {
+        navigate(vulnerabilityConfigurationReportsPath);
+    }
+
+    const wizardSteps: WizardStep[] = [
+        {
+            name: wizardStepNames[0],
+            component: <ReportParametersForm title={wizardStepNames[0]} formik={formik} />,
+        },
+        {
+            name: wizardStepNames[1],
+            component: <DeliveryDestinationsForm title={wizardStepNames[1]} formik={formik} />,
+            isDisabled: isStepDisabled(wizardStepNames[1]),
+        },
+        {
+            name: wizardStepNames[2],
+            component: <ReportReviewForm title={wizardStepNames[2]} formValues={formik.values} />,
+            nextButtonText: finalStepNextButtonText,
+            isDisabled: isStepDisabled(wizardStepNames[2]),
+        },
+    ];
+
+    function isStepDisabled(stepName: string | undefined): boolean {
+        if (stepName === wizardStepNames[0]) {
+            return false;
+        }
+        if (stepName === wizardStepNames[1]) {
+            return !isEmpty(formik.errors.reportParameters);
+        }
+        if (stepName === wizardStepNames[2]) {
+            return (
+                !isEmpty(formik.errors.reportParameters) ||
+                !isEmpty(formik.errors.deliveryDestinations) ||
+                !isEmpty(formik.errors.schedule)
+            );
+        }
+        return false;
+    }
+
+    return (
+        <Wizard
+            navAriaLabel={navAriaLabel}
+            mainAriaLabel={mainAriaLabel}
+            hasNoBodyPadding
+            steps={wizardSteps}
+            onSave={onSave}
+            onClose={onClose}
+            footer={
+                <ReportFormWizardFooter
+                    wizardSteps={wizardSteps}
+                    saveText={finalStepNextButtonText}
+                    onSave={onSave}
+                    isSaving={isSaving}
+                    isStepDisabled={isStepDisabled}
+                />
+            }
+        />
+    );
+}
+
+export default ReportFormWizard;


### PR DESCRIPTION
### Description

Combines the nearly identical form wizards for create, clone, and edit in VM reporting for ease of testing and migrating to the non-deprecated PF Wizard component.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Existing e2e tests for the report wizard and config creation.

Manual smoke test of edit and clone functionality.
