### PR TITLE
ROX-29308: Use retrying kubectl wrapper in sensor-wait script

### DIFF
--- a/scripts/ci/sensor-wait.sh
+++ b/scripts/ci/sensor-wait.sh
@@ -2,7 +2,7 @@
 set -eu
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-export ORCH_CMD=${ORCH_CMD:-"${ROOT}/scripts/retry-kubectl.sh"}
+ORCH_CMD=${ORCH_CMD:-"${ROOT}/scripts/retry-kubectl.sh"}
 
 # Wait for sensor to be up
 #

--- a/scripts/ci/sensor-wait.sh
+++ b/scripts/ci/sensor-wait.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+export ORCH_CMD=${ORCH_CMD:-"${ROOT}/scripts/retry-kubectl.sh"}
+
 # Wait for sensor to be up
 #
 # Usage:
@@ -14,7 +17,7 @@ sensor_wait() {
 
     start_time="$(date '+%s')"
     while true; do
-      sensor_json="$(kubectl -n "${sensor_namespace}" get deploy/sensor -o json)"
+      sensor_json="$("$ORCH_CMD" </dev/null -n "${sensor_namespace}" get deploy/sensor -o json)"
       if [[ "$(jq '.status.replicas' <<<"${sensor_json}")" == 1 && "$(jq '.status.readyReplicas' <<<"${sensor_json}")" == 1 ]]; then
         break
       fi
@@ -22,8 +25,8 @@ sensor_wait() {
       echo "Sensor readyReplicas: $(jq '.status.readyReplicas' <<<"${sensor_json}")"
       if (( $(date '+%s') - start_time > 1200 )); then
         echo "Waiting for sensor in ns ${sensor_namespace} to be ready timed out." > "${QA_DEPLOY_WAIT_INFO}" || true
-        kubectl -n "${sensor_namespace}" get pod -o wide
-        kubectl -n "${sensor_namespace}" get deploy -o wide
+        "$ORCH_CMD" </dev/null -n "${sensor_namespace}" get pod -o wide
+        "$ORCH_CMD" </dev/null -n "${sensor_namespace}" get deploy -o wide
         echo >&2 "Timed out after 20m"
         exit 1
       fi
@@ -31,19 +34,19 @@ sensor_wait() {
     done
     echo "Sensor is running"
 
-    if ! kubectl -n "${sensor_namespace}" get ds/collector ; then
+    if ! "$ORCH_CMD" </dev/null -n "${sensor_namespace}" get ds/collector ; then
         return
     fi
 
     echo "Waiting for collectors to start"
     start_time="$(date '+%s')"
-    until [ "$(kubectl -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $2}')" -eq "$(kubectl -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $4}')" ]; do
-      echo "Desired collectors: $(kubectl -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $2}')"
-      echo "Ready collectors: $(kubectl -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $4}')"
+    until [ "$("$ORCH_CMD" </dev/null -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $2}')" -eq "$("$ORCH_CMD" </dev/null -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $4}')" ]; do
+      echo "Desired collectors: $("$ORCH_CMD" </dev/null -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $2}')"
+      echo "Ready collectors: $("$ORCH_CMD" </dev/null -n "${sensor_namespace}" get ds/collector | tail -n +2 | awk '{print $4}')"
       if (( $(date '+%s') - start_time > 1200 )); then
         echo "Waiting for collectors in ns ${sensor_namespace} to be ready timed out." > "${QA_DEPLOY_WAIT_INFO}" || true
-        kubectl -n "${sensor_namespace}" get pod -o wide
-        kubectl -n "${sensor_namespace}" get ds -o wide
+        "$ORCH_CMD" </dev/null -n "${sensor_namespace}" get pod -o wide
+        "$ORCH_CMD" </dev/null -n "${sensor_namespace}" get ds -o wide
         echo >&2 "Timed out after 20m"
         exit 1
       fi


### PR DESCRIPTION
### Description

See https://issues.redhat.com/browse/ROX-29308.

According to the CI failure logs linked in the ticket:
```
INFO: Fri May 30 23:18:51 UTC 2025: [upgrade-to-HEAD-sensor] Sensor deployed. Waiting for sensor to be up
INFO: Fri May 30 23:18:51 UTC 2025: [upgrade-to-HEAD-sensor] Waiting for sensor to start in namespace stackrox-sensor
INFO: Fri May 30 23:18:51 UTC 2025: [upgrade-to-HEAD-sensor] Sensor replicas: 1
INFO: Fri May 30 23:18:51 UTC 2025: [upgrade-to-HEAD-sensor] Sensor readyReplicas: null
INFO: Fri May 30 23:19:31 UTC 2025: [upgrade-to-HEAD-sensor] Unable to connect to the server: dial tcp: lookup api.rox-ci-38203904.ocp.ci.rox.systems on 172.30.0.10:53: read udp 10.128.73.106:41695->172.30.0.10:53: i/o timeout
INFO: Fri May 30 23:19:31 UTC 2025: [post-test-tear-down] FAILED: Test "Upgrade from old Helm chart to HEAD Helm chart with Scanner v4 enabled" failed. Look above for the test steps that have led to this failure.
```

it seems that the problem is that the `kubectl` calls in the `sensor-wait.sh` script failed because of a network timeout.

This change replaces the usage of `kubectl` within that script with our retrying wrapper.

### User-facing documentation

Neither CHANGELOG, nor doc changes needed. This PR only touches an internal script.

### Testing and quality

The `sensor-wait.sh` script is used in CI as part of automated tests.

#### Automated testing

Script is indirectly used in CI tests.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
