### PR TITLE
ROX-29629: Network Graph URL State

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.constants.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.constants.ts
@@ -1,4 +1,6 @@
 export const DEFAULT_NETWORK_GRAPH_PAGE_SIZE = 10;
 
 // searchable and sortable query parameter fields
+export const EDGE_STATE = 'EDGE_STATE';
 export const EXTERNAL_SOURCE_ADDRESS_QUERY = 'External Source Address';
+export const TIME_WINDOW = 'TIME_WINDOW';

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -1,8 +1,6 @@
 import React, { useMemo } from 'react';
 import { Visualization, VisualizationProvider } from '@patternfly/react-topology';
 
-import { TimeWindow } from 'constants/timeWindows';
-
 import stylesComponentFactory from './components/stylesComponentFactory';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import defaultComponentFactory from './components/defaultComponentFactory';
@@ -29,7 +27,6 @@ export type NetworkGraphProps = {
     setNetworkPolicyModification: SetNetworkPolicyModification;
     scopeHierarchy: NetworkScopeHierarchy;
     isSimulating: boolean;
-    timeWindow: TimeWindow;
 };
 function NetworkGraph({
     isReadyForVisualization,
@@ -41,7 +38,6 @@ function NetworkGraph({
     setNetworkPolicyModification,
     scopeHierarchy,
     isSimulating,
-    timeWindow,
 }: NetworkGraphProps) {
     const controller = useMemo(() => {
         const newController = new Visualization();
@@ -63,7 +59,6 @@ function NetworkGraph({
                     setNetworkPolicyModification={setNetworkPolicyModification}
                     edgeState={edgeState}
                     scopeHierarchy={scopeHierarchy}
-                    timeWindow={timeWindow}
                 />
             </VisualizationProvider>
         </SimulationFrame>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { TimeWindow } from 'constants/timeWindows';
 import relatedEntitySVG from 'images/network-graph/related-entity.svg';
 import filteredEntitySVG from 'images/network-graph/filtered-entity.svg';
 
@@ -282,7 +281,6 @@ type NetworkGraphContainerProps = {
     simulation: Simulation;
     clusterDeploymentCount: number;
     scopeHierarchy: NetworkScopeHierarchy;
-    timeWindow: TimeWindow;
 };
 
 // the order of model modification is as follows:
@@ -301,7 +299,6 @@ function NetworkGraphContainer({
     simulation,
     clusterDeploymentCount,
     scopeHierarchy,
-    timeWindow,
 }: NetworkGraphContainerProps) {
     const { simulator, setNetworkPolicyModification } = useNetworkPolicySimulator({
         simulation,
@@ -382,7 +379,6 @@ function NetworkGraphContainer({
             edgeState={edgeState}
             scopeHierarchy={scopeHierarchy}
             isSimulating={isSimulating}
-            timeWindow={timeWindow}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphURLStateContext.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphURLStateContext.tsx
@@ -9,10 +9,11 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import { edgeStates, EdgeState } from './components/EdgeStateSelect';
 import { DEFAULT_NETWORK_GRAPH_PAGE_SIZE, EDGE_STATE, TIME_WINDOW } from './NetworkGraph.constants';
 
+export const SIDE_PANEL_SEARCH_PREFIX = 's2';
+
 export type NetworkGraphURLStateValue = {
     pagination: ReturnType<typeof useURLPagination>;
-    paginationAnomalous: ReturnType<typeof useURLPagination>;
-    paginationBaseline: ReturnType<typeof useURLPagination>;
+    paginationSecondary: ReturnType<typeof useURLPagination>;
 
     searchFilter: ReturnType<typeof useURLSearch>;
     searchFilterSidePanel: ReturnType<typeof useURLSearch>;
@@ -42,11 +43,10 @@ const NetworkGraphURLStateContext = createContext<NetworkGraphURLStateValue | un
 
 export function NetworkGraphURLStateProvider({ children }: { children: ReactNode }) {
     const pagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-    const paginationAnomalous = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'anomalous');
-    const paginationBaseline = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'baseline');
+    const paginationSecondary = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'secondary');
 
     const searchFilter = useURLSearch();
-    const searchFilterSidePanel = useURLSearch('s2');
+    const searchFilterSidePanel = useURLSearch(SIDE_PANEL_SEARCH_PREFIX);
 
     const [selectedTabSidePanel, setSelectedTabSidePanel] = useURLParameter(
         'sidePanelTabState',
@@ -64,8 +64,7 @@ export function NetworkGraphURLStateProvider({ children }: { children: ReactNode
     const value = useMemo<NetworkGraphURLStateValue>(
         () => ({
             pagination,
-            paginationAnomalous,
-            paginationBaseline,
+            paginationSecondary,
             searchFilter,
             searchFilterSidePanel,
             sidePanelTab: { selectedTabSidePanel, setSelectedTabSidePanel },
@@ -76,8 +75,7 @@ export function NetworkGraphURLStateProvider({ children }: { children: ReactNode
         [
             edgeState,
             pagination,
-            paginationAnomalous,
-            paginationBaseline,
+            paginationSecondary,
             searchFilter,
             searchFilterSidePanel,
             selectedTabSidePanel,
@@ -97,7 +95,7 @@ export function NetworkGraphURLStateProvider({ children }: { children: ReactNode
     );
 }
 
-export function useNetworkGraphURLState() {
+function useNetworkGraphURLState() {
     const context = useContext(NetworkGraphURLStateContext);
     if (!context) {
         throw new Error(
@@ -108,8 +106,7 @@ export function useNetworkGraphURLState() {
 }
 
 export const usePagination = () => useNetworkGraphURLState().pagination;
-export const usePaginationAnomalous = () => useNetworkGraphURLState().paginationAnomalous;
-export const usePaginationBaseline = () => useNetworkGraphURLState().paginationBaseline;
+export const usePaginationSecondary = () => useNetworkGraphURLState().paginationSecondary;
 export const useSearchFilter = () => useNetworkGraphURLState().searchFilter;
 export const useSearchFilterSidePanel = () => useNetworkGraphURLState().searchFilterSidePanel;
 export const useSidePanelTab = () => useNetworkGraphURLState().sidePanelTab;

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphURLStateContext.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphURLStateContext.tsx
@@ -1,0 +1,118 @@
+import React, { createContext, ReactNode, useContext, useMemo } from 'react';
+
+import { timeWindows, TimeWindow } from 'constants/timeWindows';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLParameter, { HistoryAction, QueryValue } from 'hooks/useURLParameter';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+
+import { edgeStates, EdgeState } from './components/EdgeStateSelect';
+import { DEFAULT_NETWORK_GRAPH_PAGE_SIZE, EDGE_STATE, TIME_WINDOW } from './NetworkGraph.constants';
+
+export type NetworkGraphURLStateValue = {
+    pagination: ReturnType<typeof useURLPagination>;
+    paginationAnomalous: ReturnType<typeof useURLPagination>;
+    paginationBaseline: ReturnType<typeof useURLPagination>;
+
+    searchFilter: ReturnType<typeof useURLSearch>;
+    searchFilterSidePanel: ReturnType<typeof useURLSearch>;
+
+    sidePanelTab: {
+        selectedTabSidePanel: QueryValue;
+        setSelectedTabSidePanel: (tab: QueryValue, historyAction?: HistoryAction) => void;
+    };
+
+    sidePanelToggle: {
+        selectedToggleSidePanel: QueryValue;
+        setSelectedToggleSidePanel: (toggle: QueryValue, historyAction?: HistoryAction) => void;
+    };
+
+    edgeState: {
+        edgeState: EdgeState;
+        setEdgeState: (edgeState: EdgeState, historyAction?: HistoryAction) => void;
+    };
+
+    timeWindow: {
+        timeWindow: TimeWindow;
+        setTimeWindow: (timeWindow: TimeWindow, historyAction?: HistoryAction) => void;
+    };
+};
+
+const NetworkGraphURLStateContext = createContext<NetworkGraphURLStateValue | undefined>(undefined);
+
+export function NetworkGraphURLStateProvider({ children }: { children: ReactNode }) {
+    const pagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
+    const paginationAnomalous = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'anomalous');
+    const paginationBaseline = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'baseline');
+
+    const searchFilter = useURLSearch();
+    const searchFilterSidePanel = useURLSearch('s2');
+
+    const [selectedTabSidePanel, setSelectedTabSidePanel] = useURLParameter(
+        'sidePanelTabState',
+        undefined
+    );
+
+    const [selectedToggleSidePanel, setSelectedToggleSidePanel] = useURLParameter(
+        'sidePanelToggleState',
+        undefined
+    );
+
+    const [edgeState, setEdgeState] = useURLStringUnion(EDGE_STATE, edgeStates, 'active');
+    const [timeWindow, setTimeWindow] = useURLStringUnion(TIME_WINDOW, timeWindows, 'Past hour');
+
+    const value = useMemo<NetworkGraphURLStateValue>(
+        () => ({
+            pagination,
+            paginationAnomalous,
+            paginationBaseline,
+            searchFilter,
+            searchFilterSidePanel,
+            sidePanelTab: { selectedTabSidePanel, setSelectedTabSidePanel },
+            sidePanelToggle: { selectedToggleSidePanel, setSelectedToggleSidePanel },
+            edgeState: { edgeState, setEdgeState },
+            timeWindow: { timeWindow, setTimeWindow },
+        }),
+        [
+            edgeState,
+            pagination,
+            paginationAnomalous,
+            paginationBaseline,
+            searchFilter,
+            searchFilterSidePanel,
+            selectedTabSidePanel,
+            selectedToggleSidePanel,
+            setEdgeState,
+            setSelectedTabSidePanel,
+            setSelectedToggleSidePanel,
+            setTimeWindow,
+            timeWindow,
+        ]
+    );
+
+    return (
+        <NetworkGraphURLStateContext.Provider value={value}>
+            {children}
+        </NetworkGraphURLStateContext.Provider>
+    );
+}
+
+export function useNetworkGraphURLState() {
+    const context = useContext(NetworkGraphURLStateContext);
+    if (!context) {
+        throw new Error(
+            'useNetworkGraphURLState must be used within <NetworkGraphURLStateProvider>'
+        );
+    }
+    return context;
+}
+
+export const usePagination = () => useNetworkGraphURLState().pagination;
+export const usePaginationAnomalous = () => useNetworkGraphURLState().paginationAnomalous;
+export const usePaginationBaseline = () => useNetworkGraphURLState().paginationBaseline;
+export const useSearchFilter = () => useNetworkGraphURLState().searchFilter;
+export const useSearchFilterSidePanel = () => useNetworkGraphURLState().searchFilterSidePanel;
+export const useSidePanelTab = () => useNetworkGraphURLState().sidePanelTab;
+export const useSidePanelToggle = () => useNetworkGraphURLState().sidePanelToggle;
+export const useEdgeState = () => useNetworkGraphURLState().edgeState;
+export const useTimeWindow = () => useNetworkGraphURLState().timeWindow;

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Popover } from '@patternfly/react-core';
 import {
@@ -14,13 +14,12 @@ import {
     VisualizationSurface,
 } from '@patternfly/react-topology';
 
-import { TimeWindow } from 'constants/timeWindows';
 import { networkBasePath } from 'routePaths';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
-import useURLSearch from 'hooks/useURLSearch';
-import useURLPagination from 'hooks/useURLPagination';
+import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
+import { QueryValue } from 'hooks/useURLParameter';
 import DeploymentSideBar from './deployment/DeploymentSideBar';
 import NamespaceSideBar from './namespace/NamespaceSideBar';
 import GenericEntitiesSideBar from './genericEntities/GenericEntitiesSideBar';
@@ -35,7 +34,6 @@ import { Simulation } from './utils/getSimulation';
 import LegendContent from './components/LegendContent';
 
 import { EdgeState } from './components/EdgeStateSelect';
-import { deploymentTabs } from './utils/deploymentUtils';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
 import {
     NetworkPolicySimulator,
@@ -49,6 +47,15 @@ import {
     InternalEntitiesIcon,
 } from './common/NetworkGraphIcons';
 import { DEFAULT_NETWORK_GRAPH_PAGE_SIZE } from './NetworkGraph.constants';
+
+import {
+    usePagination,
+    usePaginationAnomalous,
+    usePaginationBaseline,
+    useSearchFilterSidePanel,
+    useSidePanelTab,
+    useSidePanelToggle,
+} from './NetworkGraphURLStateContext';
 
 // TODO: move these type defs to a central location
 export const UrlNodeType = {
@@ -76,7 +83,6 @@ export type TopologyComponentProps = {
     setNetworkPolicyModification: SetNetworkPolicyModification;
     edgeState: EdgeState;
     scopeHierarchy: NetworkScopeHierarchy;
-    timeWindow: TimeWindow;
 };
 
 const TopologyComponent = ({
@@ -88,7 +94,6 @@ const TopologyComponent = ({
     setNetworkPolicyModification,
     edgeState,
     scopeHierarchy,
-    timeWindow,
 }: TopologyComponentProps) => {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNetworkGraphExternalIpsEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_EXTERNAL_IPS');
@@ -96,26 +101,24 @@ const TopologyComponent = ({
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForNetworkPolicy = hasReadAccess('NetworkPolicy');
 
-    const { detailID: selectedExternalIP } = useParams();
+    const { detailID: selectedExternalIP, nodeId: nodeIdParam } = useParams();
 
     // three paginations (default + two flows tables: anomalous & baseline)
     // deployment flows section has 2 tables instead of 1 which is why we need anomalous+baseline.
     // set at the topology level so we can reset every table when switching nodes.
-    const urlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-    const { setPage, setPerPage } = urlPagination;
-    const anomalousUrlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'anomalous');
-    const { setPage: setPageAnomalous, setPerPage: setPerPageAnomalous } = anomalousUrlPagination;
-    const baselineUrlPagination = useURLPagination(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'baseline');
-    const { setPage: setPageBaseline, setPerPage: setPerPageBaseline } = baselineUrlPagination;
+    const { setPerPage } = usePagination();
+    const { setPerPage: setPerPageAnomalous } = usePaginationAnomalous();
+    const { setPerPage: setPerPageBaseline } = usePaginationBaseline();
 
-    const urlSearchFiltering = useURLSearch('sidePanel');
-    const { setSearchFilter } = urlSearchFiltering;
+    const { setSelectedTabSidePanel } = useSidePanelTab();
+    const { setSelectedToggleSidePanel } = useSidePanelToggle();
+
+    const { setSearchFilter } = useSearchFilterSidePanel();
 
     const firstRenderRef = useRef(true);
     const location = useLocation();
     const navigate = useNavigate();
     const controller = useVisualizationController();
-    const [defaultDeploymentTab, setDefaultDeploymentTab] = useState(deploymentTabs.DETAILS);
 
     const closeSidebar = useCallback(() => {
         const queryString = clearSimulationQuery(location.search);
@@ -125,32 +128,48 @@ const TopologyComponent = ({
     type OnNavigateArgs = {
         nodeID: string;
         externalIP?: string;
+        parametersQuery?: QueryValue;
+        searchFilter?: QueryValue;
     };
 
-    function onNavigate({ nodeID, externalIP }: OnNavigateArgs) {
+    function onNavigate({ nodeID, externalIP, parametersQuery, searchFilter }: OnNavigateArgs) {
         const newSelectedId = nodeID || '';
         const newSelectedEntity = getNodeById(model?.nodes, newSelectedId);
+
         if (selectedNode && !newSelectedId) {
             closeSidebar();
-        } else if (newSelectedEntity?.data.type === 'EXTRANEOUS') {
-            setDefaultDeploymentTab(deploymentTabs.FLOWS);
-        } else if (newSelectedEntity) {
-            setDefaultDeploymentTab(deploymentTabs.DETAILS);
-            const { data, id } = newSelectedEntity;
-            const [newNodeType, newNodeId] = getUrlParamsForNode(data.type, id);
-            const queryString = clearSimulationQuery(location.search);
-            // if found, and it's not the logical grouping of all external sources, then trigger URL update
-            if (newNodeId !== 'EXTERNAL') {
-                let newURL = `${networkBasePath}/${newNodeType}/${encodeURIComponent(newNodeId)}`;
-                if (externalIP) {
-                    newURL = `${newURL}/externalIP/${externalIP}`;
-                }
-                newURL = `${newURL}${queryString}`;
-                navigate(newURL);
-            } else {
-                // otherwise, return to the graph-only state
-                navigate(`${networkBasePath}${queryString}`);
+            return;
+        }
+        if (!newSelectedEntity) {
+            return;
+        }
+
+        // TODO: figure out better way to handle deleting query parameters
+        const modifiedSearchFilter = getQueryObject(location.search);
+        delete modifiedSearchFilter.simulation;
+        delete modifiedSearchFilter.sidePanelTabState;
+        delete modifiedSearchFilter.sidePanel;
+        if (parametersQuery) {
+            Object.assign(modifiedSearchFilter, parametersQuery);
+        }
+
+        if (searchFilter) {
+            Object.assign(modifiedSearchFilter, searchFilter);
+        }
+
+        const queryString = getQueryString(modifiedSearchFilter);
+
+        const { data, id } = newSelectedEntity;
+        const [nodeType, nodeId] = getUrlParamsForNode(data.type, id);
+
+        if (nodeId !== 'EXTERNAL') {
+            let url = `${networkBasePath}/${nodeType}/${encodeURIComponent(nodeId)}`;
+            if (externalIP) {
+                url += `/externalIP/${externalIP}`;
             }
+            navigate(`${url}${queryString}`);
+        } else {
+            navigate(`${networkBasePath}${queryString}`);
         }
     }
 
@@ -158,8 +177,8 @@ const TopologyComponent = ({
         getSearchFilterFromScopeHierarchy(scopeHierarchy)
     );
 
-    function onNodeSelect(nodeID: string) {
-        onNavigate({ nodeID });
+    function onNodeSelect(nodeID: string, parametersQuery?: QueryValue, searchFilter?: QueryValue) {
+        onNavigate({ nodeID, parametersQuery, searchFilter });
     }
 
     function onExternalIPSelect(externalIP: string | undefined) {
@@ -202,22 +221,22 @@ const TopologyComponent = ({
     });
 
     useEffect(() => {
-        setPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-        setPage(1);
-        setPerPageAnomalous(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-        setPageAnomalous(1);
-        setPerPageBaseline(DEFAULT_NETWORK_GRAPH_PAGE_SIZE);
-        setPageBaseline(1);
-        setSearchFilter({});
+        if (!nodeIdParam) {
+            setPerPage(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'replace');
+            setPerPageAnomalous(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'replace');
+            setPerPageBaseline(DEFAULT_NETWORK_GRAPH_PAGE_SIZE, 'replace');
+            setSearchFilter({}, 'replace');
+            setSelectedTabSidePanel(undefined, 'replace');
+            setSelectedToggleSidePanel(undefined, 'replace');
+        }
     }, [
-        setPage,
         setPerPage,
         setSearchFilter,
-        setPageAnomalous,
         setPerPageAnomalous,
-        setPageBaseline,
         setPerPageBaseline,
-        selectedNode,
+        setSelectedTabSidePanel,
+        setSelectedToggleSidePanel,
+        nodeIdParam,
     ]);
 
     useEffect(() => {
@@ -282,11 +301,6 @@ const TopologyComponent = ({
                             edges={model?.edges || []}
                             edgeState={edgeState}
                             onNodeSelect={onNodeSelect}
-                            defaultDeploymentTab={defaultDeploymentTab}
-                            anomalousUrlPagination={anomalousUrlPagination}
-                            baselineUrlPagination={baselineUrlPagination}
-                            urlSearchFiltering={urlSearchFiltering}
-                            timeWindow={timeWindow}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'EXTERNAL_GROUP' && (
@@ -322,9 +336,6 @@ const TopologyComponent = ({
                                 selectedExternalIP={selectedExternalIP}
                                 onNodeSelect={onNodeSelect}
                                 onExternalIPSelect={onExternalIPSelect}
-                                timeWindow={timeWindow}
-                                urlPagination={urlPagination}
-                                urlSearchFiltering={urlSearchFiltering}
                             />
                         ) : (
                             <GenericEntitiesSideBar

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -3,7 +3,9 @@ import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
-export type EdgeState = 'active' | 'inactive';
+export const edgeStates = ['active', 'inactive'] as const;
+
+export type EdgeState = (typeof edgeStates)[number];
 
 type EdgeStateSelectProps = {
     edgeState: EdgeState;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
@@ -4,12 +4,13 @@ import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn, IAction } from '@patter
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
-import { UseUrlSearchReturn } from 'hooks/useURLSearch';
 import { NetworkBaselinePeerStatus } from 'types/networkBaseline.proto';
 import { TableUIState } from 'utils/getTableUIState';
 
 import { BaselineStatusType } from '../types/flow.type';
 import { getFlowKey } from '../utils/flowUtils';
+
+import { useSearchFilterSidePanel } from '../NetworkGraphURLStateContext';
 
 type FlowTableProps = {
     pagination: UseURLPaginationResult;
@@ -17,7 +18,6 @@ type FlowTableProps = {
     statusType: BaselineStatusType;
     tableState: TableUIState<NetworkBaselinePeerStatus>;
     areAllRowsSelected: boolean;
-    urlSearchFiltering: UseUrlSearchReturn;
     onSelectAll: (sel: boolean) => void;
     rowActions: (flow: NetworkBaselinePeerStatus) => IAction[];
     isFlowSelected: (flow: NetworkBaselinePeerStatus) => boolean;
@@ -30,14 +30,13 @@ export function FlowTable({
     statusType,
     tableState,
     areAllRowsSelected,
-    urlSearchFiltering,
     onSelectAll,
     rowActions,
     isFlowSelected,
     onRowSelect,
 }: FlowTableProps) {
     const { page, perPage, setPage, setPerPage } = pagination;
-    const { setSearchFilter } = urlSearchFiltering;
+    const { setSearchFilter } = useSearchFilterSidePanel();
     return (
         <>
             <ToolbarContent>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
-import useURLSearch from 'hooks/useURLSearch';
 import { useFetchClusterNamespacesForPermissions } from 'hooks/useFetchClusterNamespacesForPermissions';
 import useFetchNamespaceDeployments from 'hooks/useFetchNamespaceDeployments';
 import { nonGlobalResourceNamesForNetworkGraph } from 'routePaths';
@@ -10,6 +9,8 @@ import { SearchFilter } from 'types/search';
 import ClusterSelector, { ClusterSelectorProps } from './ClusterSelector';
 import NamespaceSelector from './NamespaceSelector';
 import DeploymentSelector from './DeploymentSelector';
+
+import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 export type NetworkBreadcrumbsProps = {
     clusters: ClusterSelectorProps['clusters'];
@@ -26,7 +27,7 @@ function NetworkBreadcrumbs({
     selectedDeployments,
     onScopeChange,
 }: NetworkBreadcrumbsProps) {
-    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useSearchFilter();
 
     const { namespaces } = useFetchClusterNamespacesForPermissions(
         nonGlobalResourceNamesForNetworkGraph,

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 
 import SearchFilterInput from 'Components/SearchFilterInput';
-import useURLSearch from 'hooks/useURLSearch';
 import searchOptionsToQuery from 'services/searchOptionsToQuery';
 import { getSearchOptionsForCategory } from 'services/SearchService';
 import { orchestratorComponentsOption } from 'utils/orchestratorComponents';
+
+import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 import './NetworkSearch.css';
 
@@ -31,7 +32,7 @@ function NetworkSearch({
     isDisabled,
 }: NetworkSearchProps) {
     const [searchOptions, setSearchOptions] = useState<string[]>([]);
-    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { searchFilter, setSearchFilter } = useSearchFilter();
 
     useEffect(() => {
         const { request, cancel } = getSearchOptionsForCategory(searchCategory);

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -33,7 +33,8 @@ import BothPolicyRules from 'images/network-graph/both-policy-rules.svg?react';
 import EgressOnly from 'images/network-graph/egress-only.svg?react';
 import IngressOnly from 'images/network-graph/ingress-only.svg?react';
 import NoPolicyRules from 'images/network-graph/no-policy-rules.svg?react';
-import { deploymentTabs } from '../utils/deploymentUtils';
+
+import { useSidePanelTab } from '../NetworkGraphURLStateContext';
 
 import './DeploymentDetails.css';
 
@@ -43,7 +44,6 @@ type DeploymentDetailsProps = {
     numAnomalousInternalFlows: number;
     listenPorts: ListenPort[];
     networkPolicyState: NetworkPolicyState;
-    onDeploymentTabsSelect: (tab: string) => void;
 };
 
 function DetailSection({ title, children }) {
@@ -75,17 +75,18 @@ function DeploymentDetails({
     numAnomalousInternalFlows,
     listenPorts,
     networkPolicyState,
-    onDeploymentTabsSelect,
 }: DeploymentDetailsProps) {
     const labelKeys = Object.keys(deployment.labels);
     const annotationKeys = Object.keys(deployment.annotations);
 
+    const { setSelectedTabSidePanel } = useSidePanelTab();
+
     const onNetworkFlowsTabSelect = () => {
-        onDeploymentTabsSelect(deploymentTabs.FLOWS);
+        setSelectedTabSidePanel('FLOWS');
     };
 
     const onNetworkPoliciesTabSelect = () => {
-        onDeploymentTabsSelect(deploymentTabs.NETWORK_POLICIES);
+        setSelectedTabSidePanel('NETWORK_POLICIES');
     };
 
     return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -1,11 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import { Divider, Stack, StackItem, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
-import { TimeWindow } from 'constants/timeWindows';
 import useAnalytics, { DEPLOYMENT_FLOWS_TOGGLE_CLICKED } from 'hooks/useAnalytics';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
-import { UseUrlSearchReturn } from 'hooks/useURLSearch';
 
 import { CustomNodeModel } from '../types/topology.type';
 import { EdgeState } from '../components/EdgeStateSelect';
@@ -14,7 +11,14 @@ import InternalFlows from './InternalFlows';
 import ExternalFlows from './ExternalFlows';
 import { isInternalFlow } from '../utils/networkGraphUtils';
 
-export type DeploymentFlowsView = 'external-flows' | 'internal-flows';
+import {
+    usePaginationAnomalous,
+    usePaginationBaseline,
+    useSearchFilterSidePanel,
+    useSidePanelToggle,
+} from '../NetworkGraphURLStateContext';
+
+export type DeploymentFlowsView = 'EXTERNAL_FLOWS' | 'INTERNAL_FLOWS';
 
 type DeploymentFlowsProps = {
     deploymentId: string;
@@ -25,10 +29,6 @@ type DeploymentFlowsProps = {
     networkFlowsError: string;
     networkFlows: Flow[];
     refetchFlows: () => void;
-    anomalousUrlPagination: UseURLPaginationResult;
-    baselineUrlPagination: UseURLPaginationResult;
-    urlSearchFiltering: UseUrlSearchReturn;
-    timeWindow: TimeWindow;
 };
 
 function DeploymentFlows({
@@ -40,34 +40,26 @@ function DeploymentFlows({
     networkFlowsError,
     networkFlows,
     refetchFlows,
-    anomalousUrlPagination,
-    baselineUrlPagination,
-    urlSearchFiltering,
-    timeWindow,
 }: DeploymentFlowsProps) {
     const { analyticsTrack } = useAnalytics();
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isNetworkGraphExternalIpsEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_EXTERNAL_IPS');
-    const [selectedView, setSelectedView] = useState<DeploymentFlowsView>('internal-flows');
 
-    const { setPage: setPageAnomalous } = anomalousUrlPagination;
-    const { setPage: setPageBaseline } = baselineUrlPagination;
-    const { setSearchFilter } = urlSearchFiltering;
+    const { setPage: setPageAnomalous } = usePaginationAnomalous();
+    const { setPage: setPageBaseline } = usePaginationBaseline();
+    const { setSearchFilter } = useSearchFilterSidePanel();
+    const { selectedToggleSidePanel, setSelectedToggleSidePanel } = useSidePanelToggle();
 
-    useEffect(() => {
-        setPageAnomalous(1);
-        setPageBaseline(1);
-        setSearchFilter({});
-    }, [selectedView, setPageAnomalous, setPageBaseline, setSearchFilter]);
-
-    // can be removed when routing is added to network graph
     const handleToggle = useCallback(
         (view: DeploymentFlowsView) => {
-            if (view !== selectedView) {
-                setSelectedView(view);
+            if (view !== selectedToggleSidePanel) {
+                setSelectedToggleSidePanel(view);
+                setPageAnomalous(1);
+                setPageBaseline(1);
+                setSearchFilter({});
 
                 const formattedView =
-                    view === 'internal-flows' ? 'Internal Flows' : 'External Flows';
+                    view === 'INTERNAL_FLOWS' ? 'Internal Flows' : 'External Flows';
 
                 analyticsTrack({
                     event: DEPLOYMENT_FLOWS_TOGGLE_CLICKED,
@@ -75,7 +67,14 @@ function DeploymentFlows({
                 });
             }
         },
-        [selectedView, analyticsTrack]
+        [
+            analyticsTrack,
+            selectedToggleSidePanel,
+            setPageAnomalous,
+            setPageBaseline,
+            setSearchFilter,
+            setSelectedToggleSidePanel,
+        ]
     );
 
     if (!isNetworkGraphExternalIpsEnabled) {
@@ -95,6 +94,8 @@ function DeploymentFlows({
         );
     }
 
+    const selectedView = selectedToggleSidePanel ?? 'INTERNAL_FLOWS';
+
     return (
         <div className="pf-v5-u-h-100">
             <Stack>
@@ -103,21 +104,21 @@ function DeploymentFlows({
                         <ToggleGroupItem
                             text="Internal flows"
                             buttonId="internal-flows"
-                            isSelected={selectedView === 'internal-flows'}
-                            onChange={() => handleToggle('internal-flows')}
+                            isSelected={selectedView === 'INTERNAL_FLOWS'}
+                            onChange={() => handleToggle('INTERNAL_FLOWS')}
                         />
                         <ToggleGroupItem
                             text="External flows"
                             buttonId="external-flows"
-                            isSelected={selectedView === 'external-flows'}
-                            onChange={() => handleToggle('external-flows')}
+                            isSelected={selectedView === 'EXTERNAL_FLOWS'}
+                            onChange={() => handleToggle('EXTERNAL_FLOWS')}
                         />
                     </ToggleGroup>
                 </StackItem>
                 <Divider component="hr" />
                 <StackItem isFilled style={{ overflow: 'auto' }}>
                     <Stack className="pf-v5-u-p-md">
-                        {selectedView === 'internal-flows' ? (
+                        {selectedView === 'INTERNAL_FLOWS' ? (
                             <InternalFlows
                                 nodes={nodes}
                                 deploymentId={deploymentId}
@@ -129,13 +130,7 @@ function DeploymentFlows({
                                 refetchFlows={refetchFlows}
                             />
                         ) : (
-                            <ExternalFlows
-                                deploymentId={deploymentId}
-                                timeWindow={timeWindow}
-                                anomalousUrlPagination={anomalousUrlPagination}
-                                baselineUrlPagination={baselineUrlPagination}
-                                urlSearchFiltering={urlSearchFiltering}
-                            />
+                            <ExternalFlows deploymentId={deploymentId} />
                         )}
                     </Stack>
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -29,8 +29,8 @@ import { FlowTable } from '../components/FlowTable';
 import { useNetworkBaselineStatus } from '../hooks/useNetworkBaselineStatus';
 import { EXTERNAL_SOURCE_ADDRESS_QUERY } from '../NetworkGraph.constants';
 import {
-    usePaginationAnomalous,
-    usePaginationBaseline,
+    usePagination,
+    usePaginationSecondary,
     useSearchFilterSidePanel,
     useTimeWindow,
 } from '../NetworkGraphURLStateContext';
@@ -77,8 +77,8 @@ function ExternalFlows({ deploymentId }: ExternalFlowsProps) {
     const { searchFilter, setSearchFilter } = useSearchFilterSidePanel();
     const { timeWindow } = useTimeWindow();
 
-    const anomalousPagination = usePaginationAnomalous();
-    const baselinePagination = usePaginationBaseline();
+    const anomalousPagination = usePagination();
+    const baselinePagination = usePaginationSecondary();
 
     const { setPage: setPageAnomalous } = anomalousPagination;
     const { setPage: setPageBaseline } = baselinePagination;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -17,10 +17,7 @@ import pluralize from 'pluralize';
 
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
-import { TimeWindow } from 'constants/timeWindows';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
-import { UseUrlSearchReturn } from 'hooks/useURLSearch';
 import { markNetworkBaselineStatuses } from 'services/NetworkService';
 import { NetworkBaselinePeerStatus, PeerStatus } from 'types/networkBaseline.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -31,6 +28,12 @@ import { FlowBulkDropdown } from '../components/FlowBulkDropdown';
 import { FlowTable } from '../components/FlowTable';
 import { useNetworkBaselineStatus } from '../hooks/useNetworkBaselineStatus';
 import { EXTERNAL_SOURCE_ADDRESS_QUERY } from '../NetworkGraph.constants';
+import {
+    usePaginationAnomalous,
+    usePaginationBaseline,
+    useSearchFilterSidePanel,
+    useTimeWindow,
+} from '../NetworkGraphURLStateContext';
 import { getFlowKey } from '../utils/flowUtils';
 
 function getUniquePendingFlows(flows: NetworkBaselinePeerStatus[]) {
@@ -60,10 +63,6 @@ function getUniquePendingFlows(flows: NetworkBaselinePeerStatus[]) {
 
 type ExternalFlowsProps = {
     deploymentId: string;
-    timeWindow: TimeWindow;
-    anomalousUrlPagination: UseURLPaginationResult;
-    baselineUrlPagination: UseURLPaginationResult;
-    urlSearchFiltering: UseUrlSearchReturn;
 };
 
 type PendingStatusChange = {
@@ -74,26 +73,27 @@ type PendingStatusChange = {
     uniqueFlows: ReturnType<typeof getUniquePendingFlows>;
 };
 
-function ExternalFlows({
-    deploymentId,
-    timeWindow,
-    anomalousUrlPagination,
-    baselineUrlPagination,
-    urlSearchFiltering,
-}: ExternalFlowsProps) {
-    const { searchFilter, setSearchFilter } = urlSearchFiltering;
+function ExternalFlows({ deploymentId }: ExternalFlowsProps) {
+    const { searchFilter, setSearchFilter } = useSearchFilterSidePanel();
+    const { timeWindow } = useTimeWindow();
+
+    const anomalousPagination = usePaginationAnomalous();
+    const baselinePagination = usePaginationBaseline();
+
+    const { setPage: setPageAnomalous } = anomalousPagination;
+    const { setPage: setPageBaseline } = baselinePagination;
 
     const anomalous = useNetworkBaselineStatus(
         deploymentId,
         timeWindow,
-        anomalousUrlPagination,
+        anomalousPagination,
         searchFilter,
         'ANOMALOUS'
     );
     const baseline = useNetworkBaselineStatus(
         deploymentId,
         timeWindow,
-        baselineUrlPagination,
+        baselinePagination,
         searchFilter,
         'BASELINE'
     );
@@ -107,9 +107,6 @@ function ExternalFlows({
     const [pendingStatusChange, setPendingStatusChange] = useState<PendingStatusChange | null>(
         null
     );
-
-    const { setPage: setPageAnomalous } = anomalousUrlPagination;
-    const { setPage: setPageBaseline } = baselineUrlPagination;
 
     useEffect(() => {
         setPageAnomalous(1);
@@ -308,7 +305,6 @@ function ExternalFlows({
                                     statusType="ANOMALOUS"
                                     tableState={anomalous.tableState}
                                     areAllRowsSelected={areAllPageAnomalousSelected}
-                                    urlSearchFiltering={urlSearchFiltering}
                                     onSelectAll={selectAllAnomalousFlows}
                                     isFlowSelected={isFlowSelected}
                                     onRowSelect={onSelectFlow}
@@ -363,7 +359,6 @@ function ExternalFlows({
                                     statusType="BASELINE"
                                     tableState={baseline.tableState}
                                     areAllRowsSelected={areAllPageBaselineSelected}
-                                    urlSearchFiltering={urlSearchFiltering}
                                     onSelectAll={selectAllBaselineFlows}
                                     isFlowSelected={isFlowSelected}
                                     onRowSelect={onSelectFlow}

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/EntityDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/EntityDetails.tsx
@@ -28,6 +28,7 @@ import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
 import { EXTERNAL_SOURCE_ADDRESS_QUERY } from '../NetworkGraph.constants';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import {
+    SIDE_PANEL_SEARCH_PREFIX,
     usePagination,
     useSearchFilterSidePanel,
     useTimeWindow,
@@ -61,7 +62,7 @@ function EntityDetails({
     onExternalIPSelect,
 }: EntityDetailsProps) {
     const { page, perPage, setPage, setPerPage } = usePagination();
-    const { buildSearchQuery, searchFilter } = useSearchFilterSidePanel();
+    const { searchFilter } = useSearchFilterSidePanel();
     const { timeWindow } = useTimeWindow();
 
     const clusterId = scopeHierarchy.cluster.id;
@@ -174,11 +175,13 @@ function EntityDetails({
                                                         sidePanelTabState: 'FLOWS',
                                                         sidePanelToggleState: 'EXTERNAL_FLOWS',
                                                     },
-                                                    buildSearchQuery({
-                                                        [EXTERNAL_SOURCE_ADDRESS_QUERY]: [
-                                                            `${externalIPName}/32`,
-                                                        ],
-                                                    })
+                                                    {
+                                                        [SIDE_PANEL_SEARCH_PREFIX]: {
+                                                            [EXTERNAL_SOURCE_ADDRESS_QUERY]: [
+                                                                `${externalIPName}/32`,
+                                                            ],
+                                                        },
+                                                    }
                                                 );
                                             };
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
@@ -11,10 +11,6 @@ import {
     ToggleGroupItem,
 } from '@patternfly/react-core';
 
-import { TimeWindow } from 'constants/timeWindows';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
-import { UseUrlSearchReturn } from 'hooks/useURLSearch';
-
 import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
 import ExternalFlowsTable from './ExternalFlowsTable';
 import ExternalIpsContainer from './ExternalIpsContainer';
@@ -22,6 +18,8 @@ import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import { getNodeById } from '../utils/networkGraphUtils';
 import EntityDetails from './EntityDetails';
+
+import { usePagination, useSearchFilterSidePanel } from '../NetworkGraphURLStateContext';
 
 export type ExternalEntitiesView = 'external-ips' | 'workloads-with-external-flows';
 
@@ -34,9 +32,6 @@ export type ExternalEntitiesSideBarProps = {
     scopeHierarchy: NetworkScopeHierarchy;
     onNodeSelect: (id: string) => void;
     onExternalIPSelect: (externalIP: string | undefined) => void;
-    timeWindow: TimeWindow;
-    urlPagination: UseURLPaginationResult;
-    urlSearchFiltering: UseUrlSearchReturn;
 };
 
 function EntityTitleText({ text, id }: { text: string | undefined; id: string }) {
@@ -56,15 +51,12 @@ function ExternalEntitiesSideBar({
     selectedExternalIP,
     onNodeSelect,
     onExternalIPSelect,
-    timeWindow,
-    urlPagination,
-    urlSearchFiltering,
 }: ExternalEntitiesSideBarProps): ReactElement {
     const [selectedView, setSelectedView] = useState<ExternalEntitiesView>('external-ips');
 
     const entityNode = getNodeById(nodes, id);
-    const { setPage } = urlPagination;
-    const { setSearchFilter } = urlSearchFiltering;
+    const { setPage } = usePagination();
+    const { setSearchFilter } = useSearchFilterSidePanel();
 
     useEffect(() => {
         setPage(1);
@@ -80,9 +72,6 @@ function ExternalEntitiesSideBar({
                 scopeHierarchy={scopeHierarchy}
                 onNodeSelect={onNodeSelect}
                 onExternalIPSelect={onExternalIPSelect}
-                timeWindow={timeWindow}
-                urlPagination={urlPagination}
-                urlSearchFiltering={urlSearchFiltering}
             />
         );
     }
@@ -126,9 +115,6 @@ function ExternalEntitiesSideBar({
                         <ExternalIpsContainer
                             scopeHierarchy={scopeHierarchy}
                             onExternalIPSelect={onExternalIPSelect}
-                            timeWindow={timeWindow}
-                            urlPagination={urlPagination}
-                            urlSearchFiltering={urlSearchFiltering}
                         />
                     ) : (
                         <ExternalFlowsTable

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsContainer.tsx
@@ -1,11 +1,8 @@
 import React, { useCallback, useEffect } from 'react';
 import isEmpty from 'lodash/isEmpty';
 
-import { TimeWindow } from 'constants/timeWindows';
 import useAnalytics, { EXTERNAL_IPS_SIDE_PANEL } from 'hooks/useAnalytics';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useRestQuery from 'hooks/useRestQuery';
-import { UseUrlSearchReturn } from 'hooks/useURLSearch';
 import { getExternalIpsFlowsMetadata } from 'services/NetworkService';
 import { ExternalNetworkFlowsMetadataResponse } from 'types/networkFlow.proto';
 import { getTableUIState } from 'utils/getTableUIState';
@@ -14,26 +11,26 @@ import ExternalIpsTable from './ExternalIpsTable';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { timeWindowToISO } from '../utils/timeWindow';
 
+import {
+    usePagination,
+    useSearchFilterSidePanel,
+    useTimeWindow,
+} from '../NetworkGraphURLStateContext';
+
 type ExternalIpsContainerProps = {
     scopeHierarchy: NetworkScopeHierarchy;
     onExternalIPSelect: (externalIP: string) => void;
-    timeWindow: TimeWindow;
-    urlSearchFiltering: UseUrlSearchReturn;
-    urlPagination: UseURLPaginationResult;
 };
 
-function ExternalIpsContainer({
-    scopeHierarchy,
-    onExternalIPSelect,
-    timeWindow,
-    urlSearchFiltering,
-    urlPagination,
-}: ExternalIpsContainerProps) {
+function ExternalIpsContainer({ scopeHierarchy, onExternalIPSelect }: ExternalIpsContainerProps) {
     const clusterId = scopeHierarchy.cluster.id;
     const { namespaces, deployments } = scopeHierarchy;
+
     const { analyticsTrack } = useAnalytics();
-    const { searchFilter } = urlSearchFiltering;
-    const { page, perPage } = urlPagination;
+    const { searchFilter } = useSearchFilterSidePanel();
+    const { timeWindow } = useTimeWindow();
+    const { page, perPage } = usePagination();
+
     const fetchExternalIpsFlowsMetadata =
         useCallback((): Promise<ExternalNetworkFlowsMetadataResponse> => {
             const fromTimestamp = timeWindowToISO(timeWindow);
@@ -78,8 +75,6 @@ function ExternalIpsContainer({
             onExternalIPSelect={onExternalIPSelect}
             tableState={tableState}
             totalEntities={externalIpsFlowsMetadata?.totalEntities ?? 0}
-            urlPagination={urlPagination}
-            urlSearchFiltering={urlSearchFiltering}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
@@ -14,8 +14,6 @@ import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import useMetadata from 'hooks/useMetadata';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
-import { UseUrlSearchReturn } from 'hooks/useURLSearch';
 import { TableUIState } from 'utils/getTableUIState';
 import { getVersionedDocs } from 'utils/versioning';
 import { ExternalNetworkFlowsMetadata } from 'types/networkFlow.proto';
@@ -23,24 +21,22 @@ import { ExternalNetworkFlowsMetadata } from 'types/networkFlow.proto';
 import IPMatchFilter from '../common/IPMatchFilter';
 import { EXTERNAL_SOURCE_ADDRESS_QUERY } from '../NetworkGraph.constants';
 
+import { usePagination, useSearchFilterSidePanel } from '../NetworkGraphURLStateContext';
+
 export type ExternalIpsTableProps = {
     onExternalIPSelect: (externalIP: string) => void;
     tableState: TableUIState<ExternalNetworkFlowsMetadata>;
     totalEntities: number;
-    urlSearchFiltering: UseUrlSearchReturn;
-    urlPagination: UseURLPaginationResult;
 };
 
 function ExternalIpsTable({
     onExternalIPSelect,
     tableState,
     totalEntities,
-    urlSearchFiltering,
-    urlPagination,
 }: ExternalIpsTableProps) {
     const { version } = useMetadata();
-    const { page, perPage, setPage, setPerPage } = urlPagination;
-    const { searchFilter, setSearchFilter } = urlSearchFiltering;
+    const { page, perPage, setPage, setPerPage } = usePagination();
+    const { searchFilter, setSearchFilter } = useSearchFilterSidePanel();
 
     useEffect(() => {
         setPage(1);

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
@@ -1,9 +1,10 @@
 import cloneDeep from 'lodash/cloneDeep';
 
-import useURLSearch from 'hooks/useURLSearch';
 import { ClusterScopeObject } from 'services/RolesService';
 import { SearchFilter } from 'types/search';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+
+import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 export function getScopeHierarchyFromSearch(
     searchFilter: SearchFilter,
@@ -60,7 +61,7 @@ const emptyScopeHierarchy = {
  * Returns the current scope hierarchy from the URL search params.
  */
 export function useScopeHierarchy(availableClusters: ClusterScopeObject[]): NetworkScopeHierarchy {
-    const { searchFilter } = useURLSearch();
+    const { searchFilter } = useSearchFilter();
 
     return (
         getScopeHierarchyFromSearch(searchFilter, availableClusters) ??

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     Flex,
     FlexItem,
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import uniq from 'lodash/uniq';
 
-import useTabs from 'hooks/patternfly/useTabs';
+import { QueryValue } from 'hooks/useURLParameter';
 import {
     getDeploymentNodesInNamespace,
     getNodeById,
@@ -24,6 +24,7 @@ import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
 import NamespaceDeployments from './NamespaceDeployments';
 import NetworkPolicies from '../common/NetworkPolicies';
+import { useSidePanelTab } from '../NetworkGraphURLStateContext';
 
 type NamespaceSideBarProps = {
     labelledById: string; // corresponds to aria-labelledby prop of TopologySideBar
@@ -33,6 +34,15 @@ type NamespaceSideBarProps = {
     onNodeSelect: (id: string) => void;
 };
 
+const NAMESPACE_TABS = ['DEPLOYMENTS', 'NETWORK_POLICIES'] as const;
+type NamespaceTabKey = (typeof NAMESPACE_TABS)[number];
+
+const DEFAULT_NAMESPACE_TAB: NamespaceTabKey = 'DEPLOYMENTS';
+
+function isValidNamespaceTab(value: QueryValue): value is NamespaceTabKey {
+    return typeof value === 'string' && NAMESPACE_TABS.some((tab) => tab === value);
+}
+
 function NamespaceSideBar({
     labelledById,
     namespaceId,
@@ -40,10 +50,7 @@ function NamespaceSideBar({
     edges,
     onNodeSelect,
 }: NamespaceSideBarProps) {
-    // component state
-    const { activeKeyTab, onSelectTab } = useTabs({
-        defaultTab: 'Deployments',
-    });
+    const { selectedTabSidePanel, setSelectedTabSidePanel } = useSidePanelTab();
 
     // derived state
     const namespaceNode = getNodeById(nodes, namespaceId);
@@ -63,6 +70,16 @@ function NamespaceSideBar({
         return [...acc, ...policyIds];
     }, [] as string[]);
     const uniqueNamespacePolicyIds = uniq(namespacePolicyIds);
+
+    const activeTab: NamespaceTabKey = isValidNamespaceTab(selectedTabSidePanel)
+        ? selectedTabSidePanel
+        : DEFAULT_NAMESPACE_TAB;
+
+    useEffect(() => {
+        if (selectedTabSidePanel !== undefined && !isValidNamespaceTab(selectedTabSidePanel)) {
+            setSelectedTabSidePanel(DEFAULT_NAMESPACE_TAB, 'replace');
+        }
+    }, [selectedTabSidePanel, setSelectedTabSidePanel]);
 
     return (
         <Stack>
@@ -84,31 +101,34 @@ function NamespaceSideBar({
                 </Flex>
             </StackItem>
             <StackItem>
-                <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
+                <Tabs
+                    activeKey={activeTab}
+                    onSelect={(_e, key) => setSelectedTabSidePanel(key.toString())}
+                >
                     <Tab
-                        eventKey="Deployments"
-                        tabContentId="Deployments"
+                        eventKey="DEPLOYMENTS"
+                        tabContentId="DEPLOYMENTS"
                         title={<TabTitleText>Deployments</TabTitleText>}
                     />
                     <Tab
-                        eventKey="Network policies"
-                        tabContentId="Network_policies"
+                        eventKey="NETWORK_POLICIES"
+                        tabContentId="NETWORK_POLICIES"
                         title={<TabTitleText>Network policies</TabTitleText>}
                     />
                 </Tabs>
             </StackItem>
             <StackItem isFilled style={{ overflow: 'auto' }}>
                 <TabContent
-                    eventKey="Deployments"
-                    id="Deployments"
-                    hidden={activeKeyTab !== 'Deployments'}
+                    eventKey="DEPLOYMENTS"
+                    id="DEPLOYMENTS"
+                    hidden={activeTab !== 'DEPLOYMENTS'}
                 >
                     <NamespaceDeployments deployments={deployments} onNodeSelect={onNodeSelect} />
                 </TabContent>
                 <TabContent
-                    eventKey="Network policies"
-                    id="Network_policies"
-                    hidden={activeKeyTab !== 'Network policies'}
+                    eventKey="NETWORK_POLICIES"
+                    id="NETWORK_POLICIES"
+                    hidden={activeTab !== 'NETWORK_POLICIES'}
                     className="pf-v5-u-h-100"
                 >
                     <NetworkPolicies

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -15,8 +15,9 @@ import { gql, useQuery } from '@apollo/client';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import useTableSort from 'hooks/useTableSort';
-import { SearchFilter } from 'types/search';
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+
+import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 const deploymentQuery = gql`
     query getDeploymentsForPolicyGeneration($query: String!, $pagination: Pagination!) {
@@ -32,14 +33,12 @@ const sortFields = ['Deployment', 'Namespace'];
 const defaultSortOption = { field: 'Deployment', direction: 'asc' } as const;
 
 export type DeploymentScopeModalProps = {
-    searchFilter: SearchFilter;
     scopeDeploymentCount: number;
     isOpen: boolean;
     onClose: () => void;
 };
 
 function DeploymentScopeModal({
-    searchFilter,
     scopeDeploymentCount,
     isOpen,
     onClose,
@@ -47,6 +46,8 @@ function DeploymentScopeModal({
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const [page, setPage] = useState(1);
     const [perPage, setPerPage] = useState(20);
+
+    const { searchFilter } = useSearchFilter();
 
     const options = {
         skip: !isOpen,

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Button, Flex, pluralize } from '@patternfly/react-core';
 
-import useURLSearch from 'hooks/useURLSearch';
-
 import DeploymentScopeModal from './DeploymentScopeModal';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { ClusterIcon, DeploymentIcon, NamespaceIcon } from '../common/NetworkGraphIcons';
@@ -18,7 +16,6 @@ function NetworkPoliciesGenerationScope({
     scopeHierarchy,
     scopeDeploymentCount,
 }: NetworkPoliciesGenerationScopeProps) {
-    const { searchFilter } = useURLSearch();
     const isOnlyClusterScope =
         scopeHierarchy.namespaces.length === 0 && scopeHierarchy.deployments.length === 0;
     const [showDeploymentModal, setShowDeploymentModal] = React.useState(false);
@@ -45,7 +42,6 @@ function NetworkPoliciesGenerationScope({
     return (
         <>
             <DeploymentScopeModal
-                searchFilter={searchFilter}
                 scopeDeploymentCount={scopeDeploymentCount}
                 isOpen={showDeploymentModal}
                 onClose={() => setShowDeploymentModal(false)}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -5,9 +5,10 @@ import { DownloadIcon } from '@patternfly/react-icons';
 
 import CodeViewer from 'Components/CodeViewer';
 import useAnalytics, { DOWNLOAD_NETWORK_POLICIES } from 'hooks/useAnalytics';
-import useURLSearch from 'hooks/useURLSearch';
 import download from 'utils/download';
 import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
+
+import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 type NetworkPoliciesYAMLProp = {
     yaml: string;
@@ -17,7 +18,7 @@ type NetworkPoliciesYAMLProp = {
 
 function NetworkPoliciesYAML({ yaml, style, additionalControls }: NetworkPoliciesYAMLProp) {
     const { analyticsTrack } = useAnalytics();
-    const { searchFilter } = useURLSearch();
+    const { searchFilter } = useSearchFilter();
 
     const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
         const properties = getPropertiesForAnalytics(searchFilter);

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -22,6 +22,7 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import sortBy from 'lodash/sortBy';
+import { ParsedQs } from 'qs';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 import usePermissions from 'hooks/usePermissions';
@@ -29,7 +30,7 @@ import useRestQuery from 'hooks/useRestQuery';
 import useAnalytics, { GENERATE_NETWORK_POLICIES } from 'hooks/useAnalytics';
 import useTabs from 'hooks/patternfly/useTabs';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
+import { getQueryObject } from 'utils/queryStringUtils';
 import { fetchNetworkPoliciesByClusterId } from 'services/NetworkService';
 
 import ViewActiveYAMLs from './ViewActiveYAMLs';
@@ -53,12 +54,18 @@ import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
 
 import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
-// @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
-export function clearSimulationQuery(search: string): string {
+// @TODO: Consider a better approach to managing the side panel related state
+export function clearSidePanelQuery(search: string): ParsedQs {
     const modifiedSearchFilter = getQueryObject(search);
     delete modifiedSearchFilter.simulation;
-    const queryString = getQueryString(modifiedSearchFilter);
-    return queryString;
+    delete modifiedSearchFilter.sidePanelTabState;
+    delete modifiedSearchFilter.sidePanelToggleState;
+    delete modifiedSearchFilter.sidePanel;
+    delete modifiedSearchFilter.page;
+    delete modifiedSearchFilter.perPage;
+    delete modifiedSearchFilter.secondaryPage;
+    delete modifiedSearchFilter.secondaryPerPage;
+    return modifiedSearchFilter;
 }
 
 export type NetworkPolicySimulatorSidePanelProps = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -27,7 +27,6 @@ import PopoverBodyContent from 'Components/PopoverBodyContent';
 import usePermissions from 'hooks/usePermissions';
 import useRestQuery from 'hooks/useRestQuery';
 import useAnalytics, { GENERATE_NETWORK_POLICIES } from 'hooks/useAnalytics';
-import useURLSearch from 'hooks/useURLSearch';
 import useTabs from 'hooks/patternfly/useTabs';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
@@ -51,6 +50,8 @@ import CompareYAMLModal from './CompareYAMLModal';
 import CodeCompareIcon from './CodeCompareIcon';
 import NetworkPoliciesGenerationScope from './NetworkPoliciesGenerationScope';
 import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
+
+import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 // @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
 export function clearSimulationQuery(search: string): string {
@@ -82,7 +83,7 @@ function NetworkPolicySimulatorSidePanel({
     scopeDeploymentCount,
 }: NetworkPolicySimulatorSidePanelProps) {
     const { analyticsTrack } = useAnalytics();
-    const { searchFilter } = useURLSearch();
+    const { searchFilter } = useSearchFilter();
 
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForNotifiers = hasReadAccess('Integration');

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
@@ -5,9 +5,10 @@ import { useNavigate } from 'react-router-dom';
 import { networkBasePath } from 'routePaths';
 import useAnalytics, { CLUSTER_LEVEL_SIMULATOR_OPENED } from 'hooks/useAnalytics';
 import useURLParameter from 'hooks/useURLParameter';
-import useURLSearch from 'hooks/useURLSearch';
 import { Simulation } from '../utils/getSimulation';
 import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
+
+import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 type SimulateNetworkPolicyButtonProps = {
     simulation: Simulation;
@@ -17,7 +18,7 @@ type SimulateNetworkPolicyButtonProps = {
 function SimulateNetworkPolicyButton({ simulation, isDisabled }: SimulateNetworkPolicyButtonProps) {
     const { analyticsTrack } = useAnalytics();
     const navigate = useNavigate();
-    const { searchFilter } = useURLSearch();
+    const { searchFilter } = useSearchFilter();
 
     const [, setSimulationQueryValue] = useURLParameter('simulation', undefined);
 

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -506,7 +506,7 @@ function redactParsedQs(value: RawQueryStringValue, key: string): RawQueryString
 function redactSearchParams(location: string): string {
     // Top level URL parameters that can contain user or installation-specific information. Any
     // key that should have its value redacted should be added to this list.
-    const topLevelSearchKeys = ['s', 's2', 'sidePanel'];
+    const topLevelSearchKeys = ['s', 's2'];
 
     try {
         const url = new URL(location);

--- a/ui/apps/platform/src/hooks/useURLPagination.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLPagination.test.tsx
@@ -43,7 +43,7 @@ test('should update pagination parameters in the URL', async () => {
     expect(params.get('page')).toBe('2');
     expect(params.get('perPage')).toBe(null);
 
-    // Check that updating the perPage parameter also resets the page parameter to 1
+    // Check that updating the perPage parameter also resets the page parameter
     await actAndFlushTaskQueue(() => {
         const { setPerPage } = result.current;
         setPerPage(20);
@@ -51,7 +51,7 @@ test('should update pagination parameters in the URL', async () => {
     params = new URLSearchParams(testLocation.search);
     expect(result.current.page).toBe(1);
     expect(result.current.perPage).toBe(20);
-    expect(params.get('page')).toBe('1');
+    expect(params.get('page')).toBe(null);
     expect(params.get('perPage')).toBe('20');
 });
 
@@ -98,7 +98,7 @@ test('should not add history states when setting values with a "replace" action'
     // Check the length of the history stack after updating the perPage parameter
     params = new URLSearchParams(history.location.search);
     expect(history.index).toBe(0);
-    expect(params.get('page')).toBe('1');
+    expect(params.get('page')).toBe(null);
     expect(params.get('perPage')).toBe('20');
 });
 
@@ -145,6 +145,6 @@ test('should only add a single history state when setting perPage without an act
     // Check the length of the history stack after updating the perPage parameter
     params = new URLSearchParams(history.location.search);
     expect(history.index).toBe(2);
-    expect(params.get('page')).toBe('1');
+    expect(params.get('page')).toBe(null);
     expect(params.get('perPage')).toBe('20');
 });

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -31,9 +31,9 @@ function useURLPagination(defaultPerPage: number, keyPrefix?: string): UseURLPag
             // If the history action is 'push', we push a new perPage and replace the page in
             // order to keep a single record on the history stack.
             setPerPageString(num !== defaultPerPage ? String(num) : undefined, historyAction);
-            setPageString('1', 'replace');
+            setPage(1, historyAction);
         },
-        [setPageString, setPerPageString, defaultPerPage]
+        [setPage, setPerPageString, defaultPerPage]
     );
     return {
         page: safeNumber(page, 1),

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -11,7 +11,6 @@ export type SetSearchFilter = (newFilter: SearchFilter, historyAction?: HistoryA
 export type UseUrlSearchReturn = {
     searchFilter: SearchFilter;
     setSearchFilter: SetSearchFilter;
-    buildSearchQuery: (filter: SearchFilter) => qs.ParsedQs;
 };
 
 function parseFilter(rawFilter: QueryValue): SearchFilter {
@@ -46,12 +45,7 @@ function useURLSearch(keyPrefix = 's'): UseUrlSearchReturn {
         searchFilterRef.current = sanitizedFilter;
     }
 
-    // TODO: explore alternatives. Might not be beneficial.
-    // wanting a way to make a search query when using `Navigate()` that's
-    // tightly coupled with useURLSearch/useURLParameter
-    const buildSearchQuery = (filter: SearchFilter) => ({ [keyPrefix]: filter });
-
-    return { searchFilter: searchFilterRef.current, setSearchFilter, buildSearchQuery };
+    return { searchFilter: searchFilterRef.current, setSearchFilter };
 }
 
 export default useURLSearch;

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual';
 
 import { SearchFilter } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
+
 import useURLParameter, { HistoryAction, QueryValue } from './useURLParameter';
 
 export type SetSearchFilter = (newFilter: SearchFilter, historyAction?: HistoryAction) => void;
@@ -10,6 +11,7 @@ export type SetSearchFilter = (newFilter: SearchFilter, historyAction?: HistoryA
 export type UseUrlSearchReturn = {
     searchFilter: SearchFilter;
     setSearchFilter: SetSearchFilter;
+    buildSearchQuery: (filter: SearchFilter) => qs.ParsedQs;
 };
 
 function parseFilter(rawFilter: QueryValue): SearchFilter {
@@ -44,7 +46,12 @@ function useURLSearch(keyPrefix = 's'): UseUrlSearchReturn {
         searchFilterRef.current = sanitizedFilter;
     }
 
-    return { searchFilter: searchFilterRef.current, setSearchFilter };
+    // TODO: explore alternatives. Might not be beneficial.
+    // wanting a way to make a search query when using `Navigate()` that's
+    // tightly coupled with useURLSearch/useURLParameter
+    const buildSearchQuery = (filter: SearchFilter) => ({ [keyPrefix]: filter });
+
+    return { searchFilter: searchFilterRef.current, setSearchFilter, buildSearchQuery };
 }
 
 export default useURLSearch;


### PR DESCRIPTION
### Description

Adds more comprehensive URL state to Network Graph.

#### 1. Expanded URL state beyond just graph scope

Previously, only cluster, namespace, deployment, and selected node were reflected in the URL.

This PR expands URL state to include:

- `sidePanelTabState` (e.g. `DETAILS`, `FLOWS`)
- `sidePanelToggleState` (e.g. `INTERNAL_FLOWS`, `EXTERNAL_FLOWS`)
- `EDGE_STATE` (`active` / `inactive`)
- `TIME_WINDOW`
- Pagination state (including anomalous/baseline for 2 table pagination)
- Search filters for both the main graph and side panel

#### 2. Centralized URL state access

Introduced `NetworkGraphURLStateContext`.

This helps avoid prop drilling and hopefully makes URL state easier to reuse and maintain.

#### 3. Added `buildSearchQuery` utility to `useURLSearch`

An attempt to make preserving existing search filters in the URL easier when routing using `navigate()`

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Verified that pages retain their exact state after page refreshes, including:
- Selected tab and toggle in the side panel
- Time window and edge state
- Applied search filters and pagination settings

Before:
![Screenshot 2025-06-23 at 2 58 14 PM](https://github.com/user-attachments/assets/d1a54219-2962-4b0b-bd27-1034c267eb68)

After:
![Screenshot 2025-06-23 at 2 58 33 PM](https://github.com/user-attachments/assets/6a67cb40-ec3f-41d0-98dd-ba342b6b7495)

