### PR TITLE
ROX-29305: add retries to AuthProviderService

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/AuthProviderService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/AuthProviderService.groovy
@@ -82,15 +82,17 @@ class AuthProviderService extends BaseService {
         // There are two redirects: first from the generic URL to the auth provider's URL, and then from the auth
         // provider's URL to the token response URL.
         for (int i = 0; i < 2; i++) {
-            def response =
-                    given().header("Content-Type", "application/json")
-                            .config(RestAssuredConfig.newConfig().sslConfig(
-                            SSLConfig.sslConfig().with().sslSocketFactory(socketFactory)
-                                    .and().allowAllHostnames()))
-                            .when()
-                            .redirects().follow(false)
-                            .get("https://${Env.mustGetHostname()}:${Env.mustGetPort()}${location}")
-            location = response.getHeader("Location")
+            Helpers.withRetry(3, 2) {
+                def response =
+                        given().header("Content-Type", "application/json")
+                                .config(RestAssuredConfig.newConfig().sslConfig(
+                                SSLConfig.sslConfig().with().sslSocketFactory(socketFactory)
+                                        .and().allowAllHostnames()))
+                                .when()
+                                .redirects().follow(false)
+                                .get("https://${Env.mustGetHostname()}:${Env.mustGetPort()}${location}")
+                location = response.getHeader("Location")
+            }
         }
         def fullURL = new URL("https://${Env.mustGetHostname()}:${Env.mustGetPort()}${location}")
         def token = ""


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Hopefully this will take care of rare errors such as:

```
java.net.ConnectException: Connection timed out
	at java.base/sun.nio.ch.Net.connect(Net.java:579)
	at java.base/sun.nio.ch.Net.connect(Net.java:568)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:593)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:633)
	at org.apache.http.conn.ssl.SSLSocketFactory.connectSocket(SSLSocketFactory.java:543)
	at org.apache.http.conn.ssl.SSLSocketFactory.connectSocket(SSLSocketFactory.java:415)
	at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:180)
	at org.apache.http.impl.conn.ManagedClientConnectionImpl.open(ManagedClientConnectionImpl.java:326)
	at org.apache.http.impl.client.DefaultRequestDirector.tryExecute(DefaultRequestDirector.java:668)
	at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:481)
	at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:835)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at io.restassured.internal.RestAssuredHttpBuilder.doRequest(RestAssuredHttpBuilder.java:141)
	at io.restassured.internal.http.HTTPBuilder.doRequest(HTTPBuilder.java:496)
	at io.restassured.internal.http.HTTPBuilder.request(HTTPBuilder.java:453)
	at io.restassured.internal.RequestSpecificationImpl.sendHttpRequest(RequestSpecificationImpl.groovy:1480)
	at io.restassured.internal.RequestSpecificationImpl.sendRequest(RequestSpecificationImpl.groovy:1229)
	at io.restassured.internal.filter.SendRequestFilter.filter(SendRequestFilter.groovy:30)
	at io.restassured.internal.filter.FilterContextImpl.next(FilterContextImpl.groovy:72)
	at io.restassured.filter.time.TimingFilter.filter(TimingFilter.java:56)
	at io.restassured.internal.filter.FilterContextImpl.next(FilterContextImpl.groovy:72)
	at io.restassured.internal.filter.CsrfFilter.filter(CsrfFilter.groovy:70)
	at io.restassured.internal.filter.FilterContextImpl.next(FilterContextImpl.groovy:72)
	at io.restassured.internal.RequestSpecificationImpl.applyPathParamsAndSendRequest(RequestSpecificationImpl.groovy:1704)
	at io.restassured.internal.RequestSpecificationImpl.applyPathParamsAndSendRequest(RequestSpecificationImpl.groovy:1710)
	at io.restassured.internal.RequestSpecificationImpl.get(RequestSpecificationImpl.groovy:172)
	at services.AuthProviderService.getAuthProviderLoginToken(AuthProviderService.groovy:92)
	at ClientCertAuthTest.setupSpec(ClientCertAuthTest.groovy:43)
```

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI