### PR TITLE
ROX-29655: Fix inconsistent names in Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
@@ -9,7 +9,7 @@ type NodeUpdateSectionProps = {
     updateNetworkNodes: () => void;
 };
 
-const NodesUpdateSection = ({
+const NodeUpdateSection = ({
     isLoading,
     lastUpdatedTime,
     nodeUpdatesCount,
@@ -30,4 +30,4 @@ const NodesUpdateSection = ({
     return <em>Last updated {lastUpdatedTime ? `at ${lastUpdatedTime}` : 'never'}</em>;
 };
 
-export default NodesUpdateSection;
+export default NodeUpdateSection;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
@@ -37,13 +37,13 @@ import useModifyBaselineStatuses from '../api/useModifyBaselineStatuses';
 import useToggleAlertingOnBaselineViolation from '../api/useToggleAlertingOnBaselineViolation';
 import useFetchBaselineNetworkPolicy from '../api/useFetchBaselineNetworkPolicy';
 
-type DeploymentBaselinesProps = {
+type DeploymentBaselineProps = {
     deployment: Deployment;
     deploymentId: string;
     onNodeSelect: (id: string) => void;
 };
 
-function DeploymentBaselines({ deployment, deploymentId, onNodeSelect }: DeploymentBaselinesProps) {
+function DeploymentBaseline({ deployment, deploymentId, onNodeSelect }: DeploymentBaselineProps) {
     // component state
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
@@ -267,4 +267,4 @@ function DeploymentBaselines({ deployment, deploymentId, onNodeSelect }: Deploym
     );
 }
 
-export default DeploymentBaselines;
+export default DeploymentBaseline;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -32,7 +32,7 @@ import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import { DeploymentIcon } from '../common/NetworkGraphIcons';
 import DeploymentDetails from './DeploymentDetails';
 import DeploymentFlows from './DeploymentFlows';
-import DeploymentBaselines from './DeploymentBaseline';
+import DeploymentBaseline from './DeploymentBaseline';
 import NetworkPolicies from '../common/NetworkPolicies';
 import useSimulation from '../hooks/useSimulation';
 import { EdgeState } from '../components/EdgeStateSelect';
@@ -253,7 +253,7 @@ function DeploymentSideBar({
                             className="pf-v5-u-h-100"
                         >
                             {activeKeyTab === deploymentTabs.BASELINE && (
-                                <DeploymentBaselines
+                                <DeploymentBaseline
                                     deployment={deployment}
                                     deploymentId={deploymentId}
                                     onNodeSelect={onNodeSelect}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -13,19 +13,19 @@ import SelectSingle from 'Components/SelectSingle';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 
-type ViewActiveYamlsProps = {
+type ViewActiveYAMLsProps = {
     networkPolicies: NetworkPolicy[];
     generateNetworkPolicies: () => void;
     undoNetworkPolicies: () => void;
     onFileInputChange: (_event: DropEvent, file: File) => void;
 };
 
-function ViewActiveYamls({
+function ViewActiveYAMLs({
     networkPolicies,
     generateNetworkPolicies,
     undoNetworkPolicies,
     onFileInputChange,
-}: ViewActiveYamlsProps) {
+}: ViewActiveYAMLsProps) {
     const [selectedNetworkPolicy, setSelectedNetworkPolicy] = React.useState<
         NetworkPolicy | undefined
     >(networkPolicies?.[0]);
@@ -97,4 +97,4 @@ function ViewActiveYamls({
     );
 }
 
-export default ViewActiveYamls;
+export default ViewActiveYAMLs;


### PR DESCRIPTION
### Description

Prerequisite changes for future `'pluginGeneric/export-default-react'` lint rule.

### Problem

Find in Files results can mislead if component name is inconsistent with file name.

### Solution

1. Rename components according to file name.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.