### PR TITLE
feat(env): Add validation for Integer Setting

### DIFF
--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"os"
 	"strconv"
+
+	"github.com/stackrox/rox/pkg/errox"
 )
 
 // IntegerSetting represents an environment variable which should be parsed into an integer
@@ -61,14 +63,13 @@ func RegisterIntegerSetting(envVar string, defaultValue int) *IntegerSetting {
 // WithMinimum specifies the minimal allowed value that passes the validation.
 func (s *IntegerSetting) WithMinimum(min int) *IntegerSetting {
 	if s.defaultValue < min {
-		panic(fmt.Errorf(
-			"programmer error: default %d < minimum %d for %s",
+		panic(errox.InvariantViolation.Newf("programmer error: default %d < minimum %d for %s",
 			s.defaultValue, min, s.envVar,
 		))
 	}
 	s.minimumValue = min
 	if s.minimumValue > s.maximumValue {
-		panic(fmt.Errorf("programmer error: incorrect validation config for %s: "+
+		panic(errox.InvariantViolation.Newf("programmer error: incorrect validation config for %s: "+
 			"minimum value %d must be smaller or equal to maximum value %d",
 			s.EnvVar(), s.minimumValue, s.maximumValue))
 	}
@@ -78,14 +79,13 @@ func (s *IntegerSetting) WithMinimum(min int) *IntegerSetting {
 // WithMaximum specifies the maximal allowed value that passes the validation.
 func (s *IntegerSetting) WithMaximum(max int) *IntegerSetting {
 	if s.defaultValue > max {
-		panic(fmt.Errorf(
-			"programmer error: default %d > maximum %d for %s",
+		panic(errox.InvariantViolation.Newf("programmer error: default %d > maximum %d for %s",
 			s.defaultValue, max, s.envVar,
 		))
 	}
 	s.maximumValue = max
 	if s.minimumValue > s.maximumValue {
-		panic(fmt.Errorf("programmer error: incorrect validation config for %s: "+
+		panic(errox.InvariantViolation.Newf("programmer error: incorrect validation config for %s: "+
 			"minimum value %d must be smaller or equal to maximum value %d",
 			s.EnvVar(), s.minimumValue, s.maximumValue))
 	}

--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -62,30 +62,29 @@ func RegisterIntegerSetting(envVar string, defaultValue int) *IntegerSetting {
 
 // WithMinimum specifies the minimal allowed value that passes the validation.
 func (s *IntegerSetting) WithMinimum(min int) *IntegerSetting {
-	if s.defaultValue < min {
-		panic(errox.InvariantViolation.Newf("programmer error: default %d < minimum %d for %s",
-			s.defaultValue, min, s.envVar,
-		))
-	}
 	s.minimumValue = min
-	if s.minimumValue > s.maximumValue {
-		panic(errox.InvariantViolation.Newf("programmer error: incorrect validation config for %s: "+
-			"minimum value %d must be smaller or equal to maximum value %d",
-			s.EnvVar(), s.minimumValue, s.maximumValue))
-	}
-	return s
+	return s.mustValidate()
 }
 
 // WithMaximum specifies the maximal allowed value that passes the validation.
 func (s *IntegerSetting) WithMaximum(max int) *IntegerSetting {
-	if s.defaultValue > max {
-		panic(errox.InvariantViolation.Newf("programmer error: default %d > maximum %d for %s",
-			s.defaultValue, max, s.envVar,
+	s.maximumValue = max
+	return s.mustValidate()
+}
+
+func (s *IntegerSetting) mustValidate() *IntegerSetting {
+	if s.defaultValue < s.minimumValue {
+		panic(errox.InvariantViolation.Newf("programmer error: default %d < minimum %d for %s",
+			s.defaultValue, s.minimumValue, s.envVar,
 		))
 	}
-	s.maximumValue = max
+	if s.defaultValue > s.maximumValue {
+		panic(errox.InvariantViolation.Newf("programmer error: default %d > maximum %d for %s",
+			s.defaultValue, s.maximumValue, s.envVar,
+		))
+	}
 	if s.minimumValue > s.maximumValue {
-		panic(errox.InvariantViolation.Newf("programmer error: incorrect validation config for %s: "+
+		panic(errox.InvariantViolation.Newf("programmer error: incorrect integer bounds for %s: "+
 			"minimum value %d must be smaller or equal to maximum value %d",
 			s.EnvVar(), s.minimumValue, s.maximumValue))
 	}

--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -5,8 +5,6 @@ import (
 	"math"
 	"os"
 	"strconv"
-
-	"github.com/stackrox/rox/pkg/errox"
 )
 
 // IntegerSetting represents an environment variable which should be parsed into an integer
@@ -73,19 +71,20 @@ func (s *IntegerSetting) WithMaximum(max int) *IntegerSetting {
 
 func (s *IntegerSetting) mustValidate() *IntegerSetting {
 	if s.defaultValue < s.minimumValue {
-		panic(errox.InvariantViolation.Newf("programmer error: default %d < minimum %d for %s",
+		panic(fmt.Errorf("programmer error: default value %d is smaller than the minimum %d for %q",
 			s.defaultValue, s.minimumValue, s.envVar,
-		))
+		).Error())
 	}
 	if s.defaultValue > s.maximumValue {
-		panic(errox.InvariantViolation.Newf("programmer error: default %d > maximum %d for %s",
+		panic(fmt.Errorf("programmer error: default value %d is larger than the maximum %d for %q",
 			s.defaultValue, s.maximumValue, s.envVar,
-		))
+		).Error())
 	}
 	if s.minimumValue > s.maximumValue {
-		panic(errox.InvariantViolation.Newf("programmer error: incorrect integer bounds for %s: "+
+		panic(fmt.Errorf("programmer error: incorrect integer bounds for %q: "+
 			"minimum value %d must be smaller or equal to maximum value %d",
-			s.EnvVar(), s.minimumValue, s.maximumValue))
+			s.EnvVar(), s.minimumValue, s.maximumValue,
+		).Error())
 	}
 	return s
 }

--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -55,7 +55,6 @@ func RegisterIntegerSetting(envVar string, defaultValue int) *IntegerSetting {
 		minimumValue: math.MinInt,
 		maximumValue: math.MaxInt,
 	}
-
 	Settings[s.EnvVar()] = s
 	return s
 }

--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -10,7 +10,12 @@ import (
 type IntegerSetting struct {
 	envVar       string
 	defaultValue int
-	intSettingOptions
+
+	// Optional validation of the value
+	minimumValue int
+	minSet       bool
+	maximumValue int
+	maxSet       bool
 }
 
 // EnvVar returns the string name of the environment variable
@@ -18,7 +23,7 @@ func (s *IntegerSetting) EnvVar() string {
 	return s.envVar
 }
 
-// DefaultValue returns the default vaule for the setting
+// DefaultValue returns the default value for the setting
 func (s *IntegerSetting) DefaultValue() int {
 	return s.defaultValue
 }
@@ -35,75 +40,55 @@ func (s *IntegerSetting) IntegerSetting() int {
 		return s.defaultValue
 	}
 	v, err := strconv.Atoi(val)
-	if err != nil {
-		return s.defaultValue
-	}
-	if v < s.minimumValue && s.minSet {
-		return s.defaultValue
-	}
-	if v > s.maximumValue && s.maxSet {
+	if err != nil || (s.minSet && v < s.minimumValue) || (s.maxSet && v > s.maximumValue) {
 		return s.defaultValue
 	}
 	return v
 }
 
 // RegisterIntegerSetting globally registers and returns a new integer setting.
-func RegisterIntegerSetting(envVar string, defaultValue int, opts ...IntegerSettingOption) *IntegerSetting {
+func RegisterIntegerSetting(envVar string, defaultValue int) *IntegerSetting {
 	s := &IntegerSetting{
 		envVar:       envVar,
 		defaultValue: defaultValue,
-	}
-	for _, opt := range opts {
-		opt.apply(&s.intSettingOptions)
-	}
-	if s.defaultValue < s.minimumValue && s.minSet {
-		panic(fmt.Errorf("programmer error: default value for %s must be at least %d",
-			s.EnvVar(), s.minimumValue))
-	}
-	if s.defaultValue > s.maximumValue && s.maxSet {
-		panic(fmt.Errorf("programmer error: default value for %s must be maximally %d",
-			s.EnvVar(), s.maximumValue))
-	}
-	if s.minSet && s.maxSet && s.minimumValue > s.maximumValue {
-		panic(fmt.Errorf("programmer error: incorrect validation config for %s: "+
-			"minimum value %d must be smaller or equal to maximum value %d",
-			s.EnvVar(), s.minimumValue, s.maximumValue))
 	}
 
 	Settings[s.EnvVar()] = s
 	return s
 }
 
-type intSettingOptions struct {
-	minimumValue int
-	minSet       bool
-	maximumValue int
-	maxSet       bool
+// WithMinimum specifies the minimal allowed value that passes the validation.
+func (s *IntegerSetting) WithMinimum(min int) *IntegerSetting {
+	if s.defaultValue < min {
+		panic(fmt.Errorf(
+			"programmer error: default %d < minimum %d for %s",
+			s.defaultValue, min, s.envVar,
+		))
+	}
+	s.minSet = true
+	s.minimumValue = min
+	if s.maxSet && s.minimumValue > s.maximumValue {
+		panic(fmt.Errorf("programmer error: incorrect validation config for %s: "+
+			"minimum value %d must be smaller or equal to maximum value %d",
+			s.EnvVar(), s.minimumValue, s.maximumValue))
+	}
+	return s
 }
 
-type intSettingOptionFn func(*intSettingOptions)
-
-func (f intSettingOptionFn) apply(so *intSettingOptions) {
-	f(so)
-}
-
-// IntegerSettingOption is an interface that abstracts additional options for a setting (e.g., a default value).
-type IntegerSettingOption interface {
-	apply(*intSettingOptions)
-}
-
-// WithMinimum specifies the minimum allowed value that passes the validation.
-func WithMinimum(val int) IntegerSettingOption {
-	return intSettingOptionFn(func(so *intSettingOptions) {
-		so.minimumValue = val
-		so.minSet = true
-	})
-}
-
-// WithMaximum specifies the minimum allowed value that passes the validation.
-func WithMaximum(val int) IntegerSettingOption {
-	return intSettingOptionFn(func(so *intSettingOptions) {
-		so.maximumValue = val
-		so.maxSet = true
-	})
+// WithMaximum specifies the maximal allowed value that passes the validation.
+func (s *IntegerSetting) WithMaximum(max int) *IntegerSetting {
+	if s.defaultValue > max {
+		panic(fmt.Errorf(
+			"programmer error: default %d > maximum %d for %s",
+			s.defaultValue, max, s.envVar,
+		))
+	}
+	s.maxSet = true
+	s.maximumValue = max
+	if s.minSet && s.minimumValue > s.maximumValue {
+		panic(fmt.Errorf("programmer error: incorrect validation config for %s: "+
+			"minimum value %d must be smaller or equal to maximum value %d",
+			s.EnvVar(), s.minimumValue, s.maximumValue))
+	}
+	return s
 }

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -13,70 +13,73 @@ func TestIntegerSetting(t *testing.T) {
 	cases := map[string]struct {
 		value        string
 		defaultValue int
-		opts         []IntegerSettingOption
+		minOpt       func() int
+		maxOpt       func() int
 		wantPanic    bool
 		wantValue    int
 	}{
 		"shall pass validation with no options": {
 			value:        "1",
 			defaultValue: 5,
-			opts:         nil,
 			wantPanic:    false,
 			wantValue:    1,
 		},
 		"shall pass validation with minimum": {
 			value:        "1",
 			defaultValue: 5,
-			opts:         []IntegerSettingOption{WithMinimum(0)},
+			minOpt:       func() int { return 0 },
 			wantPanic:    false,
 			wantValue:    1,
 		},
 		"shall fail validation with minimum": {
 			value:        "1",
 			defaultValue: 5,
-			opts:         []IntegerSettingOption{WithMinimum(5)},
+			minOpt:       func() int { return 5 },
 			wantPanic:    false,
 			wantValue:    5,
 		},
 		"shall panic with minimum": {
 			value:        "1",
 			defaultValue: 5,
-			opts:         []IntegerSettingOption{WithMinimum(10)},
+			minOpt:       func() int { return 10 },
 			wantPanic:    true,
 			wantValue:    1,
 		},
 		"shall pass validation with min and max": {
 			value:        "1",
 			defaultValue: 5,
-			opts:         []IntegerSettingOption{WithMinimum(0), WithMaximum(10)},
+			minOpt:       func() int { return 0 },
+			maxOpt:       func() int { return 10 },
 			wantPanic:    false,
 			wantValue:    1,
 		},
 		"shall fail validation with min and max": {
 			value:        "11",
 			defaultValue: 5,
-			opts:         []IntegerSettingOption{WithMinimum(5), WithMaximum(10)},
+			minOpt:       func() int { return 5 },
+			maxOpt:       func() int { return 10 },
 			wantPanic:    false,
 			wantValue:    5,
 		},
 		"shall panic with min and max": {
 			value:        "1",
 			defaultValue: 5,
-			opts:         []IntegerSettingOption{WithMinimum(10), WithMaximum(15)},
+			minOpt:       func() int { return 10 },
+			maxOpt:       func() int { return 15 },
 			wantPanic:    true,
 			wantValue:    1,
 		},
 		"default value of min should have no influence if no WithMinimum is used explicitly": {
 			value:        "-5",
 			defaultValue: -1,
-			opts:         []IntegerSettingOption{},
 			wantPanic:    false,
 			wantValue:    -5,
 		},
 		"options used incorrectly should panic": {
 			value:        "1",
 			defaultValue: 5,
-			opts:         []IntegerSettingOption{WithMinimum(10), WithMaximum(0)},
+			minOpt:       func() int { return 10 },
+			maxOpt:       func() int { return 0 },
 			wantPanic:    true,
 			wantValue:    1,
 		},
@@ -86,15 +89,27 @@ func TestIntegerSetting(t *testing.T) {
 		t.Run(tname, func(t *testing.T) {
 			name := newRandomName()
 			s := &IntegerSetting{}
+
+			registerFunc := func(name string, defaultValue int, min, max func() int) *IntegerSetting {
+				if tt.minOpt != nil && tt.maxOpt != nil {
+					return RegisterIntegerSetting(name, defaultValue).WithMinimum(min()).WithMaximum(max())
+				}
+				if tt.minOpt != nil {
+					return RegisterIntegerSetting(name, defaultValue).WithMinimum(min())
+				}
+				if tt.maxOpt != nil {
+					return RegisterIntegerSetting(name, defaultValue).WithMaximum(max())
+				}
+				return RegisterIntegerSetting(name, defaultValue)
+			}
+			defer unregisterSetting(name)
 			if tt.wantPanic {
 				assert.Panics(t, func() {
-					s = RegisterIntegerSetting(name, tt.defaultValue, tt.opts...)
-					defer unregisterSetting(name)
+					s = registerFunc(name, tt.defaultValue, tt.minOpt, tt.maxOpt)
 				})
 				return
 			}
-			s = RegisterIntegerSetting(name, tt.defaultValue, tt.opts...)
-			defer unregisterSetting(name)
+			s = registerFunc(name, tt.defaultValue, tt.minOpt, tt.maxOpt)
 			a.NoError(os.Setenv(name, tt.value))
 
 			a.Equal(tt.wantValue, s.IntegerSetting())

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -91,7 +91,7 @@ func TestIntegerSetting(t *testing.T) {
 			wantPanic:    false,
 			wantValue:    5,
 		},
-		"using border value for int64 should not yield default value": {
+		"using border value for int should not yield default value": {
 			value:        strconv.Itoa(math.MaxInt),
 			defaultValue: 5,
 			wantPanic:    false,

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestIntegerSetting(t *testing.T) {
-	maxInt64PlusOne := big.NewInt(math.MaxInt64)
-	maxInt64PlusOne.Add(maxInt64PlusOne, big.NewInt(1))
-
 	cases := map[string]struct {
 		value        string
 		defaultValue int
@@ -88,12 +85,12 @@ func TestIntegerSetting(t *testing.T) {
 			wantValue:    1,
 		},
 		"crossing the max/min value of int should return default value": {
-			value:        maxInt64PlusOne.Text(10),
+			// We use bigInt here to get the max value (because int may be int32 or int64) and do plus-one arithmetic.
+			value:        new(big.Int).Add(big.NewInt(math.MaxInt), big.NewInt(1)).Text(10), // math.MaxInt + 1
 			defaultValue: 5,
 			wantPanic:    false,
 			wantValue:    5,
 		},
-		// This testcase may fail if the system running this test uses int32 as the type for int
 		"using border value for int64 should not yield default value": {
 			value:        strconv.Itoa(math.MaxInt),
 			defaultValue: 5,

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -83,6 +83,19 @@ func TestIntegerSetting(t *testing.T) {
 			wantPanic:    true,
 			wantValue:    1,
 		},
+		"crossing the max/min value of int should return default value": {
+			value:        "9223372036854775808", // = MaxInt64 + 1
+			defaultValue: 5,
+			wantPanic:    false,
+			wantValue:    5,
+		},
+		// This testcase may fail if the system running this test uses int32 as the type for int
+		"using border value for int64 should not yield default value": {
+			value:        "9223372036854775807", // = MaxInt64
+			defaultValue: 5,
+			wantPanic:    false,
+			wantValue:    9223372036854775807,
+		},
 	}
 
 	for tname, tt := range cases {

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -120,14 +120,12 @@ func TestIntegerSetting(t *testing.T) {
 // testRegisterSetting is a helper to the function-under-test with its options.
 // It was created to avoid code repetition, as it must be called in two places depending on whether we test for panics.
 func testRegisterSetting(_ *testing.T, name string, defaultValue int, min, max func() int) *IntegerSetting {
-	if min != nil && max != nil {
-		return RegisterIntegerSetting(name, defaultValue).WithMinimum(min()).WithMaximum(max())
-	}
+	s := RegisterIntegerSetting(name, defaultValue)
 	if min != nil {
-		return RegisterIntegerSetting(name, defaultValue).WithMinimum(min())
+		s = s.WithMinimum(min())
 	}
 	if max != nil {
-		return RegisterIntegerSetting(name, defaultValue).WithMaximum(max())
+		s = s.WithMaximum(max())
 	}
-	return RegisterIntegerSetting(name, defaultValue)
+	return s
 }

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestIntegerSetting(t *testing.T) {
-	a := assert.New(t)
 	maxInt64PlusOne := big.NewInt(math.MaxInt64)
 	maxInt64PlusOne.Add(maxInt64PlusOne, big.NewInt(1))
 
@@ -128,9 +127,9 @@ func TestIntegerSetting(t *testing.T) {
 				return
 			}
 			s = registerFunc(name, tt.defaultValue, tt.minOpt, tt.maxOpt)
-			a.NoError(os.Setenv(name, tt.value))
+			assert.NoError(t, os.Setenv(name, tt.value))
 
-			a.Equal(tt.wantValue, s.IntegerSetting())
+			assert.Equal(t, tt.wantValue, s.IntegerSetting())
 		})
 	}
 }

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -1,0 +1,103 @@
+package env
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegerSetting(t *testing.T) {
+	a := assert.New(t)
+
+	cases := map[string]struct {
+		value        string
+		defaultValue int
+		opts         []IntegerSettingOption
+		wantPanic    bool
+		wantValue    int
+	}{
+		"shall pass validation with no options": {
+			value:        "1",
+			defaultValue: 5,
+			opts:         nil,
+			wantPanic:    false,
+			wantValue:    1,
+		},
+		"shall pass validation with minimum": {
+			value:        "1",
+			defaultValue: 5,
+			opts:         []IntegerSettingOption{WithMinimum(0)},
+			wantPanic:    false,
+			wantValue:    1,
+		},
+		"shall fail validation with minimum": {
+			value:        "1",
+			defaultValue: 5,
+			opts:         []IntegerSettingOption{WithMinimum(5)},
+			wantPanic:    false,
+			wantValue:    5,
+		},
+		"shall panic with minimum": {
+			value:        "1",
+			defaultValue: 5,
+			opts:         []IntegerSettingOption{WithMinimum(10)},
+			wantPanic:    true,
+			wantValue:    1,
+		},
+		"shall pass validation with min and max": {
+			value:        "1",
+			defaultValue: 5,
+			opts:         []IntegerSettingOption{WithMinimum(0), WithMaximum(10)},
+			wantPanic:    false,
+			wantValue:    1,
+		},
+		"shall fail validation with min and max": {
+			value:        "11",
+			defaultValue: 5,
+			opts:         []IntegerSettingOption{WithMinimum(5), WithMaximum(10)},
+			wantPanic:    false,
+			wantValue:    5,
+		},
+		"shall panic with min and max": {
+			value:        "1",
+			defaultValue: 5,
+			opts:         []IntegerSettingOption{WithMinimum(10), WithMaximum(15)},
+			wantPanic:    true,
+			wantValue:    1,
+		},
+		"default value of min should have no influence if no WithMinimum is used explicitly": {
+			value:        "-5",
+			defaultValue: -1,
+			opts:         []IntegerSettingOption{},
+			wantPanic:    false,
+			wantValue:    -5,
+		},
+		"options used incorrectly should panic": {
+			value:        "1",
+			defaultValue: 5,
+			opts:         []IntegerSettingOption{WithMinimum(10), WithMaximum(0)},
+			wantPanic:    true,
+			wantValue:    1,
+		},
+	}
+
+	for tname, tt := range cases {
+		t.Run(tname, func(t *testing.T) {
+			name := newRandomName()
+			s := &IntegerSetting{}
+			if tt.wantPanic {
+				assert.Panics(t, func() {
+					s = RegisterIntegerSetting(name, tt.defaultValue, tt.opts...)
+					defer unregisterSetting(name)
+				})
+				return
+			}
+			s = RegisterIntegerSetting(name, tt.defaultValue, tt.opts...)
+			defer unregisterSetting(name)
+			a.NoError(os.Setenv(name, tt.value))
+
+			a.Equal(tt.wantValue, s.IntegerSetting())
+		})
+	}
+}

--- a/pkg/env/integersetting_test.go
+++ b/pkg/env/integersetting_test.go
@@ -1,7 +1,10 @@
 package env
 
 import (
+	"math"
+	"math/big"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +12,8 @@ import (
 
 func TestIntegerSetting(t *testing.T) {
 	a := assert.New(t)
+	maxInt64PlusOne := big.NewInt(math.MaxInt64)
+	maxInt64PlusOne.Add(maxInt64PlusOne, big.NewInt(1))
 
 	cases := map[string]struct {
 		value        string
@@ -84,17 +89,17 @@ func TestIntegerSetting(t *testing.T) {
 			wantValue:    1,
 		},
 		"crossing the max/min value of int should return default value": {
-			value:        "9223372036854775808", // = MaxInt64 + 1
+			value:        maxInt64PlusOne.Text(10),
 			defaultValue: 5,
 			wantPanic:    false,
 			wantValue:    5,
 		},
 		// This testcase may fail if the system running this test uses int32 as the type for int
 		"using border value for int64 should not yield default value": {
-			value:        "9223372036854775807", // = MaxInt64
+			value:        strconv.Itoa(math.MaxInt),
 			defaultValue: 5,
 			wantPanic:    false,
-			wantValue:    9223372036854775807,
+			wantValue:    math.MaxInt,
 		},
 	}
 


### PR DESCRIPTION
### Description

Inspired by discussion in https://github.com/stackrox/stackrox/pull/15176#discussion_r2152078824

When specifying an Integer Setting (read from an env variable), we could add optional validation with its allowed minimum and maximum value. If the boundaries are not held, then the default value would be used. If the default is not within the boundaries, then we could panic to loudly indicate programmer error.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- Unit tests
