### PR TITLE
fix: Helm: Keep scanner-v4 enabled except for upgrades from 4.7

### DIFF
--- a/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
@@ -20,7 +20,7 @@
   {{- $installVersionUnknown := kindIs "invalid" $stackroxHelm.installXYVersion -}}
   {{- $upgradingFromPre4_8 := or $installVersionUnknown (semverCompare "< 4.8" $stackroxHelm.installXYVersion) -}}
   {{- if and $helmRelease.IsUpgrade $upgradingFromPre4_8 -}}
-    {{- include "srox.note" (list $ (printf "Scanner V4 disabled due to upgrade from version %s.x" $stackroxHelm.installXYVersion)) -}}
+    {{- include "srox.note" (list $ "Scanner V4 disabled by default: this deployment was initially installed before version 4.8.") -}}
     {{- $_ := set $scannerV4 "disable" true -}}
   {{- end -}}
 {{- end -}}

--- a/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_defaulting.tpl
@@ -1,24 +1,27 @@
 {{/*
-  srox.scannerV4Defaulting <Helm .Release> <Scanner V4 configuration>
+  srox.scannerV4Defaulting <Helm .> <Helm .Release> <Scanner V4 configuration> <Stackrox Helm ConfigMap content>
 
   Encapsulates the Scanner V4 defaulting logic.
 */}}
 
 {{- define "srox.scannerV4Defaulting" -}}
 
-{{- $helmRelease := index . 0 -}}
-{{- $scannerV4 := index . 1 -}}
+{{- $ := index . 0 -}}
+{{- $helmRelease := index . 1 -}}
+{{- $scannerV4 := index . 2 -}}
+{{- $stackroxHelm := index . 3 -}}
 
 {{- if kindIs "invalid" $scannerV4.disable -}}
-
-  {{/* Default to not-installed (i.e. upgrades). */}}
-  {{- $_ := set $scannerV4 "disable" true -}}
-
-  {{/* Currently the automatic enabling of Scanner V4 only kicks in for new installations, not for upgrades. */}}
-  {{- if $helmRelease.IsInstall -}}
-    {{- $_ := set $scannerV4 "disable" false -}}
+  {{/* Scanner V4 neither explicitly enabled or disabled, apply defaulting logic. */}}
+  {{/* By default Scanner V4 will be installed. */}}
+  {{- $_ := set $scannerV4 "disable" false -}}
+  {{/* Currently there is one exception: when upgrading from a pre-4.8 version, which did not
+       install Scanner V4 by default. */}}
+  {{- $installVersionUnknown := kindIs "invalid" $stackroxHelm.installXYVersion -}}
+  {{- $upgradingFromPre4_8 := or $installVersionUnknown (semverCompare "< 4.8" $stackroxHelm.installXYVersion) -}}
+  {{- if and $helmRelease.IsUpgrade $upgradingFromPre4_8 -}}
+    {{- include "srox.note" (list $ (printf "Scanner V4 disabled due to upgrade from version %s.x" $stackroxHelm.installXYVersion)) -}}
+    {{- $_ := set $scannerV4 "disable" true -}}
   {{- end -}}
-
 {{- end -}}
-
 {{- end -}}

--- a/image/templates/helm/stackrox-central/.helmtplignore.htpl
+++ b/image/templates/helm/stackrox-central/.helmtplignore.htpl
@@ -34,4 +34,7 @@ templates/*
 !templates/01-central-*-db-tls-secret.yaml
 templates/*
 [< end >]
+[< if .KubectlOutput >]
+templates/00-stackrox-helm-configmap.yaml
+[< end >]
 templates/keep.yaml

--- a/image/templates/helm/stackrox-central/templates/00-stackrox-helm-configmap.yaml
+++ b/image/templates/helm/stackrox-central/templates/00-stackrox-helm-configmap.yaml
@@ -1,0 +1,14 @@
+{{- include "srox.init" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stackrox-central-helm
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "srox.labels" (list . "configmap" "stackrox-central-helm") | nindent 4 }}
+  annotations:
+    {{- $annotations := dict "helm.sh/hook" "pre-install" -}}
+    {{- include "srox.annotations" (list . "configmap" "stackrox-central-helm" $annotations) | nindent 4 }}
+data:
+  installAppVersion: {{ .Chart.AppVersion | quote }}
+  installXYVersion: {{ .Chart.AppVersion | regexFind "^\\d+\\.\\d+" | quote }}

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -151,6 +151,9 @@
 
 {{ include "srox.setInstallMethod" (list $) }}
 
+{{/* Attempt to retrieve stackrox-central-helm ConfigMap. Must be done before the defaulting logic is applied. */}}
+{{ include "srox.retrieveStackroxCentralHelmConfigMap" (list $) }}
+
 {{/* Apply defaults */}}
 {{ $defaultsCfg := dict }}
 {{ $platformCfgFile := dict }}
