### PR TITLE
fix(tests): Proper output sequencing on scanner V4 test case teardown

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -58,13 +58,16 @@ current_label=""
 post_processor_pid=""
 
 _begin() {
+    local label="${1:-}"
+
     # In case it is convenient for a given test-case, _begin() can take care of the initialization.
     if [[ $initialized = "false" ]]; then
         init
         initialized="true"
+    elif [[ -n "$post_processor_pid" ]]; then
+        _end
     fi
 
-    local label="${1:-}"
     current_label="$label"
 
     # Save original stdout and stderr fds as 4 and 5.
@@ -102,12 +105,6 @@ emit_timing_data() {
     cat <<EOT
 TIMING_DATA: {"test": "$test", "step": "$step", "seconds_spent": $seconds_spent}
 EOT
-}
-
-# Combined _end() and _begin() for convenience.
-_step() {
-    _end
-    _begin "$1"
 }
 
 export TEST_SUITE_ABORTED="false"
@@ -303,7 +300,7 @@ setup() {
         setup_deployment_env false false
     fi
 
-    _step "pre-test-tear-down"
+    _begin "pre-test-tear-down"
 
     if [[ "${SKIP_INITIAL_TEARDOWN:-}" != "true" ]] && (( test_case_no == 0 )); then
         # executing teardown to begin test execution in a well-defined state
@@ -446,7 +443,7 @@ central:
 EOT
     )
 
-    _step "verify-scanner-V4-not-deployed"
+    _begin "verify-scanner-V4-not-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_no_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
 
@@ -454,7 +451,7 @@ EOT
     deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$MAIN_IMAGE_TAG" "" \
         --reuse-values
 
-    _step "verify-scanner-V4-not-deployed"
+    _begin "verify-scanner-V4-not-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_no_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
 
@@ -463,7 +460,7 @@ EOT
         --reuse-values \
         --set scannerV4.disable=false
 
-    _step "verify-scanners-deployed"
+    _begin "verify-scanners-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
@@ -476,19 +473,19 @@ EOT
         "$EARLIER_MAIN_IMAGE_TAG" "$old_sensor_chart" \
         "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
 
-    _step "verify-scanner-V2-not-deployed"
+    _begin "verify-scanner-V2-not-deployed"
     verify_no_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
-    _step "verify-scanner-V4-not-deployed"
+    _begin "verify-scanner-V4-not-deployed"
     verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
-    _step "upgrade-to-HEAD-sensor"
+    _begin "upgrade-to-HEAD-sensor"
     deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" "" "" "" "" ""
 
-    _step "verify-scanner-V2-not-deployed"
+    _begin "verify-scanner-V2-not-deployed"
     verify_no_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
-    _step "verify-scanner-V4-not-deployed"
+    _begin "verify-scanner-V4-not-deployed"
     verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
     _begin "enable-scanners-in-secured-cluster"
@@ -501,10 +498,10 @@ EOT
         --set scannerV4.disable=false \
         --set scanner.disable=false
 
-    _step "verify-scanner-V2-deployed"
+    _begin "verify-scanner-V2-deployed"
     verify_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
-    _step "verify-scanner-V4-deployed"
+    _begin "verify-scanner-V4-deployed"
     verify_scannerV4_indexer_deployed "$CUSTOM_SENSOR_NAMESPACE"
 
     _end
@@ -534,13 +531,13 @@ EOT
         "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
 
     ######################
-    _step "verifying-central-scanners-deployed"
+    _begin "verifying-central-scanners-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
 
     ######################
-    _step "verifying-sensor-scanners-deployed"
+    _begin "verifying-sensor-scanners-deployed"
     verify_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
     verify_scannerV4_indexer_deployed "$CUSTOM_SENSOR_NAMESPACE"
     run verify_deployment_scannerV4_env_var_set "$CUSTOM_SENSOR_NAMESPACE" "sensor"
@@ -560,14 +557,14 @@ EOT
         "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
 
     ######################
-    _step "verifying-central-scanners-deployed"
+    _begin "verifying-central-scanners-deployed"
     info "Verifying that scanners are still installed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
 
     ######################
-    _step "verifying-sensor-scanners-deployed"
+    _begin "verifying-sensor-scanners-deployed"
     info "Verifying that scanners are still installed"
     verify_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
     verify_scannerV4_indexer_deployed "$CUSTOM_SENSOR_NAMESPACE"
@@ -580,19 +577,19 @@ EOT
         --reuse-values --set scannerV4.disable=true
 
     ######################
-    _step "disabling-sensor-scanners"
+    _begin "disabling-sensor-scanners"
     info "Disabling Scanner V4 for secured-cluster-services"
     deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" "" "" "" "" "" \
         --set scannerV4.disable=true --set scanner.disable=true
 
     ######################
-    _step "verifying-central-scanner-v4-not-deployed"
+    _begin "verifying-central-scanner-v4-not-deployed"
     info "Verifying Scanner V4 is getting removed for central-services"
     verify_deployment_deletion_with_timeout 4m "$CUSTOM_CENTRAL_NAMESPACE" scanner-v4-indexer scanner-v4-matcher scanner-v4-db
     run ! verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
 
     ######################
-    _step "verifying-sensor-scanner-v4-not-deployed"
+    _begin "verifying-sensor-scanner-v4-not-deployed"
     info "Verifying Scanner V4 is getting removed for secured-cluster-services"
     verify_deployment_deletion_with_timeout 4m "$CUSTOM_SENSOR_NAMESPACE" scanner-v4-indexer scanner-v4-db
     run ! verify_deployment_scannerV4_env_var_set "$CUSTOM_SENSOR_NAMESPACE" "sensor"
@@ -625,7 +622,7 @@ EOT
         "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
 
     ######################
-    _step "verifying-central-scanners-deployed"
+    _begin "verifying-central-scanners-deployed"
     info "Verifying that scanners are deployed"
     verify_scannerV2_deployed "$namespace"
     verify_scannerV4_deployed "$namespace"
@@ -633,7 +630,7 @@ EOT
     verify_deployment_scannerV4_env_var_set "$namespace" "central"
 
     ######################
-    _step "verifying-sensor-scanners-enabled"
+    _begin "verifying-sensor-scanners-enabled"
     info "Verifying that scanner V4 is enabled for sensor"
     run verify_deployment_scannerV4_env_var_set "$namespace" "sensor"
 
@@ -652,14 +649,14 @@ EOT
         "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
 
     ######################
-    _step "verifying-central-scanners-deployed"
+    _begin "verifying-central-scanners-deployed"
     info "Verifying that scanners are still installed"
     verify_scannerV2_deployed "$namespace"
     verify_scannerV4_deployed "$namespace"
     verify_deployment_scannerV4_env_var_set "$namespace" "central"
 
     ######################
-    _step "verifying-sensor-scanners-deployed"
+    _begin "verifying-sensor-scanners-deployed"
     info "Verifying that scanner V4 is still enabled for sensor"
     run verify_deployment_scannerV4_env_var_set "$namespace" "sensor"
 
@@ -670,19 +667,19 @@ EOT
         --reuse-values --set scannerV4.disable=true
 
     ######################
-    _step "disabling-sensor-scanners"
+    _begin "disabling-sensor-scanners"
     info "Disabling Scanner V4 for secured-cluster-services"
     deploy_sensor_with_helm "$namespace" "$namespace" "" "" "" "" "" \
         --set scannerV4.disable=true --set scanner.disable=true
 
     ######################
-    _step "verifying-central-scanner-v4-not-deployed"
+    _begin "verifying-central-scanner-v4-not-deployed"
     info "Verifying Scanner V4 is getting removed for central-services"
     verify_deployment_deletion_with_timeout 4m "$namespace" scanner-v4-indexer scanner-v4-matcher scanner-v4-db
     run ! verify_deployment_scannerV4_env_var_set "$namespace" "central"
 
     ######################
-    _step "verifying-sensor-scanner-v4-not-deployed"
+    _begin "verifying-sensor-scanner-v4-not-deployed"
     info "Verifying Scanner V4 is not enables for sensor"
     run ! verify_deployment_scannerV4_env_var_set "$namespace" "sensor"
 
@@ -740,13 +737,13 @@ EOT
 
     _deploy_stackrox
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed
     verify_no_scannerV4_deployed
     run ! verify_deployment_scannerV4_env_var_set "stackrox" "central"
 
-    _step "deploy-scanner-v4"
+    _begin "deploy-scanner-v4"
 
     assert [ -d "${scanner_bundle}" ]
     assert [ -d "${scanner_bundle}/scanner-v4" ]
@@ -785,7 +782,7 @@ EOT
     VERSION="${OPERATOR_VERSION_TAG}" deploy_stackrox_operator
     _deploy_stackrox
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
@@ -817,7 +814,7 @@ EOT
     VERSION="${OPERATOR_VERSION_TAG}" deploy_stackrox_operator
     _deploy_stackrox "" "${CUSTOM_CENTRAL_NAMESPACE}" "${CUSTOM_SENSOR_NAMESPACE}"
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
     verify_scannerV4_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
@@ -851,12 +848,12 @@ EOT
     VERSION="${OPERATOR_VERSION_TAG}" make -C operator deploy-previous-via-olm
     ROX_SCANNER_V4="false" _deploy_stackrox "" "${CUSTOM_CENTRAL_NAMESPACE}" "${CUSTOM_SENSOR_NAMESPACE}"
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
     verify_scannerV2_deployed "${CUSTOM_SENSOR_NAMESPACE}"
 
-    _step "upgrade-operator"
+    _begin "upgrade-operator"
 
     # Upgrade operator
     info "Upgrading StackRox Operator to version ${OPERATOR_VERSION_TAG}..."
@@ -869,7 +866,7 @@ EOT
     sleep 60
     "${ORCH_CMD}" </dev/null -n stackrox-operator wait --for=condition=Ready --timeout=3m pods -l app=rhacs-operator
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
     verify_scannerV2_deployed "${CUSTOM_SENSOR_NAMESPACE}"
@@ -880,7 +877,7 @@ EOT
 
     wait_until_central_validation_webhook_is_ready "${CUSTOM_CENTRAL_NAMESPACE}"
 
-    _step "patch-central"
+    _begin "patch-central"
 
     # Enable Scanner V4 on central side.
     info "Patching Central"
@@ -926,7 +923,7 @@ EOT
     sleep 60
     "${ORCH_CMD}" </dev/null -n "${CUSTOM_CENTRAL_NAMESPACE}" wait --for=condition=Ready pods -l app=central || true
 
-    _step "patch-secured-cluster"
+    _begin "patch-secured-cluster"
 
     info "Patching SecuredCluster"
     # Enable Scanner V4 on secured-cluster side
@@ -961,7 +958,7 @@ EOT
     sleep 60
     "${ORCH_CMD}" </dev/null -n "${CUSTOM_SENSOR_NAMESPACE}" wait --for=condition=Ready pods -l app=sensor || true
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
     verify_scannerV4_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
@@ -970,7 +967,7 @@ EOT
     verify_scannerV4_indexer_deployed "${CUSTOM_SENSOR_NAMESPACE}"
     verify_deployment_scannerV4_env_var_set "${CUSTOM_SENSOR_NAMESPACE}" "sensor"
 
-    _step "disable-scanner-v4"
+    _begin "disable-scanner-v4"
 
     # Test disabling of Scanner V4.
     info "Disabling Scanner V4 for Central"
@@ -991,7 +988,7 @@ spec:
 EOT
     )
 
