### PR TITLE
ROX-29600: Add metric for ALPN results

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -596,6 +596,7 @@ func startGRPCServer() {
 		GRPCMetrics:        metrics.GRPCSingleton(),
 		HTTPMetrics:        metrics.HTTPSingleton(),
 		Endpoints:          endpointCfgs,
+		Subsystem:          pkgMetrics.CentralSubsystem,
 	}
 
 	if devbuild.IsEnabled() {

--- a/pkg/grpc/endpoints_test.go
+++ b/pkg/grpc/endpoints_test.go
@@ -86,7 +86,7 @@ func (s *misdirectedRequestSuite) testWithEndpoint(name string, baseCfg Endpoint
 	cfg := baseCfg
 	cfg.ListenEndpoint = "127.0.0.1:0"
 
-	addr, servers, err := cfg.instantiate(s.httpHandler, s.grpcSrv)
+	addr, servers, err := cfg.instantiate(s.httpHandler, s.grpcSrv, "test")
 	s.Require().NoError(err, "instantiating server for endpoint config")
 
 	serverErrs := make(chan error, len(servers))

--- a/pkg/grpc/metrics/prom.go
+++ b/pkg/grpc/metrics/prom.go
@@ -30,10 +30,6 @@ func newALPMetricForSub(sub string) *prometheus.CounterVec {
 
 func ObserveALPN(sub, endpointAddr, remoteAddr, alp string) {
 	if metric, found := alpnEndpointMetrics[sub]; found {
-		metric.With(map[string]string{
-			"endpoint":   endpointAddr,
-			"remoteAddr": remoteAddr,
-			"alp":        alp,
-		}).Inc()
+		metric.WithLabelValues(endpointAddr, remoteAddr, alp).Inc()
 	}
 }

--- a/pkg/grpc/metrics/prom.go
+++ b/pkg/grpc/metrics/prom.go
@@ -6,30 +6,22 @@ import (
 )
 
 var (
-	alpnEndpointMetrics = make(map[string]*prometheus.CounterVec)
+	alpnEndpointMetric = prometheus.NewCounterVec(
+		// Leaving subsystem empty to skip duplicating this metric for each component
+		prometheus.CounterOpts{
+			Namespace: pkgMetrics.PrometheusNamespace,
+			Subsystem: "", // empty, so fqName = rox_endpoint_tls_handshakes_with_negotiated_alp_total
+			Name:      "endpoint_tls_handshakes_with_negotiated_alp_total",
+			Help:      "Number of finished TLS handshakes ...",
+		},
+		[]string{"subsystem", "endpoint", "remoteAddr", "alp"},
+	)
 )
 
 func init() {
-	// Only Central and Sensor expose an endpoint that demultiplexes connections based on ALPN.
-	for _, subsystem := range []pkgMetrics.Subsystem{pkgMetrics.CentralSubsystem, pkgMetrics.SensorSubsystem} {
-		metric := newALPMetricForSub(subsystem.String())
-		alpnEndpointMetrics[subsystem.String()] = metric
-		prometheus.MustRegister(metric)
-	}
-}
-
-func newALPMetricForSub(sub string) *prometheus.CounterVec {
-	return prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: pkgMetrics.PrometheusNamespace,
-		Subsystem: sub,
-		Name:      "endpoint_tls_handshakes_with_negotiated_alp_total",
-		Help: "Number of finished TLS handshakes to a given endpoint with " +
-			"given Application Level Protocol being negotiated as a result of ALPN.",
-	}, []string{"endpoint", "remoteAddr", "alp"})
+	prometheus.MustRegister(alpnEndpointMetric)
 }
 
 func ObserveALPN(sub, endpointAddr, remoteAddr, alp string) {
-	if metric, found := alpnEndpointMetrics[sub]; found {
-		metric.WithLabelValues(endpointAddr, remoteAddr, alp).Inc()
-	}
+	alpnEndpointMetric.WithLabelValues(sub, endpointAddr, remoteAddr, alp).Inc()
 }

--- a/pkg/grpc/metrics/prom.go
+++ b/pkg/grpc/metrics/prom.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
+)
+
+var (
+	alpnEndpointMetrics = make(map[string]*prometheus.CounterVec)
+)
+
+func init() {
+	// Only Central and Sensor expose an endpoint that demultiplexes connections based on ALPN.
+	for _, subsystem := range []pkgMetrics.Subsystem{pkgMetrics.CentralSubsystem, pkgMetrics.SensorSubsystem} {
+		metric := newALPMetricForSub(subsystem.String())
+		alpnEndpointMetrics[subsystem.String()] = metric
+		prometheus.MustRegister(metric)
+	}
+}
+
+func newALPMetricForSub(sub string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: sub,
+		Name:      "endpoint_tls_handshakes_with_negotiated_alp_total",
+		Help: "Number of finished TLS handshakes to a given endpoint with " +
+			"given Application Level Protocol being negotiated as a result of ALPN.",
+	}, []string{"endpoint", "remoteAddr", "alp"})
+}
+
+func ObserveALPN(sub, endpointAddr, remoteAddr, alp string) {
+	if metric, found := alpnEndpointMetrics[sub]; found {
+		metric.With(map[string]string{
+			"endpoint":   endpointAddr,
+			"remoteAddr": remoteAddr,
+			"alp":        alp,
+		}).Inc()
+	}
+}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/routes"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/netutil/pipeconn"
 	"github.com/stackrox/rox/pkg/sync"
 	promhttp "github.com/travelaudience/go-promhttp"
