### PR TITLE
ROX-29723: Fix Scan V4 defaults that break dele scan + remove itself

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
@@ -18,7 +18,7 @@
   {{- if $.Release.IsInstall -}}
     {{- $_ := set $scannerV4 "disable" false -}}
   {{- end -}}
-  
+
   {{/* If this is an upgrade and Scanner V4 Indexer is installed, it should stay installed. */}}
   {{- if $scannerV4.disable -}}
     {{ $indexerDeployment := dict }}

--- a/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
@@ -1,12 +1,12 @@
 {{/*
-  srox.scannerV4Defaulting <Helm .Release> <Scanner V4 configuration>
+  srox.scannerV4Defaulting $ <Scanner V4 configuration>
 
   Encapsulates the Scanner V4 defaulting logic.
 */}}
 
 {{- define "srox.scannerV4Defaulting" -}}
 
-{{- $helmRelease := index . 0 -}}
+{{- $ := index . 0 -}}
 {{- $scannerV4 := index . 1 -}}
 
 {{- if kindIs "invalid" $scannerV4.disable -}}
@@ -15,8 +15,18 @@
   {{- $_ := set $scannerV4 "disable" true -}}
 
   {{/* Currently the automatic enabling of Scanner V4 only kicks in for new installations, not for upgrades. */}}
-  {{- if $helmRelease.IsInstall -}}
+  {{- if $.Release.IsInstall -}}
     {{- $_ := set $scannerV4 "disable" false -}}
+  {{- end -}}
+  
+  {{/* If this is an upgrade and Scanner V4 Indexer is installed, it should stay installed. */}}
+  {{- if $scannerV4.disable -}}
+    {{ $indexerDeployment := dict }}
+    {{ include "srox.safeLookup" (list $ $indexerDeployment "apps/v1" "Deployment" $.Release.Namespace "scanner-v4-indexer") }}
+    {{ if $indexerDeployment.result }}
+      {{ include "srox.note" (list $ "Detected existing scanner-v4-indexer installation, keeping Scanner V4 installed.") }}
+      {{- $_ := set $scannerV4 "disable" false -}}
+    {{ end }}
   {{- end -}}
 
 {{- end -}}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -135,16 +135,16 @@
     {{- end -}}
   {{ end }}
 
