### PR TITLE
ROX-29816: byodb postgres 17 e2e test

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -326,3 +326,23 @@ class CustomSetTest(BaseTest):
         self.run_with_graceful_kill(
             ["qa-tests-backend/scripts/run-custom-pz.sh"], CustomSetTest.TEST_TIMEOUT
         )
+
+
+class BYODBTest(BaseTest):
+    TEST_TIMEOUT = 60 * 60 * 2
+    TEST_OUTPUT_DIR = "/tmp/byodb-test-logs"
+
+    def run(self):
+        print("Executing the BYODB Test")
+
+        def set_dirs_after_start():
+            # let post test know where logs are
+            self.test_outputs = [
+                BYODBTest.TEST_OUTPUT_DIR,
+            ]
+
+        self.run_with_graceful_kill(
+            ["tests/byodb/run.sh", BYODBTest.TEST_OUTPUT_DIR],
+            BYODBTest.TEST_TIMEOUT,
+            post_start_hook=set_dirs_after_start,
+        )

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -306,7 +306,6 @@ function launch_central {
         fi
     fi
 
-
     # Do not default to running monitoring locally for resource reasons, which can be overridden
     # with MONITORING_SUPPORT=true, otherwise default it to true on all other systems
     is_local_dev=$(local_dev)
@@ -417,6 +416,14 @@ function launch_central {
         helm_args+=(
           --set scannerV4.disable="${_disable}"
         )
+      fi
+
+      if [[ -n "$EXTERNAL_DB" ]]; then
+          helm_args+=(
+            --set "central.db.password.value=${EXTERNAL_DB_PASSWORD}"
+            --set "central.db.external=true"
+            --set "central.db.source.connectionString=host=${EXTERNAL_DATABASE_HOST} client_encoding=UTF8 user=${EXTERNAL_DB_USER} dbname=${EXTERNAL_DATABASE_NAME} statement_timeout=1200000"
+          )
       fi
 
       local helm_chart="$unzip_dir/chart"

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -39,6 +39,9 @@ class Env {
     // only has secured-cluster deployed and connects to a remote central
     static final String ONLY_SECURED_CLUSTER = System.getenv("ONLY_SECURED_CLUSTER") ?: "false"
 
+    // IS_BYODB specifies that this is testing an external Postgres database
+    static final boolean IS_BYODB = (System.getenv("BYODB_TEST") == "true")
+
     private static final Env INSTANCE = new Env()
 
     static String get(String key, String defVal = null) {

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -30,6 +30,7 @@ import spock.lang.Tag
 // skip if executed in a test environment with just secured-cluster deployed in the test cluster
 // i.e. central is deployed elsewhere
 @IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
+@IgnoreIf({ Env.BYODB_TEST == "true" })
 class CertRotationTest extends BaseSpecification {
 
     def generateCerts(String path, String expectedFileName, JsonObject data = null) {

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Tag
 // skip if executed in a test environment with just secured-cluster deployed in the test cluster
 // i.e. central is deployed elsewhere
 @IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
-@IgnoreIf({ Env.BYODB_TEST == "true" })
+@IgnoreIf({ Env.IS_BYODB })
 class CertRotationTest extends BaseSpecification {
 
     def generateCerts(String path, String expectedFileName, JsonObject data = null) {

--- a/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
@@ -5,13 +5,16 @@ import io.stackrox.proto.api.v1.ApiTokenService
 import services.BaseService
 import services.ClusterInitBundleService
 import services.ClusterService
+import util.Env
 
 import org.junit.Assume
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Tag
 
 @Tag("BAT")
 @Tag("PZ")
+@IgnoreIf({ Env.BYODB_TEST == "true" })
 class ClusterInitBundleTest extends BaseSpecification {
 
     @Shared

--- a/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Tag
 
 @Tag("BAT")
 @Tag("PZ")
-@IgnoreIf({ Env.BYODB_TEST == "true" })
+@IgnoreIf({ Env.IS_BYODB })
 class ClusterInitBundleTest extends BaseSpecification {
 
     @Shared

--- a/qa-tests-backend/src/test/groovy/ClustersTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClustersTest.groovy
@@ -2,12 +2,15 @@ import io.stackrox.proto.storage.ClusterOuterClass
 
 import services.ClusterService
 import util.Cert
+import util.Env
 
+import spock.lang.IgnoreIf
 import spock.lang.Stepwise
 import spock.lang.Tag
 
 @Tag("BAT")
 @Tag("PZ")
+@IgnoreIf({ Env.BYODB_TEST == "true" })
 @Stepwise
 class ClustersTest extends BaseSpecification {
 

--- a/qa-tests-backend/src/test/groovy/ClustersTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClustersTest.groovy
@@ -10,7 +10,7 @@ import spock.lang.Tag
 
 @Tag("BAT")
 @Tag("PZ")
-@IgnoreIf({ Env.BYODB_TEST == "true" })
+@IgnoreIf({ Env.IS_BYODB })
 @Stepwise
 class ClustersTest extends BaseSpecification {
 

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -321,6 +321,7 @@ class ImageManagementTest extends BaseSpecification {
 
     @Tag("BAT")
     @Tag("Integration")
+    @IgnoreIf({ Env.BYODB_TEST == "true" })
     def "Verify CI/CD Integration Endpoint with notifications"() {
         when:
         "Clone and scope the policy for test"

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -321,7 +321,7 @@ class ImageManagementTest extends BaseSpecification {
 
     @Tag("BAT")
     @Tag("Integration")
-    @IgnoreIf({ Env.BYODB_TEST == "true" })
+    @IgnoreIf({ Env.IS_BYODB })
     def "Verify CI/CD Integration Endpoint with notifications"() {
         when:
         "Clone and scope the policy for test"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -316,13 +316,16 @@ refresh_gke_token() {
 
 teardown_gke_cluster() {
     local canceled="${1:-false}"
+    local byodb="${BYODB_TEST:-false}"
 
     info "Tearing down the GKE cluster: ${CLUSTER_NAME:-}, canceled: ${canceled}"
 
     require_environment "CLUSTER_NAME"
     require_executable "gcloud"
 
-    if [[ "${canceled}" == "false" ]]; then
+    if [[ "${canceled}" == "false" ]] &&
+       [[ "${byodb}" == "false" ]]
+    then
         # (prefix output to avoid triggering prow log focus)
         "$SCRIPTS_ROOT/scripts/ci/cleanup-deployment.sh" 2>&1 | sed -e 's/^/out: /' || true
     fi

--- a/scripts/ci/jobs/gke_external_pg_17_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_external_pg_17_qa_e2e_tests.py
@@ -4,15 +4,29 @@
 Run qa-tests-backend in a GKE cluster with external PG 17
 """
 import os
-from base_qa_e2e_test import make_qa_e2e_test_runner
+from runners import ClusterTestRunner
 from clusters import GKECluster
+from pre_tests import PreSystemTests
+from ci_tests import BYODBTest
+from post_tests import PostClusterTest, FinalPost
 
 # set test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
-os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
+os.environ["POSTGRES_VERSION"] = "17"
+os.environ["BYODB_TEST"] = "true"
 
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
-make_qa_e2e_test_runner(cluster=GKECluster("qa-external-pg-17-e2e-test")).run()
+ClusterTestRunner(
+    cluster=GKECluster("byodb-test", machine_type="e2-standard-8"),
+    pre_test=PreSystemTests(),
+    test=BYODBTest(),
+    post_test=PostClusterTest(
+        collect_central_artifacts=False
+    ),
+    final_post=FinalPost(
+        store_qa_tests_data=True,
+    ),
+).run()

--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -52,5 +52,17 @@
         "job": "compliance-e2e-tests",
         "logfile": "collector-previous",
         "logline": "Socket closed"
+    },
+    {
+        "comment": "Scanner V4 slow to start",
+        "job": "gke-external-pg-17-qa-e2e-tests",
+        "logfile": "indexer-previous",
+        "logline": "panic: migrate: failed to connect to"
+    },
+    {
+        "comment": "Scanner V4 slow to start matcher",
+        "job": "gke-external-pg-17-qa-e2e-tests",
+        "logfile": "matcher-previous",
+        "logline": "panic: migrate: failed to connect to"
     }
 ]

--- a/scripts/grab-data-from-central.sh
+++ b/scripts/grab-data-from-central.sh
@@ -46,7 +46,12 @@ main() {
     fi
 
     mkdir -p "${dest}"
-    roxctl --ca="" --insecure-skip-tls-verify -e "${api_endpoint}" central backup --output "${dest}"
+
+    # backup not supported for external databases
+    local byodb="${BYODB_TEST:-false}"
+    if [ "${byodb}" == "false" ]; then
+        roxctl --ca="" --insecure-skip-tls-verify -e "${api_endpoint}" central backup --output "${dest}"
+    fi
 
     # Pull some data not found from the database
     set +e

--- a/tests/byodb/lib.sh
+++ b/tests/byodb/lib.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+set -euo pipefail
+
+# Test utility functions for upgrades
+deploy_external_postgres() {
+    pwd
+    EXTERNAL_DB_PASSWORD="$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c12 || true)"
+    EXTERNAL_DB_USER=stackrox
+    EXTERNAL_DATABASE_NAME=stackrox
+    EXTERNAL_DATABASE_HOST=postgres.database
+    ci_export "EXTERNAL_DB_PASSWORD" "$EXTERNAL_DB_PASSWORD"
+    ci_export "EXTERNAL_DB_USER" "$EXTERNAL_DB_USER"
+    ci_export "EXTERNAL_DATABASE_NAME" "$EXTERNAL_DATABASE_NAME"
+    ci_export "EXTERNAL_DATABASE_HOST" "$EXTERNAL_DATABASE_HOST"
+    ci_export "EXTERNAL_DB" true
+
+    kubectl create namespace database
+    envsubst < ./tests/byodb/simple-postgres.yaml | kubectl apply -f -
+
+    kubectl wait --for=condition=Ready pod -l app=postgres -n database --timeout=180s
+}
+
+preamble() {
+    info "Starting test preamble"
+
+    if is_darwin; then
+        HOST_OS="darwin"
+    elif is_linux; then
+        HOST_OS="linux"
+    else
+        die "Only linux or darwin are supported for this test"
+    fi
+
+    case "$(uname -m)" in
+        x86_64) TEST_HOST_PLATFORM="${HOST_OS}_amd64" ;;
+        aarch64) TEST_HOST_PLATFORM="${HOST_OS}_arm64" ;;
+        arm64) TEST_HOST_PLATFORM="${HOST_OS}_arm64" ;;
+        ppc64le) TEST_HOST_PLATFORM="${HOST_OS}_ppc64le" ;;
+        s390x) TEST_HOST_PLATFORM="${HOST_OS}_s390x" ;;
+        *) die "Unknown architecture" ;;
+    esac
+
+    require_executable "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl"
+
+    if is_CI; then
+        if ! command -v yq >/dev/null 2>&1; then
+            sudo wget https://github.com/mikefarah/yq/releases/download/v4.4.1/yq_linux_amd64 -O /usr/bin/yq
+            sudo chmod 0755 /usr/bin/yq
+        fi
+    else
+        require_executable yq
+    fi
+}

--- a/tests/byodb/run.sh
+++ b/tests/byodb/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+set -euo pipefail
+
+# Tests for an external Postgres.
+
+TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+
+CURRENT_TAG="$(make --quiet --no-print-directory tag)"
+
+# shellcheck source=../../qa-tests-backend/scripts/run-part-1.sh
+source "$TEST_ROOT/qa-tests-backend/scripts/run-part-1.sh"
+# shellcheck source=../../scripts/lib.sh
+source "$TEST_ROOT/scripts/lib.sh"
+# shellcheck source=../../scripts/ci/lib.sh
+source "$TEST_ROOT/scripts/ci/lib.sh"
+# shellcheck source=../../scripts/ci/sensor-wait.sh
+source "$TEST_ROOT/scripts/ci/sensor-wait.sh"
+# shellcheck source=../../scripts/setup-certs.sh
+source "$TEST_ROOT/tests/scripts/setup-certs.sh"
+# shellcheck source=../../tests/e2e/lib.sh
+source "$TEST_ROOT/tests/e2e/lib.sh"
+# shellcheck source=../../tests/byodb/lib.sh
+source "$TEST_ROOT/tests/byodb/lib.sh"
+
+test_byodb() {
+    info "Starting upgrade test"
+
+    if [[ "$#" -ne 1 ]]; then
+        die "missing args. usage: test_byodb <log-output-dir>"
+    fi
+
+    local log_output_dir="$1"
+
+    require_environment "KUBECONFIG"
+
+    export_test_environment
+
+    DEPLOY_DIR="deploy/k8s"
+    QUAY_REPO="stackrox-io"
+    REGISTRY="quay.io/$QUAY_REPO"
+
+    export OUTPUT_FORMAT="helm"
+    export CLUSTER_TYPE_FOR_TEST=K8S
+    export ROX_ACTIVE_VULN_REFRESH_INTERVAL=1m
+    export ROX_NETPOL_FIELDS=true
+
+    if is_CI; then
+        export ROXCTL_IMAGE_REPO="quay.io/$QUAY_REPO/roxctl"
+        require_environment "LONGTERM_LICENSE"
+        export ROX_LICENSE_KEY="${LONGTERM_LICENSE}"
+    fi
+
+    preamble
+    setup_deployment_env false false
+    setup_podsecuritypolicies_config
+    remove_existing_stackrox_resources
+
+    run_byodb_test "$log_output_dir"
+}
+
+run_byodb_test() {
+    info "Testing byodb"
+
+    if [[ "$#" -ne 1 ]]; then
+        die "missing args. usage: run_byodb_test <log-output-dir>"
+    fi
+
+    cd "$TEST_ROOT"
+    local log_output_dir="$1"
+
+    # There is an issue on gke v1.24 for these older releases where we may have a
+    # timeout trying to get the metadata for the cloud provider.  Rather than extend
+    # the general wait_for_api time period and potentially hide issues from other
+    # tests we will extend the wait period for these tests.
+    export MAX_WAIT_SECONDS=600
+
+    # Deploy a simple postgres to use as an external database
+    deploy_external_postgres
+
+    # Run the QA BAT Tests.  Part 1 only as Part 2 deals more with sensor
+    run_part_1
+
+    collect_and_check_stackrox_logs "$log_output_dir" "byodb_QA"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    test_byodb "$*"
+fi

--- a/tests/byodb/simple-postgres.yaml
+++ b/tests/byodb/simple-postgres.yaml
@@ -1,0 +1,61 @@
+# statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: database
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:${POSTGRES_VERSION}
+        ports:
+        - containerPort: 5432
+          name: postgres
+        env:
+        - name: POSTGRES_USER
+          value: ${EXTERNAL_DB_USER}
+        - name: POSTGRES_PASSWORD
+          value: ${EXTERNAL_DB_PASSWORD}
+        - name: POSTGRES_DB
+          value: "stackrox"
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+  - metadata:
+      name: pgdata
+      namespace: database
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "standard-rwo"
+      resources:
+        requests:
+          storage: 1Gi
+
+---
+
+# service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: database
+spec:
+  selector:
+    app: postgres
+  ports:
+  - protocol: TCP
+    port: 5432
+    targetPort: 5432


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In order to better state our support position of Postgres versions we need an e2e test that uses an external database.  In the interest of keeping things simple, this test creates a simple Postgres database in the cluster similar to our `central-db`.  But it is not our `central-db`; it uses different images and the connection from central states this is an external database.  So this satisfies the requirement of using an external (to central) database.  This was the path taken mostly to simplify the approach.  We can easily create another test and just pass set the `POSTGRES_VERSION` env var to pull a different postgres version.   Consideration was given to setting up a gcp database, but there would be a lot of work in figuring out the commands and secrets to do such within the framework of our CI.  That path would also incur costs and the hope is to run this test nightly.  This path is a viable one and simple.  If we wish to become more complex and create tests for the cloud providers, we can do so at a later time.  Some tests were flagged as ignore as they seemed irrelevant to the database.

Per a suggestion from @BradLugo some minor updates to the deploy k8s scripts to all for connecting to an external database via the scripts.  This is to allow tests in general to execute in a more consistent manner with the bonus of helping anyone use an external database easily with their own cluster.  The creation of the database itself is outside the scope of the scripts.  This was put in for helm output only.  If someone would like to extend that to OCP and non-helm we can do that outside the scope of this PR.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The whole purpose is just this test.