### PR TITLE
ROX-29753: service account search to get results in one query

### DIFF
--- a/central/serviceaccount/internal/store/store.go
+++ b/central/serviceaccount/internal/store/store.go
@@ -15,6 +15,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.ServiceAccount, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ServiceAccount, []int, error)
 	Walk(context.Context, func(sa *storage.ServiceAccount) error) error
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.ServiceAccount) error) error
 
 	Upsert(ctx context.Context, serviceaccount *storage.ServiceAccount) error
 	Delete(ctx context.Context, id string) error

--- a/central/serviceaccount/search/searcher_impl.go
+++ b/central/serviceaccount/search/searcher_impl.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/search/paginated"
 )
 
-const whenUnlimited = 1000
+const whenUnlimited = 100
 
 type searcherImpl struct {
 	storage store.Store


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Searching raw services results, used 2 passes to get the data.  First it would make a query to get the IDs and then it would take the IDs to get the data.  This is a left over concept from our dackbox indexer and old key value store.  Now that we have Postgres we can simply get the data we do not and in most cases should not get the IDs first as that is a waste of a trip to the database.  This solves that by converting that function to use the new `GetByQueryFn` utilities to simply get the objects from the query.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI should be sufficient here as functionality is exactly the same.