### PR TITLE
chore(roxctl): wrap errors with context messages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -168,7 +168,7 @@ linters:
     rules:
       - linters:
           - wrapcheck
-        path: ^(central|compliance|integration-tests|local|migrator|operator|scanner|sensor/tests/helper|tests|tools|scale)/
+        path: ^(central|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor/tests/helper|tests|tools|scale)/
       - linters:
           - forbidigo
         path: (central/graphql/schema/print|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale|govulncheck)/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -168,7 +168,7 @@ linters:
     rules:
       - linters:
           - wrapcheck
-        path: ^(central|compliance|integration-tests|local|migrator|operator|pkg|roxctl/scanner|roxctl/central|scanner|sensor/tests/helper|tests|tools|scale)/
+        path: ^(central|compliance|integration-tests|local|migrator|operator|scanner|sensor/tests/helper|tests|tools|scale)/
       - linters:
           - forbidigo
         path: (central/graphql/schema/print|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale|govulncheck)/

--- a/roxctl/central/backup/backup.go
+++ b/roxctl/central/backup/backup.go
@@ -68,7 +68,7 @@ func parseUserProvidedOutput(userProvidedOutput string) (string, error) {
 	f, err := os.Stat(userProvidedOutput)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return "", err
+			return "", errors.Wrapf(err, "statting output path %q", userProvidedOutput)
 		}
 		// If they specified a directory, it must exist.
 		if strings.HasSuffix(userProvidedOutput, string(os.PathSeparator)) {
@@ -78,7 +78,7 @@ func parseUserProvidedOutput(userProvidedOutput string) (string, error) {
 		containingDir := filepath.Dir(userProvidedOutput)
 		dirExists, err := fileutils.Exists(containingDir)
 		if err != nil {
-			return "", err
+			return "", errors.Wrapf(err, "checking if directory %q exists", containingDir)
 		}
 		if !dirExists {
 			return "", errox.InvalidArgs.Newf("invalid output %q: containing directory %q does not exist",
@@ -103,7 +103,7 @@ func getFilePath(respHeader http.Header, userProvidedOutput string) (string, err
 	if finalLocation == "" || strings.HasSuffix(finalLocation, string(os.PathSeparator)) {
 		parsedFileName, err := download.ParseFilenameFromHeader(respHeader)
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "parsing filename from response header")
 		}
 		finalLocation = filepath.Join(finalLocation, parsedFileName)
 	}
@@ -125,12 +125,12 @@ func (cmd *centralBackupCommand) backup(timeout time.Duration, full bool) error 
 
 	client, err := cmd.env.HTTPClient(0)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "creating HTTP client")
 	}
 
 	req, err := client.NewReq(http.MethodGet, endpoint, nil)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "creating backup request")
 	}
 
 	reqCtx, cancel := context.WithCancel(context.Background())
@@ -141,7 +141,7 @@ func (cmd *centralBackupCommand) backup(timeout time.Duration, full bool) error 
 	t := time.AfterFunc(timeout, cancel)
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "executing backup request")
 	}
 	if !t.Stop() {
 		// The context will be canceled so we also can't do any reads.
@@ -168,9 +168,9 @@ func (cmd *centralBackupCommand) backup(timeout time.Duration, full bool) error 
 	defer utils.IgnoreError(file.Close)
 
 	if err := transfer.Copy(reqCtx, cancel, filename, max(0, resp.ContentLength), resp.Body, file, deadline, idleTimeout); err != nil {
-		return err
+		return errors.Wrap(err, "copying backup data")
 	}
 
 	cmd.env.Logger().PrintfLn("Wrote backup file to %q", filename)
-	return file.Close()
+	return errors.Wrap(file.Close(), "closing backup file")
 }

--- a/roxctl/central/backup/backup.go
+++ b/roxctl/central/backup/backup.go
@@ -68,7 +68,7 @@ func parseUserProvidedOutput(userProvidedOutput string) (string, error) {
 	f, err := os.Stat(userProvidedOutput)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return "", errors.Wrapf(err, "statting output path %q", userProvidedOutput)
+			return "", errors.Wrapf(err, "checking output path %q", userProvidedOutput)
 		}
 		// If they specified a directory, it must exist.
 		if strings.HasSuffix(userProvidedOutput, string(os.PathSeparator)) {
@@ -103,7 +103,7 @@ func getFilePath(respHeader http.Header, userProvidedOutput string) (string, err
 	if finalLocation == "" || strings.HasSuffix(finalLocation, string(os.PathSeparator)) {
 		parsedFileName, err := download.ParseFilenameFromHeader(respHeader)
 		if err != nil {
-			return "", errors.Wrap(err, "parsing filename from response header")
+			return "", errors.Wrap(err, "retrieving filename from response header")
 		}
 		finalLocation = filepath.Join(finalLocation, parsedFileName)
 	}

--- a/roxctl/central/backup/backup.go
+++ b/roxctl/central/backup/backup.go
@@ -125,7 +125,7 @@ func (cmd *centralBackupCommand) backup(timeout time.Duration, full bool) error 
 
 	client, err := cmd.env.HTTPClient(0)
 	if err != nil {
-		return errors.Wrap(err, "creating HTTP client")
+		return errors.Wrap(err, "creating HTTP client for backup")
 	}
 
 	req, err := client.NewReq(http.MethodGet, endpoint, nil)

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -74,7 +74,7 @@ func (cmd *centralCertCommand) certs() error {
 	defer cancel()
 	conn, err := tlsutils.DialContextWithRetries(ctx, "tcp", endpoint, &config)
 	if err != nil {
-		return errors.Wrap(err, "connecting to server")
+		return errors.Wrap(err, "connecting to server to retrieve central certificates")
 	}
 	defer utils.IgnoreError(conn.Close)
 
@@ -95,7 +95,7 @@ func (cmd *centralCertCommand) certs() error {
 		// Open the given filename.
 		handle, err = os.Create(cmd.filename)
 		if err != nil {
-			return errors.Wrapf(err, "creating output file %q", cmd.filename)
+			return errors.Wrapf(err, "creating central certificate output file %q", cmd.filename)
 		}
 	}
 

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/ioutils"
@@ -60,7 +61,7 @@ func (cmd *centralCertCommand) certs() error {
 	// Parse out the endpoint and server name for connecting to.
 	endpoint, serverName, err := cmd.env.ConnectNames()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting connection names")
 	}
 
 	// Connect to the given server. We're not expecting the endpoint be
@@ -73,7 +74,7 @@ func (cmd *centralCertCommand) certs() error {
 	defer cancel()
 	conn, err := tlsutils.DialContextWithRetries(ctx, "tcp", endpoint, &config)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "connecting to server")
 	}
 	defer utils.IgnoreError(conn.Close)
 
@@ -94,7 +95,7 @@ func (cmd *centralCertCommand) certs() error {
 		// Open the given filename.
 		handle, err = os.Create(cmd.filename)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "creating output file %q", cmd.filename)
 		}
 	}
 