-{{- if eq $.Chart.Name "stackrox-secured-cluster-services" -}}
-  {{/* Special handling for the secured-cluster-services chart in case it gets deployed
-       to the same namespace as central-services. */}}
-  {{ $centralDeployment := dict }}
-  {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
-  {{ if $centralDeployment.result }}
-    {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
-    {{ $_ := set $components "indexer" false }}
-  {{ end }}
-{{- end }}
+  {{- if eq $.Chart.Name "stackrox-secured-cluster-services" -}}
+    {{/* Special handling for the secured-cluster-services chart in case it gets deployed
+        to the same namespace as central-services. */}}
+    {{ $centralDeployment := dict }}
+    {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
+    {{ if $centralDeployment.result }}
+      {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
+      {{ $_ := set $components "indexer" false }}
+    {{ end }}
+  {{- end }}
 
 {{- end -}} {{/* if not $scannerV4Cfg.disable */}}
 

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -162,7 +162,7 @@
 {{ $_ = set $rox "_defaults" $defaultsCfg }}
 {{ $_ = include "srox.mergeInto" (list $rox $defaultsCfg.defaults) }}
 
-{{ $_ = include "srox.scannerV4Defaulting" (list .Release $rox.scannerV4) }}
+{{ $_ = include "srox.scannerV4Defaulting" (list $ $rox.scannerV4) }}
 
 {{/* Expand applicable config values */}}
 {{ $expandables := $.Files.Get "internal/expandables.yaml" | fromYaml }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -348,7 +348,6 @@ The following block checks for the validity of the provided init bundle. (`helm 
   {{ if $centralDeployment.result }}
     {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner from this chart and configuring sensor to use existing scanner instance, if any.") }}
     {{ $_ := set $._rox.scanner "disable" true }}
-    {{ $_ := set $._rox.scannerV4 "disable" true }}
   {{ end }}
 
   {{ $_ := set $._rox.sensor.localImageScanning "enabled" "true" }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -136,8 +136,8 @@
 {{ include "srox.getPVCs" (list $) }}
 
 [<- if not .KubectlOutput >]
-{{ $_ := include "srox.scannerV4Defaulting" (list .Release $._rox.scannerV4) }}
-{{ include "srox.scannerDefaulting" (list .Release $._rox.scanner) }}
+{{ $_ := include "srox.scannerV4Defaulting" (list $ $._rox.scannerV4) }}
+{{ include "srox.scannerDefaulting" (list $ $._rox.scanner) }}
 {{ if ne $._rox.scanner.mode "slim" }}
   {{ include "srox.fail" (print "Only scanner slim mode is allowed in Secured Cluster. To solve this, set to slim mode: scanner.mode=slim.") }}
 {{ end }}


### PR DESCRIPTION
### Description

When using helm - the ROX_SCANNER_V4 and ROX_SCANNER_V4_INDEXER_ENDPOINT env vars are NOT set on Sensor if scanner V4 is enabled (scannerV4.disable=false or unset) when installing a secured cluster into the same namespace as Central.

As a result, delegated scanning with Scanner V4 in same namespace installs will not be usable in 4.8 current state.

Additionally, if a user performs a fresh install of ACS in 4.8 they will by default have Scanner V4 installed (expected) - however if that same users modifies a value (such as the LogLevel) and re-applies the helm template, Scanner V4 will be uninstalled - which is likely not desired.

Operator testing has not yet been performed as of writing this



### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

New install manual test results on various cluster types and setups:

cluster | scanner.disable | scannerV4.disable | scanner | indexer | ROX_LOCAL_IMAGE_SCANNING_ENABLED | ROX_SCANNER_V4
--- | --- | --- | --- | --- | --- | ---
ocp w/ central | unset | unset | existing | existing | true  | true
ocp w/ central | true  | unset | n/a      | existing | true  | true
ocp w/ central | unset | true  | existing | n/a      | true  | unset
ocp w/ central | true  | true  | n/a      | n/a      | unset | unset
ocp w/ central | false | unset | n/a      | existing | true  | true
ocp w/ central | unset | false | existing | existing | true  | true
ocp w/ central | false | false | existing | existing | true  | true
gke secured cluster only | unset | unset | installed | installed | true  | true
gke secured cluster only | true  | unset | n/a       | installed | true  | true
gke secured cluster only | unset | true  | installed | n/a       | true  | unset
gke secured cluster only | true  | true  | n/a       | n/a       | unset | unset
gke secured cluster only | false | unset | installed | installed | true  | true
gke secured cluster only | unset | false | installed | installed | true  | true
gke secured cluster only | false | false | installed | installed | true  | true
ocp secured cluster only | unset | unset | installed | installed | true  | true
ocp secured cluster only | true  | unset | n/a       | installed | true  | true
ocp secured cluster only | unset | true  | installed | n/a       | true  | unset
ocp secured cluster only | true  | true  | n/a       | n/a       | unset | unset
ocp secured cluster only | false | unset | installed | installed | true  | true
ocp secured cluster only | unset | false | installed | installed | true  | true
ocp secured cluster only | false | false | installed | installed | true  | true

**Upgrade testing**
Re-ran helm upgrade on a previously installed secured cluster:
- Before fix - when Scanner V4 had been installed by default, noticed that Scanner V4 was uninstalled on upgrade (not desired).  After repeating this same test with the changes in this PR, Scanner V4 stays installed.

Re-ran helm upgrade on a previously installed central:
- Before fix - when Scanner V4 had been installed by default, noticed that Scanner V4 was uninstalled on upgrade (not desired). After repeating this same test with the changes in this PR, Scanner V4 stays installed.
