### PR TITLE
ROX-29755: Recover reprocessing when Sensor's are 'stuck'

### DIFF
--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -271,12 +271,25 @@ var (
 		Help:      "Duration of the signature verification reprocessor loop in seconds",
 	})
 
-	msgToSensorSkipCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	msgToSensorNotSentCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "msg_to_sensor_skip_count",
+		Name:      "msg_to_sensor_not_sent_count",
 		Help:      "Total messages not sent to Sensor due to errors or other reasons",
-	}, []string{"ClusterID", "type"})
+	}, []string{"ClusterID", "type", "reason"})
+)
+
+// Reasons for a message not being sent.
+var (
+	// NotSentError indicates that an attempt was made to send the message
+	// but an error was encountered.
+	NotSentError = "error"
+	// NotSentSignal indicates that a signal prevented the message from being
+	// sent, such as a timeout.
+	NotSentSignal = "signal"
+	// NotSentSkip indicates that no attempt was made to send the message,
+	// perhaps due to prior errors.
+	NotSentSkip = "skip"
 )
 
 func startTimeToMS(t time.Time) float64 {
@@ -475,14 +488,14 @@ func SetReprocessorDuration(start time.Time) {
 	reprocessorDurationGauge.Set(time.Since(start).Seconds())
 }
 
-// IncrementMsgToSensorSkipCounter increments the count of messages not sent to Sensor due to
+// IncrementMsgToSensorNotSentCounter increments the count of messages not sent to Sensor due to
 // errors or other reasons.
-func IncrementMsgToSensorSkipCounter(clusterID string, msg *central.MsgToSensor) {
+func IncrementMsgToSensorNotSentCounter(clusterID string, msg *central.MsgToSensor, reason string) {
 	if msg.GetMsg() == nil {
 		return
 	}
 	typ := event.GetEventTypeWithoutPrefix(msg.GetMsg())
-	msgToSensorSkipCounter.With(prometheus.Labels{"ClusterID": clusterID, "type": typ}).Inc()
+	msgToSensorNotSentCounter.With(prometheus.Labels{"ClusterID": clusterID, "type": typ, "reason": reason}).Inc()
 }
 
 // SetSignatureVerificationReprocessorDuration registers how long a signature verification reprocessing step took.

--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -478,6 +478,9 @@ func SetReprocessorDuration(start time.Time) {
 // IncrementMsgToSensorSkipCounter increments the count of messages not sent to Sensor due to
 // errors or other reasons.
 func IncrementMsgToSensorSkipCounter(clusterID string, msg *central.MsgToSensor) {
+	if msg.GetMsg() == nil {
+		return
+	}
 	typ := event.GetEventTypeWithoutPrefix(msg.GetMsg())
 	msgToSensorSkipCounter.With(prometheus.Labels{"ClusterID": clusterID, "type": typ}).Inc()
 }

--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -270,6 +270,13 @@ var (
 		Name:      "signature_verification_reprocessor_duration_seconds",
 		Help:      "Duration of the signature verification reprocessor loop in seconds",
 	})
+
+	msgToSensorSkipCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "msg_to_sensor_skip_count",
+		Help:      "Total messages not sent to Sensor due to errors or other reasons",
+	}, []string{"ClusterID", "type"})
 )
 
 func startTimeToMS(t time.Time) float64 {
@@ -466,6 +473,13 @@ func IncSensorEventsDeduper(deduped bool, msg *central.MsgFromSensor) {
 // SetReprocessorDuration registers how long a reprocessing step took.
 func SetReprocessorDuration(start time.Time) {
 	reprocessorDurationGauge.Set(time.Since(start).Seconds())
+}
+
+// IncrementMsgToSensorSkipCounter increments the count of messages not sent to Sensor due to
+// errors or other reasons.
+func IncrementMsgToSensorSkipCounter(clusterID string, msg *central.MsgToSensor) {
+	typ := event.GetEventTypeWithoutPrefix(msg.GetMsg())
+	msgToSensorSkipCounter.With(prometheus.Labels{"ClusterID": clusterID, "type": typ}).Inc()
 }
 
 // SetSignatureVerificationReprocessorDuration registers how long a signature verification reprocessing step took.

--- a/central/metrics/central_test.go
+++ b/central/metrics/central_test.go
@@ -1,0 +1,60 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIncrementMsgToSensorSkipCounter(t *testing.T) {
+	t.Run("no panic on nil msg", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			IncrementMsgToSensorSkipCounter("", nil)
+		})
+	})
+
+	t.Run("no panic on nil inner msg", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			IncrementMsgToSensorSkipCounter("", &central.MsgToSensor{
+				Msg: nil,
+			})
+		})
+	})
+
+	t.Run("inc and extract type", func(t *testing.T) {
+		// Clear any prior values.
+		prometheus.Unregister(msgToSensorSkipCounter)
+		prometheus.Register(msgToSensorSkipCounter)
+
+		// Get references to the counters.
+		updImgCounter, err := msgToSensorSkipCounter.GetMetricWith(
+			prometheus.Labels{"ClusterID": "a", "type": "UpdatedImage"},
+		)
+		require.NoError(t, err)
+		reprocessDeployCounter, err := msgToSensorSkipCounter.GetMetricWith(
+			prometheus.Labels{"ClusterID": "b", "type": "ReprocessDeployments"},
+		)
+		require.NoError(t, err)
+
+		// Sanity check.
+		assert.Equal(t, 0.0, testutil.ToFloat64(updImgCounter))
+		assert.Equal(t, 0.0, testutil.ToFloat64(reprocessDeployCounter))
+
+		// Verify the count is incremented and type extracted.
+		IncrementMsgToSensorSkipCounter("a", &central.MsgToSensor{
+			Msg: &central.MsgToSensor_UpdatedImage{},
+		})
+		assert.Equal(t, 1.0, testutil.ToFloat64(updImgCounter))
+		assert.Equal(t, 0.0, testutil.ToFloat64(reprocessDeployCounter))
+
+		IncrementMsgToSensorSkipCounter("b", &central.MsgToSensor{
+			Msg: &central.MsgToSensor_ReprocessDeployments{},
+		})
+		assert.Equal(t, 1.0, testutil.ToFloat64(updImgCounter))
+		assert.Equal(t, 1.0, testutil.ToFloat64(reprocessDeployCounter))
+	})
+}