@@ -103,9 +104,9 @@ func (cmd *centralCertCommand) certs() error {
 
 	// Write out the leaf cert in PEM format.
 	if err := writeCertPEM(handle, certs[0]); err != nil {
-		return err
+		return errors.Wrap(err, "writing certificate to PEM format")
 	}
-	return handle.Close()
+	return errors.Wrap(handle.Close(), "closing certificate file")
 }
 
 func skipTLSValidation() bool {
@@ -121,7 +122,7 @@ func writeCertPEM(writer io.Writer, cert *x509.Certificate) error {
 		Bytes: cert.Raw,
 	}
 	if err := pem.Encode(writer, pemkey); err != nil {
-		return err
+		return errors.Wrap(err, "encoding certificate to PEM")
 	}
 	return nil
 }

--- a/roxctl/central/cert/cert.go
+++ b/roxctl/central/cert/cert.go
@@ -61,7 +61,7 @@ func (cmd *centralCertCommand) certs() error {
 	// Parse out the endpoint and server name for connecting to.
 	endpoint, serverName, err := cmd.env.ConnectNames()
 	if err != nil {
-		return errors.Wrap(err, "getting connection names")
+		return errors.Wrap(err, "getting endpoint and server names")
 	}
 
 	// Connect to the given server. We're not expecting the endpoint be
@@ -104,7 +104,7 @@ func (cmd *centralCertCommand) certs() error {
 
 	// Write out the leaf cert in PEM format.
 	if err := writeCertPEM(handle, certs[0]); err != nil {
-		return errors.Wrap(err, "writing certificate to PEM format")
+		return errors.Wrap(err, "writing certificate")
 	}
 	return errors.Wrap(handle.Close(), "closing certificate file")
 }
@@ -122,7 +122,7 @@ func writeCertPEM(writer io.Writer, cert *x509.Certificate) error {
 		Bytes: cert.Raw,
 	}
 	if err := pem.Encode(writer, pemkey); err != nil {
-		return errors.Wrap(err, "encoding certificate to PEM")
+		return errors.Wrap(err, "encoding certificate")
 	}
 	return nil
 }

