### PR TITLE
ROX-29756: Update graphql 16.11.0 in dependencies

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -34,7 +34,7 @@
                 "file-saver": "^2.0.5",
                 "formik": "^2.2.9",
                 "framer-motion": "^10.0.0",
-                "graphql": "^16.8.1",
+                "graphql": "^16.11.0",
                 "history": "^5.3.0",
                 "html2canvas": "1.0.0-rc.7",
                 "initials": "^3.1.2",
@@ -12390,9 +12390,10 @@
             }
         },
         "node_modules/graphql": {
-            "version": "16.8.1",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-            "integrity": "sha1-GTCpZb7xFwYDcCrNtort0/PPbwc= sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+            "version": "16.11.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+            "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+            "license": "MIT",
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -38,7 +38,7 @@
         "file-saver": "^2.0.5",
         "formik": "^2.2.9",
         "framer-motion": "^10.0.0",
-        "graphql": "^16.8.1",
+        "graphql": "^16.11.0",
         "history": "^5.3.0",
         "html2canvas": "1.0.0-rc.7",
         "initials": "^3.1.2",


### PR DESCRIPTION
### Description

Only one `import` statement:
https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useInvalidateVulnerabilityQueries.ts#L2

By the way, both `graphql` and `@apollo/client` have several alpha releases for next major version.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run build` in ui/apps/platform
2. CI