### PR TITLE
ROX-28151: Custom Prometheus metrics tracker runner

### DIFF
--- a/central/config/service/service.go
+++ b/central/config/service/service.go
@@ -67,16 +67,18 @@ type Service interface {
 }
 
 // New returns a new Service instance using the given DataStore.
-func New(datastore datastore.DataStore) Service {
+func New(datastore datastore.DataStore, ar customMetrics.Runner) Service {
 	return &serviceImpl{
-		datastore: datastore,
+		datastore:  datastore,
+		aggregator: ar,
 	}
 }
 
 type serviceImpl struct {
 	v1.UnimplementedConfigServiceServer
 
-	datastore datastore.DataStore
+	datastore  datastore.DataStore
+	aggregator customMetrics.Runner
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.
@@ -165,8 +167,9 @@ func (s *serviceImpl) PutConfig(ctx context.Context, req *v1.PutConfigRequest) (
 		}
 	}
 
-	if err := customMetrics.ParseConfiguration(
-		req.GetConfig().GetPrivateConfig().GetPrometheusMetricsConfig()); err != nil {
+	customMetricsCfg, err := s.aggregator.ParseConfiguration(
+		req.GetConfig().GetPrivateConfig().GetPrometheusMetricsConfig())
+	if err != nil {
 		return nil, err
 	}
 
@@ -185,7 +188,7 @@ func (s *serviceImpl) PutConfig(ctx context.Context, req *v1.PutConfigRequest) (
 	}
 	matcher.Singleton().SetRegexes(regexes)
 	go reprocessor.Singleton().RunReprocessor()
-
+	s.aggregator.Reconfigure(customMetricsCfg)
 	return req.GetConfig(), nil
 }
 

--- a/central/config/service/service_test.go
+++ b/central/config/service/service_test.go
@@ -72,7 +72,7 @@ func (s *configServiceTestSuite) SetupSuite() {
 	s.ctx = sac.WithAllAccess(context.Background())
 	s.db = pgtest.ForT(s.T())
 	s.dataStore = datastore.NewForTest(s.T(), s.db.DB)
-	s.srv = New(s.dataStore)
+	s.srv = New(s.dataStore, nil)
 
 	// Not found because Singleton() was not called and default configuration was not initialize.
 	cfg, err := s.srv.GetVulnerabilityExceptionConfig(s.ctx, &v1.Empty{})

--- a/central/config/service/singleton.go
+++ b/central/config/service/singleton.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/stackrox/rox/central/config/datastore"
+	"github.com/stackrox/rox/central/metrics/aggregator"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -12,7 +13,7 @@ var (
 )
 
 func initialize() {
-	as = New(datastore.Singleton())
+	as = New(datastore.Singleton(), aggregator.Singleton())
 }
 
 // Singleton provides the instance of the Service interface to register.

--- a/central/main.go
+++ b/central/main.go
@@ -872,7 +872,14 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			// The access is behind authorization because the metric label
 			// values may include sensitive data, such as deployment names and
 			// CVEs.
-			Route:         "GET /metrics/",
+			Route:         "GET /metrics",
+			Authorizer:    user.With(permissions.View(resources.Administration)),
+			ServerHandler: customMetrics.Singleton(),
+			Compression:   true,
+		},
+		{
+			// Same as above, for custom paths.
+			Route:         "GET /metrics/{custom}",
 			Authorizer:    user.With(permissions.View(resources.Administration)),
 			ServerHandler: customMetrics.Singleton(),
 			Compression:   true,

--- a/central/main.go
+++ b/central/main.go
@@ -872,7 +872,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			// The access is behind authorization because the metric label
 			// values may include sensitive data, such as deployment names and
 			// CVEs.
-			Route:         "/metrics/{custom}",
+			Route:         "GET /metrics/",
 			Authorizer:    user.With(permissions.View(resources.Administration)),
 			ServerHandler: customMetrics.Singleton(),
 			Compression:   true,

--- a/central/main.go
+++ b/central/main.go
@@ -872,7 +872,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			// The access is behind authorization because the metric label
 			// values may include sensitive data, such as deployment names and
 			// CVEs.
-			Route:         "/metrics",
+			Route:         "/metrics/{custom}",
 			Authorizer:    user.With(permissions.View(resources.Administration)),
 			ServerHandler: customMetrics.Singleton(),
 			Compression:   true,

--- a/central/metrics/aggregator/common/config_parser.go
+++ b/central/metrics/aggregator/common/config_parser.go
@@ -28,6 +28,25 @@ type metricExposure struct {
 	exposure metrics.Exposure
 }
 
+func (me *metricExposure) String() string {
+	switch me.exposure {
+	case metrics.INTERNAL:
+		return "internal path /metrics"
+	case metrics.EXTERNAL:
+		if me.registry == "" {
+			return "external path /metrics"
+		}
+		return "external path /metrics/" + me.registry
+	case metrics.BOTH:
+		if me.registry == "" {
+			return "internal and external path /metrics"
+		}
+		return "internal path /metrics and external path /metrics/" + me.registry
+	default:
+		return "not exposed"
+	}
+}
+
 type Configuration struct {
 	metrics        MetricsConfiguration
 	metricRegistry map[MetricName]metricExposure

--- a/central/metrics/aggregator/common/config_parser.go
+++ b/central/metrics/aggregator/common/config_parser.go
@@ -95,7 +95,7 @@ func parseMetricLabels(config map[string]*storage.PrometheusMetricsConfig_Labels
 	return result, nil
 }
 
-func ParseConfiguration(cfg *storage.PrometheusMetricsConfig_Metrics, currentMetrics MetricsConfiguration, labelOrder map[Label]int) (*Configuration, error) {
+func parseConfiguration(cfg *storage.PrometheusMetricsConfig_Metrics, currentMetrics MetricsConfiguration, labelOrder map[Label]int) (*Configuration, error) {
 	metricRegistry := make(map[MetricName]metricExposure, len(cfg.GetMetrics()))
 
 	for metric, labels := range cfg.GetMetrics() {

--- a/central/metrics/aggregator/common/config_parser_test.go
+++ b/central/metrics/aggregator/common/config_parser_test.go
@@ -90,7 +90,7 @@ func Test_parseErrors(t *testing.T) {
 
 func TestParseConfiguration(t *testing.T) {
 	t.Run("bad metric name", func(t *testing.T) {
-		cfg, err := ParseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
+		cfg, err := parseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
 			GatheringPeriodMinutes: 121,
 			Metrics: map[string]*storage.PrometheusMetricsConfig_Labels{
 				" ": nil,
@@ -103,7 +103,7 @@ func TestParseConfiguration(t *testing.T) {
 	})
 
 	t.Run("bad registry name", func(t *testing.T) {
-		cfg, err := ParseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
+		cfg, err := parseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
 			GatheringPeriodMinutes: 121,
 			Metrics: map[string]*storage.PrometheusMetricsConfig_Labels{
 				"m1": {
@@ -119,7 +119,7 @@ func TestParseConfiguration(t *testing.T) {
 
 	t.Run("test parse sequence", func(t *testing.T) {
 		// Good:
-		cfg0, err := ParseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
+		cfg0, err := parseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
 			GatheringPeriodMinutes: 121,
 			Metrics:                makeTestMetricLabels(t),
 			Filter:                 "Cluster:name",
@@ -132,7 +132,7 @@ func TestParseConfiguration(t *testing.T) {
 		}
 
 		// Bad:
-		cfg1, err := ParseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
+		cfg1, err := parseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
 			GatheringPeriodMinutes: 121,
 			Metrics: map[string]*storage.PrometheusMetricsConfig_Labels{
 				"m1": {
@@ -147,7 +147,7 @@ func TestParseConfiguration(t *testing.T) {
 		assert.Nil(t, cfg1)
 
 		// Another good:
-		cfg2, err := ParseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
+		cfg2, err := parseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
 			GatheringPeriodMinutes: 121,
 			Metrics: map[string]*storage.PrometheusMetricsConfig_Labels{
 				"m2": {
@@ -168,7 +168,7 @@ func TestParseConfiguration(t *testing.T) {
 	})
 
 	t.Run("test bad query", func(t *testing.T) {
-		cfg, err := ParseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
+		cfg, err := parseConfiguration(&storage.PrometheusMetricsConfig_Metrics{
 			GatheringPeriodMinutes: 121,
 			Metrics:                makeTestMetricLabels(t),
 			Filter:                 "bad query?",
@@ -185,7 +185,7 @@ func TestParseConfiguration(t *testing.T) {
 			GatheringPeriodMinutes: 121,
 			Metrics:                makeTestMetricLabels(t),
 		}
-		cfg0, err := ParseConfiguration(storageConfig, nil, testLabelOrder)
+		cfg0, err := parseConfiguration(storageConfig, nil, testLabelOrder)
 		assert.NoError(t, err)
 
 		for _, labels := range storageConfig.Metrics {
@@ -207,7 +207,7 @@ func TestParseConfiguration(t *testing.T) {
 			}
 		}
 
-		cfg1, err := ParseConfiguration(storageConfig, cfg0.metrics, testLabelOrder)
+		cfg1, err := parseConfiguration(storageConfig, cfg0.metrics, testLabelOrder)
 
 		assert.ErrorIs(t, err, errInvalidConfiguration, err)
 		assert.Nil(t, cfg1)
@@ -218,14 +218,14 @@ func TestParseConfiguration(t *testing.T) {
 			GatheringPeriodMinutes: 121,
 			Metrics:                makeTestMetricLabels(t),
 		}
-		cfg0, err := ParseConfiguration(storageConfig, nil, testLabelOrder)
+		cfg0, err := parseConfiguration(storageConfig, nil, testLabelOrder)
 		assert.NoError(t, err)
 		for _, config := range storageConfig.Metrics {
 			if config.Exposure == storage.PrometheusMetricsConfig_Labels_BOTH {
 				config.Labels["CVE"] = &storage.PrometheusMetricsConfig_Labels_Expression{}
 			}
 		}
-		cfg1, err := ParseConfiguration(storageConfig, cfg0.metrics, testLabelOrder)
+		cfg1, err := parseConfiguration(storageConfig, cfg0.metrics, testLabelOrder)
 
 		assert.ErrorIs(t, err, errInvalidConfiguration, err)
 		assert.True(t, strings.Contains(err.Error(), "cannot alter metrics"))

--- a/central/metrics/aggregator/common/tracker_base.go
+++ b/central/metrics/aggregator/common/tracker_base.go
@@ -96,6 +96,9 @@ func MakeTrackerBase[Finding Countable](category, description string,
 
 func (tracker *TrackerBase[Finding]) ParseConfiguration(cfg *storage.PrometheusMetricsConfig_Metrics) (*Configuration, error) {
 	current := tracker.GetConfiguration()
+	if current == nil {
+		current = &Configuration{}
+	}
 	return parseConfiguration(cfg, current.metrics, tracker.labelOrder)
 }
 

--- a/central/metrics/aggregator/image_vulnerabilities/labels.go
+++ b/central/metrics/aggregator/image_vulnerabilities/labels.go
@@ -1,24 +1,29 @@
 package image_vulnerabilities
 
 import (
+	"strconv"
+
 	"github.com/stackrox/rox/central/metrics/aggregator/common"
-	"github.com/stackrox/rox/generated/storage"
 )
 
-var (
-	getters = []common.LabelGetter[*finding]{
-		{Label: "Cluster", Getter: func(f *finding) string { return f.deployment.GetClusterName() }},
-	}
+var getters = []common.LabelGetter[*finding]{
+	{Label: "Cluster", Getter: func(f *finding) string { return f.deployment.GetClusterName() }},
+	{Label: "Namespace", Getter: func(f *finding) string { return f.deployment.GetNamespace() }},
+	{Label: "Deployment", Getter: func(f *finding) string { return f.deployment.GetName() }},
+	{Label: "IsPlatformWorkload", Getter: isPlatformWorkload},
 
-	labels = common.MakeLabelOrderMap(getters)
-)
+	{Label: "ImageID", Getter: func(f *finding) string { return f.image.GetId() }},
+	{Label: "ImageRegistry", Getter: func(f *finding) string { return f.name.GetRegistry() }},
+	{Label: "ImageRemote", Getter: func(f *finding) string { return f.name.GetRemote() }},
+	{Label: "ImageTag", Getter: func(f *finding) string { return f.name.GetTag() }},
+	{Label: "Component", Getter: func(f *finding) string { return f.component.GetName() }},
+	{Label: "ComponentVersion", Getter: func(f *finding) string { return f.component.GetVersion() }},
+	{Label: "OperatingSystem", Getter: func(f *finding) string { return f.image.GetScan().GetOperatingSystem() }},
 
-type finding struct {
-	common.OneOrMore
-	deployment *storage.Deployment
-}
-
-func ParseConfiguration(config *storage.PrometheusMetricsConfig_Metrics) error {
-	_, err := common.ParseConfiguration(config, nil, labels)
-	return err
+	{Label: "CVE", Getter: func(f *finding) string { return f.vuln.GetCve() }},
+	{Label: "CVSS", Getter: func(f *finding) string { return strconv.FormatFloat(float64(f.vuln.GetCvss()), 'f', 1, 32) }},
+	{Label: "Severity", Getter: func(f *finding) string { return f.vuln.GetSeverity().String() }},
+	{Label: "SeverityV2", Getter: func(f *finding) string { return f.vuln.GetCvssV2().GetSeverity().String() }},
+	{Label: "SeverityV3", Getter: func(f *finding) string { return f.vuln.GetCvssV3().GetSeverity().String() }},
+	{Label: "IsFixable", Getter: func(f *finding) string { return strconv.FormatBool(f.vuln.GetFixedBy() != "") }},
 }

--- a/central/metrics/aggregator/image_vulnerabilities/tracker.go
+++ b/central/metrics/aggregator/image_vulnerabilities/tracker.go
@@ -1,0 +1,74 @@
+package image_vulnerabilities
+
+import (
+	"context"
+	"iter"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
+	"github.com/stackrox/rox/central/metrics/aggregator/common"
+	"github.com/stackrox/rox/central/platform/matcher"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+type finding struct {
+	common.OneOrMore
+	deployment *storage.Deployment
+	image      *storage.Image
+	name       *storage.ImageName
+	component  *storage.EmbeddedImageScanComponent
+	vuln       *storage.EmbeddedVulnerability
+}
+
+func isPlatformWorkload(f *finding) string {
+	p, _ := matcher.Singleton().MatchDeployment(f.deployment)
+	return strconv.FormatBool(p)
+}
+
+func New(gauge func(string, prometheus.Labels, int), ds deploymentDS.DataStore) *common.TrackerBase[*finding] {
+	tc := common.MakeTrackerBase(
+		"vulnerabilities",
+		"aggregated CVEs",
+		getters,
+		func(ctx context.Context, q *v1.Query, mcfg common.MetricsConfiguration) iter.Seq[*finding] {
+			return trackVulnerabilityMetrics(ctx, q, mcfg, ds)
+		},
+		gauge)
+	return tc
+}
+
+func trackVulnerabilityMetrics(ctx context.Context, query *v1.Query, _ common.MetricsConfiguration, ds deploymentDS.DataStore) iter.Seq[*finding] {
+	return func(yield func(*finding) bool) {
+		finding := &finding{}
+		_ = ds.WalkByQuery(ctx, query, func(deployment *storage.Deployment) error {
+			finding.deployment = deployment
+			images, err := ds.GetImagesForDeployment(ctx, deployment)
+			if err != nil {
+				return nil // Nothing can be done with this error here.
+			}
+			for _, finding.image = range images {
+				if !forEachImageVuln(yield, finding) {
+					return common.ErrStopIterator
+				}
+			}
+			return nil
+		})
+	}
+}
+
+// forEachImageVuln yields a finding for every vulnerability associated with
+// each image name.
+func forEachImageVuln(yield func(*finding) bool, f *finding) bool {
+	for _, f.component = range f.image.GetScan().GetComponents() {
+		for _, f.vuln = range f.component.GetVulns() {
+			for _, f.name = range f.image.GetNames() {
+				if !yield(f) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}

--- a/central/metrics/aggregator/image_vulnerabilities/tracker_test.go
+++ b/central/metrics/aggregator/image_vulnerabilities/tracker_test.go
@@ -1,0 +1,218 @@
+package image_vulnerabilities
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	deploymentMockDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
+	v1api "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+type image storage.Image
+
+func (i *image) withCVE(cve ...*storage.EmbeddedVulnerability) *image {
+	if i.Scan == nil {
+		i.Scan = &storage.ImageScan{
+			OperatingSystem: "os",
+			Components:      []*storage.EmbeddedImageScanComponent{{}}}
+	}
+	is := i.Scan
+	is.Components[0].Vulns = append(is.Components[0].Vulns, cve...)
+	return i
+}
+
+func makeTestImage(id string) *image {
+	return &image{Id: id}
+}
+
+func (i *image) withTags(tags ...string) *image {
+	for _, tag := range tags {
+		i.Names = append(i.Names, &storage.ImageName{
+			Remote:   "remote",
+			Tag:      tag,
+			Registry: "registry",
+		})
+	}
+	return i
+}
+
+func getTestData() ([]*storage.Deployment, map[string][]*storage.Image) {
+	cves := getTestCVEs()
+
+	images := getTestImages(cves)
+
+	deployments := []*storage.Deployment{
+		{Id: "deployment-0", Name: "D0", Namespace: "namespace-1", ClusterName: "cluster-1"},
+		{Id: "deployment-1", Name: "D1", Namespace: "namespace-2", ClusterName: "cluster-1"},
+		{Id: "deployment-2", Name: "D2", Namespace: "namespace-2", ClusterName: "cluster-1"},
+		{Id: "deployment-3", Name: "D3", Namespace: "namespace-2", ClusterName: "cluster-2"},
+	}
+
+	deploymentImages := map[string][]*storage.Image{
+		deployments[0].Id: {images[0]},
+		deployments[1].Id: {images[0], images[1]},
+		deployments[2].Id: {images[2]},
+		deployments[3].Id: {images[3]},
+	}
+	return deployments, deploymentImages
+}
+
+func getTestImages(cves []*storage.EmbeddedVulnerability) []*storage.Image {
+	return []*storage.Image{
+		(*storage.Image)(makeTestImage("image-0").withTags("tag").withCVE(cves[0])),
+		(*storage.Image)(makeTestImage("image-1").withTags("tag").withCVE(cves[0], cves[1])),
+		(*storage.Image)(makeTestImage("image-2").withTags("tag").withCVE(cves[1])),
+		(*storage.Image)(makeTestImage("image-3").withTags("tag", "latest").withCVE(cves[1], cves[2])),
+	}
+}
+
+func getTestCVEs() []*storage.EmbeddedVulnerability {
+	return []*storage.EmbeddedVulnerability{
+		{Cve: "cve-0", Cvss: 7.5,
+			CvssV3:   &storage.CVSSV3{Severity: storage.CVSSV3_CRITICAL},
+			Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+		},
+		{Cve: "cve-1", Cvss: 5.0,
+			CvssV3:   &storage.CVSSV3{Severity: storage.CVSSV3_MEDIUM},
+			Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+		},
+		{Cve: "cve-2", Cvss: 3.0,
+			CvssV3:   &storage.CVSSV3{Severity: storage.CVSSV3_LOW},
+			Severity: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+		},
+	}
+}
+
+type labelsTotal struct {
+	labels prometheus.Labels
+	total  int
+}
+
+func TestQueryDeploymentsAndImages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ds := deploymentMockDS.NewMockDataStore(ctrl)
+
+	deployments, deploymentImages := getTestData()
+
+	ds.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(1).
+		Do(func(_ context.Context, _ *v1api.Query, f func(*storage.Deployment) error) {
+			for _, deployment := range deployments {
+				_ = f(deployment)
+			}
+		}).
+		Return(nil)
+
+	for _, deployment := range deployments {
+		ds.EXPECT().GetImagesForDeployment(gomock.Any(), deployment).
+			Times(1).Return(deploymentImages[deployment.Id], nil)
+	}
+
+	var actual = make(map[string][]*labelsTotal)
+
+	gauge := func(metric string, labels prometheus.Labels, total int) {
+		actual[metric] = append(actual[metric], &labelsTotal{labels, total})
+	}
+
+	tracker := New(gauge, ds)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg, err := tracker.ParseConfiguration(
+		&storage.PrometheusMetricsConfig_Metrics{
+			GatheringPeriodMinutes: 121,
+			Metrics: map[string]*storage.PrometheusMetricsConfig_Labels{
+				"Severity_count": {
+					Labels: map[string]*storage.PrometheusMetricsConfig_Labels_Expression{
+						"Severity": {},
+					},
+					Exposure: storage.PrometheusMetricsConfig_Labels_INTERNAL,
+				},
+				"Cluster_Namespace_Severity_count": {
+					Labels: map[string]*storage.PrometheusMetricsConfig_Labels_Expression{
+						"Cluster":   {},
+						"Namespace": {},
+						"Severity":  {},
+					},
+				},
+				"Deployment_ImageTag_count": {
+					Labels: map[string]*storage.PrometheusMetricsConfig_Labels_Expression{
+						"Deployment": {
+							Expression: []*storage.PrometheusMetricsConfig_Labels_Expression_Condition{{
+								Operator: "=",
+								Argument: "*3",
+							}}},
+						"ImageTag": {
+							Expression: []*storage.PrometheusMetricsConfig_Labels_Expression_Condition{{
+								Operator: "=",
+								Argument: "latest",
+							}}},
+					}}},
+		})
+
+	assert.NoError(t, err)
+	tracker.Reconfigure(ctx, cfg)
+	tracker.Run(ctx)
+
+	expected := map[string][]*labelsTotal{
+		"Severity_count": {
+			{prometheus.Labels{"Severity": "CRITICAL_VULNERABILITY_SEVERITY"}, 3},
+			{prometheus.Labels{"Severity": "MODERATE_VULNERABILITY_SEVERITY"}, 4},
+			{prometheus.Labels{"Severity": "LOW_VULNERABILITY_SEVERITY"}, 2},
+		},
+		"Cluster_Namespace_Severity_count": {
+			{prometheus.Labels{"Cluster": "cluster-1", "Namespace": "namespace-1", "Severity": "CRITICAL_VULNERABILITY_SEVERITY"}, 1},
+			{prometheus.Labels{"Cluster": "cluster-1", "Namespace": "namespace-2", "Severity": "CRITICAL_VULNERABILITY_SEVERITY"}, 2},
+			{prometheus.Labels{"Cluster": "cluster-1", "Namespace": "namespace-2", "Severity": "MODERATE_VULNERABILITY_SEVERITY"}, 2},
+			{prometheus.Labels{"Cluster": "cluster-2", "Namespace": "namespace-2", "Severity": "MODERATE_VULNERABILITY_SEVERITY"}, 2},
+			{prometheus.Labels{"Cluster": "cluster-2", "Namespace": "namespace-2", "Severity": "LOW_VULNERABILITY_SEVERITY"}, 2},
+		},
+		"Deployment_ImageTag_count": {
+			{prometheus.Labels{"Deployment": "D3", "ImageTag": "latest"}, 2},
+		},
+	}
+
+	for metric := range expected {
+		assert.Contains(t, actual, metric)
+	}
+	for metric, records := range actual {
+		assert.ElementsMatch(t, expected[metric], records)
+	}
+}
+
+func Test_forEachImageVuln(t *testing.T) {
+	i := 0
+	interrupt := func(*finding) bool { i++; return false }
+	pass := func(*finding) bool { i++; return true }
+
+	t.Run("no panic on empty finding", func(t *testing.T) {
+		i = 0
+		assert.True(t, forEachImageVuln(interrupt, &finding{}))
+		assert.Zero(t, i)
+		assert.True(t, forEachImageVuln(pass, &finding{}))
+		assert.Zero(t, i)
+	})
+
+	t.Run("interruption on false", func(t *testing.T) {
+		i = 0
+
+		image := makeTestImage("test")
+		image.withTags("test")
+		cves := getTestCVEs()
+		image.withCVE(cves...)
+
+		assert.True(t, forEachImageVuln(pass, &finding{
+			image: (*storage.Image)(image),
+		}))
+		assert.Equal(t, len(cves), i)
+
+		assert.False(t, forEachImageVuln(interrupt, &finding{
+			image: (*storage.Image)(image),
+		}))
+		assert.Equal(t, len(cves)+1, i)
+	})
+}

--- a/central/metrics/aggregator/singleton.go
+++ b/central/metrics/aggregator/singleton.go
@@ -113,8 +113,10 @@ func (ar *aggregatorRunner) Stop() {
 
 func (ar *aggregatorRunner) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if h := ar.getHandler(req); h != nil {
+		log.Debug("Serving metrics", req.URL.Path)
 		h.ServeHTTP(w, req)
 	} else {
+		log.Debug("Unknown registry name", req.URL.Path)
 		// Serve empty OK for unknown registry names.
 		w.WriteHeader(http.StatusOK)
 	}

--- a/central/metrics/aggregator/singleton.go
+++ b/central/metrics/aggregator/singleton.go
@@ -1,11 +1,155 @@
 package aggregator
 
 import (
+	"context"
+	"net/http"
+	"strings"
+
+	configDS "github.com/stackrox/rox/central/config/datastore"
+	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/metrics/aggregator/common"
 	"github.com/stackrox/rox/central/metrics/aggregator/image_vulnerabilities"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/travelaudience/go-promhttp"
 )
 
-func ParseConfiguration(config *storage.PrometheusMetricsConfig) error {
-	return image_vulnerabilities.ParseConfiguration(
-		config.GetImageVulnerabilities())
+var (
+	runner    *aggregatorRunner
+	oneRunner sync.Once
+
+	log = logging.LoggerForModule()
+)
+
+type aggregatorRunner struct {
+	http.Handler
+	handlers    map[string]http.Handler
+	handlersMux sync.Mutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	image_vulnerabilities common.Tracker
+}
+
+type Runner interface {
+	http.Handler
+	Start()
+	Stop()
+	ParseConfiguration(*storage.PrometheusMetricsConfig) (*RunnerConfiguration, error)
+	Reconfigure(*RunnerConfiguration)
+}
+
+func Singleton() Runner {
+	oneRunner.Do(func() {
+		runner = makeRunner(configDS.Singleton(), deploymentDS.Singleton())
+	})
+	return runner
+}
+
+func makeRunner(ds configDS.DataStore, dds deploymentDS.DataStore) *aggregatorRunner {
+	ar := &aggregatorRunner{
+		handlers: map[string]http.Handler{},
+	}
+
+	systemPrivateConfig, err := ds.GetPrivateConfig(
+		sac.WithAllAccess(context.Background()))
+	if err != nil {
+		log.Errorw("Failed to read Prometheus metrics configuration from the DB", logging.Err(err))
+		return ar
+	}
+
+	ar.image_vulnerabilities = image_vulnerabilities.New(metrics.SetCustomAggregatedCount, dds)
+	ar.ctx, ar.cancel = context.WithCancel(sac.WithAllAccess(context.Background()))
+
+	cfg, err := ar.ParseConfiguration(systemPrivateConfig.GetPrometheusMetricsConfig())
+	if err != nil {
+		log.Errorw("Failed to configure Prometheus metrics", logging.Err(err))
+	} else {
+		ar.Reconfigure(cfg)
+	}
+	return ar
+}
+
+// RunnerConfiguration is to pass between ParseConfiguration and Reconfigure.
+type RunnerConfiguration struct {
+	image_vulnerabilities *common.Configuration
+}
+
+func (ar *aggregatorRunner) ParseConfiguration(cfg *storage.PrometheusMetricsConfig) (*RunnerConfiguration, error) {
+	if ar == nil {
+		return nil, nil
+	}
+	var err error
+	runnerConfig := &RunnerConfiguration{}
+	runnerConfig.image_vulnerabilities, err = ar.image_vulnerabilities.ParseConfiguration(cfg.GetImageVulnerabilities())
+	if err != nil {
+		return nil, err
+	}
+	return runnerConfig, nil
+}
+
+func (ar *aggregatorRunner) Reconfigure(cfg *RunnerConfiguration) {
+	if ar == nil {
+		return
+	}
+	ar.image_vulnerabilities.Reconfigure(ar.ctx, cfg.image_vulnerabilities)
+}
+
+func (ar *aggregatorRunner) Start() {
+	if ar == nil {
+		return
+	}
+	for _, tracker := range []common.Tracker{ar.image_vulnerabilities} {
+		go tracker.Run(ar.ctx)
+	}
+}
+
+func (ar *aggregatorRunner) Stop() {
+	if ar == nil {
+		return
+	}
+	ar.cancel()
+}
+func (ar *aggregatorRunner) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if ar == nil {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	if h := ar.getHandler(req); h != nil {
+		h.ServeHTTP(w, req)
+	} else {
+		// Serve empty OK for unknown registry names.
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func (ar *aggregatorRunner) getHandler(req *http.Request) http.Handler {
+	registryName, ok := ar.getRegistryName(req)
+	if !ok {
+		return nil
+	}
+	registry := metrics.GetExternalRegistry(registryName)
+	ar.handlersMux.Lock()
+	defer ar.handlersMux.Unlock()
+	h, ok := ar.handlers[registryName]
+	if !ok {
+		h = promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+		ar.handlers[registryName] = h
+	}
+	return h
+}
+
+func (*aggregatorRunner) getRegistryName(req *http.Request) (string, bool) {
+	registryName, ok := strings.CutPrefix(req.URL.Path, "/metrics")
+	if ok && (registryName == "" || strings.HasPrefix(registryName, "/")) {
+		registryName = strings.TrimPrefix(registryName, "/")
+		if metrics.IsKnownRegistry(registryName) {
+			return registryName, true
+		}
+	}
+	return "", false
 }

--- a/central/metrics/aggregator/singleton_test.go
+++ b/central/metrics/aggregator/singleton_test.go
@@ -1,12 +1,20 @@
 package aggregator
 
 import (
+	"context"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	configDS "github.com/stackrox/rox/central/config/datastore/mocks"
+	deploymentDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func Test_getRegistryName(t *testing.T) {
@@ -44,4 +52,94 @@ func Test_getRegistryName(t *testing.T) {
 		assert.False(t, ok)
 		assert.Empty(t, name)
 	}
+}
+
+func TestRunner_ParseConfiguration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Run("nil configuration", func(t *testing.T) {
+		cds := configDS.NewMockDataStore(ctrl)
+		cds.EXPECT().GetPrivateConfig(gomock.Any()).Times(1).Return(
+			&storage.PrivateConfig{
+				PrometheusMetricsConfig: nil,
+			},
+			nil)
+		runner := makeRunner(cds, nil)
+		cfg, err := runner.ParseConfiguration(nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg)
+		runner.Reconfigure(&RunnerConfiguration{})
+	})
+}
+
+func TestRunner(t *testing.T) {
+	t.Run("nil runner", func(t *testing.T) {
+		var runner *aggregatorRunner
+		assert.NotPanics(t, func() {
+			runner.Start()
+			runner.Stop()
+		})
+		cfg, err := runner.ParseConfiguration(nil)
+		assert.NotNil(t, cfg)
+		assert.NoError(t, err)
+
+		rec := httptest.NewRecorder()
+		runner.ServeHTTP(rec, nil)
+		assert.Equal(t, 200, rec.Result().StatusCode)
+	})
+}
+
+func TestRunner_ServeHTTP(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	cds := configDS.NewMockDataStore(ctrl)
+	cds.EXPECT().GetPrivateConfig(gomock.Any()).Times(1).Return(
+		&storage.PrivateConfig{
+			PrometheusMetricsConfig: &storage.PrometheusMetricsConfig{
+				ImageVulnerabilities: &storage.PrometheusMetricsConfig_Metrics{
+					GatheringPeriodMinutes: 10,
+					Metrics: map[string]*storage.PrometheusMetricsConfig_Labels{
+						"metric1": {
+							Labels: map[string]*storage.PrometheusMetricsConfig_Labels_Expression{
+								"Cluster":  nil,
+								"Severity": nil,
+							},
+							Exposure:     storage.PrometheusMetricsConfig_Labels_EXTERNAL,
+							RegistryName: "custom",
+						}}}}},
+		nil)
+
+	dds := deploymentDS.NewMockDataStore(ctrl)
+
+	dds.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(1).
+		Do(func(_ context.Context, _ *v1.Query, f func(*storage.Deployment) error) {
+			_ = f(&storage.Deployment{
+				Name:        "deployment1",
+				ClusterName: "cluster1",
+			})
+		}).
+		Return(nil)
+
+	dds.EXPECT().GetImagesForDeployment(gomock.Any(), gomock.Any()).
+		Times(1).Return([]*storage.Image{{
+		Names: []*storage.ImageName{{FullName: "fullname1"}},
+		Scan: &storage.ImageScan{
+			Components: []*storage.EmbeddedImageScanComponent{{
+				Vulns: []*storage.EmbeddedVulnerability{{
+					Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+				}},
+			}},
+		}},
+	}, nil)
+
+	runner := makeRunner(cds, dds)
+	rec := httptest.NewRecorder()
+	runner.ServeHTTP(rec, httptest.NewRequest("GET", "/metrics/custom", nil))
+
+	result := rec.Result()
+	assert.Equal(t, 200, result.StatusCode)
+	body, err := io.ReadAll(result.Body)
+	_ = result.Body.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, "--", string(body))
 }

--- a/central/metrics/aggregator/singleton_test.go
+++ b/central/metrics/aggregator/singleton_test.go
@@ -133,6 +133,8 @@ func TestRunner_ServeHTTP(t *testing.T) {
 	}, nil)
 
 	runner := makeRunner(cds, dds)
+	runner.Stop()
+	runner.image_vulnerabilities.Run(runner.ctx)
 	rec := httptest.NewRecorder()
 	runner.ServeHTTP(rec, httptest.NewRequest("GET", "/metrics/custom", nil))
 
@@ -141,5 +143,9 @@ func TestRunner_ServeHTTP(t *testing.T) {
 	body, err := io.ReadAll(result.Body)
 	_ = result.Body.Close()
 	assert.NoError(t, err)
-	assert.Equal(t, "--", string(body))
+	assert.Equal(t,
+		`# HELP rox_central_metric1 The total number of aggregated CVEs aggregated by Cluster,Severity and gathered every 10m0s`+"\n"+
+			`# TYPE rox_central_metric1 gauge`+"\n"+
+			`rox_central_metric1{Cluster="cluster1",Severity="IMPORTANT_VULNERABILITY_SEVERITY"} 1`+"\n",
+		string(body))
 }

--- a/central/metrics/aggregator/singleton_test.go
+++ b/central/metrics/aggregator/singleton_test.go
@@ -1,0 +1,47 @@
+package aggregator
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getRegistryName(t *testing.T) {
+	metrics.GetExternalRegistry("r1")
+	metrics.GetExternalRegistry("r2")
+
+	runner := &aggregatorRunner{}
+
+	for path, expected := range map[string]string{
+		"/metrics/r1":     "r1",
+		"/metrics/r2":     "r2",
+		"/metrics/r1?a=b": "r1",
+		"/metrics/r2?a=b": "r2",
+		"/metrics":        "",
+	} {
+		u, _ := url.Parse("https://central" + path)
+		name, ok := runner.getRegistryName(&http.Request{URL: u})
+		assert.True(t, ok)
+		assert.Equal(t, expected, name)
+	}
+
+	for _, path := range []string{
+		"",
+		"/r1",
+		"/r1/",
+		"/metrics/r1/",
+		"/metricsr1",
+		"/metricsr1/",
+		"/metricsr1/r1",
+		"/metrics/bad",
+		"/kilometrics/r1",
+	} {
+		u, _ := url.Parse("https://central" + path)
+		name, ok := runner.getRegistryName(&http.Request{URL: u})
+		assert.False(t, ok)
+		assert.Empty(t, name)
+	}
+}


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR enables the periodic metrics gathering, started from `main`. Adds support for dynamic reconfiguration via `PUT /v1/config`.

It also adds the now functional Image Vulnerabilities tracker with all necessary labels.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

##### Manual testing

*Test configuration*

```json
    "prometheusMetricsConfig": {
      "imageVulnerabilities": {
        "gatheringPeriodMinutes": 15,
        "metrics": {
          "my_metric2": {
            "labels": {
              "CVSS": {
                "expression": []
              },
              "ImageRegistry": {
                "expression": []
              }
            },
            "exposure": "EXTERNAL",
            "registryName": "custom"
          },
          "my_metric_int": {
            "labels": {
              "Severity": {
                "expression": []
              }
            },
            "exposure": "INTERNAL",
            "registryName": ""
          }
        },
        "filter": ""
      }
    }
```

*External endpoint*

```console
sh$ curl -k https://localhost:8000/metrics/custom -s -H "authorization: Bearer $ROX_API_TOKEN" | grep my_met | head
# HELP rox_central_my_metric2 The total number of aggregated CVEs aggregated by ImageRegistry,CVSS and gathered every 15m0s
# TYPE rox_central_my_metric2 gauge
rox_central_my_metric2{CVSS="0.0",ImageRegistry="us-east1-docker.pkg.dev"} 4
rox_central_my_metric2{CVSS="1.9",ImageRegistry="us-central1-docker.pkg.dev"} 1
rox_central_my_metric2{CVSS="10.0",ImageRegistry="docker.io"} 1
rox_central_my_metric2{CVSS="10.0",ImageRegistry="us-central1-docker.pkg.dev"} 10
...
```

*Internal endpoint*

```console
sh$ curl -k http://localhost:9090/metrics -s | grep my_met
# HELP rox_central_my_metric_int The total number of aggregated CVEs aggregated by Severity and gathered every 15m0s
# TYPE rox_central_my_metric_int gauge
rox_central_my_metric_int{Severity="CRITICAL_VULNERABILITY_SEVERITY"} 410
rox_central_my_metric_int{Severity="IMPORTANT_VULNERABILITY_SEVERITY"} 938
rox_central_my_metric_int{Severity="LOW_VULNERABILITY_SEVERITY"} 2020
rox_central_my_metric_int{Severity="MODERATE_VULNERABILITY_SEVERITY"} 1176
rox_central_my_metric_int{Severity="UNKNOWN_VULNERABILITY_SEVERITY"} 4
```

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #15742**
    * **PR #15743**
      * **PR #15710**
      * **PR #15744**
        * **PR #15745** 👈
          * **PR #15526**
          * **PR #15487**
<!-- GHIT dependencies end -->