### PR TITLE
ROX-29860: replace pgtype with pgx/v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	github.com/heimdalr/dag v1.5.0
 	github.com/helm/helm-mapkubeapis v0.5.2
 	github.com/heroku/docker-registry-client v0.0.0
-	github.com/jackc/pgtype v1.14.4
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/joshdk/go-junit v1.0.0
@@ -354,6 +353,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgtype v1.14.4 // indirect
 	github.com/jackc/pgx/v4 v4.18.3 // indirect
 	github.com/jackc/puddle v1.3.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/pkg/search/postgres/query_metadata.go
+++ b/pkg/search/postgres/query_metadata.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/readable"
@@ -94,7 +94,7 @@ var (
 			},
 			printer: func(val interface{}) []string {
 				asNumeric := val.(*pgtype.Numeric)
-				if asNumeric.Status != pgtype.Present {
+				if !asNumeric.Valid {
 					return nil
 				}
 				switch asNumeric.InfinityModifier {


### PR DESCRIPTION
### Description

pgx/v5 comes with pgtype so there is no need to use legacy version.

- https://github.com/jackc/pgtype/commit/045ef2b0119074dd010d0298cd3740114d4070c0