--- a/roxctl/central/crs/generate.go
+++ b/roxctl/central/crs/generate.go
@@ -31,7 +31,7 @@ func generateCRS(cliEnvironment environment.Environment, name string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to generate Cluster Registration Secrets")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/crs/generate.go
+++ b/roxctl/central/crs/generate.go
@@ -31,7 +31,7 @@ func generateCRS(cliEnvironment environment.Environment, name string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/crs/list.go
+++ b/roxctl/central/crs/list.go
@@ -25,7 +25,7 @@ func listCRSs(cliEnvironment environment.Environment, timeout time.Duration, ret
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to list Cluster Registration Secrets")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/crs/list.go
+++ b/roxctl/central/crs/list.go
@@ -25,7 +25,7 @@ func listCRSs(cliEnvironment environment.Environment, timeout time.Duration, ret
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/crs/revoke.go
+++ b/roxctl/central/crs/revoke.go
@@ -71,7 +71,7 @@ func revokeCRSs(cliEnvironment environment.Environment, idsOrNames []string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to revoke Cluster Registration Secret")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/crs/revoke.go
+++ b/roxctl/central/crs/revoke.go
@@ -21,7 +21,7 @@ import (
 func applyRevokeCRSs(ctx context.Context, cliEnvironment environment.Environment, svc v1.ClusterInitServiceClient, idsOrNames set.StringSet) error {
 	resp, err := svc.GetCRSs(ctx, &v1.Empty{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting CRSs")
 	}
 
 	var revokeIds []string
@@ -71,7 +71,7 @@ func revokeCRSs(cliEnvironment environment.Environment, idsOrNames []string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/crs/revoke.go
+++ b/roxctl/central/crs/revoke.go
@@ -21,7 +21,7 @@ import (
 func applyRevokeCRSs(ctx context.Context, cliEnvironment environment.Environment, svc v1.ClusterInitServiceClient, idsOrNames set.StringSet) error {
 	resp, err := svc.GetCRSs(ctx, &v1.Empty{})
 	if err != nil {
-		return errors.Wrap(err, "getting CRSs")
+		return errors.Wrap(err, "getting Cluster Registration Secrets")
 	}
 
 	var revokeIds []string

--- a/roxctl/central/db/restore/common.go
+++ b/roxctl/central/db/restore/common.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -16,7 +17,7 @@ func (cmd *centralDbRestoreCommand) restore(impl func(file *os.File, deadline ti
 
 	file, err := os.Open(cmd.file)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "opening backup file %q", cmd.file)
 	}
 	defer utils.IgnoreError(file.Close)
 

--- a/roxctl/central/db/restore/common.go
+++ b/roxctl/central/db/restore/common.go
@@ -17,7 +17,7 @@ func (cmd *centralDbRestoreCommand) restore(impl func(file *os.File, deadline ti
 
 	file, err := os.Open(cmd.file)
 	if err != nil {
-		return errors.Wrapf(err, "opening backup file %q", cmd.file)
+		return errors.Wrapf(err, "opening backup file %q to restore", cmd.file)
 	}
 	defer utils.IgnoreError(file.Close)
 

--- a/roxctl/central/db/restore/v1.go
+++ b/roxctl/central/db/restore/v1.go
@@ -19,7 +19,7 @@ func (cmd *centralDbRestoreCommand) restoreV1(file *os.File, deadline time.Time)
 
 	client, err := cmd.env.HTTPClient(0)
 	if err != nil {
-		return errors.Wrap(err, "creating HTTP client")
+		return errors.Wrap(err, "creating HTTP client for restore")
 	}
 
 	req, err := client.NewReq(http.MethodPost, "/db/restore", file)

--- a/roxctl/central/db/restore/v1.go
+++ b/roxctl/central/db/restore/v1.go
@@ -19,17 +19,17 @@ func (cmd *centralDbRestoreCommand) restoreV1(file *os.File, deadline time.Time)
 
 	client, err := cmd.env.HTTPClient(0)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "creating HTTP client")
 	}
 
 	req, err := client.NewReq(http.MethodPost, "/db/restore", file)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "creating restore request")
 	}
 
 	resp, err := transfer.ViaHTTP(req, client, deadline, idleTimeout)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "executing restore request")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 

--- a/roxctl/central/db/restore/v2.go
+++ b/roxctl/central/db/restore/v2.go
@@ -200,11 +200,11 @@ func dataReadersForManifest(file *os.File, manifest *v1.DBExportManifest) ([]fun
 func assembleManifestFromZIP(file *os.File, supportedCompressionTypes map[v1.DBExportManifest_EncodingType]struct{}) (*v1.DBExportManifest, error) {
 	stat, err := file.Stat()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "getting file stats for %s", file.Name())
 	}
 	zipReader, err := zip.NewReader(file, stat.Size())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "opening file %s as ZIP", file.Name())
 	}
 
 	mf := &v1.DBExportManifest{}

--- a/roxctl/central/db/restore/v2_cancel.go
+++ b/roxctl/central/db/restore/v2_cancel.go
@@ -84,5 +84,5 @@ func (cmd *centralRestoreCancelCommand) cancelActiveRestore() error {
 		Id: processStatus.GetMetadata().GetId(),
 	})
 
-	return err
+	return errors.Wrap(err, "canceling restore process")
 }

--- a/roxctl/central/db/restore/v2_restorer.go
+++ b/roxctl/central/db/restore/v2_restorer.go
@@ -85,7 +85,7 @@ func (cmd *centralDbRestoreCommand) newV2Restorer(confirm func() error, retryDea
 	dbClient := v1.NewDBServiceClient(conn)
 	httpClient, err := cmd.env.HTTPClient(0)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating HTTP client")
+		return nil, errors.Wrap(err, "creating HTTP client for central database restore")
 	}
 
 	return &v2Restorer{

--- a/roxctl/central/db/restore/v2_restorer.go
+++ b/roxctl/central/db/restore/v2_restorer.go
@@ -85,7 +85,7 @@ func (cmd *centralDbRestoreCommand) newV2Restorer(confirm func() error, retryDea
 	dbClient := v1.NewDBServiceClient(conn)
 	httpClient, err := cmd.env.HTTPClient(0)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating HTTP client")
 	}
 
 	return &v2Restorer{
@@ -236,7 +236,7 @@ func (r *v2Restorer) Run(ctx context.Context, file *os.File) (*http.Response, er
 			})
 
 			if concurrency.WaitWithDeadline(ctx, continueTime) {
-				return nil, ctx.Err()
+				return nil, errors.Wrap(ctx.Err(), "waiting for retry deadline")
 			}
 
 			nextReq, err = r.resumeAfterError(ctx)
@@ -249,14 +249,15 @@ func (r *v2Restorer) Run(ctx context.Context, file *os.File) (*http.Response, er
 		}
 	}
 
-	return nil, ctx.Err()
+	return nil, errors.Wrap(ctx.Err(), "context cancelled during restore")
 }
 
 func (r *v2Restorer) performHTTPRequest(req *http.Request) (*http.Response, error) {
 	if r.transferProgressBar != nil {
 		req.Body = r.transferProgressBar.ProxyReader(req.Body)
 	}
-	return r.httpClient.Do(req)
+	resp, err := r.httpClient.Do(req)
+	return resp, errors.Wrap(err, "executing HTTP request")
 }
 
 func (r *v2Restorer) initDataReader(file *os.File, manifest *v1.DBExportManifest) error {
@@ -272,7 +273,7 @@ func (r *v2Restorer) initDataReader(file *os.File, manifest *v1.DBExportManifest
 		readerWindowSize,
 		func() hash.Hash { return crc32.NewIEEE() },
 	)
-	return err
+	return errors.Wrap(err, "creating sliding reader")
 }
 
 func (r *v2Restorer) initResume(ctx context.Context, file *os.File, activeStatus *v1.DBRestoreProcessStatus) (*http.Request, error) {
@@ -334,7 +335,7 @@ func (r *v2Restorer) initNewProcess(ctx context.Context, file *os.File) (*http.R
 
 	format, _, err := v2backuprestore.DetermineFormat(manifest, caps.GetFormats())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "determining restore format")
 	}
 
 	st, err := file.Stat()
@@ -407,7 +408,7 @@ func (r *v2Restorer) init(ctx context.Context, file *os.File) (*http.Request, er
 
 func (r *v2Restorer) prepareResumeRequest(resumeInfo *v1.DBRestoreProcessStatus_ResumeInfo) (*http.Request, error) {
 	if pos, err := r.dataReader.Seek(resumeInfo.GetPos(), io.SeekStart); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "seeking to resume position")
 	} else if pos != resumeInfo.GetPos() {
 		return nil, errox.NotFound.Newf("could not seek to resume position %d in data: data ends at position %d", resumeInfo.GetPos(), pos)
 	} else if r.transferProgressBar != nil {
@@ -419,7 +420,7 @@ func (r *v2Restorer) prepareResumeRequest(resumeInfo *v1.DBRestoreProcessStatus_
 
 	req, err := r.httpClient.NewReq(http.MethodPost, "/db/v2/resumerestore", io.NopCloser(r.dataReader))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating resume request")
 	}
 
 	queryValues := req.URL.Query()
@@ -445,7 +446,7 @@ func (r *v2Restorer) resumeAfterError(ctx context.Context) (*http.Request, error
 		if code := status.Convert(err).Code(); code == codes.Unavailable || code == codes.DeadlineExceeded {
 			err = common.MakeRetryable(err)
 		}
-		return nil, err
+		return nil, errors.Wrap(err, "getting active restore process")
 	}
 
 	activeProcess := resp.GetActiveStatus()
@@ -467,7 +468,7 @@ func (r *v2Restorer) resumeAfterError(ctx context.Context) (*http.Request, error
 			AttemptId: r.lastAttemptID,
 		})
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "interrupting restore process")
 		}
 
 		resumeInfo = interruptResp.GetResumeInfo()

--- a/roxctl/central/db/transfer/transfer.go
+++ b/roxctl/central/db/transfer/transfer.go
@@ -41,7 +41,7 @@ func (r *progressWatchReader) Read(p []byte) (int, error) {
 		r.progressBar.IncrBy(len(p))
 	}
 
-	return count, errors.Wrap(err, "reading data")
+	return count, err //nolint:wrapcheck // we should not wrap EOF as it has special meaning and is not handled everywhere properly with errors.Is
 }
 
 func (r *progressWatchReader) Close() error {

--- a/roxctl/central/db/transfer/transfer.go
+++ b/roxctl/central/db/transfer/transfer.go
@@ -41,12 +41,12 @@ func (r *progressWatchReader) Read(p []byte) (int, error) {
 		r.progressBar.IncrBy(len(p))
 	}
 
-	return count, err
+	return count, errors.Wrap(err, "reading data")
 }
 
 func (r *progressWatchReader) Close() error {
 	if rc, ok := r.reader.(io.ReadCloser); ok {
-		return rc.Close()
+		return errors.Wrap(rc.Close(), "closing reader")
 	}
 	r.progressBar.SetTotal(r.progressBar.Current(), true)
 	atomic.StoreInt64((*int64)(&r.lastActivity), int64(timestamp.InfiniteFuture))

--- a/roxctl/central/debug/authz_trace.go
+++ b/roxctl/central/debug/authz_trace.go
@@ -58,7 +58,7 @@ func writeAuthzTraces(cliEnvironment environment.Environment, timeout time.Durat
 		}
 	}
 
