### PR TITLE
chore(ui): Replace deprecated Wizard component in VM reporting

### DIFF
--- a/ui/apps/platform/cypress/helpers/wizard.ts
+++ b/ui/apps/platform/cypress/helpers/wizard.ts
@@ -1,9 +1,9 @@
 export function getWizardNavStep(step: number | string) {
     if (typeof step === 'number') {
-        return cy.get('nav[data-ouia-component-type="PF5/WizardNav"] ol li').eq(step - 1);
+        return cy.get('*[data-ouia-component-type="PF5/WizardNavItem"]').eq(step - 1);
     }
 
-    return cy.get('nav[data-ouia-component-type="PF5/WizardNav"] ol li').contains(step);
+    return cy.get('*[data-ouia-component-type="PF5/WizardNavItem"]').contains(step);
 }
 
 export function goToWizardStep(step: number | string) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -110,7 +110,6 @@ function CloneVulnReportPage() {
                 <ReportFormWizard
                     formik={formik}
                     navAriaLabel="Report clone steps"
-                    mainAriaLabel="Report clone content"
                     wizardStepNames={wizardStepNames}
                     finalStepNextButtonText={'Create'}
                     onSave={onCreate}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
@@ -69,7 +69,6 @@ function CreateVulnReportPage() {
                 <ReportFormWizard
                     formik={formik}
                     navAriaLabel="Report creation steps"
-                    mainAriaLabel="Report creation content"
                     wizardStepNames={wizardStepNames}
                     onSave={onCreate}
                     finalStepNextButtonText={'Create'}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -103,7 +103,6 @@ function EditVulnReportPage() {
                 <ReportFormWizard
                     formik={formik}
                     navAriaLabel="Report edit steps"
-                    mainAriaLabel="Report edit content"
                     wizardStepNames={wizardStepNames}
                     onSave={onSave}
                     finalStepNextButtonText={'Save'}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Modal } from '@patternfly/react-core';
-import {
-    Wizard,
-    WizardContextConsumer,
-    WizardFooter,
-    WizardStep,
-} from '@patternfly/react-core/deprecated';
+import { Button, Modal, Wizard, WizardStep } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
 import isEmpty from 'lodash/isEmpty';
 
@@ -21,7 +15,6 @@ import { ReportFormValues } from '../forms/useReportFormValues';
 export type ReportFormWizardProps = {
     formik: FormikProps<ReportFormValues>;
     navAriaLabel: string;
-    mainAriaLabel: string;
     wizardStepNames: string[];
     finalStepNextButtonText: string;
     onSave: () => void;
@@ -31,7 +24,6 @@ export type ReportFormWizardProps = {
 function ReportFormWizard({
     formik,
     navAriaLabel,
-    mainAriaLabel,
     wizardStepNames,
     finalStepNextButtonText,
     onSave,
@@ -44,24 +36,6 @@ function ReportFormWizard({
     function onClose() {
         navigate(vulnerabilityConfigurationReportsPath);
     }
-
-    const wizardSteps: WizardStep[] = [
-        {
-            name: wizardStepNames[0],
-            component: <ReportParametersForm title={wizardStepNames[0]} formik={formik} />,
-        },
-        {
-            name: wizardStepNames[1],
-            component: <DeliveryDestinationsForm title={wizardStepNames[1]} formik={formik} />,
-            isDisabled: isStepDisabled(wizardStepNames[1]),
-        },
-        {
-            name: wizardStepNames[2],
-            component: <ReportReviewForm title={wizardStepNames[2]} formValues={formik.values} />,
-            nextButtonText: finalStepNextButtonText,
-            isDisabled: isStepDisabled(wizardStepNames[2]),
-        },
-    ];
 
     function isStepDisabled(stepName: string | undefined): boolean {
         if (stepName === wizardStepNames[0]) {
@@ -81,94 +55,68 @@ function ReportFormWizard({
     }
 
     return (
-        <Wizard
-            navAriaLabel={navAriaLabel}
-            mainAriaLabel={mainAriaLabel}
-            hasNoBodyPadding
-            steps={wizardSteps}
-            onSave={onSave}
-            onClose={onClose}
-            footer={
-                <WizardFooter>
-                    <WizardContextConsumer>
-                        {({ activeStep, onNext, onBack, onClose }) => {
-                            const firstStepName = wizardSteps[0].name;
-                            const lastStepName = wizardSteps[wizardSteps.length - 1].name;
-                            const activeStepIndex = wizardSteps.findIndex(
-                                (wizardStep) => wizardStep.name === activeStep.name
-                            );
-                            const nextStepName =
-                                activeStepIndex === wizardSteps.length - 1
-                                    ? undefined
-                                    : wizardSteps[activeStepIndex + 1].name;
-                            const isNextDisabled = isStepDisabled(nextStepName as string);
-
-                            return (
-                                <>
-                                    {activeStep.name !== lastStepName ? (
-                                        <Button
-                                            variant="primary"
-                                            type="submit"
-                                            onClick={onNext}
-                                            isDisabled={isNextDisabled}
-                                        >
-                                            Next
-                                        </Button>
-                                    ) : (
-                                        <Button
-                                            variant="primary"
-                                            type="submit"
-                                            onClick={onSave}
-                                            isLoading={isSaving}
-                                        >
-                                            {finalStepNextButtonText}
-                                        </Button>
-                                    )}
-                                    <Button
-                                        variant="secondary"
-                                        onClick={onBack}
-                                        isDisabled={activeStep.name === firstStepName}
-                                    >
-                                        Back
-                                    </Button>
-                                    <Button variant="link" onClick={openModal}>
-                                        Cancel
-                                    </Button>
-                                    <Modal
-                                        variant="small"
-                                        title="Confirm cancel"
-                                        isOpen={isModalOpen}
-                                        onClose={closeModal}
-                                        actions={[
-                                            <Button
-                                                key="confirm"
-                                                variant="primary"
-                                                onClick={onClose}
-                                            >
-                                                Confirm
-                                            </Button>,
-                                            <Button
-                                                key="cancel"
-                                                variant="secondary"
-                                                onClick={closeModal}
-                                            >
-                                                Cancel
-                                            </Button>,
-                                        ]}
-                                    >
-                                        <p>
-                                            Are you sure you want to cancel? Any unsaved changes
-                                            will be lost. You will be taken back to the list of
-                                            reports.
-                                        </p>
-                                    </Modal>
-                                </>
-                            );
-                        }}
-                    </WizardContextConsumer>
-                </WizardFooter>
-            }
-        />
+        <>
+            <Wizard navAriaLabel={navAriaLabel} onSave={onSave}>
+                <WizardStep
+                    name={wizardStepNames[0]}
+                    id={wizardStepNames[0]}
+                    key={wizardStepNames[0]}
+                    body={{ hasNoPadding: true }}
+                    footer={{
+                        isNextDisabled: isStepDisabled(wizardStepNames[1]),
+                        onClose: openModal,
+                    }}
+                >
+                    <ReportParametersForm title={wizardStepNames[0]} formik={formik} />
+                </WizardStep>
+                <WizardStep
+                    name={wizardStepNames[1]}
+                    id={wizardStepNames[1]}
+                    key={wizardStepNames[1]}
+                    body={{ hasNoPadding: true }}
+                    isDisabled={isStepDisabled(wizardStepNames[1])}
+                    footer={{
+                        isNextDisabled: isStepDisabled(wizardStepNames[2]),
+                        onClose: openModal,
+                    }}
+                >
+                    <DeliveryDestinationsForm title={wizardStepNames[1]} formik={formik} />
+                </WizardStep>
+                <WizardStep
+                    name={wizardStepNames[2]}
+                    id={wizardStepNames[2]}
+                    key={wizardStepNames[2]}
+                    body={{ hasNoPadding: true }}
+                    isDisabled={isStepDisabled(wizardStepNames[2])}
+                    footer={{
+                        nextButtonProps: { isLoading: isSaving },
+                        nextButtonText: finalStepNextButtonText,
+                        onClose: openModal,
+                    }}
+                >
+                    <ReportReviewForm title={wizardStepNames[2]} formValues={formik.values} />
+                </WizardStep>
+            </Wizard>
+            <Modal
+                variant="small"
+                title="Confirm cancel"
+                isOpen={isModalOpen}
+                onClose={closeModal}
+                actions={[
+                    <Button key="confirm" variant="primary" onClick={onClose}>
+                        Confirm
+                    </Button>,
+                    <Button key="cancel" variant="secondary" onClick={closeModal}>
+                        Cancel
+                    </Button>,
+                ]}
+            >
+                <p>
+                    Are you sure you want to cancel? Any unsaved changes will be lost. You will be
+                    taken back to the list of reports.
+                </p>
+            </Modal>
+        </>
     );
 }
 


### PR DESCRIPTION
### Description

As titled. No functional changes, only a change in the underlying component.

### Follow up issue

Going to step 2 of the wizard, adding a delivery destination, and then removing the delivery destination locks the form in an "invalid" state and makes navigation impossible without reloading.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI tests created exactly for this moment.

Manual smoke test of wizard in create/edit/clone modes.
