### PR TITLE
chore(ui): Update vscode settings in ui/apps/platform/README.md

### DIFF
--- a/ui/apps/platform/README.md
+++ b/ui/apps/platform/README.md
@@ -51,13 +51,10 @@ the value of `UI_START_TARGET`: `https://8.8.8.8:443`.
 
 ### Linting
 
-Unlike ESLint 8 which auto-detects eslint.config.js **flat config** file, ESLint plugin for Visual Studio code editor does not (yet).
-
 If **stackrox/ui** is your workspace root folder, you can create or edit stackrox/ui/.vscode/settings.json file to add the following properties:
 
 ```json
 {
-    "eslint.experimental.useFlatConfig": true,
     "eslint.workingDirectories": ["apps/platform"]
 }
 ```


### PR DESCRIPTION
### Description

Delete mention of `eslint.experimental.useFlatConfig` because no longer needed.

1. ESLint plugin version update from a year ago 2024-06-19

    https://github.com/Microsoft/vscode-eslint?tab=readme-ov-file#version-305---pre-release

    > There is a new eslint.useFlatConfig setting which is honored by ESLint version 8.57.0 and above.

    > 9.0.0 <= ESLint version < 10.x: settings is honored and defaults to `true`.

    > The experimental settings `eslint.experimental.useFlatConfig` is deprecated and should only be used for ESLint versions >= 8.21 < 8.57.0.

2. ESLint 9 upgrade on 2024-11-07 in #13164

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. See ESLint plugin version 3.0.10 in **Extensions** pane.
2. Quit Visual Studio Code.
3. Delete line from ui/.vscode/setting.json file.
4. Start Visual Studio Code and intentionally make a temporary change that so **Problems** pane displays a lint error that is not a Prettier nor TypeScript error.