### PR TITLE
chore(dependabot): use CODEOWNERS instead of reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,3 +85,11 @@ operator/**/* @stackrox/install
 /.konflux/              @stackrox/rhtap-maintainers
 /.tekton/               @stackrox/rhtap-maintainers
 rpms.*                  @stackrox/rhtap-maintainers
+
+
+# Dependencies
+**/go.mod @stackrox/backend-dep-updaters
+**/go.sum @stackrox/backend-dep-updaters
+/.github/**/* @stackrox/backend-dep-updaters
+/qa-tests-backend/build.gradle @stackrox/backend-dep-updaters
+/ui/**/package*.json @stackrox/ui-dep-updaters

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,8 +17,6 @@ updates:
       - "dependencies"
       - "area/ui"
       - "auto-retest"
-    reviewers:
-      - "stackrox/ui-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -33,8 +31,6 @@ updates:
       - "dependencies"
       - "auto-merge"
       - "auto-retest"
-    reviewers:
-      - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -49,8 +45,6 @@ updates:
       - "dependencies"
       - "auto-merge"
       - "auto-retest"
-    reviewers:
-      - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -84,8 +78,6 @@ updates:
     - "dependencies"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-      - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -100,8 +92,6 @@ updates:
     - "dependencies"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -116,8 +106,6 @@ updates:
     - "dependencies"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-      - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -132,8 +120,6 @@ updates:
     - "dependencies"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -149,8 +135,6 @@ updates:
     - "area/operator"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -166,8 +150,6 @@ updates:
     - "area/operator"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -183,8 +165,6 @@ updates:
     - "area/operator"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -200,8 +180,6 @@ updates:
     - "area/operator"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -217,8 +195,6 @@ updates:
     - "area/operator"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -238,8 +214,6 @@ updates:
     - "area/operator"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -255,8 +229,6 @@ updates:
     - "area/scanner"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/scanner"
     commit-message:
       include: scope
       prefix: chore
@@ -272,8 +244,6 @@ updates:
     - "area/operator"
     - "auto-merge"
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -288,8 +258,6 @@ updates:
     - "area/operator"
     - "auto-merge-any" # these images do not follow semver
     - "auto-retest"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -303,8 +271,6 @@ updates:
     labels:
     - "ci-all-qa-tests"
     - "dependencies"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -318,8 +284,6 @@ updates:
     labels:
     - "ci-all-qa-tests"
     - "dependencies"
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -333,8 +297,6 @@ updates:
     labels:
     - "ci-all-qa-tests"
     - "dependencies"
-    reviewers:
-    - "stackrox/scanner"
     commit-message:
       include: scope
       prefix: chore
@@ -348,8 +310,6 @@ updates:
     labels:
     - "ci-all-qa-tests"
     - "dependencies"
-    reviewers:
-    - "stackrox/scanner"
     commit-message:
       include: scope
       prefix: chore
@@ -360,8 +320,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -380,8 +338,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -396,8 +352,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -412,8 +366,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -428,8 +380,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -444,8 +394,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -461,8 +409,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -477,8 +423,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore
@@ -493,8 +437,6 @@ updates:
       interval: 'weekly'
       day: 'wednesday'
     open-pull-requests-limit: 3
-    reviewers:
-    - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
       prefix: chore


### PR DESCRIPTION
The current format is deprecated and reviers are removed and we should use CODEOWNERS instead.

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/