-	return errors.Wrap(multierror.Append(streamErr, syncErr).ErrorOrNil(), "writing authz traces")
+	return errors.Wrap(multierror.Append(streamErr, syncErr).ErrorOrNil(), "writing authorization traces")
 }
 
 func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Duration, traceOutput io.Writer) error {
@@ -68,7 +68,7 @@ func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Dura
 
 	conn, err := cliEnvironment.GRPCConnection()
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to retrieve authorization traces")
 	}
 	defer utils.IgnoreError(conn.Close)
 
@@ -76,7 +76,7 @@ func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Dura
 	client := v1.NewDebugServiceClient(conn)
 	stream, err := client.StreamAuthzTraces(ctx, &v1.Empty{})
 	if err != nil {
-		return errors.Wrap(err, "starting authz trace stream")
+		return errors.Wrap(err, "starting authorization trace stream")
 	}
 
 	// Receive authz traces from central, convert them to JSON, and write.
@@ -93,14 +93,14 @@ func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Dura
 			if errors.Is(recvErr, io.EOF) || status.Code(recvErr) == codes.Canceled || status.Code(recvErr) == codes.DeadlineExceeded {
 				return nil
 			}
-			return errors.Wrap(recvErr, "receiving authz trace")
+			return errors.Wrap(recvErr, "receiving authorization trace")
 		}
 
 		if err := jsonutil.Marshal(traceOutput, trace); err != nil {
 			return errors.Wrap(err, "marshaling a trace to JSON")
 		}
 		if _, err := traceOutput.Write([]byte{'\n'}); err != nil {
-			return errors.Wrap(err, "writing newline to output")
+			return errors.Wrap(err, "finalizing output")
 		}
 	}
 }

--- a/roxctl/central/debug/authz_trace.go
+++ b/roxctl/central/debug/authz_trace.go
@@ -58,7 +58,7 @@ func writeAuthzTraces(cliEnvironment environment.Environment, timeout time.Durat
 		}
 	}
 
-	return multierror.Append(streamErr, syncErr).ErrorOrNil()
+	return errors.Wrap(multierror.Append(streamErr, syncErr).ErrorOrNil(), "writing authz traces")
 }
 
 func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Duration, traceOutput io.Writer) error {
@@ -68,7 +68,7 @@ func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Dura
 
 	conn, err := cliEnvironment.GRPCConnection()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 
@@ -76,7 +76,7 @@ func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Dura
 	client := v1.NewDebugServiceClient(conn)
 	stream, err := client.StreamAuthzTraces(ctx, &v1.Empty{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "starting authz trace stream")
 	}
 
 	// Receive authz traces from central, convert them to JSON, and write.
@@ -93,14 +93,14 @@ func streamAuthzTraces(cliEnvironment environment.Environment, timeout time.Dura
 			if errors.Is(recvErr, io.EOF) || status.Code(recvErr) == codes.Canceled || status.Code(recvErr) == codes.DeadlineExceeded {
 				return nil
 			}
-			return recvErr
+			return errors.Wrap(recvErr, "receiving authz trace")
 		}
 
 		if err := jsonutil.Marshal(traceOutput, trace); err != nil {
 			return errors.Wrap(err, "marshaling a trace to JSON")
 		}
 		if _, err := traceOutput.Write([]byte{'\n'}); err != nil {
-			return err
+			return errors.Wrap(err, "writing newline to output")
 		}
 	}
 }

