### PR TITLE
chore(ci): only notify on master builds

### DIFF
--- a/.github/workflows/scanner-nvd-update.yaml
+++ b/.github/workflows/scanner-nvd-update.yaml
@@ -156,7 +156,7 @@ jobs:
       - upload-nvd-feeds
       - upload-nvd-api
     runs-on: ubuntu-latest
-    if: failure()
+    if: ${{ failure() && github.ref_name == 'master' }}
     steps:
     - name: Send Slack notification on workflow failure
       run: |


### PR DESCRIPTION
### Description

Only send Slack notifications for the Scanner NVD update workflow when the branch running the workflow is `master`. This should include scheduled workflows and workflows manually dispatched.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

N/A.

#### How I validated my change

I didn't but it's the same config as the versioned definitions update notification: https://github.com/stackrox/stackrox/blob/0cda15fd3bdd411f9a7afd5c2ca5fa5760d19963/.github/workflows/scanner-versioned-definitions-update.yaml#L341