@@ -162,7 +165,7 @@
 {{ $_ = set $rox "_defaults" $defaultsCfg }}
 {{ $_ = include "srox.mergeInto" (list $rox $defaultsCfg.defaults) }}
 
-{{ $_ = include "srox.scannerV4Defaulting" (list .Release $rox.scannerV4) }}
+{{ $_ = include "srox.scannerV4Defaulting" (list $ .Release $rox.scannerV4 $.stackroxHelm) }}
 
 {{/* Expand applicable config values */}}
 {{ $expandables := $.Files.Get "internal/expandables.yaml" | fromYaml }}

--- a/image/templates/helm/stackrox-central/templates/_stackrox_helm.tpl
+++ b/image/templates/helm/stackrox-central/templates/_stackrox_helm.tpl
@@ -1,0 +1,10 @@
+{{- define "srox.retrieveStackroxCentralHelmConfigMap" -}}
+{{- $ := index . 0 -}}
+{{- $stackroxHelm := dict -}}
+{{- $lookupResult := dict -}}
+{{- $_ := include "srox.safeLookup" (list $ $lookupResult "v1" "ConfigMap" $.Release.Namespace "stackrox-central-helm") -}}
+{{- if $lookupResult.result -}}
+  {{- $stackroxHelm = $lookupResult.result.data -}}
+{{- end -}}
+{{- $_ := set $ "stackroxHelm" $stackroxHelm -}}
+{{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/.helmtplignore.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/.helmtplignore.htpl
@@ -1,6 +1,7 @@
 [<- if .KubectlOutput >]
 templates/cluster-config.yaml
 templates/00-injected-ca-bundle.yaml
+templates/stackrox-helm-configmap.yaml
 internal/cluster-config.yaml.tpl
 sensor-chart-upgrade.md
 scripts/

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -140,7 +140,7 @@
 
 [<- if not .KubectlOutput >]
 {{ $_ := include "srox.scannerV4Defaulting" (list $ .Release $._rox.scannerV4 $.stackroxHelm) }}
-{{ include "srox.scannerDefaulting" (list .Release $._rox.scanner) }}
+{{ include "srox.scannerDefaulting" (list . .Release $._rox.scanner $.stackroxHelm) }}
 {{ if ne $._rox.scanner.mode "slim" }}
   {{ include "srox.fail" (print "Only scanner slim mode is allowed in Secured Cluster. To solve this, set to slim mode: scanner.mode=slim.") }}
 {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -135,8 +135,11 @@
 {{ include "srox.getStorageClasses" (list $) }}
 {{ include "srox.getPVCs" (list $) }}
 
+{{/* Attempt to retrieve stackrox-secured-cluster-helm ConfigMap. Must be done before the defaulting logic is applied. */}}
+{{ include "srox.retrieveStackroxSecuredClusterHelmConfigMap" (list $) }}
+
 [<- if not .KubectlOutput >]
-{{ $_ := include "srox.scannerV4Defaulting" (list .Release $._rox.scannerV4) }}
+{{ $_ := include "srox.scannerV4Defaulting" (list $ .Release $._rox.scannerV4 $.stackroxHelm) }}
 {{ include "srox.scannerDefaulting" (list .Release $._rox.scanner) }}
 {{ if ne $._rox.scanner.mode "slim" }}
   {{ include "srox.fail" (print "Only scanner slim mode is allowed in Secured Cluster. To solve this, set to slim mode: scanner.mode=slim.") }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_scanner-defaulting.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_scanner-defaulting.tpl
@@ -22,7 +22,7 @@
   {{- $installVersionUnknown := kindIs "invalid" $stackroxHelm.installXYVersion -}}
   {{- $upgradingFromPre4_8 := or $installVersionUnknown (semverCompare "< 4.8" $stackroxHelm.installXYVersion) -}}
   {{- if and $helmRelease.IsUpgrade $upgradingFromPre4_8 -}}
-    {{- include "srox.note" (list $ (printf "StackRox Scanner not installed due to upgrade from version %s.x" $stackroxHelm.installXYVersion)) -}}
+    {{- include "srox.note" (list $ "StackRox Scanner disabled by default: this deployment was initially installed before version 4.8.") -}}
     {{- $_ := set $scanner "disable" true -}}
   {{- end -}}
 {{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_scanner-defaulting.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_scanner-defaulting.tpl
@@ -1,5 +1,5 @@
 {{/*
-  srox.scannerDefaulting <Helm .Release> <Scanner configuration>
+  srox.scannerDefaulting <Helm .> <Helm .Release> <Scanner configuration> <Stackrox Helm ConfigMap content>
 
   Encapsulates the Scanner defaulting logic.
 
@@ -8,19 +8,22 @@
 
 {{- define "srox.scannerDefaulting" -}}
 
-{{- $helmRelease := index . 0 -}}
-{{- $scanner := index . 1 -}}
+{{- $ := index . 0 -}}
+{{- $helmRelease := index . 1 -}}
+{{- $scanner := index . 2 -}}
+{{- $stackroxHelm := index . 3 -}}
 
 {{- if kindIs "invalid" $scanner.disable -}}
-
-  {{/* Default to not-installed (i.e. upgrades). */}}
-  {{- $_ := set $scanner "disable" true -}}
-
-  {{/* Currently the automatic enabling of Scanner only kicks in for new installations, not for upgrades. */}}
-  {{- if $helmRelease.IsInstall -}}
-    {{- $_ := set $scanner "disable" false -}}
+  {{/* Scanner neither explicitly enabled or disabled, apply defaulting logic. */}}
+  {{/* By default Scanner will be installed. */}}
+  {{- $_ := set $scanner "disable" false -}}
+  {{/* Currently there is one exception: when upgrading from a pre-4.8 version, which did not
+       install Scanner by default. */}}
+  {{- $installVersionUnknown := kindIs "invalid" $stackroxHelm.installXYVersion -}}
+  {{- $upgradingFromPre4_8 := or $installVersionUnknown (semverCompare "< 4.8" $stackroxHelm.installXYVersion) -}}
+  {{- if and $helmRelease.IsUpgrade $upgradingFromPre4_8 -}}
+    {{- include "srox.note" (list $ (printf "StackRox Scanner not installed due to upgrade from version %s.x" $stackroxHelm.installXYVersion)) -}}
+    {{- $_ := set $scanner "disable" true -}}
   {{- end -}}
-
 {{- end -}}
-
 {{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_stackrox_helm.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_stackrox_helm.tpl
@@ -1,0 +1,10 @@
+{{- define "srox.retrieveStackroxSecuredClusterHelmConfigMap" -}}
+{{- $ := index . 0 -}}
+{{- $stackroxHelm := dict -}}
+{{- $lookupResult := dict -}}
+{{- $_ := include "srox.safeLookup" (list $ $lookupResult "v1" "ConfigMap" $.Release.Namespace "stackrox-secured-cluster-helm") -}}
+{{- if $lookupResult.result -}}
+  {{- $stackroxHelm = $lookupResult.result.data -}}
+{{- end -}}
+{{- $_ := set $ "stackroxHelm" $stackroxHelm -}}
+{{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/stackrox-helm-configmap.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/stackrox-helm-configmap.yaml
@@ -1,0 +1,14 @@
+{{- include "srox.init" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stackrox-secured-cluster-helm
+  namespace: {{ ._rox._namespace | quote }}
+  labels:
+    {{- include "srox.labels" (list . "configmap" "stackrox-secured-cluster-helm") | nindent 4 }}
+  annotations:
+    {{- $annotations := dict "helm.sh/hook" "pre-install" -}}
+    {{- include "srox.annotations" (list . "configmap" "stackrox-secured-cluster-helm" $annotations) | nindent 4 }}
+data:
+  installAppVersion: {{ .Chart.AppVersion | quote }}
+  installXYVersion: {{ .Chart.AppVersion | regexFind "^\\d+\\.\\d+" | quote }}

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -266,13 +266,51 @@ tests:
       release: { "isInstall": true, "isUpgrade": false }
       set:
         scanner.disable: true
+    - name: "on upgrade from >= 4.8"
+      release: { "isInstall": false, "isUpgrade": true }
+      server:
+        objects:
+          - apiVersion: v1
+            kind: Secret
+            metadata:
+              name: scanner-v4-db-tls
+              namespace: stackrox
+            stringData:
+              ca.pem: ""
+              cert.pem: ""
+              key.pem: ""
+          - apiVersion: v1
+            kind: Secret
+            metadata:
+              name: scanner-v4-matcher-tls
+              namespace: stackrox
+            stringData:
+              ca.pem: ""
+              cert.pem: ""
+              key.pem: ""
+          - apiVersion: v1
+            kind: Secret
+            metadata:
+              name: scanner-v4-indexer-tls
+              namespace: stackrox
+            stringData:
+              ca.pem: ""
+              cert.pem: ""
+              key.pem: ""
+          - apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: stackrox-central-helm
+              namespace: stackrox
+            data:
+              installXYVersion: "4.8"
   - name: "not installed"
     expect: |
       .deployments["scanner-v4-indexer"] | assertThat(. == null)
       .deployments["scanner-v4-matcher"] | assertThat(. == null)
       .deployments["scanner-v4-db"] | assertThat(. == null)
     tests:
-    - name: "on upgrade"
+    - name: "on upgrade from pre-4.8"
       release: { "isInstall": false, "isUpgrade": true }
 
 - name: "Scanner V4 can be disabled without impacting Scanner V2"

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -270,33 +270,38 @@ tests:
       release: { "isInstall": false, "isUpgrade": true }
       server:
         objects:
-          - apiVersion: v1
-            kind: Secret
-            metadata:
-              name: scanner-v4-db-tls
-              namespace: stackrox
-            stringData:
-              ca.pem: ""
-              cert.pem: ""
-              key.pem: ""
-          - apiVersion: v1
-            kind: Secret
-            metadata:
-              name: scanner-v4-matcher-tls
-              namespace: stackrox
-            stringData:
-              ca.pem: ""
-              cert.pem: ""
-              key.pem: ""
-          - apiVersion: v1
-            kind: Secret
-            metadata:
-              name: scanner-v4-indexer-tls
-              namespace: stackrox
-            stringData:
-              ca.pem: ""
-              cert.pem: ""
-              key.pem: ""
+        # Dummy secrets to avoid the chart trying to generate them and fail due to missing CA key.
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: scanner-v4-db-tls
+            namespace: stackrox
+          stringData:
+            ca.pem: ""
+            cert.pem: ""
+            key.pem: ""
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: scanner-v4-matcher-tls
+            namespace: stackrox
+          stringData:
+            ca.pem: ""
+            cert.pem: ""
+            key.pem: ""
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: scanner-v4-indexer-tls
+            namespace: stackrox
+          stringData:
+            ca.pem: ""
+            cert.pem: ""
+            key.pem: ""
+      tests:
+      - name: "from 4.8"
+        server:
+          objects:
           - apiVersion: v1
             kind: ConfigMap
             metadata:
@@ -304,6 +309,16 @@ tests:
               namespace: stackrox
             data:
               installXYVersion: "4.8"
+      - name: "from 4.9"
+        server:
+          objects:
+          - apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: stackrox-central-helm
+              namespace: stackrox
+            data:
+              installXYVersion: "4.9"
   - name: "not installed"
     expect: |
       .deployments["scanner-v4-indexer"] | assertThat(. == null)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -72,18 +72,30 @@ tests:
   release: { "isInstall": false, "isUpgrade": true}
   set:
     imagePullSecrets.allowNone: true
-  server:
-    objects:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: stackrox-secured-cluster-helm
-        namespace: stackrox
-      data:
-        installXYVersion: "4.8"
   expect: |
     .deployments["scanner"] | assertThat(. != null)
     .deployments["scanner-db"] | assertThat(. != null)
+  tests:
+  - name: "from 4.8"
+    server:
+      objects:
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: stackrox-secured-cluster-helm
+          namespace: stackrox
+        data:
+          installXYVersion: "4.8"
+  - name: "from 4.9"
+    server:
+      objects:
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: stackrox-secured-cluster-helm
+          namespace: stackrox
+        data:
+          installXYVersion: "4.9"
 
 - name: "scanner V4 enabled should only deploy indexer and db"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -44,7 +44,7 @@ tests:
     .deployments["scanner-v4-indexer"] | assertThat(. != null)
     .deployments["scanner-v4-db"] | assertThat(. != null)
 
-- name: "scanner V4 should not be installed by default for upgrades"
+- name: "scanner V4 should not be installed by default for upgrades from < 4.8"
   release: { "isInstall": false, "isUpgrade": true}
   set:
     imagePullSecrets.allowNone: true
@@ -60,13 +60,30 @@ tests:
     .deployments["scanner"] | assertThat(. != null)
     .deployments["scanner-db"] | assertThat(. != null)
 
-- name: "scanner V2 should be not installed by default for upgrades"
+- name: "scanner V2 should be not installed by default for upgrades from < 4.8"
   release: { "isInstall": false, "isUpgrade": true}
   set:
     imagePullSecrets.allowNone: true
   expect: |
     .deployments["scanner"] | assertThat(. == null)
     .deployments["scanner-db"] | assertThat(. == null)
+
+- name: "scanner V2 should be installed by default for upgrades from >= 4.8"
+  release: { "isInstall": false, "isUpgrade": true}
+  set:
+    imagePullSecrets.allowNone: true
+  server:
+    objects:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: stackrox-secured-cluster-helm
+        namespace: stackrox
+      data:
+        installXYVersion: "4.8"
+  expect: |
+    .deployments["scanner"] | assertThat(. != null)
+    .deployments["scanner-db"] | assertThat(. != null)
 
 - name: "scanner V4 enabled should only deploy indexer and db"
   set:

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -533,6 +533,34 @@ EOT
     run verify_deployment_scannerV4_env_var_set "$CUSTOM_SENSOR_NAMESPACE" "sensor"
 
     ######################
+    _begin "upgrading-head-central"
+    info "Upgrade central-services using same chart version"
+    deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$MAIN_IMAGE_TAG" "" \
+        -f <(echo "$password_setting")
+    local central_endpoint="$(get_central_endpoint "$CUSTOM_CENTRAL_NAMESPACE")"
+
+    ######################
+    _begin "uprading-head-sensor"
+    info "Upgrading secured-cluster-services using same chart version"
+    deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" \
+        "$MAIN_IMAGE_TAG" "" \
+        "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
+
+    ######################
+    _step "verifying-central-scanners-deployed"
+    info "Verifying that scanners are still installed"
+    verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
+    verify_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
+    verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
+
+    ######################
+    _step "verifying-sensor-scanners-deployed"
+    info "Verifying that scanners are still installed"
+    verify_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
+    verify_scannerV4_indexer_deployed "$CUSTOM_SENSOR_NAMESPACE"
+    run verify_deployment_scannerV4_env_var_set "$CUSTOM_SENSOR_NAMESPACE" "sensor"
+
+    ######################
     _begin "disabling-central-scanner-v4"
     info "Disabling Scanner V4 for central-services"
     deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$MAIN_IMAGE_TAG" "" \

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -472,16 +472,22 @@ EOT
         "$EARLIER_MAIN_IMAGE_TAG" "$old_sensor_chart" \
         "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
 
+    _step "verify-scanner-V2-not-deployed"
+    verify_no_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
+
     _step "verify-scanner-V4-not-deployed"
     verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
     _step "upgrade-to-HEAD-sensor"
     deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" "" "" "" "" ""
 
-    _step "verify-scanner-not-deployed"
+    _step "verify-scanner-V2-not-deployed"
+    verify_no_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
+
+    _step "verify-scanner-V4-not-deployed"
     verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
-    _begin "enable-scanner-V4-in-secured-cluster"
+    _begin "enable-scanners-in-secured-cluster"
     # Without creating the scanner-db-password secret manually Scanner V2 doesn't come up.
     # Let's just reuse an existing password for this for simplicity.
     "$ORCH_CMD" </dev/null -n "$CUSTOM_SENSOR_NAMESPACE" create secret generic scanner-db-password \
@@ -490,6 +496,9 @@ EOT
     deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" "" "" "" "" "" \
         --set scannerV4.disable=false \
         --set scanner.disable=false
+
+    _step "verify-scanner-V2-deployed"
+    verify_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
     _step "verify-scanner-V4-deployed"
     verify_scannerV4_indexer_deployed "$CUSTOM_SENSOR_NAMESPACE"


### PR DESCRIPTION
[PR to be reviewed commit-by-commit.]

### Description

**Hot fix for broken Scanner V4 defaulting logic in Helm charts.**

It is unfortunate that it has been overlooked that the `helm upgrade` scenario does *not* work as expected in the current `master` & `release-4.8` branches.

Nevertheless, this is a **release blocker** -- this PR contains a less-trivial change for our both of our Helm charts.

Context: [Slack thread](https://redhat-internal.slack.com/archives/C073B31JVDY/p1749831795950259).

I will describe the problem that has been reported by @dcaravel in my own words:

The upgrade logic in both Helm charts is broken according to common-sense expectations by users of the Helm charts. Assume:
1. Users installs central-services (resp. secured-cluster-services), relying on Scanner V4 defaults -> Scanner V4 installed.
2. User re-applies the same (or modified) Helm chart configuration using `helm upgrade`, still relying on Scanner V4 defaulting -> Scanner V4 is removed.

Why is it removed? Because the defaulting logic in the Helm chart has wrongly been based *only* on the install vs. upgrade method. And, as matter of fact, "upgrading" in Helm land can not only mean "upgrade from Version x to version x+1", it can also mean "reapply the configuration for the existing installation".

What is needed?

We need to extend the defaulting logic so that it is not
```
if upgrading then
  do_not_install_scanner_v4
else
  install_scanner_v4
```

but instead something like
```
if upgrading_from_pre_4_8 then
  do_not_install_scanner_v4
else
  install_scanner_v4
```

**Implementation Obstacle**

We don't *have* the required information, the "previous version" from which we are upgrading, available as of now. But, as I see it, we need this.

**Solution**

I have integrated new `ConfigMaps` named `stackrox-central-helm` and `stackrox-secured-cluster-helm`. I have deliberately tried to keep it quite general, in case we might need to store more information in this file at a later point in time.

In this PR, this ConfigMap is created in both of our Helm charts as a *pre-install* hook. Hence, it won't be created during upgrades, it will only be created during installation flows.

The ConfigMap contains two keys: `installAppVersion` and `installXYVersion`. Why two? `installAppVersion` is essentially the `make tag`, which means it is the most precise version we can use. But unfortunately it is not a valid semVer, because it can use letters where digits are expected (`4.9.x-...`). That's why I also added the `installXYVersion`, which is just the `4.9` part, can be compared with the built-in `semverCompare` function and should be sufficient for our use-case.

This `XYVersion` is then propagated to the Scanner V4 defaulting logic, allowing is to make the proper decision. If the ConfigMap is not present, this is interpreted as "we are upgrading from a pre-4.8 version".

**Alternatives considered**

As has been suggested on Slack, one could also check for the existence of the Scanner V4 deployments and then use this information to "keep" Scanner V4.

While possible, I think this solution would still expose surprising semantics to the user: Installing a Helm chart, deleting a deployment (or some other Scanner V4 resource) and then basically re-applying the same Helm chart configuration would *not* "re-concile" the cluster resources, it would keep Scanner V4 uninstalled.

One can argue that the same problem exists with my `ConfigMap` approach -- true in princple -- but at least it is a resource that carries `helm` in its name, plus the kind of this resource (`ConfigMap`) indicates that it might have something to do with the way the Helm chart is behaving.

### Addendum

The same problem also currently exists in the `secured-cluster-services` Helm chart for the StackRox Scanner. Background/Reminder: before 4.8 Scanner V2 was not installed by default, beginning with 4.8 it is installed by default -- hence we are in the very same situation with the same requirements for install/upgrade scenarios as with Scanner V4. I have updated my PR to include the same fixes for the Scanner V2 defaulting.

### User-facing documentation

Nothing specific to this PR.

- [x] I believe all CHANGELOG changes are already covered with previous PRs.
- [x] Same for documentation changes.

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] added unit tests
- [x] added e2e tests
- [x] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The newly added automated tests are sufficient for helm install.

For manifest install:
- [x] generate manifest bundle for central on a commit before the PR, and from this PR, and compare files to make sure the differences are as expected
- [x] the same for secured cluster manifest bundle

Comparing the secured cluster bundles shows nothing out of the ordinary, but comparing central bundles shows the following somewhat unexpected differences:
- in `helm/chart/internal/defaults.yaml`:
   ![image](https://github.com/user-attachments/assets/19cb6c37-cb9c-4eb1-82c0-97ae831ff552)
- in `helm/chart/templates/01-central-13-deployment.yaml`:
   ![image](https://github.com/user-attachments/assets/ac5a7160-c087-45e2-ac8e-fb2ea6f3bdd3)
- in `helm.chart/templates/_init.tpl`:
   ![image](https://github.com/user-attachments/assets/bc99e2fe-ba37-4ad8-b02d-94ed262d9b25)
- in `helm/chart/templates/_set_install_method.tpl`:
   ![image](https://github.com/user-attachments/assets/39dc1643-37f3-4432-9956-d1ad5055ef0f)

I think these are results of commit https://github.com/stackrox/stackrox/pull/15732/commits/33d63d2b4b5f6d7521e7759fd8d74d85ca0a4220 and looks like they fix an unrelated long-standing bug, but I feel a bit uneasy bundling this change silently in this PR.