-    _step "verify"
+    _begin "verify"
 
     verify_deployment_deletion_with_timeout 4m "${CUSTOM_CENTRAL_NAMESPACE}" scanner-v4-indexer scanner-v4-matcher scanner-v4-db
     verify_deployment_deletion_with_timeout 4m "${CUSTOM_SENSOR_NAMESPACE}" scanner-v4-indexer scanner-v4-db
@@ -1016,7 +1013,7 @@ EOT
 
     _deploy_stackrox
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed "stackrox"
     verify_scannerV4_deployed "stackrox"
@@ -1038,19 +1035,19 @@ EOT
     info "Using roxctl executable ${EARLIER_ROXCTL_PATH}/roxctl for generating pre-Scanner V4 deployment bundles"
     PATH="${EARLIER_ROXCTL_PATH}:${PATH}" MAIN_IMAGE_TAG="${EARLIER_MAIN_IMAGE_TAG}" ROX_SCANNER_V4=false _deploy_stackrox
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed
     verify_no_scannerV4_deployed
     run ! verify_deployment_scannerV4_env_var_set "stackrox" "central"
     run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor"
 
-    _step "upgrade-stackrox"
+    _begin "upgrade-stackrox"
 
     info "Upgrading StackRox using HEAD deployment bundles"
     ROX_SCANNER_V4=true _deploy_stackrox
 
-    _step "verify"
+    _begin "verify"
 
     verify_scannerV2_deployed
     verify_scannerV4_deployed


### PR DESCRIPTION
### Description

The Scanner V4 install test suite currently has buggy support for output sequencing. This PR aims to fix it.

Background:
The test suite does some child-process trickery to post-process output of spawned child process by adding certain logging prefixes to make it clear to which test-case the output belongs.

Of course this opens the doors to issues related to interleaving of messages which are actually supposed to appear in a certain order.

The test suite currently does call `wait` in some places to enforce this ordering, but it is not sufficient. We are currently only calling `wait` as part of the `_end()` function, but this function is not always executed! For example, if a test case is terminated due to a failing command, then executions jumps directly to the `teardown` command, with no `wait` being called.



### User-facing documentation

Nothing required.

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] modified existing tests

The whole change is only about improving tests.

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
