### PR TITLE
ROX-29716: Fix signature verification for OCP images

### DIFF
--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -59,6 +59,25 @@ const (
 		"TljNWItNDA0MC05ZGJlLTQ0NDgzNjE3MGJlYSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OjI5OGQxZWVk" +
 		"Mjg5M2Y2MWVkMjU0YzY4YWZmMjQxN2RlYWYzNDI2MzJhYjI2ZGJiZGIzOTkxNzE0ZTUwMWUxYzkifSwidHlwZSI6ImNvc2lnbiBjb250YWl" +
 		"uZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
+
+	// OCP image signed by Red Hat release key.
+	pemPublicKey_OCP = "-----BEGIN PUBLIC KEY-----\n" +
+		"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0ASyuH2TLWvBUqPHZ4Ip\n" +
+		"75g7EncBkgQHdJnjzxAW5KQTMh/siBoB/BoSrtiPMwnChbTCnQOIQeZuDiFnhuJ7\n" +
+		"M/D3b7JoX0m123NcCSn67mAdjBa6Bg6kukZgCP4ZUZeESajWX/EjylFcRFOXW57p\n" +
+		"RDCEN42J/jYlVqt+g9+Grker8Sz86H3l0tbqOdjbz/VxHYhwF0ctUMHsyVRDq2QP\n" +
+		"tqzNXlmlMhS/PoFr6R4u/7HCn/K+LegcO2fAFOb40KvKSKKVD6lewUZErhop1CgJ\n" +
+		"XjDtGmmO9dGMF71mf6HEfaKSdy+EE6iSF2A2Vv9QhBawMiq2kOzEiLg4nAdJT8wg\n" +
+		"ZrMAmPCqGIsXNGZ4/Q+YTwwlce3glqb5L9tfNozEdSR9N85DESfQLQEdY3CalwKM\n" +
+		"BT1OEhEX1wHRCU4drMOej6BNW0VtscGtHmCrs74jPezhwNT8ypkyS+T0zT4Tsy6f\n" +
+		"VXkJ8YSHyenSzMB2Op2bvsE3grY+s74WhG9UIA6DBxcTie15NSzKwfzaoNWODcLF\n" +
+		"p7BY8aaHE2MqFxYFX+IbjpkQRfaeQQsouDFdCkXEFVfPpbD2dk6FleaMTPuyxtIT\n" +
+		"gjVEtGQK2qGCFGiQHFd4hfV+eCA63Jro1z0zoBM5BbIIQ3+eVFwt3AlZp5UVwr6d\n" +
+		"secqki/yrmv3Y0dqZ9VOn3UCAwEAAQ==\n" +
+		"-----END PUBLIC KEY-----"
+	imgName_OCP      = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c896b5d4b05343dfe94c0f75c9232a2a68044d0fa7a21b5f51ed796d23f1fcc5"
+	b64Signature_OCP = "tkgrrtlysbiLo+chF2+EmcPXyGNfhVZIptlgyPK6b0Ptu8FGpk1AdhBckiKExLbx3QwkJci8lvPXWhFEXtGQc1lnw1knKvCenHArW5MbGYaBbZ5v1o2+mF4XIgAePi3PT3KoViCcemg8M3MQUxV8u4RnpMLdMu7PtQvYwOmafw9ja7RYUMoR4FfVn6EWLZUWQ5qtuU7hcR7eaCPKP7tIuedI2Ks+MTlT61NZTG16cmDw8TgkGdheR6xuA8Nw2PgMl3Ij6YGLRJBY/QIm3HSyTjr7QC1+S4Va0rln/4ywFyJuHtSLy/AlirpoqMwNiPM2Rdqd7JJ6MI4wTpIv55DUgQLKkwmZiVgWkklPrME7PIRUcKIICouALwJIZhchDtScl05ntJF0TXW4PK/qzEWs12O0GDYQVdGTGxYQR0Y1EXPK3Rwtq3dFF+pmvnFMY0j6jp092QPJIkQe8bf26drPitPpiVSdBn8fRKQu4TAlwTUmElg5n60kN8JznHxqO81MppNyw8PYfmK0s05b9X21yxkxy0/1g4h9kSlAgVdq6+vjs/QGaNl1n/bsF2krXw9/C8shVLBHsLDnQX7zpXxubVvSkXAfllg6tS17WJfB7ga5605TlPaMHrvyJO13jQbSDFMzaixtxaO85KjVdUOHE1e4SvFcQZzxzv2DdOiGhnE="
+	b64Payload_OCP   = "eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoicXVheS5pby9vcGVuc2hpZnQtcmVsZWFzZS1kZXYvb2NwLXY0LjAtYXJ0LWRldkBzaGEyNTY6Yzg5NmI1ZDRiMDUzNDNkZmU5NGMwZjc1YzkyMzJhMmE2ODA0NGQwZmE3YTIxYjVmNTFlZDc5NmQyM2YxZmNjNSJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OmM4OTZiNWQ0YjA1MzQzZGZlOTRjMGY3NWM5MjMyYTJhNjgwNDRkMGZhN2EyMWI1ZjUxZWQ3OTZkMjNmMWZjYzUifSwidHlwZSI6ImNvc2lnbiBjb250YWluZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ=="
 )
 
 func TestNewCosignSignatureVerifier(t *testing.T) {
@@ -126,6 +145,56 @@ func TestCosignSignatureVerifier_VerifySignature_Success(t *testing.T) {
 	require.Len(t, verifiedImageReferences, 1)
 	assert.Equal(t, img.GetName().GetFullName(), verifiedImageReferences[0],
 		"image full name should match verified image reference")
+}
+
+func TestCosignSignatureVerifier_VerifySignature_OCP_Image(t *testing.T) {
+	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{
+		Cosign: &storage.CosignPublicKeyVerification{
+			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
+				{
+					Name:            "cosignSignatureVerifier",
+					PublicKeyPemEnc: pemPublicKey_OCP,
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err, "creating public key verifier")
+
+	img, err := generateImageWithCosignSignature(imgName_OCP, b64Signature_OCP, b64Payload_OCP, nil, nil)
+	require.NoError(t, err, "creating image with signature")
+
+	status, verifiedImageReferences, err := pubKeyVerifier.VerifySignature(context.Background(), img)
+	assert.NoError(t, err, "verification should be successful")
+	assert.Equal(t, storage.ImageSignatureVerificationResult_VERIFIED, status, "status should be VERIFIED")
+	require.Len(t, verifiedImageReferences, 1)
+	assert.Contains(t, verifiedImageReferences, img.GetName().GetFullName(),
+		"image full name should match verified image reference")
+}
+
+func TestCosignSignatureVerifier_VerifySignature_NoVerifiedImageReferences(t *testing.T) {
+	pubKeyVerifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{
+		Cosign: &storage.CosignPublicKeyVerification{
+			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
+				{
+					Name:            "cosignSignatureVerifier",
+					PublicKeyPemEnc: pemPublicKey_OCP,
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err, "creating public key verifier")
+
+	// The actual signature has been created for quay.io.
+	fakeName := "docker.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c896b5d4b05343dfe94c0f75c9232a2a68044d0fa7a21b5f51ed796d23f1fcc5"
+	img, err := generateImageWithCosignSignature(fakeName, b64Signature_OCP, b64Payload_OCP, nil, nil)
+	require.NoError(t, err, "creating image with signature")
+
+	status, verifiedImageReferences, err := pubKeyVerifier.VerifySignature(context.Background(), img)
+	assert.ErrorIs(t, err, errNoVerifiedReferences)
+	assert.Equal(t, storage.ImageSignatureVerificationResult_FAILED_VERIFICATION, status, "status should be FAILED_VERIFICATION")
+	require.Empty(t, verifiedImageReferences)
 }
 
 func TestCosignSignatureVerifier_VerifySignature_Multiple_Names_One_Sig(t *testing.T) {
@@ -493,26 +562,54 @@ func TestRetrieveVerificationDataFromImage_Failure(t *testing.T) {
 	}
 }
 
-func TestDockerReferenceFromImageName(t *testing.T) {
+func TestEqualRegistryRepository(t *testing.T) {
 	cases := map[string]struct {
-		name *storage.ImageName
-		res  string
+		signatureIdentity string
+		imageName         string
+		expected          bool
 	}{
-		"shouldn't rewrite registry name for quay.io": {
-			name: &storage.ImageName{FullName: "quay.io/some-repo/image:latest"},
-			res:  "quay.io/some-repo/image",
+		"match for quay.io with image tag": {
+			signatureIdentity: "quay.io/some-repo/image",
+			imageName:         "quay.io/some-repo/image:latest",
+			expected:          true,
 		},
-		"should rewrite registry name for docker.io": {
-			name: &storage.ImageName{FullName: "docker.io/some-repo/image:latest"},
-			res:  "index.docker.io/some-repo/image",
+		"match for quay.io with image digest": {
+			signatureIdentity: "quay.io/some-repo/image",
+			imageName:         "quay.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
+			expected:          true,
+		},
+		"match for quay.io with signature digest and image digest": {
+			signatureIdentity: "quay.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
+			imageName:         "quay.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
+			expected:          true,
+		},
+		"match for docker.io with image tag": {
+			signatureIdentity: "index.docker.io/some-repo/image",
+			imageName:         "docker.io/some-repo/image:latest",
+			expected:          true,
+		},
+		"match for docker.io with image digest": {
+			signatureIdentity: "index.docker.io/some-repo/image",
+			imageName:         "docker.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
+			expected:          true,
+		},
+		"match for docker.io with signature digest and image digest": {
+			signatureIdentity: "index.docker.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
+			imageName:         "docker.io/some-repo/image@sha256:a97a153152fcd6410bdf4fb64f5622ecf97a753f07dcc89dab14509d059736cf",
+			expected:          true,
+		},
+		"no match": {
+			signatureIdentity: "index.docker.io/some-repo/image",
+			imageName:         "quay.io/some-repo/image:latest",
+			expected:          false,
 		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			res, err := dockerReferenceFromImageName(c.name)
+			ok, err := equalRegistryRepository(c.signatureIdentity, c.imageName)
 			assert.NoError(t, err)
-			assert.Equal(t, c.res, res)
+			assert.Equal(t, c.expected, ok)
 		})
 	}
 }


### PR DESCRIPTION
### Description

Manual backport of https://github.com/stackrox/stackrox/pull/15703 to 4.6

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I deployed stackrox 4.6, added a quay.io signature integration and used `roxctl` to scan an OCP image:

```console
$ roxcurl v1/metadata
{"version":"4.6.7-1-gd22d35f42c", "buildFlavor":"development", "releaseBuild":false, "licenseStatus":"VALID"}

$ roxctl --insecure-skip-tls-verify -e https://localhost:8000/ image scan -i quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c896b5d4b05343dfe94c0f75c9232a2a68044d0fa7a21b5f51ed796d23f1fcc5 --force  | jq .signatureVerificationData
{
  "results": [
    {
      "verificationTime": "2025-06-16T21:36:54.189317578Z",
      "verifierId": "io.stackrox.signatureintegration.36d85dbc-714d-4be9-9c32-5477cab609ca",
      "status": "VERIFIED",
      "verifiedImageReferences": [
        "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c896b5d4b05343dfe94c0f75c9232a2a68044d0fa7a21b5f51ed796d23f1fcc5"
      ]
    }
  ]
}```