### PR TITLE
ROX-29776: service account service drops pagination

### DIFF
--- a/central/graphql/resolvers/service_accounts.go
+++ b/central/graphql/resolvers/service_accounts.go
@@ -50,6 +50,7 @@ func (resolver *Resolver) ServiceAccount(ctx context.Context, args struct{ graph
 // ServiceAccounts gets service accounts based on a query
 func (resolver *Resolver) ServiceAccounts(ctx context.Context, args PaginatedQuery) ([]*serviceAccountResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ServiceAccounts")
+	log.Info("SHREWS -- graphql SAs")
 	if err := readServiceAccounts(ctx); err != nil {
 		return nil, err
 	}
@@ -59,7 +60,9 @@ func (resolver *Resolver) ServiceAccounts(ctx context.Context, args PaginatedQue
 		return nil, err
 	}
 
-	return resolver.wrapServiceAccounts(resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query))
+	sas, err := resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query)
+	log.Info("SHREWS -- graphql SAs -- END")
+	return resolver.wrapServiceAccounts(sas, err)
 }
 
 // ServiceAccountCount returns count of all service accounts across infrastructure

--- a/central/graphql/resolvers/service_accounts.go
+++ b/central/graphql/resolvers/service_accounts.go
@@ -50,7 +50,6 @@ func (resolver *Resolver) ServiceAccount(ctx context.Context, args struct{ graph
 // ServiceAccounts gets service accounts based on a query
 func (resolver *Resolver) ServiceAccounts(ctx context.Context, args PaginatedQuery) ([]*serviceAccountResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "ServiceAccounts")
-	log.Info("SHREWS -- graphql SAs")
 	if err := readServiceAccounts(ctx); err != nil {
 		return nil, err
 	}
@@ -60,9 +59,7 @@ func (resolver *Resolver) ServiceAccounts(ctx context.Context, args PaginatedQue
 		return nil, err
 	}
 
-	sas, err := resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query)
-	log.Info("SHREWS -- graphql SAs -- END")
-	return resolver.wrapServiceAccounts(sas, err)
+	return resolver.wrapServiceAccounts(resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query))
 }
 
 // ServiceAccountCount returns count of all service accounts across infrastructure

--- a/central/serviceaccount/service/service_impl.go
+++ b/central/serviceaccount/service/service_impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/k8srbac"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"google.golang.org/grpc"
@@ -31,6 +32,8 @@ var (
 			v1.ServiceAccountService_ListServiceAccounts_FullMethodName,
 		},
 	})
+
+	log = logging.LoggerForModule()
 )
 
 // serviceImpl provides APIs for alerts.
@@ -87,6 +90,7 @@ func (s *serviceImpl) GetServiceAccount(ctx context.Context, request *v1.Resourc
 
 // ListServiceAccounts returns all service accounts that match the query.
 func (s *serviceImpl) ListServiceAccounts(ctx context.Context, rawQuery *v1.RawQuery) (*v1.ListServiceAccountResponse, error) {
+	log.Info("SHREWS -- List SAs")
 	q, err := search.ParseQuery(rawQuery.GetQuery(), search.MatchAllIfEmpty())
 	if err != nil {
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
@@ -113,6 +117,7 @@ func (s *serviceImpl) ListServiceAccounts(ctx context.Context, rawQuery *v1.RawQ
 		})
 
 	}
+	log.Info("SHREWS -- List SAs -- END")
 	return &v1.ListServiceAccountResponse{
 		SaAndRoles: saAndRoles,
 	}, nil

--- a/central/serviceaccount/service/service_impl.go
+++ b/central/serviceaccount/service/service_impl.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/k8srbac"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
@@ -37,8 +36,6 @@ var (
 			v1.ServiceAccountService_ListServiceAccounts_FullMethodName,
 		},
 	})
-
-	log = logging.LoggerForModule()
 )
 
 // serviceImpl provides APIs for alerts.

