### PR TITLE
ROX-29406: bump kuttl timeout to 15 minutes

### DIFF
--- a/operator/kuttl-test.yaml
+++ b/operator/kuttl-test.yaml
@@ -4,10 +4,11 @@ testDirs:
 - ./tests/central
 - ./tests/controller
 - ./tests/securedcluster
-# central pod takes a while do become healthy, typically ~25s, but sometimes over a minute since container start.
+# central-db pod takes a while do become healthy, typically ~25s, but sometimes over a minute since container start.
+# Especially when there are intermittent issues re-attaching PVCs after a pod reschedule on a different node.
 # We need to add CR reconciliation, pod creation and image fetch to that.
 # Set the timeout very high so that we can collect a distribution of realistic times and later set to a flake-safe timeout.
-timeout: 600
+timeout: 900
 reportFormat: xml
 artifactsDir: build/kuttl-test-artifacts
 commands:


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Allow more time for things to settle. There is evidence in the ticket that PCVs can take over 9 minutes to re-attach on GKE after central-db pod is rescheduled on a different node.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI