### PR TITLE
ROX-29613: Prevent adding external-IPs for deleted deployments JV

### DIFF
--- a/central/deployment/cache/cache.go
+++ b/central/deployment/cache/cache.go
@@ -7,7 +7,11 @@ import (
 )
 
 const (
-	deletedDeploymentsRetentionPeriod = 2 * time.Minute
+	// 30 seconds for collector to send a message to sensor
+	// 30 seconds for sensor to send a message to central
+	// 5 minutes for afterglow
+	// 1 minute for a safety margin
+	deletedDeploymentsRetentionPeriod = 7 * time.Minute
 )
 
 var (

--- a/central/networkbaseline/service/service_impl_sql_test.go
+++ b/central/networkbaseline/service/service_impl_sql_test.go
@@ -136,7 +136,7 @@ func (s *networkBaselineServiceSuite) setupTablesExternalFlowsWithDefaultEntity(
 	fs, err := s.flowDataStore.GetFlowStore(allAllowedCtx, fixtureconsts.Cluster1)
 	s.NoError(err)
 
-	err = fs.UpsertFlows(allAllowedCtx, []*storage.NetworkFlow{flow}, timestamp.FromGoTime(ts))
+	_, err = fs.UpsertFlows(allAllowedCtx, []*storage.NetworkFlow{flow}, timestamp.FromGoTime(ts))
 	s.NoError(err)
 }
 
@@ -200,7 +200,7 @@ func (s *networkBaselineServiceSuite) setupTablesExternalFlows() {
 	fs, err := s.flowDataStore.GetFlowStore(allAllowedCtx, fixtureconsts.Cluster1)
 	s.NoError(err)
 
-	err = fs.UpsertFlows(allAllowedCtx, flows, timestamp.FromGoTime(ts))
+	_, err = fs.UpsertFlows(allAllowedCtx, flows, timestamp.FromGoTime(ts))
 	s.NoError(err)
 }
 

--- a/central/networkgraph/flow/datastore/flow.go
+++ b/central/networkgraph/flow/datastore/flow.go
@@ -21,7 +21,8 @@ type FlowDataStore interface {
 
 	// UpsertFlows upserts the given flows to the store. The flows slice might be modified by this function, so if you
 	// need to use it afterwards, create a copy.
-	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error
+	// Returns the flows actually upserted.
+	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) ([]*storage.NetworkFlow, error)
 	RemoveFlowsForDeployment(ctx context.Context, id string) error
 	RemoveStaleFlows(ctx context.Context) error
 	// RemoveOrphanedFlows - remove flows that have been orphaned by deployments

--- a/central/networkgraph/flow/datastore/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/mocks/flow.go
@@ -148,11 +148,12 @@ func (mr *MockFlowDataStoreMockRecorder) RemoveStaleFlows(ctx any) *gomock.Call 
 }
 
 // UpsertFlows mocks base method.
-func (m *MockFlowDataStore) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error {
+func (m *MockFlowDataStore) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) ([]*storage.NetworkFlow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertFlows", ctx, flows, lastUpdateTS)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]*storage.NetworkFlow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpsertFlows indicates an expected call of UpsertFlows.

--- a/central/networkgraph/service/service_impl_postgres_benchmark_test.go
+++ b/central/networkgraph/service/service_impl_postgres_benchmark_test.go
@@ -127,7 +127,7 @@ func (s *networkGraphServiceBenchmarks) setupTables(b *testing.B, numFlows int) 
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, fixtureconsts.Cluster1)
 	require.NoError(b, err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
 	require.NoError(b, err)
 
 	return id.String()
@@ -198,7 +198,7 @@ func (s *networkGraphServiceBenchmarks) setupTablesForMetadata(b *testing.B) {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, fixtureconsts.Cluster1)
 	require.NoError(b, err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
 	require.NoError(b, err)
 }
 

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -183,7 +183,7 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
 	s.NoError(err)
 
 	request := &v1.NetworkGraphRequest{
@@ -295,7 +295,7 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraphNormalizedAndUnformalized(
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
 	s.NoError(err)
 
 	request := &v1.NetworkGraphRequest{
@@ -407,7 +407,7 @@ func (s *networkGraphServiceSuite) TestGetExternalNetworkFlows() {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, allFlows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, allFlows, timestamp.FromGoTime(time.Now()))
 	s.NoError(err)
 
 	for _, tc := range []struct {
@@ -565,7 +565,7 @@ func (s *networkGraphServiceSuite) TestGetExternalNetworkFlowsMetadata() {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
 	s.NoError(err)
 
 	for _, tc := range []struct {

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl.go
@@ -34,15 +34,7 @@ func (s *flowPersisterImpl) update(ctx context.Context, newFlows []*storage.Netw
 			if err != nil {
 				return err
 			}
-			err = s.updateExternalNetworkEntityIfDiscovered(ctx, newFlow.GetProps().DstEntity)
-			if err != nil {
-				return err
-			}
 			err = s.fixupExternalNetworkEntityIdIfDiscovered(ctx, newFlow.GetProps().SrcEntity)
-			if err != nil {
-				return err
-			}
-			err = s.updateExternalNetworkEntityIfDiscovered(ctx, newFlow.GetProps().SrcEntity)
 			if err != nil {
 				return err
 			}
@@ -80,7 +72,25 @@ func (s *flowPersisterImpl) update(ctx context.Context, newFlows []*storage.Netw
 		s.firstUpdateSeen = true
 	}
 
-	return s.flowStore.UpsertFlows(ctx, convertToFlows(flowsByIndicator), now)
+	upsertedFlows, err := s.flowStore.UpsertFlows(ctx, convertToFlows(flowsByIndicator), now)
+	if err != nil {
+		return err
+	}
+
+	if features.ExternalIPs.Enabled() {
+		for _, newFlow := range upsertedFlows {
+			err := s.updateExternalNetworkEntityIfDiscovered(ctx, newFlow.GetProps().DstEntity)
+			if err != nil {
+				return err
+			}
+			err = s.updateExternalNetworkEntityIfDiscovered(ctx, newFlow.GetProps().SrcEntity)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *flowPersisterImpl) markExistingFlowsAsTerminatedIfNotSeen(ctx context.Context, currentFlows map[networkgraph.NetworkConnIndicator]timestamp.MicroTS) error {

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -260,7 +260,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateNoExternalIPs() {
 			}
 		}
 		return len(used) == len(expectedUpdateProps)
-	}), gomock.Any()).Return(nil)
+	}), gomock.Any()).Return(newFlows, nil)
 
 	suite.mockEntities.EXPECT().UpdateExternalNetworkEntity(suite.hasWriteCtx, gomock.Any(), true).Times(0)
 
@@ -394,7 +394,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 			}
 		}
 		return len(used) == len(expectedUpdateProps)
-	}), gomock.Any()).Return(nil)
+	}), gomock.Any()).Return(newFlows, nil)
 
 	suite.mockEntities.EXPECT().UpdateExternalNetworkEntity(suite.hasWriteCtx, testutils.PredMatcher("matches an external entity", func(updatedEntity *storage.NetworkEntity) bool {
 		expectedEntities := []*storage.NetworkEntityInfo{

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -277,8 +277,10 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 
 	discoveredEntity1 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{1, 2, 3, 4, 32})).ToProto()
 	discoveredEntity2 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32})).ToProto()
+	discoveredEntity3 := networkgraph.DiscoveredExternalEntity(net.IPNetworkFromCIDRBytes([]byte{3, 4, 5, 6, 32})).ToProto()
 	fixedupDiscoveredEntity1 := networkgraph.DiscoveredExternalEntityClusterScoped("cluster", net.IPNetworkFromCIDRBytes([]byte{1, 2, 3, 4, 32})).ToProto()
 	fixedupDiscoveredEntity2 := networkgraph.DiscoveredExternalEntityClusterScoped("cluster", net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32})).ToProto()
