### PR TITLE
ROX-29716: Fix signature verification for OCP images

### DIFF
--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -396,7 +396,11 @@ func verifyImageSignature(ctx context.Context, signature oci.Signature,
 	if !bundleVerified && !cosignOpts.IgnoreTlog {
 		return nil, errUnverifiedBundle
 	}
-	return getVerifiedImageReference(signature, image)
+	refs, err := getVerifiedImageReference(signature, image)
+	if len(refs) == 0 && err == nil {
+		return nil, errors.New("no verified references")
+	}
+	return refs, err
 }
 
 // getVerificationResultStatusFromErr will map an error to a specific storage.ImageSignatureVerificationResult_Status.
@@ -522,9 +526,6 @@ func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([
 		if repoReference == reference {
 			verifiedImageReferences = append(verifiedImageReferences, name.GetFullName())
 		}
-	}
-	if len(verifiedImageReferences) == 0 {
-		return nil, errors.Errorf("no verified references for %q", dockerReference)
 	}
 	return verifiedImageReferences, nil
 }

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -512,7 +512,7 @@ func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([
 	var verifiedImageReferences []string
 	imageNames := protoutils.SliceUnique(append(image.GetNames(), image.GetName()))
 	for _, name := range imageNames {
-		reference, err := getRepositoryReferenceFromImageName(name.FullName)
+		reference, err := getRepositoryReferenceFromImageName(name.GetFullName())
 		if err != nil {
 			// Theoretically, all references should be parsable.
 			// In case we somehow get an invalid entry, we will log the occurrence and skip this entry.

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -506,34 +505,35 @@ func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([
 	// - and has the same digest
 	// This way we also cover the case where we e.g. reference an image with digest format (<registry>/<repository>@<digest>)
 	// as well as images using floating tags (<registry>/<repository>:<tag>).
-	dockerReference := simpleContainer.Critical.Identity.DockerReference
-	repoReference, err := getRepositoryReferenceFromImageName(dockerReference)
-	if err != nil {
-		return nil, errors.Wrapf(err, "parsing signature docker reference %q", dockerReference)
-	}
-	log.Debugf("Retrieving verified image references from the image names [%v] and image reference within the "+
-		"signature %q", image.GetNames(), dockerReference)
+	signatureIdentity := simpleContainer.Critical.Identity.DockerReference
+	log.Debugf("Retrieving verified image references from the image names [%v] and signature identity %q",
+		image.GetNames(), signatureIdentity)
 	var verifiedImageReferences []string
 	imageNames := protoutils.SliceUnique(append(image.GetNames(), image.GetName()))
 	for _, name := range imageNames {
-		reference, err := getRepositoryReferenceFromImageName(name.GetFullName())
+		ok, err := equalRegistryRepository(signatureIdentity, name.GetFullName())
 		if err != nil {
 			// Theoretically, all references should be parsable.
 			// In case we somehow get an invalid entry, we will log the occurrence and skip this entry.
-			log.Errorf("Failed to retrieve the reference for image name %s: %v", name.GetFullName(), err)
+			log.Errorf("Failed to compare image name %q and signature identity %q: %v", name.GetFullName(), signatureIdentity, err)
 			continue
 		}
-		if repoReference == reference {
+		if ok {
 			verifiedImageReferences = append(verifiedImageReferences, name.GetFullName())
 		}
 	}
 	return verifiedImageReferences, nil
 }
 
-func getRepositoryReferenceFromImageName(imageName string) (string, error) {
-	ref, err := name.ParseReference(imageName)
+func equalRegistryRepository(signatureIdentity, imageName string) (bool, error) {
+	sigRef, err := name.ParseReference(signatureIdentity)
 	if err != nil {
-		return "", err
+		return false, errors.Wrapf(err, "parsing reference for %q", signatureIdentity)
 	}
-	return fmt.Sprintf("%s/%s", ref.Context().Registry.RegistryStr(), ref.Context().RepositoryStr()), nil
+	imgRef, err := name.ParseReference(imageName)
+	if err != nil {
+		return false, errors.Wrapf(err, "parsing reference for %q", imageName)
+	}
+	return sigRef.Context().RegistryStr() == imgRef.Context().RegistryStr() &&
+		sigRef.Context().RepositoryStr() == imgRef.Context().RepositoryStr(), nil
 }

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -46,7 +46,6 @@ var (
 	errNoImageSHA         = errors.New("no image SHA found")
 	errNoVerificationData = errors.New("verification data not found")
 	errUnverifiedBundle   = errors.New("unverified transparency log bundle")
-	errDigestMismatch     = errors.New("image digest does not match signature")
 )
 
 var once sync.Once
@@ -503,10 +502,6 @@ func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([
 	// - and has the same digest
 	// This way we also cover the case where we e.g. reference an image with digest format (<registry>/<repository>@<digest>)
 	// as well as images using floating tags (<registry>/<repository>:<tag>).
-	if simpleContainer.Critical.Image.DockerManifestDigest != image.GetId() {
-		return nil, errDigestMismatch
-	}
-
 	dockerReference := simpleContainer.Critical.Identity.DockerReference
 	repoReference, err := getRepositoryReferenceFromImageName(dockerReference)
 	if err != nil {

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -39,12 +39,13 @@ const (
 )
 
 var (
-	errCorruptedSignature = errox.InvariantViolation.New("corrupted signature")
-	errHashCreation       = errox.InvariantViolation.New("creating hash")
-	errInvalidHashAlgo    = errox.InvalidArgs.New("invalid hash algorithm used")
-	errNoImageSHA         = errors.New("no image SHA found")
-	errNoVerificationData = errors.New("verification data not found")
-	errUnverifiedBundle   = errors.New("unverified transparency log bundle")
+	errCorruptedSignature   = errox.InvariantViolation.New("corrupted signature")
+	errHashCreation         = errox.InvariantViolation.New("creating hash")
+	errInvalidHashAlgo      = errox.InvalidArgs.New("invalid hash algorithm used")
+	errNoImageSHA           = errors.New("no image SHA found")
+	errNoVerificationData   = errors.New("verification data not found")
+	errNoVerifiedReferences = errors.New("no verified references")
+	errUnverifiedBundle     = errors.New("unverified transparency log bundle")
 )
 
 var once sync.Once
@@ -397,7 +398,7 @@ func verifyImageSignature(ctx context.Context, signature oci.Signature,
 	}
 	refs, err := getVerifiedImageReference(signature, image)
 	if len(refs) == 0 && err == nil {
-		return nil, errors.New("no verified references")
+		return nil, errNoVerifiedReferences
 	}
 	return refs, err
 }

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -397,10 +397,13 @@ func verifyImageSignature(ctx context.Context, signature oci.Signature,
 		return nil, errUnverifiedBundle
 	}
 	refs, err := getVerifiedImageReference(signature, image)
-	if len(refs) == 0 && err == nil {
+	if err != nil {
+		return nil, errors.Wrap(err, "getting verified image references")
+	}
+	if len(refs) == 0 {
 		return nil, errNoVerifiedReferences
 	}
-	return refs, err
+	return refs, nil
 }
 
 // getVerificationResultStatusFromErr will map an error to a specific storage.ImageSignatureVerificationResult_Status.

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -723,22 +723,22 @@ func TestEqualRegistryRepository(t *testing.T) {
 			expected:          true,
 		},
 		"match for docker.io with image tag": {
-			signatureIdentity: "docker.io/some-repo/image",
+			signatureIdentity: "index.docker.io/some-repo/image",
 			imageName:         "docker.io/some-repo/image:latest",
 			expected:          true,
 		},
 		"match for docker.io with image digest": {
-			signatureIdentity: "docker.io/some-repo/image",
+			signatureIdentity: "index.docker.io/some-repo/image",
 			imageName:         "docker.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
 			expected:          true,
 		},
 		"match for docker.io with signature digest and image digest": {
-			signatureIdentity: "docker.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
+			signatureIdentity: "index.docker.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
 			imageName:         "docker.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
 			expected:          true,
 		},
 		"no match": {
-			signatureIdentity: "docker.io/some-repo",
+			signatureIdentity: "index.docker.io/some-repo/image",
 			imageName:         "quay.io/some-repo/image:latest",
 			expected:          false,
 		},

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -60,6 +60,25 @@ const (
 		"TljNWItNDA0MC05ZGJlLTQ0NDgzNjE3MGJlYSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
 		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
 		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
+
+	// OCP image signed by Red Hat release key.
+	pemPublicKey_OCP = "-----BEGIN PUBLIC KEY-----\n" +
+		"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0ASyuH2TLWvBUqPHZ4Ip\n" +
+		"75g7EncBkgQHdJnjzxAW5KQTMh/siBoB/BoSrtiPMwnChbTCnQOIQeZuDiFnhuJ7\n" +
+		"M/D3b7JoX0m123NcCSn67mAdjBa6Bg6kukZgCP4ZUZeESajWX/EjylFcRFOXW57p\n" +
+		"RDCEN42J/jYlVqt+g9+Grker8Sz86H3l0tbqOdjbz/VxHYhwF0ctUMHsyVRDq2QP\n" +
+		"tqzNXlmlMhS/PoFr6R4u/7HCn/K+LegcO2fAFOb40KvKSKKVD6lewUZErhop1CgJ\n" +
+		"XjDtGmmO9dGMF71mf6HEfaKSdy+EE6iSF2A2Vv9QhBawMiq2kOzEiLg4nAdJT8wg\n" +
+		"ZrMAmPCqGIsXNGZ4/Q+YTwwlce3glqb5L9tfNozEdSR9N85DESfQLQEdY3CalwKM\n" +
+		"BT1OEhEX1wHRCU4drMOej6BNW0VtscGtHmCrs74jPezhwNT8ypkyS+T0zT4Tsy6f\n" +
+		"VXkJ8YSHyenSzMB2Op2bvsE3grY+s74WhG9UIA6DBxcTie15NSzKwfzaoNWODcLF\n" +
+		"p7BY8aaHE2MqFxYFX+IbjpkQRfaeQQsouDFdCkXEFVfPpbD2dk6FleaMTPuyxtIT\n" +
+		"gjVEtGQK2qGCFGiQHFd4hfV+eCA63Jro1z0zoBM5BbIIQ3+eVFwt3AlZp5UVwr6d\n" +
+		"secqki/yrmv3Y0dqZ9VOn3UCAwEAAQ==\n" +
+		"-----END PUBLIC KEY-----"
+	imgName_OCP      = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c896b5d4b05343dfe94c0f75c9232a2a68044d0fa7a21b5f51ed796d23f1fcc5"
+	b64Signature_OCP = "tkgrrtlysbiLo+chF2+EmcPXyGNfhVZIptlgyPK6b0Ptu8FGpk1AdhBckiKExLbx3QwkJci8lvPXWhFEXtGQc1lnw1knKvCenHArW5MbGYaBbZ5v1o2+mF4XIgAePi3PT3KoViCcemg8M3MQUxV8u4RnpMLdMu7PtQvYwOmafw9ja7RYUMoR4FfVn6EWLZUWQ5qtuU7hcR7eaCPKP7tIuedI2Ks+MTlT61NZTG16cmDw8TgkGdheR6xuA8Nw2PgMl3Ij6YGLRJBY/QIm3HSyTjr7QC1+S4Va0rln/4ywFyJuHtSLy/AlirpoqMwNiPM2Rdqd7JJ6MI4wTpIv55DUgQLKkwmZiVgWkklPrME7PIRUcKIICouALwJIZhchDtScl05ntJF0TXW4PK/qzEWs12O0GDYQVdGTGxYQR0Y1EXPK3Rwtq3dFF+pmvnFMY0j6jp092QPJIkQe8bf26drPitPpiVSdBn8fRKQu4TAlwTUmElg5n60kN8JznHxqO81MppNyw8PYfmK0s05b9X21yxkxy0/1g4h9kSlAgVdq6+vjs/QGaNl1n/bsF2krXw9/C8shVLBHsLDnQX7zpXxubVvSkXAfllg6tS17WJfB7ga5605TlPaMHrvyJO13jQbSDFMzaixtxaO85KjVdUOHE1e4SvFcQZzxzv2DdOiGhnE="
+	b64Payload_OCP   = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoicXVheS5pby9vcGVuc2hpZnQtcmVsZWFzZS1kZXYvb2NwLXY0LjAtYXJ0LWRldkBzaGEyNTY6Yzg5NmI1ZDRiMDUzNDNkZmU5NGMwZjc1YzkyMzJhMmE2ODA0NGQwZmE3YTIxYjVmNTFlZDc5NmQyM2YxZmNjNSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OmM4OTZiNWQ0YjA1MzQzZGZlOTRjMGY3NWM5MjMyYTJhNjgwNDRkMGZhN2EyMWI1ZjUxZWQ3OTZkMjNmMWZjYzUifSwidHlwZSI6ImNvc2lnbiBjb250YWluZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
 )
 
 func TestUnmarshalRekorBundle(t *testing.T) {
@@ -159,6 +178,31 @@ func TestCosignSignatureVerifier_VerifySignature_Success(t *testing.T) {
 	assert.Equal(t, storage.ImageSignatureVerificationResult_VERIFIED, status, "status should be VERIFIED")
 	require.Len(t, verifiedImageReferences, 1)
 	assert.Equal(t, img.GetName().GetFullName(), verifiedImageReferences[0],
+		"image full name should match verified image reference")
+}
+
+func TestCosignSignatureVerifier_VerifySignature_OCP_Image(t *testing.T) {
+	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{
+		Cosign: &storage.CosignPublicKeyVerification{
+			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
+				{
+					Name:            "cosignSignatureVerifier",
+					PublicKeyPemEnc: pemPublicKey_OCP,
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err, "creating public key verifier")
+
+	img, err := generateImageWithCosignSignature(imgName_OCP, b64Signature_OCP, b64Payload_OCP, nil, nil, nil)
+	require.NoError(t, err, "creating image with signature")
+
+	status, verifiedImageReferences, err := pubKeyVerifier.VerifySignature(context.Background(), img)
+	assert.NoError(t, err, "verification should be successful")
+	assert.Equal(t, storage.ImageSignatureVerificationResult_VERIFIED, status, "status should be VERIFIED")
+	require.Len(t, verifiedImageReferences, 1)
+	assert.Contains(t, verifiedImageReferences, img.GetName().GetFullName(),
 		"image full name should match verified image reference")
 }
 
@@ -674,7 +718,7 @@ func TestDockerReferenceFromImageName(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			res, err := dockerReferenceFromImageName(c.name)
+			res, err := getRepositoryReferenceFromImageName(c.name.FullName)
 			assert.NoError(t, err)
 			assert.Equal(t, c.res, res)
 		})

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -718,7 +718,7 @@ func TestDockerReferenceFromImageName(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			res, err := getRepositoryReferenceFromImageName(c.name.FullName)
+			res, err := getRepositoryReferenceFromImageName(c.name.GetFullName())
 			assert.NoError(t, err)
 			assert.Equal(t, c.res, res)
 		})


### PR DESCRIPTION
### Description

OCP images are signed by [Red Hat Release Key 3](https://security.access.redhat.com/data/63405576.txt), however they show as unverified.

Steps to reproduce:

- Add signature integration for  [Red Hat Release Key 3](https://security.access.redhat.com/data/63405576.txt) without transparency log verification.
- Scan any OCP image (note that a Red Hat pull secret is needed)
- Verification fails.

The problem is that the "docker-reference" field of the signature payload contains the full image reference, including its digest:

```json
{
  "critical": {
    "identity": {
      "docker-reference": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c896b5d4b05343dfe94c0f75c9232a2a68044d0fa7a21b5f51ed796d23f1fcc5"
    },
    "image": {
      "docker-manifest-digest": "sha256:c896b5d4b05343dfe94c0f75c9232a2a68044d0fa7a21b5f51ed796d23f1fcc5"
    },
    "type": "cosign container image signature"
  },
  "optional": null
}
```

While the `getVerifiedImageReference` function previously assumed that the "docker-reference" field only contains `registry/repo`, e.g.:

```json
{
  "critical": {
    "identity": {
      "docker-reference": "quay.io/stehessel/nginx"
    },
    "image": {
      "docker-manifest-digest": "sha256:eba373a0620f68ffdc3f217041ad25ef084475b8feb35b992574cd83698e9e3c"
    },
    "type": "cosign container image signature"
  },
  "optional": null
}
```

The fix is to only consider the registry and repository parts of the docker reference, and compare them with the image name.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

We deployed the fix in an OCP cluster, added a signature integration for Red Hat Release Key 3, and observed that the image signatures are verified.

![SCR-20250612-pwaa](https://github.com/user-attachments/assets/02689e9c-8dfb-45cf-84c2-ca20ade30884)