@@ -154,6 +155,8 @@ type Config struct {
 	// MaxConnectionAge is the maximum amount of time a connection may exist before it will be closed.
 	// Default is +infinity.
 	MaxConnectionAge time.Duration
+	// Subsystem is used to enrich metrics with information about the component that runs this API.
+	Subsystem pkgMetrics.Subsystem
 }
 
 // NewAPI returns an API object.
@@ -480,7 +483,7 @@ func (a *apiImpl) run(startedSig *concurrency.ErrorSignal) {
 
 	var allSrvAndLiss []serverAndListener
 	for _, endpointCfg := range a.config.Endpoints {
-		addr, srvAndLiss, err := endpointCfg.instantiate(httpHandler, a.grpcServer)
+		addr, srvAndLiss, err := endpointCfg.instantiate(httpHandler, a.grpcServer, a.config.Subsystem)
 		if err != nil {
 			if endpointCfg.Optional {
 				log.Errorf("Failed to instantiate endpoint config of kind %s: %v", endpointCfg.Kind(), err)

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -24,6 +24,7 @@ import (
 	grpcUtil "github.com/stackrox/rox/pkg/grpc/util"
 	"github.com/stackrox/rox/pkg/kocache"
 	"github.com/stackrox/rox/pkg/logging"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/probeupload"
 	"github.com/stackrox/rox/pkg/sync"
@@ -248,6 +249,7 @@ func (s *Sensor) Start() {
 				ServeHTTP:      true,
 			},
 		},
+		Subsystem: pkgMetrics.SensorSubsystem,
 	}
 	s.server = pkgGRPC.NewAPI(conf)
 
@@ -265,6 +267,7 @@ func (s *Sensor) Start() {
 				ServeHTTP:      true,
 			},
 		},
+		Subsystem: pkgMetrics.SensorSubsystem,
 	}
 
 	s.webhookServer = pkgGRPC.NewAPI(webhookConfig)


### PR DESCRIPTION
### Description

Let's have more insight on the application-level protocols used in the connections if ALP is used for demuxing the listeners. Note that this happens only in Sensor and Central as only them share a port between http and grpc listeners.

Note that this metric breaks with the pattern, where the name of the subsystem is part of metric name. Instead, the subsystem is a label. So this: 
```
rox_central_endpoint_tls_handshakes_with_negotiated_alp_total
``` 
becomes now
```
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="central"}
```
This change was introduced to not duplicate metrics in the code only because the subsystem is different.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Tested on a cluster.

- Central. In this example:
   - Sensor (IP 1.192) is calling over `pure-grpc` and `""` (two connections in parallel)
   - IP 2.2 is unknown pod
   - IP 2.45 is scanner-v4-matcher

```
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="central",alp="",endpoint=":8443",remoteAddr="10.128.2.45"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="central",alp="",endpoint=":8443",remoteAddr="10.131.1.192"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="central",alp="h2",endpoint=":8443",remoteAddr="10.128.2.2"} 7
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="central",alp="https://alpn.stackrox.io/#pure-grpc",endpoint=":8443",remoteAddr="10.131.1.192"} 1
```

- Sensor. In this example:
    - 3 Admission-controllers are calling over pure-grpc
    - 3 Collectors are calling over http2 

```
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="sensor",alp="h2",endpoint=":8443",remoteAddr="10.128.0.89"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="sensor",alp="h2",endpoint=":8443",remoteAddr="10.128.2.31"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total="sensor",alp="h2",endpoint=":8443",remoteAddr="10.129.0.148"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="sensor",alp="h2",endpoint=":8443",remoteAddr="10.130.0.148"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="sensor",alp="h2",endpoint=":8443",remoteAddr="10.131.0.62"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="sensor",alp="https://alpn.stackrox.io/#pure-grpc",endpoint=":8443",remoteAddr="10.128.2.60"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="sensor",alp="https://alpn.stackrox.io/#pure-grpc",endpoint=":8443",remoteAddr="10.128.2.61"} 1
rox_endpoint_tls_handshakes_with_negotiated_alp_total{subsystem="sensor",alp="https://alpn.stackrox.io/#pure-grpc",endpoint=":8443",remoteAddr="10.131.1.126"} 1
```

- Admission Controller, Compliance, Scanner v2, Scanner v4 indexer, and Scanner v4 matcher do not use ALP demux, so this metric is not recorded.