+	fixedupDiscoveredEntity3 := networkgraph.DiscoveredExternalEntityClusterScoped("cluster", net.IPNetworkFromCIDRBytes([]byte{3, 4, 5, 6, 32})).ToProto()
 
 	secondTimestamp := time.Now()
 	newFlows := []*storage.NetworkFlow{
@@ -300,6 +302,37 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 			},
 			LastSeenTimestamp: protoconv.ConvertTimeToTimestamp(secondTimestamp),
 		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				SrcEntity:  discoveredEntity3,
+				DstEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: "someNode1"},
+				DstPort:    4,
+				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+			},
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestamp(secondTimestamp),
+		},
+	}
+
+	actuallyUpsertedFlows := []*storage.NetworkFlow{
+		{
+			Props: &storage.NetworkFlowProperties{
+				SrcEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: "someNode1"},
+				DstEntity:  discoveredEntity1,
+				DstPort:    3,
+				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+			},
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestamp(secondTimestamp),
+		},
+		{
+			Props: &storage.NetworkFlowProperties{
+				SrcEntity:  discoveredEntity2,
+				DstEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: "someNode1"},
+				DstPort:    4,
+				L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+			},
+			LastSeenTimestamp: protoconv.ConvertTimeToTimestamp(secondTimestamp),
+		},
+		// We simulate that the third flow was filtered out during Upsert().
 	}
 
 	// The properties of the flows we expect updates to. Properties identify flows uniquely.
@@ -312,6 +345,12 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 		},
 		{
 			SrcEntity:  fixedupDiscoveredEntity2,
+			DstEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: "someNode1"},
+			DstPort:    4,
+			L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+		},
+		{
+			SrcEntity:  fixedupDiscoveredEntity3,
 			DstEntity:  &storage.NetworkEntityInfo{Type: storage.NetworkEntityInfo_DEPLOYMENT, Id: "someNode1"},
 			DstPort:    4,
 			L4Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
@@ -342,6 +381,20 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 					Type:                  storage.NetworkEntityInfo_EXTERNAL_SOURCE,
 					ID:                    "cluster__Mi4zLjQuNS8zMg",
 					ExternalEntityAddress: net.IPNetworkFromCIDRBytes([]byte{2, 3, 4, 5, 32}),
+					Discovered:            true,
+				},
+				DstEntity: networkgraph.Entity{
+					Type: storage.NetworkEntityInfo_DEPLOYMENT,
+					ID:   "someNode1",
+				},
+				DstPort:  4,
+				Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+			}: timestamp.FromGoTime(secondTimestamp),
+			{
+				SrcEntity: networkgraph.Entity{
+					Type:                  storage.NetworkEntityInfo_EXTERNAL_SOURCE,
+					ID:                    "cluster__My40LjUuNi8zMg",
+					ExternalEntityAddress: net.IPNetworkFromCIDRBytes([]byte{3, 4, 5, 6, 32}),
 					Discovered:            true,
 				},
 				DstEntity: networkgraph.Entity{
@@ -394,12 +447,13 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdateWithExternalIPs() {
 			}
 		}
 		return len(used) == len(expectedUpdateProps)
-	}), gomock.Any()).Return(newFlows, nil)
+	}), gomock.Any()).Return(actuallyUpsertedFlows, nil)
 
 	suite.mockEntities.EXPECT().UpdateExternalNetworkEntity(suite.hasWriteCtx, testutils.PredMatcher("matches an external entity", func(updatedEntity *storage.NetworkEntity) bool {
 		expectedEntities := []*storage.NetworkEntityInfo{
 			discoveredEntity1,
 			discoveredEntity2,
+			// not discoveredEntity3 since the flow was filtered
 		}
 
 		for i := range expectedEntities {


### PR DESCRIPTION
### Description

When flows are received from Sensor, they are filtered before being inserted into the database, and in particular, flows for deleted deployments are ignored. However, there is no such check for 'discovered' network entities. Thus when a flow arrives in central for a deployment that has been deleted, the flow will not be inserted into the database, but the external entity will be inserted into the database. This causes 'already orphaned' entities to be stored and never destroyed.

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- [ ] The reproducer was manually replayed and no entities were inserted after the deployment was destroyed.
