### PR TITLE
fix: Fix image-defaults flag in scanner install test

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -236,7 +236,7 @@ EOT
         if [[ "$ROXCTL_BUILT_IN_RELEASE_MODE" == "true" ]]; then
             # development-build image defaults are not available in the release mode, so we set opensource
             # (which which uses the same image names) and override the registry/org elsewhere.
-            roxctl helm output central-services --image_defaults=opensource \
+            roxctl helm output central-services --image-defaults=opensource \
                 --output-dir="${HEAD_HELM_CHART_CENTRAL_SERVICES_DIR}" --remove
         else
             roxctl helm output central-services \
@@ -252,7 +252,7 @@ EOT
         if [[ "$ROXCTL_BUILT_IN_RELEASE_MODE" == "true" ]]; then
             # development-build image defaults are not available in the release mode, so we set opensource
             # (which which uses the same image names) and override the registry/org elsewhere.
-            roxctl helm output secured-cluster-services --image_defaults=opensource \
+            roxctl helm output secured-cluster-services --image-defaults=opensource \
                 --output-dir="${HEAD_HELM_CHART_SECURED_CLUSTER_SERVICES_DIR}" --remove
         else
             roxctl helm output secured-cluster-services \


### PR DESCRIPTION
### Description

As titled, `s/_/-/`.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Viewing output in release-4.8 workflow failure.

` INFO: Tue Jun 17 13:09:17 UTC 2025: [setup-file] ERROR:	unknown flag: --image_defaults `

Locally with `roxctl helm output secured-cluster-services --help` to validate flag naming.
