### PR TITLE
ROX-29160: Add feature flag ROX_RED_HAT_IMAGES_SIGNED_POLICY

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -123,7 +123,7 @@ var (
 	CustomizablePlatformComponents = registerFeature("Adds the ability to customize the regex rules for identifying platform components", "ROX_CUSTOMIZABLE_PLATFORM_COMPONENTS", enabled)
 
 	// Adds built-in policy to ensure that Red Hat images are signed by Red Hat Release Key
-	RedHatImagesSignedPolicy = registerFeature("Adds built-in policy to ensure that Red Hat images are signed by Red Hat Release Key", "ROX_RED_HAT_IMAGES_SIGNED_POLICY", unchangeableInProd)
+	RedHatImagesSignedPolicy = registerFeature("Adds built-in policy to ensure that Red Hat images are signed by the Red Hat release key", "ROX_RED_HAT_IMAGES_SIGNED_POLICY", unchangeableInProd)
 )
 
 // The following feature flags are related to Scanner V4.

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -121,6 +121,9 @@ var (
 
 	// Adds the ability to customize the regex rules for identifying platform components
 	CustomizablePlatformComponents = registerFeature("Adds the ability to customize the regex rules for identifying platform components", "ROX_CUSTOMIZABLE_PLATFORM_COMPONENTS", enabled)
+
+	// Adds built-in policy to ensure that Red Hat images are signed by Red Hat Release Key
+	RedHatImagesSignedPolicy = registerFeature("Adds built-in policy to ensure that Red Hat images are signed by Red Hat Release Key", "ROX_RED_HAT_IMAGES_SIGNED_POLICY", unchangeableInProd)
 )
 
 // The following feature flags are related to Scanner V4.


### PR DESCRIPTION
### Description

This PR introduces a new feature flag (ROX_RED_HAT_IMAGES_SIGNED_POLICY) to be able to deliver parts of [ROX-29160](https://issues.redhat.com/browse/ROX-29160) gradually without interfering with StackRox normal operation.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

I followed the same process as with other flags.
