### PR TITLE
ROX-29563: Ignore comparing volatile annotations

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -194,6 +194,10 @@ class Helpers {
         return false
     }
 
+    private static final Set<String> VOLATILE_ANNOTATIONS_TO_IGNORE = [
+        "machineconfiguration.openshift.io/lastSyncedControllerConfigResourceVersion"
+    ].toSet()
+
     static void compareAnnotations(Map<String, String> orchestratorAnnotations,
                                    Map<String, String> stackroxAnnotations) {
         if (stackroxAnnotations == orchestratorAnnotations) {
@@ -211,6 +215,11 @@ class Helpers {
                 // is more complicated than we'd like to test
                 log.info "Removing long annotation value from comparison: " +
                          "key: ${name}, length: ${orchestratorTruncated[name].length()}"
+                stackroxTruncated.remove(name)
+                orchestratorTruncated.remove(name)
+            }
+
+            if (VOLATILE_ANNOTATIONS_TO_IGNORE.contains(name)) {
                 stackroxTruncated.remove(name)
                 orchestratorTruncated.remove(name)
             }


### PR DESCRIPTION
### Description

We are comparing annotations that are coming from resource versions. This is quite a volatile value, and this PR is introducing functionality to allow ignoring such annotations because they are not relevant for validating functionality correctness.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] let CI run