--- a/central/serviceaccount/service/service_impl.go
+++ b/central/serviceaccount/service/service_impl.go
@@ -22,7 +22,12 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"google.golang.org/grpc"
+)
+
+const (
+	maxServiceAccountsReturned = 1000
 )
 
 var (
@@ -95,6 +100,10 @@ func (s *serviceImpl) ListServiceAccounts(ctx context.Context, rawQuery *v1.RawQ
 	if err != nil {
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
+
+	// Fill in pagination.
+	paginated.FillPagination(q, rawQuery.GetPagination(), maxServiceAccountsReturned)
+
 	serviceAccounts, err := s.serviceAccounts.SearchRawServiceAccounts(ctx, q)
 
 	if err != nil {

--- a/central/serviceaccount/service/service_impl.go
+++ b/central/serviceaccount/service/service_impl.go
@@ -95,7 +95,6 @@ func (s *serviceImpl) GetServiceAccount(ctx context.Context, request *v1.Resourc
 
 // ListServiceAccounts returns all service accounts that match the query.
 func (s *serviceImpl) ListServiceAccounts(ctx context.Context, rawQuery *v1.RawQuery) (*v1.ListServiceAccountResponse, error) {
-	log.Info("SHREWS -- List SAs")
 	q, err := search.ParseQuery(rawQuery.GetQuery(), search.MatchAllIfEmpty())
 	if err != nil {
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
@@ -126,7 +125,6 @@ func (s *serviceImpl) ListServiceAccounts(ctx context.Context, rawQuery *v1.RawQ
 		})
 
 	}
-	log.Info("SHREWS -- List SAs -- END")
 	return &v1.ListServiceAccountResponse{
 		SaAndRoles: saAndRoles,
 	}, nil


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The pagination portion of the query was not pulled into the query.  This issue is as old as time, present at least since 2019 based on historical PRs.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Spun up a cluster and ran curl commands against the endpoint.
Before
```
dashrews-mac:stackrox dashrews$ curl --insecure "https://localhost:8000/v1/serviceaccounts?pagination.limit=2" -u admin: | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  115k  100  115k    0     0  82921      0  0:00:01  0:00:01 --:--:-- 82930
{
   "saAndRoles" : [
      {
         "clusterRoles" : [
            {
               "annotations" : {
                  "rbac.authorization.kubernetes.io/autoupdate" : "true"
               },
               "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
               "clusterName" : "remote",
               "clusterRole" : true,
               "createdAt" : "2025-06-18T14:24:33Z",
               "id" : "d773d4b8-3e44-483b-a4c0-299943043444",
               "labels" : {
                  "kubernetes.io/bootstrapping" : "rbac-defaults"
               },
               "name" : "system:controller:replicaset-controller",
               "namespace" : "",
               "rules" : [
                  {
                     "apiGroups" : [
                        "apps",
                        "extensions"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "replicasets"
                     ],
                     "verbs" : [
                        "get",
                        "list",
                        "update",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "apps",
                        "extensions"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "replicasets/status"
                     ],
                     "verbs" : [
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "apps",
                        "extensions"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "replicasets/finalizers"
                     ],
                     "verbs" : [
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        ""
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "pods"
                     ],
                     "verbs" : [
                        "create",
                        "delete",
                        "list",
                        "patch",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "",
                        "events.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "events"
                     ],
                     "verbs" : [
                        "create",
                        "patch",
                        "update"
                     ]
                  }
               ]
            }
         ],
         "deploymentRelationships" : [],
         "scopedRoles" : [],
         "serviceAccount" : {
            "annotations" : {},
            "automountToken" : true,
            "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
            "clusterName" : "remote",
            "createdAt" : "2025-06-18T14:24:58Z",
            "id" : "41f525de-d8d8-48cf-b28c-affc7d7ebd21",
            "imagePullSecrets" : [],
            "labels" : {},
            "name" : "replicaset-controller",
            "namespace" : "kube-system",
            "secrets" : []
         }
      },
      {
         "clusterRoles" : [
            {
               "annotations" : {
                  "rbac.authorization.kubernetes.io/autoupdate" : "true"
               },
               "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
               "clusterName" : "remote",
               "clusterRole" : true,
               "createdAt" : "2025-06-18T14:24:34Z",
               "id" : "d6f2cb28-2b67-43df-a932-7ab5d1ac606e",
               "labels" : {
                  "kubernetes.io/bootstrapping" : "rbac-defaults"
               },
               "name" : "system:controller:validatingadmissionpolicy-status-controller",
               "namespace" : "",
               "rules" : [
                  {
                     "apiGroups" : [
                        "admissionregistration.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "validatingadmissionpolicies"
                     ],
                     "verbs" : [
                        "get",
                        "list",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "admissionregistration.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "validatingadmissionpolicies/status"
                     ],
                     "verbs" : [
                        "get",
                        "patch",
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "",
                        "events.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "events"
                     ],
                     "verbs" : [
                        "create",
                        "patch",
                        "update"
                     ]
                  }
               ]
            }
         ],
         "deploymentRelationships" : [],
         "scopedRoles" : [],
         "serviceAccount" : {
            "annotations" : {},
            "automountToken" : true,
            "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
            "clusterName" : "remote",
            "createdAt" : "2025-06-18T14:24:55Z",
            "id" : "69780cc5-4b78-47f8-8a3c-5386d0436320",
            "imagePullSecrets" : [],
            "labels" : {},
            "name" : "validatingadmissionpolicy-status-controller",
            "namespace" : "kube-system",
            "secrets" : []
         }
      },
      {
         "clusterRoles" : [],
         "deploymentRelationships" : [
            {
               "id" : "31bd7721-1044-43e3-b966-98d3fcb107ca",
               "name" : "central-db"
            }
         ],
         "scopedRoles" : [],
         "serviceAccount" : {
            "annotations" : {
               "email" : "support@stackrox.com",
               "meta.helm.sh/release-name" : "stackrox-central-services",
               "meta.helm.sh/release-namespace" : "stackrox",
               "owner" : "stackrox"
            },
            "automountToken" : true,
            "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
            "clusterName" : "remote",
            "createdAt" : "2025-06-18T14:41:16Z",
            "id" : "8c411205-cfbb-4f09-b883-f9948ac449b8",
            "imagePullSecrets" : [
               "stackrox",
               "stackrox-scanner"
            ],
            "labels" : {
               "app.kubernetes.io/component" : "central",
               "app.kubernetes.io/instance" : "stackrox-central-services",
               "app.kubernetes.io/managed-by" : "Helm",
               "app.kubernetes.io/name" : "stackrox",
               "app.kubernetes.io/part-of" : "stackrox-central-services",
               "app.kubernetes.io/version" : "4.7.3",
               "helm.sh/chart" : "stackrox-central-services-400.7.3"
            },
            "name" : "central-db",
            "namespace" : "stackrox",
            "secrets" : []
         }
      },
      {
         "clusterRoles" : [],
         "deploymentRelationships" : [],
         "scopedRoles" : [],
         "serviceAccount" : {
            "annotations" : {},
            "automountToken" : true,
            "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
            "clusterName" : "remote",
            "createdAt" : "2025-06-18T14:41:12Z",
            "id" : "ba371087-0685-4031-9b2b-6111fd50d845",
            "imagePullSecrets" : [],
            "labels" : {},
            "name" : "default",
            "namespace" : "stackrox",
            "secrets" : []
         }
      },
      {
         "clusterRoles" : [
            {
               "annotations" : {
                  "components.gke.io/component-name" : "managed-prometheus",
                  "components.gke.io/component-version" : "0.15.1-gke.0",
                  "components.gke.io/layer" : "addon"
               },
               "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
               "clusterName" : "remote",
               "clusterRole" : true,
               "createdAt" : "2025-06-18T14:26:33Z",
               "id" : "476bbb7a-2f66-450e-b3dc-75fe9f4ac1a4",
               "labels" : {
                  "addonmanager.kubernetes.io/mode" : "Reconcile"
               },
               "name" : "gmp-system:operator",
               "namespace" : "",
               "rules" : [
                  {
                     "apiGroups" : [
                        "monitoring.googleapis.com"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "clusterpodmonitorings",
                        "clusterrules",
                        "globalrules",
                        "clusternodemonitorings",
                        "podmonitorings",
                        "rules"
                     ],
                     "verbs" : [
                        "get",
                        "list",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "monitoring.googleapis.com"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "clusterpodmonitorings/status",
                        "clusterrules/status",
                        "globalrules/status",
                        "clusternodemonitorings/status",
                        "podmonitorings/status",
                        "rules/status"
                     ],
                     "verbs" : [
                        "get",
                        "patch",
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "apiextensions.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [
                        "verticalpodautoscalers.autoscaling.k8s.io"
                     ],
                     "resources" : [
                        "customresourcedefinitions"
                     ],
                     "verbs" : [
                        "get"
                     ]
                  }
               ]
            }
         ],
         "deploymentRelationships" : [
            {
               "id" : "1ea1e8a9-de81-4683-9f8e-ebc3890cca44",
               "name" : "gmp-operator"
            }
         ],
         "scopedRoles" : [
            {
               "namespace" : "gmp-public",
               "roles" : [
                  {
                     "annotations" : {
                        "components.gke.io/component-name" : "managed-prometheus",
                        "components.gke.io/component-version" : "0.15.1-gke.0",
                        "components.gke.io/layer" : "addon"
                     },
                     "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
                     "clusterName" : "remote",
                     "clusterRole" : false,
                     "createdAt" : "2025-06-18T14:26:35Z",
                     "id" : "0f35bcf7-f9f6-4c56-b4e7-ed6bad599dfc",
                     "labels" : {
                        "addonmanager.kubernetes.io/mode" : "Reconcile"
                     },
                     "name" : "operator",
                     "namespace" : "gmp-public",
                     "rules" : [
                        {
                           "apiGroups" : [
                              ""
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [],
                           "resources" : [
                              "secrets"
                           ],
                           "verbs" : [
                              "get",
                              "list",
                              "watch"
                           ]
                        },
                        {
                           "apiGroups" : [
                              "monitoring.googleapis.com"
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [],
                           "resources" : [
                              "operatorconfigs"
                           ],
                           "verbs" : [
                              "get",
                              "update",
                              "list",
                              "watch"
                           ]
                        }
                     ]
                  }
               ]
            },
            {
               "namespace" : "gmp-system",
               "roles" : [
                  {
                     "annotations" : {
                        "components.gke.io/component-name" : "managed-prometheus",
                        "components.gke.io/component-version" : "0.15.1-gke.0",
                        "components.gke.io/layer" : "addon"
                     },
                     "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
                     "clusterName" : "remote",
                     "clusterRole" : false,
                     "createdAt" : "2025-06-18T14:26:34Z",
                     "id" : "3aede280-4e8d-43ac-858f-b473ea168321",
                     "labels" : {
                        "addonmanager.kubernetes.io/mode" : "Reconcile"
                     },
                     "name" : "operator",
                     "namespace" : "gmp-system",
                     "rules" : [
                        {
                           "apiGroups" : [
                              ""
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [],
                           "resources" : [
                              "pods"
                           ],
                           "verbs" : [
                              "list",
                              "watch"
                           ]
                        },
                        {
                           "apiGroups" : [
                              ""
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [],
                           "resources" : [
                              "secrets"
                           ],
                           "verbs" : [
                              "list",
                              "watch",
                              "create"
                           ]
                        },
                        {
                           "apiGroups" : [
                              ""
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "collection",
                              "rules",
                              "alertmanager"
                           ],
                           "resources" : [
                              "secrets"
                           ],
                           "verbs" : [
                              "get",
                              "patch",
                              "update"
                           ]
                        },
                        {
                           "apiGroups" : [
                              ""
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [],
                           "resources" : [
                              "configmaps"
                           ],
                           "verbs" : [
                              "list",
                              "watch",
                              "create"
                           ]
                        },
                        {
                           "apiGroups" : [
                              ""
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "collector",
                              "rule-evaluator",
                              "rules-generated"
                           ],
                           "resources" : [
                              "configmaps"
                           ],
                           "verbs" : [
                              "get",
                              "patch",
                              "update"
                           ]
                        },
                        {
                           "apiGroups" : [
                              "apps"
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "collector"
                           ],
                           "resources" : [
                              "daemonsets"
                           ],
                           "verbs" : [
                              "get",
                              "list",
                              "watch"
                           ]
                        },
                        {
                           "apiGroups" : [
                              "apps"
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "rule-evaluator"
                           ],
                           "resources" : [
                              "deployments"
                           ],
                           "verbs" : [
                              "get",
                              "list",
                              "watch"
                           ]
                        },
                        {
                           "apiGroups" : [
                              "apps"
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "rule-evaluator"
                           ],
                           "resources" : [
                              "deployments/scale"
                           ],
                           "verbs" : [
                              "get",
                              "patch",
                              "update"
                           ]
                        },
                        {
                           "apiGroups" : [
                              ""
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "alertmanager"
                           ],
                           "resources" : [
                              "services"
                           ],
                           "verbs" : [
                              "get",
                              "list",
                              "watch"
                           ]
                        },
                        {
                           "apiGroups" : [
                              "apps"
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "alertmanager"
                           ],
                           "resources" : [
                              "statefulsets"
                           ],
                           "verbs" : [
                              "get",
                              "list",
                              "watch"
                           ]
                        },
                        {
                           "apiGroups" : [
                              "apps"
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [
                              "alertmanager"
                           ],
                           "resources" : [
                              "statefulsets/scale"
                           ],
                           "verbs" : [
                              "get",
                              "patch",
                              "update"
                           ]
                        },
                        {
                           "apiGroups" : [
                              "autoscaling.k8s.io"
                           ],
                           "nonResourceUrls" : [],
                           "resourceNames" : [],
                           "resources" : [
                              "verticalpodautoscalers"
                           ],
                           "verbs" : [
                              "create",
                              "delete",
                              "get",
                              "list",
                              "watch"
                           ]
                        }
                     ]
                  }
               ]
            }
         ],
         "serviceAccount" : {
            "annotations" : {
               "components.gke.io/component-name" : "managed-prometheus",
               "components.gke.io/component-version" : "0.15.1-gke.0",
               "components.gke.io/layer" : "addon"
            },
            "automountToken" : true,
            "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
            "clusterName" : "remote",
            "createdAt" : "2025-06-18T14:26:33Z",
            "id" : "dccd7aff-a18c-4f95-a8ab-52a1f7efb635",
            "imagePullSecrets" : [],
            "labels" : {
               "addonmanager.kubernetes.io/mode" : "Reconcile"
            },
            "name" : "operator",
            "namespace" : "gmp-system",
            "secrets" : []
         }
      },
      {
         "clusterRoles" : [
            {
               "annotations" : {
                  "rbac.authorization.kubernetes.io/autoupdate" : "true"
               },
               "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
               "clusterName" : "remote",
               "clusterRole" : true,
               "createdAt" : "2025-06-18T14:24:33Z",
               "id" : "24bc0b4f-210d-4976-8315-1af4b2377b2d",
               "labels" : {
                  "kubernetes.io/bootstrapping" : "rbac-defaults"
               },
               "name" : "system:controller:attachdetach-controller",
               "namespace" : "",
               "rules" : [
                  {
                     "apiGroups" : [
                        ""
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "persistentvolumeclaims",
                        "persistentvolumes"
                     ],
                     "verbs" : [
                        "list",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        ""
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "nodes"
                     ],
                     "verbs" : [
                        "get",
                        "list",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        ""
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "nodes/status"
                     ],
                     "verbs" : [
                        "patch",
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        ""
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "pods"
                     ],
                     "verbs" : [
                        "list",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "",
                        "events.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "events"
                     ],
                     "verbs" : [
                        "create",
                        "patch",
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "storage.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "volumeattachments"
                     ],
                     "verbs" : [
                        "create",
                        "delete",
                        "get",
                        "list",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "storage.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "csidrivers"
                     ],
                     "verbs" : [
                        "get",
                        "list",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "storage.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "csinodes"
                     ],
                     "verbs" : [
                        "get",
                        "list",
                        "watch"
                     ]
                  }
               ]
            }
         ],
         "deploymentRelationships" : [],
         "scopedRoles" : [],
         "serviceAccount" : {
            "annotations" : {},
            "automountToken" : true,
            "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
            "clusterName" : "remote",
            "createdAt" : "2025-06-18T14:24:57Z",
            "id" : "c6e3357a-ba7f-4979-a773-851cd16113e4",
            "imagePullSecrets" : [],
            "labels" : {},
            "name" : "attachdetach-controller",
            "namespace" : "kube-system",
            "secrets" : []
         }
      },
...
```

After
```
dashrews-mac:stackrox dashrews$ curl --insecure "https://localhost:8000/v1/serviceaccounts?pagination.limit=1" -u admin: | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1443  100  1443    0     0   3698      0 --:--:-- --:--:-- --:--:--  3690
{
   "saAndRoles" : [
      {
         "clusterRoles" : [
            {
               "annotations" : {
                  "rbac.authorization.kubernetes.io/autoupdate" : "true"
               },
               "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
               "clusterName" : "remote",
               "clusterRole" : true,
               "createdAt" : "2025-06-18T14:24:33Z",
               "id" : "d773d4b8-3e44-483b-a4c0-299943043444",
               "labels" : {
                  "kubernetes.io/bootstrapping" : "rbac-defaults"
               },
               "name" : "system:controller:replicaset-controller",
               "namespace" : "",
               "rules" : [
                  {
                     "apiGroups" : [
                        "apps",
                        "extensions"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "replicasets"
                     ],
                     "verbs" : [
                        "get",
                        "list",
                        "update",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "apps",
                        "extensions"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "replicasets/status"
                     ],
                     "verbs" : [
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "apps",
                        "extensions"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "replicasets/finalizers"
                     ],
                     "verbs" : [
                        "update"
                     ]
                  },
                  {
                     "apiGroups" : [
                        ""
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "pods"
                     ],
                     "verbs" : [
                        "create",
                        "delete",
                        "list",
                        "patch",
                        "watch"
                     ]
                  },
                  {
                     "apiGroups" : [
                        "",
                        "events.k8s.io"
                     ],
                     "nonResourceUrls" : [],
                     "resourceNames" : [],
                     "resources" : [
                        "events"
                     ],
                     "verbs" : [
                        "create",
                        "patch",
                        "update"
                     ]
                  }
               ]
            }
         ],
         "deploymentRelationships" : [],
         "scopedRoles" : [],
         "serviceAccount" : {
            "annotations" : {},
            "automountToken" : true,
            "clusterId" : "ac1ee931-ddcb-4bcc-a6b4-ac2da559c0e3",
            "clusterName" : "remote",
            "createdAt" : "2025-06-18T14:24:58Z",
            "id" : "41f525de-d8d8-48cf-b28c-affc7d7ebd21",
            "imagePullSecrets" : [],
            "labels" : {},
            "name" : "replicaset-controller",
            "namespace" : "kube-system",
            "secrets" : []
         }
      }
   ]
}

```