--- a/roxctl/central/debug/debug.go
+++ b/roxctl/central/debug/debug.go
@@ -76,7 +76,7 @@ func logLevelCommand(cliEnvironment environment.Environment) *cobra.Command {
 func (cmd *centralDebugLogLevelCommand) getLogLevel() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to retrieve log level")
 	}
 	defer func() {
 		_ = conn.Close()
@@ -117,7 +117,7 @@ func (cmd *centralDebugLogLevelCommand) printGetLogLevelResponse(r *v1.LogLevelR
 func (cmd *centralDebugLogLevelCommand) setLogLevel() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to set log level")
 	}
 	defer func() {
 		_ = conn.Close()

--- a/roxctl/central/debug/debug.go
+++ b/roxctl/central/debug/debug.go
@@ -76,7 +76,7 @@ func logLevelCommand(cliEnvironment environment.Environment) *cobra.Command {
 func (cmd *centralDebugLogLevelCommand) getLogLevel() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer func() {
 		_ = conn.Close()
@@ -117,7 +117,7 @@ func (cmd *centralDebugLogLevelCommand) printGetLogLevelResponse(r *v1.LogLevelR
 func (cmd *centralDebugLogLevelCommand) setLogLevel() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer func() {
 		_ = conn.Close()

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -66,6 +66,9 @@ func downloadDiagnosticsCommand(cliEnvironment environment.Environment) *cobra.C
 				OutputDir:      outputDir,
 				OutputFileName: outputFileName,
 			}, cliEnvironment)
+			if err != nil {
+				err = errors.Wrap(err, "downloading diagnostic bundle")
+			}
 			if isTimeoutError(err) {
 				cliEnvironment.Logger().ErrfLn(`Timeout has been reached while creating diagnostic bundle.
 Timeout value used was %s, while default timeout value is %s.

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -46,7 +46,7 @@ func generateJWTSigningKey(fileMap map[string][]byte) error {
 func restoreJWTSigningKey(fileMap map[string][]byte, backupBundle string) error {
 	z, err := zip.NewReader(backupBundle)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "opening backup bundle")
 	}
 	defer utils.IgnoreError(z.Close)
 
@@ -60,7 +60,7 @@ func restoreJWTSigningKey(fileMap map[string][]byte, backupBundle string) error 
 	case z.ContainsFile(path.Join(backup.KeysBaseFolder, backup.JwtKeyInPem)):
 		jwtKeyPem, err := z.ReadFrom(path.Join(backup.KeysBaseFolder, backup.JwtKeyInPem))
 		if err != nil {
-			return err
+			return errors.Wrap(err, "reading JWT key from backup bundle")
 		}
 		fileMap[certgen.JWTKeyPEMFileName] = jwtKeyPem
 		decode, _ := pem.Decode(jwtKeyPem)
@@ -77,27 +77,28 @@ func restoreJWTSigningKey(fileMap map[string][]byte, backupBundle string) error 
 func restoreCA(backupBundle string) (mtls.CA, error) {
 	z, err := zip.NewReader(backupBundle)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "opening backup bundle")
 	}
 	defer utils.IgnoreError(z.Close)
 
 	caCert, err := z.ReadFrom(path.Join(backup.KeysBaseFolder, backup.CaCertPem))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "reading CA certificate from backup bundle")
 	}
 
 	caKey, err := z.ReadFrom(path.Join(backup.KeysBaseFolder, backup.CaKeyPem))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "reading CA key from backup bundle")
 	}
 
-	return mtls.LoadCAForSigning(caCert, caKey)
+	ca, err := mtls.LoadCAForSigning(caCert, caKey)
+	return ca, errors.Wrap(err, "loading CA for signing")
 }
 
 func restoreCentralDBPassword(fileMap map[string][]byte, backupBundle string) error {
 	z, err := zip.NewReader(backupBundle)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "opening backup bundle")
 	}
 	defer utils.IgnoreError(z.Close)
 
@@ -110,7 +111,7 @@ func restoreCentralDBPassword(fileMap map[string][]byte, backupBundle string) er
 
 	centralDBPass, err := z.ReadFrom(passPath)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "reading central DB password from backup bundle")
 	}
 
 	fileMap["central-db-password"] = centralDBPass
@@ -124,29 +125,29 @@ func populateMTLSFiles(fileMap map[string][]byte, backupBundle string) error {
 	switch backupBundle {
 	case "":
 		if ca, err = certgen.GenerateCA(); err != nil {
-			return err
+			return errors.Wrap(err, "generating CA")
 		}
 	default:
 		if ca, err = restoreCA(backupBundle); err != nil {
-			return err
+			return errors.Wrap(err, "restoring CA from backup bundle")
 		}
 
 		if err = restoreCentralDBPassword(fileMap, backupBundle); err != nil {
-			return err
+			return errors.Wrap(err, "restoring central DB password")
 		}
 	}
 	certgen.AddCAToFileMap(fileMap, ca)
 
 	if err := certgen.IssueCentralCert(fileMap, ca); err != nil {
-		return err
+		return errors.Wrap(err, "issuing central certificate")
 	}
 	if err := certgen.IssueOtherServiceCerts(fileMap, ca, []mtls.Subject{mtls.CentralDBSubject}); err != nil {
-		return err
+		return errors.Wrap(err, "issuing other service certificates")
 	}
 	fileMap["central-db-password"] = []byte(renderer.CreatePassword())
 
 	if err := certgen.IssueScannerCerts(fileMap, ca); err != nil {
-		return err
+		return errors.Wrap(err, "issuing scanner certificates")
 	}
 
 	fileMap["scanner-db-password"] = []byte(renderer.CreatePassword())
@@ -194,7 +195,7 @@ func updateConfig(config *renderer.Config) error {
 	if !config.PasswordDisabled {
 		htpasswd, err := renderer.GenerateHtpasswd(config)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "generating htpasswd")
 		}
 		config.SecretsByteMap["htpasswd"] = htpasswd
 	}
@@ -301,7 +302,7 @@ func outputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	}
 
 	if err := config.WriteInstructions(io.ErrOut()); err != nil {
-		return err
+		return errors.Wrap(err, "writing instructions")
 	}
 	return nil
 }
@@ -388,5 +389,5 @@ func runInteractive(cmd *cobra.Command) error {
 	mode.SetInteractiveMode()
 	// Overwrite os.Args because cobra uses them
 	os.Args = walkTree(cmd)
-	return cmd.Execute()
+	return errors.Wrap(cmd.Execute(), "executing command")
 }

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -147,7 +147,7 @@ func populateMTLSFiles(fileMap map[string][]byte, backupBundle string) error {
 	fileMap["central-db-password"] = []byte(renderer.CreatePassword())
 
 	if err := certgen.IssueScannerCerts(fileMap, ca); err != nil {
-		return errors.Wrap(err, "issuing scanner certificates")
+		return errors.Wrap(err, "issuing scanner certificates for MTLS")
 	}
 
 	fileMap["scanner-db-password"] = []byte(renderer.CreatePassword())

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -46,7 +46,7 @@ func generateJWTSigningKey(fileMap map[string][]byte) error {
 func restoreJWTSigningKey(fileMap map[string][]byte, backupBundle string) error {
 	z, err := zip.NewReader(backupBundle)
 	if err != nil {
-		return errors.Wrap(err, "opening backup bundle")
+		return errors.Wrap(err, "opening JWT key backup bundle")
 	}
 	defer utils.IgnoreError(z.Close)
 
@@ -77,7 +77,7 @@ func restoreJWTSigningKey(fileMap map[string][]byte, backupBundle string) error 
 func restoreCA(backupBundle string) (mtls.CA, error) {
 	z, err := zip.NewReader(backupBundle)
 	if err != nil {
-		return nil, errors.Wrap(err, "opening backup bundle")
+		return nil, errors.Wrap(err, "opening CA backup bundle")
 	}
 	defer utils.IgnoreError(z.Close)
 
@@ -98,7 +98,7 @@ func restoreCA(backupBundle string) (mtls.CA, error) {
 func restoreCentralDBPassword(fileMap map[string][]byte, backupBundle string) error {
 	z, err := zip.NewReader(backupBundle)
 	if err != nil {
-		return errors.Wrap(err, "opening backup bundle")
+		return errors.Wrap(err, "opening central DB credential backup bundle")
 	}
 	defer utils.IgnoreError(z.Close)
 

--- a/roxctl/central/generate/interactive.go
+++ b/roxctl/central/generate/interactive.go
@@ -34,7 +34,7 @@ func readUserInput(prompt string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	text, err := reader.ReadString('\n')
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "reading user input")
 	}
 	return strings.TrimSpace(text), nil
 }
@@ -158,7 +158,7 @@ func getPassword(fd int) (passwd string, err error) {
 	if term.IsTerminal(fd) {
 		bytes, err := term.ReadPassword(fd)
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "reading password from terminal")
 		}
 		passwd = string(bytes)
 		printlnToStderr("")
@@ -166,7 +166,7 @@ func getPassword(fd int) (passwd string, err error) {
 		reader := bufio.NewReader(os.Stdin)
 		passwd, err = reader.ReadString('\n')
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "reading password from stdin")
 		}
 	}
 	return strings.TrimSuffix(passwd, "\n"), nil

--- a/roxctl/central/generate/validate.go
+++ b/roxctl/central/generate/validate.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"crypto/tls"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/renderer"
 )
@@ -47,5 +48,5 @@ func validateDefaultTLSCert(certPEM, keyPEM []byte) error {
 	}
 
 	_, err := tls.X509KeyPair(certPEM, keyPEM)
-	return err
+	return errors.Wrap(err, "validating TLS certificate and key pair")
 }

--- a/roxctl/central/initbundles/fetch_ca.go
+++ b/roxctl/central/initbundles/fetch_ca.go
@@ -24,7 +24,7 @@ func fetchCAConfig(cliEnvironment environment.Environment, outputFile string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/initbundles/fetch_ca.go
+++ b/roxctl/central/initbundles/fetch_ca.go
@@ -24,7 +24,7 @@ func fetchCAConfig(cliEnvironment environment.Environment, outputFile string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to retrieve init bundle CA")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/initbundles/generate.go
+++ b/roxctl/central/initbundles/generate.go
@@ -29,7 +29,7 @@ func generateInitBundle(cliEnvironment environment.Environment, name string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to generate init bundle")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/initbundles/generate.go
+++ b/roxctl/central/initbundles/generate.go
@@ -29,7 +29,7 @@ func generateInitBundle(cliEnvironment environment.Environment, name string,
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/initbundles/list.go
+++ b/roxctl/central/initbundles/list.go
@@ -26,7 +26,7 @@ func listInitBundles(cliEnvironment environment.Environment, timeout time.Durati
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/initbundles/list.go
+++ b/roxctl/central/initbundles/list.go
@@ -26,7 +26,7 @@ func listInitBundles(cliEnvironment environment.Environment, timeout time.Durati
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to list init bundles")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -24,7 +24,7 @@ import (
 func applyRevokeInitBundles(ctx context.Context, cliEnvironment environment.Environment, svc v1.ClusterInitServiceClient, idsOrNames set.StringSet, force bool) error {
 	resp, err := svc.GetInitBundles(ctx, &v1.Empty{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting init bundles")
 	}
 
 	impactedIDNameMap := map[string]string{}
@@ -97,7 +97,8 @@ func confirmImpactedClusterIds(impactedClusterIDNameMap map[string]string, out i
 
 	_, _ = out.Write([]byte("Are you sure you want to revoke the init bundle(s)? [y/N] "))
 
-	return flags.ReadUserYesNoConfirmation(in)
+	confirm, err := flags.ReadUserYesNoConfirmation(in)
+	return confirm, errors.Wrap(err, "reading user confirmation")
 }
 
 func printResponseResult(logger logger.Logger, resp *v1.InitBundleRevokeResponse) {
@@ -117,7 +118,7 @@ func revokeInitBundles(cliEnvironment environment.Environment, idsOrNames []stri
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing gRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -118,7 +118,7 @@ func revokeInitBundles(cliEnvironment environment.Environment, idsOrNames []stri
 
 	conn, err := cliEnvironment.GRPCConnection(common.WithRetryTimeout(retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing gRPC connection")
+		return errors.Wrap(err, "establishing gRPC connection to revoke init bundles")
 	}
 	defer utils.IgnoreError(conn.Close)
 	svc := v1.NewClusterInitServiceClient(conn)

--- a/roxctl/central/login/login.go
+++ b/roxctl/central/login/login.go
@@ -154,7 +154,7 @@ If no browser window opens, please click on the following URL:
 		l.env.Logger().ErrfLn(`Waited %s for the authorization flow to succeed, but did not finish.
 In case you want to increase the timeout, use the --timeout flag.`, l.timeout.String())
 		if err := server.Close(); err != nil {
-			return errors.Wrap(err, "closing HTTP server")
+			return errors.Wrap(err, "closing login HTTP server")
 		}
 		return errors.New("ran into timeout during authorization flow")
 
@@ -163,7 +163,7 @@ In case you want to increase the timeout, use the --timeout flag.`, l.timeout.St
 			return errors.Wrap(err, "error within authorization flow")
 		}
 		time.Sleep(time.Second) // Wait until the page is served successfully, then close the server.
-		return errors.Wrap(server.Close(), "closing HTTP server")
+		return errors.Wrap(server.Close(), "closing login HTTP server")
 	}
 }
 

--- a/roxctl/central/login/login.go
+++ b/roxctl/central/login/login.go
@@ -154,7 +154,7 @@ If no browser window opens, please click on the following URL:
 		l.env.Logger().ErrfLn(`Waited %s for the authorization flow to succeed, but did not finish.
 In case you want to increase the timeout, use the --timeout flag.`, l.timeout.String())
 		if err := server.Close(); err != nil {
-			return err
+			return errors.Wrap(err, "closing HTTP server")
 		}
 		return errors.New("ran into timeout during authorization flow")
 
@@ -163,7 +163,7 @@ In case you want to increase the timeout, use the --timeout flag.`, l.timeout.St
 			return errors.Wrap(err, "error within authorization flow")
 		}
 		time.Sleep(time.Second) // Wait until the page is served successfully, then close the server.
-		return server.Close()
+		return errors.Wrap(server.Close(), "closing HTTP server")
 	}
 }
 

--- a/roxctl/central/userpki/create/create.go
+++ b/roxctl/central/userpki/create/create.go
@@ -108,7 +108,7 @@ func (cmd *centralUserPkiCreateCommand) createProvider() error {
 
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing gRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	ctx, cancel := context.WithTimeout(pkgCommon.Context(), cmd.timeout)
@@ -134,7 +134,7 @@ func (cmd *centralUserPkiCreateCommand) createProvider() error {
 	}
 	provider, err := authService.PostAuthProvider(ctx, req)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "creating auth provider")
 	}
 
 	_, err = groupService.CreateGroup(ctx, &storage.Group{
@@ -145,7 +145,7 @@ func (cmd *centralUserPkiCreateCommand) createProvider() error {
 	})
 
 	if err != nil {
-		return err
+		return errors.Wrap(err, "creating group")
 	}
 
 	cmd.env.Logger().PrintfLn("Provider created with ID %s", provider.GetId())

--- a/roxctl/central/userpki/create/create.go
+++ b/roxctl/central/userpki/create/create.go
@@ -108,7 +108,7 @@ func (cmd *centralUserPkiCreateCommand) createProvider() error {
 
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing gRPC connection")
+		return errors.Wrap(err, "establishing gRPC connection to create user PKI auth provider")
 	}
 	defer utils.IgnoreError(conn.Close)
 	ctx, cancel := context.WithTimeout(pkgCommon.Context(), cmd.timeout)

--- a/roxctl/central/userpki/delete/delete.go
+++ b/roxctl/central/userpki/delete/delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -47,10 +48,10 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 			centralUserPkiDeleteCommand := makeCentralUserPkiDeleteCommand(cliEnvironment, cmd, args)
 			deleteProvider, err := centralUserPkiDeleteCommand.prepareDeleteProvider()
 			if err != nil {
-				return err
+				return errors.Wrap(err, "preparing delete provider")
 			}
 			if err := flags.CheckConfirmation(cmd, cliEnvironment.Logger(), cliEnvironment.InputOutput()); err != nil {
-				return err
+				return errors.Wrap(err, "checking confirmation")
 			}
 			return deleteProvider()
 		},
@@ -71,13 +72,14 @@ func makeCentralUserPkiDeleteCommand(cliEnvironment environment.Environment, cmd
 }
 
 func getAuthProviderByID(ctx context.Context, svc v1.AuthProviderServiceClient, id string) (*storage.AuthProvider, error) {
-	return svc.GetAuthProvider(ctx, &v1.GetAuthProviderRequest{Id: id})
+	prov, err := svc.GetAuthProvider(ctx, &v1.GetAuthProviderRequest{Id: id})
+	return prov, errors.Wrap(err, "getting auth provider by ID")
 }
 
 func getAuthProviderByName(ctx context.Context, svc v1.AuthProviderServiceClient, name string) (*storage.AuthProvider, error) {
 	provs, err := svc.GetAuthProviders(ctx, &v1.GetAuthProvidersRequest{Name: name, Type: userpki.TypeName})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "getting auth providers by name")
 	}
 	all := provs.GetAuthProviders()
 	if len(all) == 0 {
@@ -92,7 +94,7 @@ func getAuthProviderByName(ctx context.Context, svc v1.AuthProviderServiceClient
 func (cmd *centralUserPkiDeleteCommand) prepareDeleteProvider() (func() error, error) {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "establishing gRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 	ctx, cancel := context.WithTimeout(pkgCommon.Context(), cmd.timeout)
@@ -110,7 +112,7 @@ func (cmd *centralUserPkiDeleteCommand) prepareDeleteProvider() (func() error, e
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "getting auth provider")
 	}
 	group, err := groupService.GetGroup(ctx, &storage.GroupProperties{AuthProviderId: prov.GetId()})
 
@@ -127,12 +129,12 @@ func (cmd *centralUserPkiDeleteCommand) prepareDeleteProvider() (func() error, e
 			Id: prov.GetId(),
 		})
 		if err != nil {
-			return err
+			return errors.Wrap(err, "deleting auth provider")
 		}
 
 		groups, err := groupService.GetGroups(ctx, &v1.GetGroupsRequest{})
 		if err != nil {
-			return err
+			return errors.Wrap(err, "getting groups")
 		}
 		var relevantGroups []*storage.Group
 		for _, v := range groups.GetGroups() {
@@ -146,7 +148,7 @@ func (cmd *centralUserPkiDeleteCommand) prepareDeleteProvider() (func() error, e
 				RequiredGroups: nil,
 			})
 			if err != nil {
-				return err
+				return errors.Wrap(err, "updating groups")
 			}
 		}
 		cmd.env.Logger().PrintfLn("Successfully deleted.")

--- a/roxctl/central/userpki/delete/delete.go
+++ b/roxctl/central/userpki/delete/delete.go
@@ -51,7 +51,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 				return errors.Wrap(err, "preparing delete provider")
 			}
 			if err := flags.CheckConfirmation(cmd, cliEnvironment.Logger(), cliEnvironment.InputOutput()); err != nil {
-				return errors.Wrap(err, "checking confirmation")
+				return errors.Wrap(err, "checking deletion confirmation")
 			}
 			return deleteProvider()
 		},
@@ -94,7 +94,7 @@ func getAuthProviderByName(ctx context.Context, svc v1.AuthProviderServiceClient
 func (cmd *centralUserPkiDeleteCommand) prepareDeleteProvider() (func() error, error) {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return nil, errors.Wrap(err, "establishing gRPC connection")
+		return nil, errors.Wrap(err, "establishing gRPC connection to delete user PKI auth provider")
 	}
 	defer utils.IgnoreError(conn.Close)
 	ctx, cancel := context.WithTimeout(pkgCommon.Context(), cmd.timeout)
@@ -112,7 +112,7 @@ func (cmd *centralUserPkiDeleteCommand) prepareDeleteProvider() (func() error, e
 	}
 
 	if err != nil {
-		return nil, errors.Wrap(err, "getting auth provider")
+		return nil, errors.Wrap(err, "getting auth provider to delete")
 	}
 	group, err := groupService.GetGroup(ctx, &storage.GroupProperties{AuthProviderId: prov.GetId()})
 

--- a/roxctl/central/userpki/list/list.go
+++ b/roxctl/central/userpki/list/list.go
@@ -58,7 +58,7 @@ func (cmd *centralUserPkiListCommand) construct(cbr *cobra.Command) error {
 func (cmd *centralUserPkiListCommand) listProviders() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing gRPC connection")
+		return errors.Wrap(err, "establishing gRPC connection to list user PKI auth providers")
 	}
 	defer utils.IgnoreError(conn.Close)
 

--- a/roxctl/central/userpki/list/list.go
+++ b/roxctl/central/userpki/list/list.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/cloudflare/cfssl/helpers"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -57,7 +58,7 @@ func (cmd *centralUserPkiListCommand) construct(cbr *cobra.Command) error {
 func (cmd *centralUserPkiListCommand) listProviders() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing gRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 
@@ -68,14 +69,14 @@ func (cmd *centralUserPkiListCommand) listProviders() error {
 	groupClient := v1.NewGroupServiceClient(conn)
 	providers, err := authClient.GetAuthProviders(ctx, &v1.GetAuthProvidersRequest{Type: userpki.TypeName})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting auth providers")
 	}
 	if cmd.json {
 		err = jsonutil.MarshalPretty(cmd.env.InputOutput().Out(), providers)
 		if err == nil {
 			cmd.env.Logger().PrintfLn("")
 		}
-		return err
+		return errors.Wrap(err, "marshalling providers to JSON")
 	}
 	if len(providers.GetAuthProviders()) == 0 {
 		cmd.env.Logger().InfofLn("No user certificate providers configured")
@@ -83,7 +84,7 @@ func (cmd *centralUserPkiListCommand) listProviders() error {
 	}
 	groups, err := groupClient.GetGroups(ctx, &v1.GetGroupsRequest{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting groups")
 	}
 	defaultRoles := make(map[string]string)
 	for _, g := range groups.GetGroups() {

--- a/roxctl/central/whoami/whoami.go
+++ b/roxctl/central/whoami/whoami.go
@@ -49,7 +49,7 @@ func makeCentralWhoAmICommand(cliEnvironment environment.Environment, cbr *cobra
 func (cmd *centralWhoAmICommand) whoami() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return errors.Wrap(err, "establishing GRPC connection")
+		return errors.Wrap(err, "establishing GRPC connection to retrieve user role information")
 	}
 	defer utils.IgnoreError(conn.Close)
 

--- a/roxctl/central/whoami/whoami.go
+++ b/roxctl/central/whoami/whoami.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -48,7 +49,7 @@ func makeCentralWhoAmICommand(cliEnvironment environment.Environment, cbr *cobra
 func (cmd *centralWhoAmICommand) whoami() error {
 	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "establishing GRPC connection")
 	}
 	defer utils.IgnoreError(conn.Close)
 
@@ -57,12 +58,12 @@ func (cmd *centralWhoAmICommand) whoami() error {
 
 	auth, err := v1.NewAuthServiceClient(conn).GetAuthStatus(ctx, &v1.Empty{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting auth status")
 	}
 
 	perms, err := v1.NewRoleServiceClient(conn).GetMyPermissions(ctx, &v1.Empty{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "getting user permissions")
 	}
 
 	// Lexicographically sort the set of resources we have (known) access to.

--- a/roxctl/scanner/downloaddb/downloaddb.go
+++ b/roxctl/scanner/downloaddb/downloaddb.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	pkgErrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/env"
@@ -55,7 +56,7 @@ func (cmd *scannerDownloadDBCommand) downloadDB() error {
 	// Get the list of file names to attempt to download.
 	bundleFileNames, err := cmd.buildBundleFileNames()
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "building bundle file names")
 	}
 
 	var errs []error
@@ -140,20 +141,20 @@ func (cmd *scannerDownloadDBCommand) versionFromCentral() (string, error) {
 	client, err := cmd.env.HTTPClient(cmd.timeout)
 	if err != nil {
 		cmd.env.Logger().WarnfLn("issue building central http client: %v", err)
-		return "", err
+		return "", pkgErrors.Wrap(err, "building HTTP client")
 	}
 
 	resp, err := client.DoReqAndVerifyStatusCode("v1/metadata", http.MethodGet, http.StatusOK, nil)
 	if err != nil {
 		cmd.env.Logger().WarnfLn("error contacting central: %v", err)
-		return "", err
+		return "", pkgErrors.Wrap(err, "contacting central")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
 	var metadata v1.Metadata
 	if err := jsonutil.JSONReaderToProto(resp.Body, &metadata); err != nil {
 		cmd.env.Logger().WarnfLn("error reading metadata from central: %v", err)
-		return "", err
+		return "", pkgErrors.Wrap(err, "reading metadata from central")
 	}
 
 	return metadata.GetVersion(), nil
@@ -186,7 +187,8 @@ func (cmd *scannerDownloadDBCommand) buildAndValidateOutputFileName(bundleFileNa
 // buildDownloadURL returns the URL from which to download the vulnerability
 // database from.
 func (cmd *scannerDownloadDBCommand) buildDownloadURL(bundleFileName string) (string, error) {
-	return url.JoinPath(env.ScannerDBDownloadBaseURL.Setting(), bundleFileName)
+	downloadURL, err := url.JoinPath(env.ScannerDBDownloadBaseURL.Setting(), bundleFileName)
+	return downloadURL, pkgErrors.Wrap(err, "building download URL")
 }
 
 // httpClient builds a retryable http client for non-ACS requests (such as
@@ -205,7 +207,7 @@ func (cmd *scannerDownloadDBCommand) httpClient() *retryablehttp.Client {
 func (cmd *scannerDownloadDBCommand) downloadVulnDB(url string, outFileName string) error {
 	resp, err := cmd.httpClient().Get(url)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "getting vulnerability database")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
@@ -215,12 +217,12 @@ func (cmd *scannerDownloadDBCommand) downloadVulnDB(url string, outFileName stri
 
 	err = os.MkdirAll(filepath.Dir(outFileName), 0700)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "creating output directory")
 	}
 
 	outFile, err := os.Create(outFileName)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "creating output file")
 	}
 	defer utils.IgnoreError(outFile.Close)
 
@@ -239,7 +241,7 @@ func (cmd *scannerDownloadDBCommand) downloadVulnDB(url string, outFileName stri
 	cmd.env.Logger().InfofLn("Downloading %q %s", url, size)
 	_, err = io.Copy(outFile, resp.Body)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "copying vulnerability database data")
 	}
 
 	if err := outFile.Close(); err != nil {

--- a/roxctl/scanner/downloaddb/downloaddb.go
+++ b/roxctl/scanner/downloaddb/downloaddb.go
@@ -56,7 +56,7 @@ func (cmd *scannerDownloadDBCommand) downloadDB() error {
 	// Get the list of file names to attempt to download.
 	bundleFileNames, err := cmd.buildBundleFileNames()
 	if err != nil {
-		return pkgErrors.Wrap(err, "building bundle file names")
+		return pkgErrors.Wrap(err, "building scanner DB bundle file names")
 	}
 
 	var errs []error
@@ -141,20 +141,20 @@ func (cmd *scannerDownloadDBCommand) versionFromCentral() (string, error) {
 	client, err := cmd.env.HTTPClient(cmd.timeout)
 	if err != nil {
 		cmd.env.Logger().WarnfLn("issue building central http client: %v", err)
-		return "", pkgErrors.Wrap(err, "building HTTP client")
+		return "", pkgErrors.Wrap(err, "building HTTP client to retrieve scanner DB")
 	}
 
 	resp, err := client.DoReqAndVerifyStatusCode("v1/metadata", http.MethodGet, http.StatusOK, nil)
 	if err != nil {
 		cmd.env.Logger().WarnfLn("error contacting central: %v", err)
-		return "", pkgErrors.Wrap(err, "contacting central")
+		return "", pkgErrors.Wrap(err, "contacting central to retrieve scanner DB")
 	}
 	defer utils.IgnoreError(resp.Body.Close)
 
 	var metadata v1.Metadata
 	if err := jsonutil.JSONReaderToProto(resp.Body, &metadata); err != nil {
 		cmd.env.Logger().WarnfLn("error reading metadata from central: %v", err)
-		return "", pkgErrors.Wrap(err, "reading metadata from central")
+		return "", pkgErrors.Wrap(err, "reading scanner DB metadata from central")
 	}
 
 	return metadata.GetVersion(), nil
@@ -188,7 +188,7 @@ func (cmd *scannerDownloadDBCommand) buildAndValidateOutputFileName(bundleFileNa
 // database from.
 func (cmd *scannerDownloadDBCommand) buildDownloadURL(bundleFileName string) (string, error) {
 	downloadURL, err := url.JoinPath(env.ScannerDBDownloadBaseURL.Setting(), bundleFileName)
-	return downloadURL, pkgErrors.Wrap(err, "building download URL")
+	return downloadURL, pkgErrors.Wrap(err, "building scanner DB download URL")
 }
 
 // httpClient builds a retryable http client for non-ACS requests (such as
@@ -217,12 +217,12 @@ func (cmd *scannerDownloadDBCommand) downloadVulnDB(url string, outFileName stri
 
 	err = os.MkdirAll(filepath.Dir(outFileName), 0700)
 	if err != nil {
-		return pkgErrors.Wrap(err, "creating output directory")
+		return pkgErrors.Wrap(err, "creating scanner DB download output directory")
 	}
 
 	outFile, err := os.Create(outFileName)
 	if err != nil {
-		return pkgErrors.Wrap(err, "creating output file")
+		return pkgErrors.Wrap(err, "creating scanner DB output file")
 	}
 	defer utils.IgnoreError(outFile.Close)
 


### PR DESCRIPTION
Wrap unwrapped errors in roxctl package with proper context messages to improve debugging and error traceability. Error messages use gerund form (e.g. 'establishing connection') instead of 'failed to' pattern.

This addresses 50+ wrapcheck violations and significantly improves error context for debugging roxctl operations.

Follows the same pattern as https://github.com/stackrox/stackrox/pull/15045

Assisted-by: Claude (Anthropic AI assistant)