--- a/central/metrics/central_test.go
+++ b/central/metrics/central_test.go
@@ -28,7 +28,7 @@ func TestIncrementMsgToSensorSkipCounter(t *testing.T) {
 	t.Run("inc and extract type", func(t *testing.T) {
 		// Clear any prior values.
 		prometheus.Unregister(msgToSensorSkipCounter)
-		prometheus.Register(msgToSensorSkipCounter)
+		require.NoError(t, prometheus.Register(msgToSensorSkipCounter))
 
 		// Get references to the counters.
 		updImgCounter, err := msgToSensorSkipCounter.GetMetricWith(

--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -40,5 +40,6 @@ func init() {
 		signatureVerificationReprocessorDurationGauge,
 		pruningDurationHistogramVec,
 		storeCacheOperationHistogramVec,
+		msgToSensorSkipCounter,
 	)
 }

--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -40,6 +40,6 @@ func init() {
 		signatureVerificationReprocessorDurationGauge,
 		pruningDurationHistogramVec,
 		storeCacheOperationHistogramVec,
-		msgToSensorSkipCounter,
+		msgToSensorNotSentCounter,
 	)
 }

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -478,8 +478,12 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 // injectMessage will inject a message onto connection, an error will be returned if the
 // injection fails for any reason, including timeout.
 func (l *loopImpl) injectMessage(ctx context.Context, conn connection.SensorConnection, msg *central.MsgToSensor) error {
-	ctx, cancel := context.WithTimeout(ctx, env.ReprocessInjectMessageTimeout.DurationSetting())
-	defer cancel()
+	dur := env.ReprocessInjectMessageTimeout.DurationSetting()
+	if dur > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, dur)
+		defer cancel()
+	}
 
 	err := conn.InjectMessage(ctx, msg)
 	if err != nil {

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -486,7 +486,7 @@ func (l *loopImpl) injectMessage(ctx context.Context, conn connection.SensorConn
 
 	err := conn.InjectMessage(ctx, msg)
 	if err != nil {
-		return errors.Wrap(err, "error injecting message to sensor")
+		return errors.Wrap(err, "injecting message to sensor")
 	}
 
 	return nil

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -357,16 +357,6 @@ func (l *loopImpl) reprocessImage(id string, fetchOpt imageEnricher.FetchOption,
 	return image, true
 }
 
-func (l *loopImpl) getActiveImageIDs() ([]string, error) {
-	query := search.NewQueryBuilder().AddStringsHighlighted(search.DeploymentID, search.WildcardString).ProtoQuery()
-	results, err := l.images.Search(allAccessCtx, query)
-	if err != nil {
-		return nil, errors.Wrap(err, "error searching for active image IDs")
-	}
-
-	return search.ResultsToIDs(results), nil
-}
-
 func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.FetchOption,
 	imgReprocessingFunc imageReprocessingFunc, imageQuery *v1.Query) {
 	if l.stopSig.IsDone() {

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -464,7 +464,7 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 			clusterID := conn.ClusterID()
 			if skipClusterIDs.Contains(clusterID) {
 				metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
-				log.Debugw("Not sending reprocess deployments to cluster due to prior errors",
+				log.Errorw("Not sending reprocess deployments to cluster due to prior errors",
 					logging.ClusterID(clusterID),
 				)
 				continue

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -404,7 +404,7 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 					log.Debugw("Not sending updated image to cluster due to prior errors",
 						logging.ImageID(image.GetId()),
 						logging.ImageName(image.GetName().GetFullName()),
-						logging.ClusterID(clusterID),
+						logging.String("dst_cluster", clusterID),
 					)
 					continue
 				}
@@ -424,7 +424,8 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 					log.Errorw("Error sending updated image to cluster, skipping cluster until next reprocessing cycle",
 						logging.ImageName(image.GetName().GetFullName()),
 						logging.ImageID(image.GetId()), logging.Err(err),
-						logging.ClusterID(clusterID),
+						// Not using logging.ClusterID() to avoid "duplicate resource ID field found" panic
+						logging.String("dst_cluster", clusterID),
 					)
 				}
 			}

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -421,7 +421,7 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 
 				// If were prior errors, do not attempt to send a message to this cluster.
 				if skipClusterIDs.Contains(clusterID) {
-					metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
+					metrics.IncrementMsgToSensorNotSentCounter(clusterID, msg, metrics.NotSentSkip)
 					log.Debugw("Not sending updated image to cluster due to prior errors",
 						logging.ImageID(image.GetId()),
 						logging.ImageName(image.GetName().GetFullName()),
@@ -463,7 +463,7 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 		for _, conn := range l.connManager.GetActiveConnections() {
 			clusterID := conn.ClusterID()
 			if skipClusterIDs.Contains(clusterID) {
-				metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
+				metrics.IncrementMsgToSensorNotSentCounter(clusterID, msg, metrics.NotSentSkip)
 				log.Errorw("Not sending reprocess deployments to cluster due to prior errors",
 					logging.ClusterID(clusterID),
 				)

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -73,6 +73,8 @@ var (
 			// to include those as well.
 			time.Unix(0, 0), time.Now().Add(10*time.Second)).
 		ProtoQuery()
+
+	injectMessageTimeoutDur = env.ReprocessInjectMessageTimeout.DurationSetting()
 )
 
 // Singleton returns the singleton reprocessor loop
@@ -478,10 +480,9 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 // injectMessage will inject a message onto connection, an error will be returned if the
 // injection fails for any reason, including timeout.
 func (l *loopImpl) injectMessage(ctx context.Context, conn connection.SensorConnection, msg *central.MsgToSensor) error {
-	dur := env.ReprocessInjectMessageTimeout.DurationSetting()
-	if dur > 0 {
+	if injectMessageTimeoutDur > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, dur)
+		ctx, cancel = context.WithTimeout(ctx, injectMessageTimeoutDur)
 		defer cancel()
 	}
 

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -415,12 +415,12 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 
 				// If were prior errors, do not attempt to send a message to this cluster.
 				if skipClusterIDs.Contains(clusterID) {
+					metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
 					log.Debugw("Not sending updated image to cluster due to prior errors",
 						logging.ImageID(image.GetId()),
 						logging.ImageName(image.GetName().GetFullName()),
 						logging.String("dst_cluster", clusterID),
 					)
-					metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
 					continue
 				}
 
@@ -433,7 +433,6 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 						// Not using logging.ClusterID() to avoid "duplicate resource ID field found" panic
 						logging.String("dst_cluster", clusterID),
 					)
-					metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
 				}
 			}
 		}(result.ID, clusterIDSet)
@@ -458,10 +457,10 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 		for _, conn := range l.connManager.GetActiveConnections() {
 			clusterID := conn.ClusterID()
 			if skipClusterIDs.Contains(clusterID) {
+				metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
 				log.Debugw("Not sending reprocess deployments to cluster due to prior errors",
 					logging.ClusterID(clusterID),
 				)
-				metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
 				continue
 			}
 
@@ -471,7 +470,6 @@ func (l *loopImpl) reprocessImagesAndResyncDeployments(fetchOpt imageEnricher.Fe
 					logging.ClusterID(clusterID),
 					logging.Err(err),
 				)
-				metrics.IncrementMsgToSensorSkipCounter(clusterID, msg)
 			}
 		}
 	}

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -7,71 +7,20 @@ import (
 	"testing"
 	"time"
 
-	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
 	imagePG "github.com/stackrox/rox/central/image/datastore/store/postgres"
 	imagePostgresV2 "github.com/stackrox/rox/central/image/datastore/store/v2/postgres"
-	platformmatcher "github.com/stackrox/rox/central/platform/matcher"
 	"github.com/stackrox/rox/central/ranking"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
-	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
-	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
-
-func TestGetActiveImageIDs(t *testing.T) {
-	t.Parallel()
-
-	testCtx := sac.WithAllAccess(context.Background())
-
-	var (
-		pool          postgres.DB
-		imageDS       imageDatastore.DataStore
-		deploymentsDS deploymentDatastore.DataStore
-		err           error
-	)
-
-	testingDB := pgtest.ForT(t)
-	pool = testingDB.DB
-	defer pool.Close()
-
-	mockCtrl := gomock.NewController(t)
-	if features.FlattenCVEData.Enabled() {
-		imageDS = imageDatastore.NewWithPostgres(imagePostgresV2.New(pool, false, concurrency.NewKeyFence()), nil, ranking.ImageRanker(), ranking.ComponentRanker())
-	} else {
-		imageDS = imageDatastore.NewWithPostgres(imagePG.New(pool, false, concurrency.NewKeyFence()), nil, ranking.ImageRanker(), ranking.ComponentRanker())
-	}
-	deploymentsDS, err = deploymentDatastore.New(pool, nil, nil, nil, nil, nil, filter.NewFilter(5, 5, []int{5}), ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker(), platformmatcher.GetTestPlatformMatcherWithDefaultPlatformComponentConfig(mockCtrl))
-	require.NoError(t, err)
-
-	loop := NewLoop(nil, nil, nil, deploymentsDS, imageDS, nil, nil, nil, nil).(*loopImpl)
-
-	ids, err := loop.getActiveImageIDs()
-	require.NoError(t, err)
-	require.Equal(t, 0, len(ids))
-
-	deployment := fixtures.GetDeployment()
-	require.NoError(t, deploymentsDS.UpsertDeployment(testCtx, deployment))
-
-	images := fixtures.DeploymentImages()
-	imageIDs := make([]string, 0, len(images))
-	for _, image := range images {
-		require.NoError(t, imageDS.UpsertImage(testCtx, image))
-		imageIDs = append(imageIDs, image.GetId())
-	}
-
-	ids, err = loop.getActiveImageIDs()
-	require.NoError(t, err)
-	require.ElementsMatch(t, imageIDs, ids)
-}
 
 func TestImagesWithSignaturesQuery(t *testing.T) {
 	t.Parallel()

--- a/central/reprocessor/reprocessor_unit_test.go
+++ b/central/reprocessor/reprocessor_unit_test.go
@@ -2,13 +2,19 @@ package reprocessor
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	mockImageDataStore "github.com/stackrox/rox/central/image/datastore/mocks"
 	nodeDatastoreMocks "github.com/stackrox/rox/central/node/datastore/mocks"
 	riskManagerMocks "github.com/stackrox/rox/central/risk/manager/mocks"
+	"github.com/stackrox/rox/central/sensor/service/connection"
+	connectionMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
 	imageEnricher "github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/images/enricher/mocks"
@@ -16,8 +22,11 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/sensor/event"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
 )
@@ -255,5 +264,143 @@ func TestReprocessImage(t *testing.T) {
 		assert.NotNil(tt, retImage)
 		assert.True(tt, proto.Equal(image, retImage))
 		assert.True(tt, reprocessed)
+	})
+}
+
+func TestReprocessImagesAndResyncDeployments_SkipBrokenSensor(t *testing.T) {
+	imgs := []*storage.Image{}
+	for _, cluster := range []string{"a", "b"} { // two clusters
+		// Create at least one more image than max semaphore size to ensure skip logic is executed.
+		for i := range imageReprocessorSemaphoreSize + 1 {
+			imgs = append(imgs, &storage.Image{Id: fmt.Sprintf("img%d-%s", i, cluster)})
+		}
+	}
+
+	results := []search.Result{}
+	for _, img := range imgs {
+		results = append(results, search.Result{
+			ID: img.Id,
+			Matches: map[string][]string{
+				// Last character of image ID is the cluster.
+				imageClusterIDFieldPath: {img.Id[len(img.Id)-1:]},
+			}},
+		)
+	}
+
+	newReprocessorLoop := func(t *testing.T) (*loopImpl, *connectionMocks.MockSensorConnection, *connectionMocks.MockSensorConnection) {
+		ctrl := gomock.NewController(t)
+
+		connA := connectionMocks.NewMockSensorConnection(ctrl)
+		connB := connectionMocks.NewMockSensorConnection(ctrl)
+		connManager := connectionMocks.NewMockManager(ctrl)
+		imageDS := mockImageDataStore.NewMockDataStore(ctrl)
+		riskManager := riskManagerMocks.NewMockManager(ctrl)
+
+		connA.EXPECT().ClusterID().AnyTimes().Return("a")
+		connB.EXPECT().ClusterID().AnyTimes().Return("b")
+
+		connManager.EXPECT().GetConnection("a").AnyTimes().Return(connA)
+		connManager.EXPECT().GetConnection("b").AnyTimes().Return(connB)
+		connManager.EXPECT().GetActiveConnections().Return([]connection.SensorConnection{connA, connB})
+
+		imageDS.EXPECT().Search(gomock.Any(), gomock.Any()).AnyTimes().Return(results, nil)
+		for _, img := range imgs {
+			imageDS.EXPECT().GetImage(gomock.Any(), img.Id).AnyTimes().Return(img, true, nil)
+		}
+
+		riskManager.EXPECT().CalculateRiskAndUpsertImage(gomock.Any()).AnyTimes().Return(nil)
+
+		testLoop := &loopImpl{
+			images:      imageDS,
+			risk:        riskManager,
+			connManager: connManager,
+			stopSig:     concurrency.NewSignal(),
+		}
+		return testLoop, connA, connB
+	}
+
+	reprocessFuncUpdate := func(_ context.Context, _ imageEnricher.EnrichmentContext, _ *storage.Image) (imageEnricher.EnrichmentResult, error) {
+		return imageEnricher.EnrichmentResult{ImageUpdated: true}, nil
+	}
+	updatedImageTypeCond := gomock.Cond(func(msg *central.MsgToSensor) bool {
+		return event.GetEventTypeWithoutPrefix(msg.GetMsg()) == "UpdatedImage"
+	})
+	reprocessDeploymentsTypeCond := gomock.Cond(func(msg *central.MsgToSensor) bool {
+		return event.GetEventTypeWithoutPrefix(msg.GetMsg()) == "ReprocessDeployments"
+	})
+
+	t.Run("send all messages when clusters are healthy", func(t *testing.T) {
+		testLoop, connA, connB := newReprocessorLoop(t)
+
+		// Expect every updated image to be sent.
+		connA.EXPECT().InjectMessage(gomock.Any(), updatedImageTypeCond).Times(len(imgs) / 2).Return(nil)
+		connB.EXPECT().InjectMessage(gomock.Any(), updatedImageTypeCond).Times(len(imgs) / 2).Return(nil)
+
+		// Expect each cluster to be sent a reprocess deployments message.
+		connA.EXPECT().InjectMessage(gomock.Any(), reprocessDeploymentsTypeCond).Times(1).Return(nil)
+		connB.EXPECT().InjectMessage(gomock.Any(), reprocessDeploymentsTypeCond).Times(1).Return(nil)
+
+		testLoop.reprocessImagesAndResyncDeployments(0, reprocessFuncUpdate, nil)
+	})
+
+	t.Run("skip some messages when are broken clusters", func(t *testing.T) {
+		testLoop, connA, connB := newReprocessorLoop(t)
+
+		// Cluster "a" is healthy, expect all applicable images to be sent.
+		connA.EXPECT().InjectMessage(gomock.Any(), updatedImageTypeCond).Times(len(imgs) / 2).Return(nil)
+		// Cluster "b" is not healthy, expect at MOST imageReprocessorSemaphoreSize attempted messages.
+		connB.EXPECT().InjectMessage(gomock.Any(), updatedImageTypeCond).MaxTimes(int(imageReprocessorSemaphoreSize)).Return(errors.New("broken"))
+
+		connA.EXPECT().InjectMessage(gomock.Any(), reprocessDeploymentsTypeCond).Times(1).Return(nil)
+		// No reprocess deployments message is sent due to previous failures.
+		connB.EXPECT().InjectMessage(gomock.Any(), reprocessDeploymentsTypeCond).Times(0).Return(nil)
+
+		testLoop.reprocessImagesAndResyncDeployments(0, reprocessFuncUpdate, nil)
+	})
+}
+
+func TestInjectMessage(t *testing.T) {
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_ReprocessDeployments{
+			ReprocessDeployments: &central.ReprocessDeployments{},
+		},
+	}
+	contextWithTimeout := gomock.Cond(func(ctx context.Context) bool {
+		_, hasTimeout := ctx.Deadline()
+		return hasTimeout
+	})
+	contextWithoutTimeout := gomock.Cond(func(ctx context.Context) bool {
+		_, hasTimeout := ctx.Deadline()
+		return !hasTimeout
+	})
+	t.Run("use timeout when duration set", func(t *testing.T) {
+		testLoop := &loopImpl{
+			injectMessageTimeoutDur: 1 * time.Millisecond, // Can be anything non-zero
+		}
+
+		ctrl := gomock.NewController(t)
+		conn := connectionMocks.NewMockSensorConnection(ctrl)
+
+		// Validate created context has a timeout.
+		conn.EXPECT().InjectMessage(contextWithTimeout, gomock.Any()).Return(nil)
+
+		err := testLoop.injectMessage(ctx, conn, msg)
+		require.NoError(t, err)
+	})
+
+	t.Run("no timeout when duration zero", func(t *testing.T) {
+		testLoop := &loopImpl{
+			injectMessageTimeoutDur: 0,
+		}
+
+		ctrl := gomock.NewController(t)
+		conn := connectionMocks.NewMockSensorConnection(ctrl)
+
+		// Validate created context DOES NOT have a timeout.
+		conn.EXPECT().InjectMessage(contextWithoutTimeout, gomock.Any()).Return(nil)
+
+		err := testLoop.injectMessage(ctx, conn, msg)
+		require.NoError(t, err)
 	})
 }

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -243,7 +243,7 @@ func (c *sensorConnection) runSend(server central.SensorService_CommunicateServe
 			return
 		case msg := <-c.sendC:
 			if err := wrappedStream.Send(msg); err != nil {
-				metrics.IncrementMsgToSensorSkipCounter(c.clusterID, msg)
+				metrics.IncrementMsgToSensorNotSentCounter(c.clusterID, msg, metrics.NotSentError)
 				c.stopSig.SignalWithError(errors.Wrap(err, "send error"))
 				return
 			}
@@ -276,13 +276,13 @@ func (c *sensorConnection) InjectMessage(ctx concurrency.Waitable, msg *central.
 	case c.sendC <- msg:
 		return nil
 	case <-ctx.Done():
-		metrics.IncrementMsgToSensorSkipCounter(c.clusterID, msg)
+		metrics.IncrementMsgToSensorNotSentCounter(c.clusterID, msg, metrics.NotSentSignal)
 		if errCtx, ok := ctx.(concurrency.ErrorWaitable); ok {
 			return errors.Wrap(errCtx.Err(), "context aborted")
 		}
 		return errors.New("context aborted")
 	case <-c.stopSig.Done():
-		metrics.IncrementMsgToSensorSkipCounter(c.clusterID, msg)
+		metrics.IncrementMsgToSensorNotSentCounter(c.clusterID, msg, metrics.NotSentSignal)
 		return errors.Wrap(c.stopSig.Err(), "could not send message as sensor connection was stopped")
 	}
 }

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -275,6 +275,9 @@ func (c *sensorConnection) InjectMessage(ctx concurrency.Waitable, msg *central.
 	case c.sendC <- msg:
 		return nil
 	case <-ctx.Done():
+		if errCtx, ok := ctx.(concurrency.ErrorWaitable); ok {
+			return fmt.Errorf("context aborted: %v", errCtx.Err())
+		}
 		return errors.New("context aborted")
 	case <-c.stopSig.Done():
 		return errors.Wrap(c.stopSig.Err(), "could not send message as sensor connection was stopped")

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -276,7 +276,7 @@ func (c *sensorConnection) InjectMessage(ctx concurrency.Waitable, msg *central.
 		return nil
 	case <-ctx.Done():
 		if errCtx, ok := ctx.(concurrency.ErrorWaitable); ok {
-			return fmt.Errorf("context aborted: %v", errCtx.Err())
+			return errors.Wrap(errCtx.Err(), "context aborted")
 		}
 		return errors.New("context aborted")
 	case <-c.stopSig.Done():

--- a/pkg/env/reprocessing_interval.go
+++ b/pkg/env/reprocessing_interval.go
@@ -17,5 +17,6 @@ var (
 	OrchestratorVulnScanInterval = registerDurationSetting("ROX_ORCHESTRATOR_VULN_SCAN_INTERVAL", 2*time.Hour)
 	// ReprocessInjectMessageTimeout specifies the duration to wait when sending a message to sensor during reprocessing. If this duration
 	// is exceeded subsequent messages targeting this particular sensor will be skipped until the next reprocessing cycle.
-	ReprocessInjectMessageTimeout = registerDurationSetting("ROX_REPROCESSING_INJECT_MESSAGE_TIMEOUT", 1*time.Minute)
+	// Setting the duration to zero will disable the timeout.
+	ReprocessInjectMessageTimeout = registerDurationSetting("ROX_REPROCESSING_INJECT_MESSAGE_TIMEOUT", 1*time.Minute, WithDurationZeroAllowed())
 )

--- a/pkg/env/reprocessing_interval.go
+++ b/pkg/env/reprocessing_interval.go
@@ -15,4 +15,7 @@ var (
 	VulnDeferralFixableReObserveInterval = registerDurationSetting("ROX_VULN_FIXABLE_DEFERRAL_REOBSERVE_INTERVAL", 4*time.Hour)
 	// OrchestratorVulnScanInterval specifies the frequency at which Central should scan for new orchestrator-level vulnerabilities.
 	OrchestratorVulnScanInterval = registerDurationSetting("ROX_ORCHESTRATOR_VULN_SCAN_INTERVAL", 2*time.Hour)
+	// ReprocessInjectMessageTimeout specifies the duration to wait when sending a message to sensor during reprocessing. If this duration
+	// is exceeded subsequent messages targeting this particular sensor will be skipped until the next reprocessing cycle.
+	ReprocessInjectMessageTimeout = registerDurationSetting("ROX_REPROCESSING_INJECT_MESSAGE_TIMEOUT", 1*time.Minute)
 )

--- a/pkg/maputil/syncmap.go
+++ b/pkg/maputil/syncmap.go
@@ -6,6 +6,7 @@ import "github.com/stackrox/rox/pkg/sync"
 type SyncMap[K comparable, V any] interface {
 	Store(K, V)
 	Load(K) (V, bool)
+	Contains(k K) bool
 	Access(fn func(m *map[K]V))
 	RAccess(fn func(m map[K]V))
 }
@@ -26,6 +27,14 @@ func (m *syncMapImpl[K, V]) Load(k K) (V, bool) {
 	defer m.mux.RUnlock()
 	v, ok := m.data[k]
 	return v, ok
+}
+
+// Contains returns true if the map contains the key, false otherwise.
+func (m *syncMapImpl[K, V]) Contains(k K) bool {
+	m.mux.RLock()
+	defer m.mux.RUnlock()
+	_, ok := m.data[k]
+	return ok
 }
 
 // Store inserts the value v to the map at the key k, or updates the value if the

--- a/pkg/maputil/syncmap_test.go
+++ b/pkg/maputil/syncmap_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSyncMapStoreLoad(t *testing.T) {
+func TestSyncMapStoreLoadContains(t *testing.T) {
 	m := NewSyncMap[string, int]()
 	m.Store("a", 1)
 	m.Store("a", 2)
 	v, ok := m.Load("a")
 	assert.True(t, ok)
 	assert.Equal(t, 2, v)
+	assert.True(t, m.Contains("a"))
+	assert.False(t, m.Contains("b"))
 }
 
 func TestSyncMap(t *testing.T) {


### PR DESCRIPTION
### Description

Adds a timeout to the `UpdatedImage` and `ReprocessDeployments` messages sent from Central to Sensor during reprocessing. 

When the timeout triggers, no more messages will be sent by the reprocessor to that failing Sensor until the next reprocessing cycle.  Messages will resume on the next reprocessing cycle. A metric is added to count the number of skipped messages when in this state.

The timeout chosen (`1m`) was an arbitrary guess - please share if you have data / opinions on what this value should be.

(also removed some dead code)

The motivation for this change was due to observed reprocessing not happening in user environments. In one case the cause was a single sensor (out of 100's) not reading from the gRPC bi-directional stream causing grpc's [flow control mechanism](https://github.com/grpc/grpc-go/blob/v1.65.0/internal/transport/flowcontrol.go#L60) to block forever, this in turn blocked Central reprocessing for all.

This change will only 'fix' reprocessing, other ACS functions will likely NOT work while the Sensor is in this stuck state (such as generating diagnostic bundles with sensor data)

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] added unit tests
- [x] modified existing tests

#### How I validated my change

Set a low reprocessing interval (30s) and using a custom sensor image that will stop reading from the stream after triggered, observed the Central reprocessor stalling then recovering.

There will be at most 5 error logs/events per cluster (one for each goroutine that times out), the rest of the logs are debug:

```
reprocessor: 2025/06/24 21:39:35.132427 reprocessor.go:424: Error: Error sending updated image to cluster, skipping cluster until next reprocessing cycle {"image": "quay.io/rhacs-eng/collector:4.9.x-115-gcc527084cc", "image_id": "sha256:14814d797f1340eae34eb0aeb573abca0b40d6eda5eac8fb03829af5d584d832", "error": "error injecting message to sensor: context aborted: context deadline exceeded", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:35.430750 reprocessor.go:424: Error: Error sending updated image to cluster, skipping cluster until next reprocessing cycle {"image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4d5b14fb960b805b4dd220e9869fb95446166f8be2ba3a7db2f66dda4a01497f", "image_id": "sha256:4d5b14fb960b805b4dd220e9869fb95446166f8be2ba3a7db2f66dda4a01497f", "error": "error injecting message to sensor: context aborted: context deadline exceeded", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:36.015179 reprocessor.go:404: Debug: Not sending updated image to cluster due to prior errors {"image_id": "sha256:d40192d6ba8e601f75891fd58d5cf95b448c64d42c58151c57fb54ecc5bbaeed", "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d40192d6ba8e601f75891fd58d5cf95b448c64d42c58151c57fb54ecc5bbaeed", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:36.036657 reprocessor.go:424: Error: Error sending updated image to cluster, skipping cluster until next reprocessing cycle {"image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4e35d069edbf728370f143c91f521e44fd0b1b4726b9ac2528ffd90cf45951c1", "image_id": "sha256:4e35d069edbf728370f143c91f521e44fd0b1b4726b9ac2528ffd90cf45951c1", "error": "error injecting message to sensor: context aborted: context deadline exceeded", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:36.103750 reprocessor.go:424: Error: Error sending updated image to cluster, skipping cluster until next reprocessing cycle {"image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:98b9b1d008214073849d95ec6aa35a47d3108e3f7436f0d823243e399f8e6f4a", "image_id": "sha256:98b9b1d008214073849d95ec6aa35a47d3108e3f7436f0d823243e399f8e6f4a", "error": "error injecting message to sensor: context aborted: context deadline exceeded", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:36.170544 reprocessor.go:424: Error: Error sending updated image to cluster, skipping cluster until next reprocessing cycle {"image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bff86abe981ae01a5dc5c9d78aa281856c1709cde7efc2694e8fedd960acf9db", "image_id": "sha256:bff86abe981ae01a5dc5c9d78aa281856c1709cde7efc2694e8fedd960acf9db", "error": "error injecting message to sensor: context aborted: context deadline exceeded", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:36.953084 reprocessor.go:404: Debug: Not sending updated image to cluster due to prior errors {"image_id": "sha256:183be2dd687286d6b6dd93484d571dd77fdc1a5ab314702d0da9c51ba1324445", "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:183be2dd687286d6b6dd93484d571dd77fdc1a5ab314702d0da9c51ba1324445", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:37.168298 reprocessor.go:404: Debug: Not sending updated image to cluster due to prior errors {"image_id": "sha256:4f8ab6ed21a306fb05d2b2f6b340d6e36c1699954fd3f2fadc30d6154b267dda", "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4f8ab6ed21a306fb05d2b2f6b340d6e36c1699954fd3f2fadc30d6154b267dda", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:37.264409 reprocessor.go:404: Debug: Not sending updated image to cluster due to prior errors {"image_id": "sha256:5205ad4cb639bc5449eb5408ae42c16e2d95b54bf2298ec9db95e84952c3c37d", "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5205ad4cb639bc5449eb5408ae42c16e2d95b54bf2298ec9db95e84952c3c37d", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:37.289206 reprocessor.go:404: Debug: Not sending updated image to cluster due to prior errors {"image_id": "sha256:6b5eb63bfc10f1510a4b160034545c1e8439d17e305ee1dca6055bb27c9065da", "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6b5eb63bfc10f1510a4b160034545c1e8439d17e305ee1dca6055bb27c9065da", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
reprocessor: 2025/06/24 21:39:37.306696 reprocessor.go:404: Debug: Not sending updated image to cluster due to prior errors {"image_id": "sha256:eec1e20212eb1eba41af4972b335e0b3706ef6dfd3ab6d76f701431900b101e9", "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:eec1e20212eb1eba41af4972b335e0b3706ef6dfd3ab6d76f701431900b101e9", "dst_cluster": "788b76eb-34ab-44be-9200-fdbd42431172"}
```

Metrics:

```
# HELP rox_central_msg_to_sensor_not_sent_count Total messages not sent to Sensor due to errors or other reasons
# TYPE rox_central_msg_to_sensor_not_sent_count counter
rox_central_msg_to_sensor_not_sent_count{ClusterID="4005c535-3da8-45c1-a551-41b2883b40f8",reason="error",type="UpdatedImage"} 1
rox_central_msg_to_sensor_not_sent_count{ClusterID="4005c535-3da8-45c1-a551-41b2883b40f8",reason="signal",type="ClusterHealthResponse"} 1
rox_central_msg_to_sensor_not_sent_count{ClusterID="4005c535-3da8-45c1-a551-41b2883b40f8",reason="signal",type="UpdatedImage"} 59
rox_central_msg_to_sensor_not_sent_count{ClusterID="4005c535-3da8-45c1-a551-41b2883b40f8",reason="skip",type="ReprocessDeployments"} 11
rox_central_msg_to_sensor_not_sent_count{ClusterID="4005c535-3da8-45c1-a551-41b2883b40f8",reason="skip",type="UpdatedImage"} 975
```
