### PR TITLE
ROX-29750: Update yup 1.6.1 in dependencies

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -84,7 +84,7 @@
                 "store": "^2.0.12",
                 "styled-components": "^5.3.1",
                 "use-deep-compare-effect": "^1.8.1",
-                "yup": "^1.4.0"
+                "yup": "^1.6.1"
             },
             "devDependencies": {
                 "@babel/core": "^7.26.10",
@@ -24578,9 +24578,10 @@
             }
         },
         "node_modules/yup": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/yup/-/yup-1.4.0.tgz",
-            "integrity": "sha1-iY3NZg+fuXxB8YGDnT1lw+4VpD4= sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+            "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+            "license": "MIT",
             "dependencies": {
                 "property-expr": "^2.0.5",
                 "tiny-case": "^1.0.3",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -88,7 +88,7 @@
         "store": "^2.0.12",
         "styled-components": "^5.3.1",
         "use-deep-compare-effect": "^1.8.1",
-        "yup": "^1.4.0"
+        "yup": "^1.6.1"
     },
     "scripts": {
         "clean": "rm -rf ./test-results ./cypress/test-results",


### PR DESCRIPTION
### Description

https://github.com/jquense/yup/blob/master/CHANGELOG.md#161-2024-12-17

* lazy validation errors thrown in builders should resolve async like other validations

https://github.com/jquense/yup/blob/master/CHANGELOG.md#160-2024-12-16

* expose `LazySchema`

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run build` in ui/apps/platform
2. CI