### PR TITLE
chore(ui): Inline ScanConfigWizard local subcomponents

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardFooter.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardFooter.tsx
@@ -22,74 +22,64 @@ function ScanConfigWizardFooter({
     const firstStepId = wizardSteps[0].id;
     const lastStepId = wizardSteps[wizardSteps.length - 1].id;
 
-    function renderButtons(activeStepId, onNext, onBack) {
-        return (
-            <>
-                {activeStepId !== lastStepId ? (
-                    <Button
-                        variant="primary"
-                        type="submit"
-                        isDisabled={disableClusterNext && activeStepId === wizardSteps[1].id}
-                        onClick={() => proceedToNextStepIfValid(onNext, activeStepId)}
-                    >
-                        Next
-                    </Button>
-                ) : (
-                    <Button
-                        variant="primary"
-                        type="submit"
-                        isDisabled={isSaving}
-                        onClick={onSave}
-                        isLoading={isSaving}
-                    >
-                        Save
-                    </Button>
-                )}
-                <Button
-                    variant="secondary"
-                    onClick={onBack}
-                    isDisabled={activeStepId === firstStepId}
-                >
-                    Back
-                </Button>
-                <Button variant="link" onClick={openModal}>
-                    Cancel
-                </Button>
-            </>
-        );
-    }
-
-    function renderModal(leaveWizard: () => void) {
-        return (
-            <Modal
-                variant="small"
-                title="Confirm cancel"
-                isOpen={isModalOpen}
-                onClose={closeModal}
-                actions={[
-                    <Button key="confirm" variant="primary" onClick={leaveWizard}>
-                        Confirm
-                    </Button>,
-                    <Button key="cancel" variant="secondary" onClick={closeModal}>
-                        Cancel
-                    </Button>,
-                ]}
-            >
-                <p>
-                    Are you sure you want to cancel? Any unsaved changes will be lost. You will be
-                    taken back to the list of scan configurations.
-                </p>
-            </Modal>
-        );
-    }
-
     return (
         <WizardFooter>
             <WizardContextConsumer>
                 {({ activeStep, onNext, onBack, onClose }) => (
                     <>
-                        {renderButtons(activeStep.id, onNext, onBack)}
-                        {renderModal(onClose)}
+                        {activeStep.id !== lastStepId ? (
+                            <Button
+                                variant="primary"
+                                type="submit"
+                                isDisabled={
+                                    disableClusterNext && activeStep.id === wizardSteps[1].id
+                                }
+                                onClick={() =>
+                                    proceedToNextStepIfValid(onNext, String(activeStep.id))
+                                }
+                            >
+                                Next
+                            </Button>
+                        ) : (
+                            <Button
+                                variant="primary"
+                                type="submit"
+                                isDisabled={isSaving}
+                                onClick={onSave}
+                                isLoading={isSaving}
+                            >
+                                Save
+                            </Button>
+                        )}
+                        <Button
+                            variant="secondary"
+                            onClick={onBack}
+                            isDisabled={activeStep.id === firstStepId}
+                        >
+                            Back
+                        </Button>
+                        <Button variant="link" onClick={openModal}>
+                            Cancel
+                        </Button>
+                        <Modal
+                            variant="small"
+                            title="Confirm cancel"
+                            isOpen={isModalOpen}
+                            onClose={closeModal}
+                            actions={[
+                                <Button key="confirm" variant="primary" onClick={onClose}>
+                                    Confirm
+                                </Button>,
+                                <Button key="cancel" variant="secondary" onClick={closeModal}>
+                                    Cancel
+                                </Button>,
+                            ]}
+                        >
+                            <p>
+                                Are you sure you want to cancel? Any unsaved changes will be lost.
+                                You will be taken back to the list of scan configurations.
+                            </p>
+                        </Modal>
                     </>
                 )}
             </WizardContextConsumer>


### PR DESCRIPTION
### Description

Part one refactor to aid in review of deprecated wizard component replacement. This change inlines the local components for the ScanConfigWizardFooter.

Since the helper function parameters were inferred to be `any`, this also converts the second argument of `proceedToNextStepIfValid` to a string, since all calling code expects that type.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI
