### PR TITLE
ROX-29656: Fix inconsistent names in System Health

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -216,7 +216,7 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
         path: searchPath,
     },
     'system-health': {
-        component: asyncComponent(() => import('Containers/SystemHealth/DashboardPage')),
+        component: asyncComponent(() => import('Containers/SystemHealth/SystemHealthPage')),
         path: systemHealthPath,
     },
     systemconfig: {

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
@@ -14,19 +14,19 @@ import IntegrationsHealth from './IntegrationsHealth';
 import { IntegrationMergedItem } from '../utils/integrations';
 import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
 
-type IntegrationHealthWidgetProps = {
+type IntegrationHealthWidgetVisualProps = {
     integrationText: string;
     integrationsMerged: IntegrationMergedItem[];
     errorMessageFetching: string;
     isFetchingInitialRequest: boolean;
 };
 
-const IntegrationHealthWidget = ({
+const IntegrationHealthWidgetVisual = ({
     integrationText,
     integrationsMerged,
     errorMessageFetching,
     isFetchingInitialRequest,
-}: IntegrationHealthWidgetProps): ReactElement => {
+}: IntegrationHealthWidgetVisualProps): ReactElement => {
     const integrations = integrationsMerged.filter((integrationMergedItem) => {
         return integrationMergedItem.status === 'UNHEALTHY';
     });
@@ -81,4 +81,4 @@ const IntegrationHealthWidget = ({
     );
 };
 
-export default IntegrationHealthWidget;
+export default IntegrationHealthWidgetVisual;

--- a/ui/apps/platform/src/Containers/SystemHealth/SystemHealthPage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/SystemHealthPage.tsx
@@ -18,7 +18,7 @@ import BackupIntegrationHealthWidget from './Components/BackupIntegrationHealthW
 import ShowAdministrationUsage from './UsageStatistics/ShowAdministrationUsage';
 import CentralDatabaseHealthCard from './CentralDatabaseHealth/CentralDatabaseHealthCard';
 
-const SystemHealthDashboardPage = () => {
+function SystemHealthPage() {
     const { isCentralCapabilityAvailable } = useCentralCapabilities();
     const isDeclarativeConfigHealthAvailable = isCentralCapabilityAvailable(
         'centralCanDisplayDeclarativeConfigHealth'
@@ -128,6 +128,6 @@ const SystemHealthDashboardPage = () => {
             </PageSection>
         </>
     );
-};
+}
 
-export default SystemHealthDashboardPage;
+export default SystemHealthPage;


### PR DESCRIPTION
### Description

Prerequisite changes for future `'pluginGeneric/export-default-react'` lint rule.

### Problem

Find in Files results can mislead if component name is inconsistent with file name.

### Solution

1. Rename DashboardPage.jsx as SystemHealthPage.tsx and rewrite in TypeScript.
2. Rename `IntegrationHealthWidget` component according to file name.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
3. `npm run build` in ui/apps/platform folder.