### PR TITLE
ROX-19095: Ensure image names are not lost (#15353)

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -545,7 +545,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 		Id:   imgID,
 		Name: request.GetImageName(),
 		// 'Names' must be populated to enable cache hits in central AND sensor.
-		Names:          buildNames(request.GetImageName(), request.GetMetadata()),
+		Names:          buildNames(request.GetImageName(), existingImg.GetNames(), request.GetMetadata()),
 		Signature:      request.GetImageSignature(),
 		Metadata:       request.GetMetadata(),
 		Notes:          request.GetImageNotes(),
@@ -646,8 +646,9 @@ func shouldUpdateExistingScan(imgExists bool, existingImg *storage.Image, reques
 }
 
 // buildNames returns a slice containing the known image names from the various parameters.
-func buildNames(srcImage *storage.ImageName, metadata *storage.ImageMetadata) []*storage.ImageName {
-	names := []*storage.ImageName{srcImage}
+func buildNames(requestImageName *storage.ImageName, existingImageNames []*storage.ImageName, metadata *storage.ImageMetadata) []*storage.ImageName {
+	names := []*storage.ImageName{requestImageName}
+	names = append(names, existingImageNames...)
 
 	// Add a mirror name if exists.
 	if mirror := metadata.GetDataSource().GetMirror(); mirror != "" {
@@ -660,6 +661,7 @@ func buildNames(srcImage *storage.ImageName, metadata *storage.ImageMetadata) []
 		}
 	}
 
+	names = protoutils.SliceUnique(names)
 	return names
 }
 

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -183,12 +183,12 @@ func (c *cacheValue) scanAndSet(ctx context.Context, svc v1.ImageServiceClient, 
 		// Ignore the error and set the image to something basic,
 		// so alerting can progress.
 		log.Errorf("Scan request failed for image %q: %s", req.containerImage.GetName().GetFullName(), err)
-		c.image = types.ToImage(req.containerImage)
+		c.updateImageNoLock(types.ToImage(req.containerImage))
 		return
 	}
 
 	log.Debugf("Successful image scan for image %s: %d components returned by scanner", req.containerImage.GetName().GetFullName(), len(scannedImage.GetImage().GetScan().GetComponents()))
-	c.image = scannedImage.GetImage()
+	c.updateImageNoLock(scannedImage.GetImage())
 }
 
 func (c *cacheValue) scanAndSetWithLock(ctx context.Context, svc v1.ImageServiceClient, req *scanImageRequest) {


### PR DESCRIPTION
(cherry picked from commit 04b850cdfb5a8c340e6d468c26a2a0598144a3eb)

### Description

Backports #15353 to 4.7.x