### PR TITLE
ROX-29761: Make wizard Review step and button consistent

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
@@ -20,7 +20,7 @@ describe('Vulnerability Reporting form', () => {
 
     const wizardStep1 = 'Configure report parameters';
     const wizardStep2 = 'Configure delivery destinations';
-    const wizardStep3 = 'Review and create';
+    const wizardStep3 = 'Review';
 
     withAuth();
 
@@ -142,7 +142,7 @@ describe('Vulnerability Reporting form', () => {
         // Verify preview results
         validateReportParameters(expectedReportParameters);
 
-        cy.get('button:contains("Create")').click();
+        cy.get('button:contains("Save")').click();
 
         cy.get(`a:contains("${testReportName}")`).click();
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportsTable.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportsTable.test.js
@@ -45,7 +45,7 @@ describe('Vulnerability Reports table', () => {
 
         // Step 3
         clickNextToWizardStep3();
-        cy.get('h2:contains("Review and create")');
+        cy.get('h2:contains("Review")');
         */
 
         clickCancelAndConfirmInWizard();

--- a/ui/apps/platform/src/Components/TabNav/TabNavSubHeader.tsx
+++ b/ui/apps/platform/src/Components/TabNav/TabNavSubHeader.tsx
@@ -11,9 +11,7 @@ function TabNavSubHeader({ description, actions }: TabNavSubHeaderProps) {
         <PageSection variant="light" className="pf-v5-u-py-0">
             <Toolbar inset={{ default: 'insetNone' }}>
                 <ToolbarContent>
-                    <ToolbarItem alignSelf="center">
-                        <div className="pf-v5-u-font-size-sm">{description}</div>
-                    </ToolbarItem>
+                    <ToolbarItem alignSelf="center">{description}</ToolbarItem>
                     <ToolbarItem align={{ default: 'alignRight' }}>
                         <Flex>{actions}</Flex>
                     </ToolbarItem>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -219,7 +219,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
         <>
             <FormikProvider value={formik}>
                 <Wizard
-                    navAriaLabel="Scan configuration creation steps"
+                    navAriaLabel="Scan schedule configuration steps"
                     onSave={onSave}
                     onStepChange={wizardStepChanged}
                 >

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -159,7 +159,7 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
             >
                 <FormikProvider value={formik}>
                     <Wizard
-                        navAriaLabel={`${pageAction} policy steps`}
+                        navAriaLabel="Security policy configuration steps"
                         onClose={closeWizard}
                         onSave={submitForm}
                         isVisitRequired={!canJumpToAny}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -24,12 +24,6 @@ import { getReportFormValuesFromConfiguration } from '../utils';
 import ReportFormErrorAlert from './ReportFormErrorAlert';
 import ReportFormWizard from './ReportFormWizard';
 
-const wizardStepNames = [
-    'Configure report parameters',
-    'Configure delivery destinations',
-    'Review and create',
-];
-
 function CloneVulnReportPage() {
     const navigate = useNavigate();
     const { reportId } = useParams() as { reportId: string };
@@ -107,14 +101,7 @@ function CloneVulnReportPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
-                <ReportFormWizard
-                    formik={formik}
-                    navAriaLabel="Report clone steps"
-                    wizardStepNames={wizardStepNames}
-                    finalStepNextButtonText={'Create'}
-                    onSave={onCreate}
-                    isSaving={isCreating}
-                />
+                <ReportFormWizard formik={formik} onSave={onCreate} isSaving={isCreating} />
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
@@ -19,12 +19,6 @@ import useCreateReport from '../api/useCreateReport';
 import ReportFormErrorAlert from './ReportFormErrorAlert';
 import ReportFormWizard from './ReportFormWizard';
 
-const wizardStepNames = [
-    'Configure report parameters',
-    'Configure delivery destinations',
-    'Review and create',
-];
-
 function CreateVulnReportPage() {
     const navigate = useNavigate();
 
@@ -66,14 +60,7 @@ function CreateVulnReportPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
-                <ReportFormWizard
-                    formik={formik}
-                    navAriaLabel="Report creation steps"
-                    wizardStepNames={wizardStepNames}
-                    onSave={onCreate}
-                    finalStepNextButtonText={'Create'}
-                    isSaving={isLoading}
-                />
+                <ReportFormWizard formik={formik} onSave={onCreate} isSaving={isLoading} />
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -24,12 +24,6 @@ import { getReportFormValuesFromConfiguration } from '../utils';
 import ReportFormErrorAlert from './ReportFormErrorAlert';
 import ReportFormWizard from './ReportFormWizard';
 
-const wizardStepNames = [
-    'Configure report parameters',
-    'Configure delivery destinations',
-    'Review and save', // diff
-];
-
 function EditVulnReportPage() {
     const navigate = useNavigate();
     const { reportId } = useParams() as { reportId: string };
@@ -100,14 +94,7 @@ function EditVulnReportPage() {
             </PageSection>
             <Divider component="div" />
             <PageSection padding={{ default: 'noPadding' }} isCenterAligned>
-                <ReportFormWizard
-                    formik={formik}
-                    navAriaLabel="Report edit steps"
-                    wizardStepNames={wizardStepNames}
-                    onSave={onSave}
-                    finalStepNextButtonText={'Save'}
-                    isSaving={isSaving}
-                />
+                <ReportFormWizard formik={formik} onSave={onSave} isSaving={isSaving} />
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
@@ -12,23 +12,19 @@ import ReportParametersForm from '../forms/ReportParametersForm';
 import ReportReviewForm from '../forms/ReportReviewForm';
 import { ReportFormValues } from '../forms/useReportFormValues';
 
+const wizardStepNames = [
+    'Configure report parameters',
+    'Configure delivery destinations',
+    'Review',
+];
+
 export type ReportFormWizardProps = {
     formik: FormikProps<ReportFormValues>;
-    navAriaLabel: string;
-    wizardStepNames: string[];
-    finalStepNextButtonText: string;
     onSave: () => void;
     isSaving: boolean;
 };
 
-function ReportFormWizard({
-    formik,
-    navAriaLabel,
-    wizardStepNames,
-    finalStepNextButtonText,
-    onSave,
-    isSaving,
-}: ReportFormWizardProps) {
+function ReportFormWizard({ formik, onSave, isSaving }: ReportFormWizardProps) {
     const navigate = useNavigate();
 
     const { isModalOpen, openModal, closeModal } = useModal();
@@ -56,7 +52,7 @@ function ReportFormWizard({
 
     return (
         <>
-            <Wizard navAriaLabel={navAriaLabel} onSave={onSave}>
+            <Wizard navAriaLabel="Vulnerability report configuration steps" onSave={onSave}>
                 <WizardStep
                     name={wizardStepNames[0]}
                     id={wizardStepNames[0]}
@@ -90,7 +86,7 @@ function ReportFormWizard({
                     isDisabled={isStepDisabled(wizardStepNames[2])}
                     footer={{
                         nextButtonProps: { isLoading: isSaving },
-                        nextButtonText: finalStepNextButtonText,
+                        nextButtonText: 'Save',
                         onClose: openModal,
                     }}
                 >


### PR DESCRIPTION
### Description

Rebase and resolve slight merge conflict after #15789

### Problems

1. Outside viewpoint:
    * inconsistency among wizards
    * inconsistency compared to non-wizard form pages
    * inconsistency with PatternFly guidelines
2. Inside viewpoint:
    * confusion during developtment which precedents
    * umcertainty during review which patterns
    * extra props and conditional rendering

### Analysis

1. Compliance scan schedule wizard
    * **Review** step
    * **Save** button
2. Policy wizard
    * **Review** step
    * **Save** button
3. Vulnerability reporting wizard
    * **Review and create** step for clone and create versus **Review and save** step for edit
    * **Create** button for clone and create versus **Save** button for edit

Bonus `navAriaLabel`

1. Compliance scan schedule wizard
    * **Scan configuration creation steps**
2. Policy wizard
    * **clone policy steps** versus **create policy steps** versus **edit policy steps**
3. Vulnerability reporting wizard
    * **Report clone steps** versus **Report creation steps** versus **Report edit steps**

Bonus compare taglines

1. Compliance scan schedule wizard
    **Configure scan schedules** to run profile compliance checks on selected clusters
2. Policies
    **Configure security policies** for your resources.
3. Vulnerability reporting
    **Configure reports**, define collections, and assign delivery destinations to report on vulnerabilities across the organization.

### Solution

1. Replace conditional rendering in vulnerability reporting wizard
    * **Review** step
    * **Save** button
2. Replace conditional action-dependent text in `navAriaLabel` prop with pattern that is as consistent as reasonable with tagline.
    https://github.com/stackrox/stackrox/pull/15789/files#r2155355011
    * **Scan schedule** configuration steps
    * **Security policy** configuration steps
    * **Vulnerability report** configuration steps
3. Delete inconsistent `className="pf-v5-u-font-size-sm"` prop for tagline in policies.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [x] edited e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.

#### Manual testing

1. Visit /main/compliance/schedules click **Create scan schedule** and then advance to last step.
    ![Compliance](https://github.com/user-attachments/assets/54561061-8cc2-4165-9726-6e1cc81b060e)

2. Visit /main/policy-management/policies click **Create policy** and then advance to last step.
    ![Policy](https://github.com/user-attachments/assets/ad80f558-efed-448e-a06c-ddca0fdb7195)

3. Visit /main/vulnerabilities/reports/configuration click **Create report** and then advance to last step.

    * Before changes, see inconsistent step and button.
        ![Report_inconsistent](https://github.com/user-attachments/assets/1c9da90f-0bd4-4563-bb10-63cc023b0d4a)

    * After changes, see consistent step and button.
        ![Report_consistent](https://github.com/user-attachments/assets/954a9d72-6a0a-461c-8ea6-73b3befc5a2f)
