### PR TITLE
fix: untangle

### DIFF
--- a/central/authprovider/registry/singleton.go
+++ b/central/authprovider/registry/singleton.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	authProviderDS "github.com/stackrox/rox/central/authprovider/datastore"
+	groupDataStore "github.com/stackrox/rox/central/group/datastore"
 	"github.com/stackrox/rox/central/jwt"
 	"github.com/stackrox/rox/central/role/mapper"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
@@ -29,5 +30,9 @@ func initialize() {
 // Singleton returns the auth providers registry.
 func Singleton() authproviders.Registry {
 	once.Do(initialize)
+	// Set the auth provider registry function in the group datastore to break circular dependency
+	groupDataStore.SetAuthProviderRegistryFunc(func() authproviders.Registry {
+		return registry
+	})
 	return registry
 }

--- a/central/authprovider/registry/singleton.go
+++ b/central/authprovider/registry/singleton.go
@@ -25,14 +25,14 @@ func initialize() {
 		ssoURLPathPrefix, tokenRedirectURLPath,
 		authProviderDS.Singleton(), jwt.IssuerFactorySingleton(),
 		mapper.FactorySingleton())
+	// Set the auth provider registry function in the group datastore to break circular dependency
+	groupDataStore.SetAuthProviderRegistryFunc(func() authproviders.Registry {
+		return registry
+	})
 }
 
 // Singleton returns the auth providers registry.
 func Singleton() authproviders.Registry {
 	once.Do(initialize)
-	// Set the auth provider registry function in the group datastore to break circular dependency
-	groupDataStore.SetAuthProviderRegistryFunc(func() authproviders.Registry {
-		return registry
-	})
 	return registry
 }

--- a/central/authprovider/service/service_impl_postgres_test.go
+++ b/central/authprovider/service/service_impl_postgres_test.go
@@ -46,7 +46,7 @@ func (s *authProviderServiceTestSuite) SetupSuite() {
 
 	roleDS := roleDataStore.GetTestPostgresDataStore(t, db)
 	authProviderDS := authProviderDataStore.GetTestPostgresDataStore(t, db)
-	groupDS := groupDataStore.GetTestPostgresDataStore(t, db, roleDS)
+	groupDS := groupDataStore.GetTestPostgresDataStore(t, db, roleDS, nil)
 	userDS := userDataStore.GetTestDataStore(t)
 	mapperFactory := roleMapper.NewStoreBasedMapperFactory(groupDS, roleDS, userDS)
 	providerRegistry := authproviders.NewStoreBackedRegistry(

--- a/central/declarativeconfig/updater/group_updater.go
+++ b/central/declarativeconfig/updater/group_updater.go
@@ -43,7 +43,7 @@ func (u *groupUpdater) Upsert(ctx context.Context, m protocompat.Message) error 
 	if !ok {
 		return errox.InvariantViolation.Newf("wrong type passed to group updater: %T", group)
 	}
-	return u.groupDS.Upsert(ctx, group, u.authProviderRegistry)
+	return u.groupDS.Upsert(ctx, group)
 }
 
 func (u *groupUpdater) DeleteResources(ctx context.Context, resourceIDsToSkip ...string) ([]string, error) {

--- a/central/declarativeconfig/updater/role_updater_test.go
+++ b/central/declarativeconfig/updater/role_updater_test.go
@@ -195,7 +195,7 @@ func (s *roleUpdaterTestSuite) TestDelete_Error() {
 			Value:          "",
 		},
 		RoleName: "test",
-	}, s.authProviderRegistry))
+	}))
 	s.Require().NoError(s.updater.healthDS.UpsertDeclarativeConfig(s.ctx, &storage.DeclarativeConfigHealth{
 		Id:     declarativeConfigUtils.HealthStatusIDForRole("test"),
 		Name:   "test",

--- a/central/declarativeconfig/updater/role_updater_test.go
+++ b/central/declarativeconfig/updater/role_updater_test.go
@@ -57,7 +57,9 @@ func (s *roleUpdaterTestSuite) SetupTest() {
 	s.Require().NotNil(s.pgTest)
 	rds := roleDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB)
 	ads := authProviderDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB)
-	s.gds = groupDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB, rds)
+	s.gds = groupDS.GetTestPostgresDataStore(s.T(), s.pgTest.DB, rds, func() authproviders.Registry {
+		return s.authProviderRegistry
+	})
 	tokenIssuerFactory := authTokenMocks.NewMockIssuerFactory(s.mockCtrl)
 	tokenIssuerFactory.EXPECT().CreateIssuer(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 	uds := userDS.GetTestDataStore(s.T())

--- a/central/group/datastore/datastore.go
+++ b/central/group/datastore/datastore.go
@@ -22,27 +22,29 @@ type DataStore interface {
 
 	Walk(ctx context.Context, authProviderID string, attributes map[string][]string) ([]*storage.Group, error)
 
-	Add(ctx context.Context, group *storage.Group, authProviderRegistry authproviders.Registry) error
-	Update(ctx context.Context, group *storage.Group, force bool, authProviderRegistry authproviders.Registry) error
-	Upsert(ctx context.Context, group *storage.Group, authProviderRegistry authproviders.Registry) error
-	Mutate(ctx context.Context, remove, update, add []*storage.Group, force bool, authProviderRegistry authproviders.Registry) error
+	Add(ctx context.Context, group *storage.Group) error
+	Update(ctx context.Context, group *storage.Group, force bool) error
+	Upsert(ctx context.Context, group *storage.Group) error
+	Mutate(ctx context.Context, remove, update, add []*storage.Group, force bool) error
 	Remove(ctx context.Context, props *storage.GroupProperties, force bool) error
 	RemoveAllWithAuthProviderID(ctx context.Context, authProviderID string, force bool) error
 	RemoveAllWithEmptyProperties(ctx context.Context) error
 }
 
 // New returns a new DataStore instance.
-func New(storage store.Store, roleDatastore datastore.DataStore) DataStore {
+func New(storage store.Store, roleDatastore datastore.DataStore, authProviderRegistry func() authproviders.Registry) DataStore {
 	return &dataStoreImpl{
-		storage:       storage,
-		roleDatastore: roleDatastore,
+		storage:              storage,
+		roleDatastore:        roleDatastore,
+		authProviderRegistry: authProviderRegistry,
 	}
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB, roleDatastore datastore.DataStore) DataStore {
 	return &dataStoreImpl{
-		storage:       pgStore.New(pool),
-		roleDatastore: roleDatastore,
+		storage:              pgStore.New(pool),
+		roleDatastore:        roleDatastore,
+		authProviderRegistry: nil,
 	}
 }

--- a/central/group/datastore/datastore.go
+++ b/central/group/datastore/datastore.go
@@ -41,10 +41,10 @@ func New(storage store.Store, roleDatastore datastore.DataStore, authProviderReg
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB, roleDatastore datastore.DataStore) DataStore {
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB, roleDatastore datastore.DataStore, authProviderRegistry func() authproviders.Registry) DataStore {
 	return &dataStoreImpl{
 		storage:              pgStore.New(pool),
 		roleDatastore:        roleDatastore,
-		authProviderRegistry: nil,
+		authProviderRegistry: authProviderRegistry,
 	}
 }

--- a/central/group/datastore/datastore_impl_postgres_test.go
+++ b/central/group/datastore/datastore_impl_postgres_test.go
@@ -51,7 +51,9 @@ func (s *groupsWithPostgresTestSuite) SetupSuite() {
 	store := postgresGroupStore.New(s.testPostgres.DB)
 	s.roleStore = roleDatastoreMocks.NewMockDataStore(s.mockCtrl)
 	s.authProviderRegistry = authProvidersMocks.NewMockRegistry(s.mockCtrl)
-	s.groupsDatastore = New(store, s.roleStore)
+	s.groupsDatastore = New(store, s.roleStore, func() authproviders.Registry {
+		return s.authProviderRegistry
+	})
 }
 
 func (s *groupsWithPostgresTestSuite) TearDownTest() {
@@ -68,12 +70,12 @@ func (s *groupsWithPostgresTestSuite) TestAddGroups() {
 	group.Props.Id = ""
 
 	// 1. Adding a group should work.
-	err := s.groupsDatastore.Add(s.ctx, group, s.authProviderRegistry)
+	err := s.groupsDatastore.Add(s.ctx, group)
 	s.NoError(err)
 
 	// 2. Adding the _same_ group twice should fail, since (auth provider ID, key, value, role name) should be unique
 	group.Props.Id = ""
-	err = s.groupsDatastore.Add(s.ctx, group, s.authProviderRegistry)
+	err = s.groupsDatastore.Add(s.ctx, group)
 	s.Error(err)
 	s.ErrorIs(err, errox.AlreadyExists)
 
@@ -81,7 +83,7 @@ func (s *groupsWithPostgresTestSuite) TestAddGroups() {
 	group.RoleName = "headmaster"
 	group.Props.Id = ""
 	s.validRoleAndAuthProvider(group.GetRoleName(), group.GetProps().GetAuthProviderId(), 1)
-	err = s.groupsDatastore.Add(s.ctx, group, s.authProviderRegistry)
+	err = s.groupsDatastore.Add(s.ctx, group)
 	s.NoError(err)
 }
 
@@ -91,11 +93,11 @@ func (s *groupsWithPostgresTestSuite) TestUpdateGroups() {
 	s.validRoleAndAuthProvider(group.GetRoleName(), group.GetProps().GetAuthProviderId(), 3)
 	// 0. Insert the group.
 	group.Props.Id = ""
-	err := s.groupsDatastore.Add(s.ctx, group, s.authProviderRegistry)
+	err := s.groupsDatastore.Add(s.ctx, group)
 	s.NoError(err)
 
 	// 1. Updating the group to be the same shouldn't throw an error as it's a no-op.
-	err = s.groupsDatastore.Update(s.ctx, group, false, s.authProviderRegistry)
+	err = s.groupsDatastore.Update(s.ctx, group, false)
 	s.NoError(err)
 
 	// 2. Create another group. Updating this group to be equal to the previously added one should fail.
@@ -108,7 +110,7 @@ func (s *groupsWithPostgresTestSuite) TestUpdateGroups() {
 		RoleName: "some-role",
 	}
 	s.validRoleAndAuthProvider(newGroup.GetRoleName(), newGroup.GetProps().GetAuthProviderId(), 1)
-	err = s.groupsDatastore.Add(s.ctx, newGroup, s.authProviderRegistry)
+	err = s.groupsDatastore.Add(s.ctx, newGroup)
 	s.NoError(err)
 
 	newGroup.Props.AuthProviderId = group.GetProps().GetAuthProviderId()
@@ -116,7 +118,7 @@ func (s *groupsWithPostgresTestSuite) TestUpdateGroups() {
 	newGroup.Props.Value = group.GetProps().GetValue()
 	newGroup.RoleName = group.GetRoleName()
 
-	err = s.groupsDatastore.Update(s.ctx, newGroup, false, s.authProviderRegistry)
+	err = s.groupsDatastore.Update(s.ctx, newGroup, false)
 	s.Error(err)
 	s.ErrorIs(err, errox.AlreadyExists)
 }
@@ -128,16 +130,16 @@ func (s *groupsWithPostgresTestSuite) TestUpsertGroups() {
 
 	// 0. Insert the group.
 	group.Props.Id = ""
-	err := s.groupsDatastore.Add(s.ctx, group, s.authProviderRegistry)
+	err := s.groupsDatastore.Add(s.ctx, group)
 	s.NoError(err)
 
 	// 1. Upserting the same group shouldn't throw an error as it's a no-op.
-	err = s.groupsDatastore.Upsert(s.ctx, group, s.authProviderRegistry)
+	err = s.groupsDatastore.Upsert(s.ctx, group)
 	s.NoError(err)
 
 	// 2. Upsert another group equal to the previously added one should fail.
 	group.Props.Id = ""
-	err = s.groupsDatastore.Upsert(s.ctx, group, s.authProviderRegistry)
+	err = s.groupsDatastore.Upsert(s.ctx, group)
 	s.Error(err)
 	s.ErrorIs(err, errox.AlreadyExists)
 }
@@ -149,14 +151,14 @@ func (s *groupsWithPostgresTestSuite) TestMutateGroups() {
 
 	// 1. Adding new groups to the store with mutate should work.
 	group.Props.Id = ""
-	err := s.groupsDatastore.Mutate(s.ctx, nil, nil, []*storage.Group{group}, false, s.authProviderRegistry)
+	err := s.groupsDatastore.Mutate(s.ctx, nil, nil, []*storage.Group{group}, false)
 	s.NoError(err)
 
 	existingGroupID := group.GetProps().GetId()
 
 	// 2. Adding the same group twice should not work.
 	group.Props.Id = ""
-	err = s.groupsDatastore.Mutate(s.ctx, nil, nil, []*storage.Group{group}, false, s.authProviderRegistry)
+	err = s.groupsDatastore.Mutate(s.ctx, nil, nil, []*storage.Group{group}, false)
 	s.Error(err)
 	s.ErrorIs(err, errox.AlreadyExists)
 
@@ -177,7 +179,7 @@ func (s *groupsWithPostgresTestSuite) TestMutateGroups() {
 
 	s.validRoleAndAuthProvider(group.GetRoleName(), group.GetProps().GetAuthProviderId(), 2)
 
-	err = s.groupsDatastore.Mutate(s.ctx, nil, []*storage.Group{group}, []*storage.Group{newGroup}, false, s.authProviderRegistry)
+	err = s.groupsDatastore.Mutate(s.ctx, nil, []*storage.Group{group}, []*storage.Group{newGroup}, false)
 	s.Error(err)
 	s.ErrorIs(err, errox.AlreadyExists)
 }

--- a/central/group/datastore/mocks/datastore.go
+++ b/central/group/datastore/mocks/datastore.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	storage "github.com/stackrox/rox/generated/storage"
-	authproviders "github.com/stackrox/rox/pkg/auth/authproviders"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -43,17 +42,17 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 }
 
 // Add mocks base method.
-func (m *MockDataStore) Add(ctx context.Context, group *storage.Group, authProviderRegistry authproviders.Registry) error {
+func (m *MockDataStore) Add(ctx context.Context, group *storage.Group) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Add", ctx, group, authProviderRegistry)
+	ret := m.ctrl.Call(m, "Add", ctx, group)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Add indicates an expected call of Add.
-func (mr *MockDataStoreMockRecorder) Add(ctx, group, authProviderRegistry any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Add(ctx, group any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockDataStore)(nil).Add), ctx, group, authProviderRegistry)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockDataStore)(nil).Add), ctx, group)
 }
 
 // ForEach mocks base method.
@@ -101,17 +100,17 @@ func (mr *MockDataStoreMockRecorder) GetFiltered(ctx, filter any) *gomock.Call {
 }
 
 // Mutate mocks base method.
-func (m *MockDataStore) Mutate(ctx context.Context, remove, update, add []*storage.Group, force bool, authProviderRegistry authproviders.Registry) error {
+func (m *MockDataStore) Mutate(ctx context.Context, remove, update, add []*storage.Group, force bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Mutate", ctx, remove, update, add, force, authProviderRegistry)
+	ret := m.ctrl.Call(m, "Mutate", ctx, remove, update, add, force)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Mutate indicates an expected call of Mutate.
-func (mr *MockDataStoreMockRecorder) Mutate(ctx, remove, update, add, force, authProviderRegistry any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Mutate(ctx, remove, update, add, force any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockDataStore)(nil).Mutate), ctx, remove, update, add, force, authProviderRegistry)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockDataStore)(nil).Mutate), ctx, remove, update, add, force)
 }
 
 // Remove mocks base method.
@@ -157,31 +156,31 @@ func (mr *MockDataStoreMockRecorder) RemoveAllWithEmptyProperties(ctx any) *gomo
 }
 
 // Update mocks base method.
-func (m *MockDataStore) Update(ctx context.Context, group *storage.Group, force bool, authProviderRegistry authproviders.Registry) error {
+func (m *MockDataStore) Update(ctx context.Context, group *storage.Group, force bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, group, force, authProviderRegistry)
+	ret := m.ctrl.Call(m, "Update", ctx, group, force)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockDataStoreMockRecorder) Update(ctx, group, force, authProviderRegistry any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Update(ctx, group, force any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDataStore)(nil).Update), ctx, group, force, authProviderRegistry)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDataStore)(nil).Update), ctx, group, force)
 }
 
 // Upsert mocks base method.
-func (m *MockDataStore) Upsert(ctx context.Context, group *storage.Group, authProviderRegistry authproviders.Registry) error {
+func (m *MockDataStore) Upsert(ctx context.Context, group *storage.Group) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upsert", ctx, group, authProviderRegistry)
+	ret := m.ctrl.Call(m, "Upsert", ctx, group)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Upsert indicates an expected call of Upsert.
-func (mr *MockDataStoreMockRecorder) Upsert(ctx, group, authProviderRegistry any) *gomock.Call {
+func (mr *MockDataStoreMockRecorder) Upsert(ctx, group any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockDataStore)(nil).Upsert), ctx, group, authProviderRegistry)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockDataStore)(nil).Upsert), ctx, group)
 }
 
 // Walk mocks base method.

--- a/central/group/datastore/singleton.go
+++ b/central/group/datastore/singleton.go
@@ -27,9 +27,7 @@ var (
 
 func initialize() {
 	ds = New(pgStore.New(globaldb.GetPostgres()), roleDatastore.Singleton(), func() authproviders.Registry {
-		return concurrency.WithRLock1(&authProviderMutex, func() authproviders.Registry {
-			return authProviderRegistryFunc()
-		})
+		return concurrency.WithRLock1(&authProviderMutex, authProviderRegistryFunc)
 	})
 
 	// Give datastore access to groups so that it can delete any groups with empty props on startup

--- a/central/group/datastore/singleton.go
+++ b/central/group/datastore/singleton.go
@@ -7,6 +7,7 @@ import (
 	pgStore "github.com/stackrox/rox/central/group/datastore/internal/store/postgres"
 	roleDatastore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/sync"
@@ -16,10 +17,16 @@ import (
 var (
 	ds   DataStore
 	once sync.Once
+
+	// Global variable to store the auth provider registry function
+	// This will be set by the auth provider registry package to break circular dependency
+	authProviderRegistryFunc func() authproviders.Registry
 )
 
 func initialize() {
-	ds = New(pgStore.New(globaldb.GetPostgres()), roleDatastore.Singleton())
+	ds = New(pgStore.New(globaldb.GetPostgres()), roleDatastore.Singleton(), func() authproviders.Registry {
+		return authProviderRegistryFunc()
+	})
 
 	// Give datastore access to groups so that it can delete any groups with empty props on startup
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
@@ -28,6 +35,12 @@ func initialize() {
 			sac.ResourceScopeKeys(resources.Access)))
 
 	utils.Should(ds.RemoveAllWithEmptyProperties(ctx))
+}
+
+// SetAuthProviderRegistryFunc sets the function to get the auth provider registry
+// This is called by the auth provider registry package to break the circular dependency
+func SetAuthProviderRegistryFunc(fn func() authproviders.Registry) {
+	authProviderRegistryFunc = fn
 }
 
 // Singleton returns the singleton providing access to the roles store.

--- a/central/group/datastore/singleton.go
+++ b/central/group/datastore/singleton.go
@@ -8,6 +8,7 @@ import (
 	roleDatastore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/sync"
@@ -15,18 +16,20 @@ import (
 )
 
 var (
-	ds                  DataStore
-	once                sync.Once
-	onceSetAuthProvider sync.Once
+	ds                DataStore
+	once              sync.Once
+	authProviderMutex sync.RWMutex
 
 	// Global variable to store the auth provider registry function
-	// This will be set by the auth provider registry package to break circular dependency
+	// This will be set by the auth provider registry package to break circular dependency.
 	authProviderRegistryFunc func() authproviders.Registry
 )
 
 func initialize() {
 	ds = New(pgStore.New(globaldb.GetPostgres()), roleDatastore.Singleton(), func() authproviders.Registry {
-		return authProviderRegistryFunc()
+		return concurrency.WithRLock1(&authProviderMutex, func() authproviders.Registry {
+			return authProviderRegistryFunc()
+		})
 	})
 
 	// Give datastore access to groups so that it can delete any groups with empty props on startup
@@ -41,7 +44,7 @@ func initialize() {
 // SetAuthProviderRegistryFunc sets the function to get the auth provider registry
 // This is called by the auth provider registry package to break the circular dependency
 func SetAuthProviderRegistryFunc(fn func() authproviders.Registry) {
-	onceSetAuthProvider.Do(func() {
+	concurrency.WithLock(&authProviderMutex, func() {
 		authProviderRegistryFunc = fn
 	})
 }

--- a/central/group/datastore/singleton.go
+++ b/central/group/datastore/singleton.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	ds   DataStore
-	once sync.Once
+	ds                  DataStore
+	once                sync.Once
+	onceSetAuthProvider sync.Once
 
 	// Global variable to store the auth provider registry function
 	// This will be set by the auth provider registry package to break circular dependency
@@ -40,7 +41,9 @@ func initialize() {
 // SetAuthProviderRegistryFunc sets the function to get the auth provider registry
 // This is called by the auth provider registry package to break the circular dependency
 func SetAuthProviderRegistryFunc(fn func() authproviders.Registry) {
-	authProviderRegistryFunc = fn
+	onceSetAuthProvider.Do(func() {
+		authProviderRegistryFunc = fn
+	})
 }
 
 // Singleton returns the singleton providing access to the roles store.

--- a/central/group/service/service_impl.go
+++ b/central/group/service/service_impl.go
@@ -120,14 +120,14 @@ func (s *serviceImpl) BatchUpdate(ctx context.Context, req *v1.GroupBatchUpdateR
 	}
 
 	removed, updated, added := diffGroups(req.GetPreviousGroups(), req.GetRequiredGroups())
-	if err := s.groups.Mutate(ctx, removed, updated, added, req.GetForce(), s.authProviderRegistry); err != nil {
+	if err := s.groups.Mutate(ctx, removed, updated, added, req.GetForce()); err != nil {
 		return nil, err
 	}
 	return &v1.Empty{}, nil
 }
 
 func (s *serviceImpl) CreateGroup(ctx context.Context, group *storage.Group) (*v1.Empty, error) {
-	err := s.groups.Add(ctx, group, s.authProviderRegistry)
+	err := s.groups.Add(ctx, group)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (s *serviceImpl) CreateGroup(ctx context.Context, group *storage.Group) (*v
 }
 
 func (s *serviceImpl) UpdateGroup(ctx context.Context, updateReq *v1.UpdateGroupRequest) (*v1.Empty, error) {
-	err := s.groups.Update(ctx, updateReq.GetGroup(), updateReq.GetForce(), s.authProviderRegistry)
+	err := s.groups.Update(ctx, updateReq.GetGroup(), updateReq.GetForce())
 	if err != nil {
 		return nil, err
 	}

--- a/central/group/service/service_test.go
+++ b/central/group/service/service_test.go
@@ -109,7 +109,7 @@ func (suite *UserServiceTestSuite) TestBatchUpdate() {
 		Mutate(contextForMock,
 			[]*storage.Group{update.GetPreviousGroups()[0]},
 			[]*storage.Group{update.GetRequiredGroups()[1]},
-			[]*storage.Group{update.GetRequiredGroups()[2]}, false, suite.authProviderRegistry).
+			[]*storage.Group{update.GetRequiredGroups()[2]}, false).
 		Return(nil)
 
 	_, err := suite.ser.BatchUpdate(contextForMock, update)
@@ -155,7 +155,7 @@ func (suite *UserServiceTestSuite) TestBatchUpdate_Dedupe_updated_group() {
 		Mutate(contextForMock,
 			gomock.Len(0),
 			[]*storage.Group{update.GetRequiredGroups()[0]},
-			gomock.Len(0), false, suite.authProviderRegistry).
+			gomock.Len(0), false).
 		Return(nil)
 
 	_, err := suite.ser.BatchUpdate(contextForMock, update)


### PR DESCRIPTION
# Fix Import Cycle Between Group Datastore and Auth Provider Registry

## Problem

The build was failing with an import cycle error:
```
imports github.com/stackrox/rox/central/auth/userpass
imports github.com/stackrox/rox/central/role/mapper
imports github.com/stackrox/rox/central/group/datastore
imports github.com/stackrox/rox/central/authprovider/registry
imports github.com/stackrox/rox/central/role/mapper: import cycle not allowed
```

The circular dependency was:
1. `central/group/datastore` → `central/authprovider/registry`
2. `central/authprovider/registry` → `central/role/mapper`
3. `central/role/mapper` → `central/group/datastore`

## Root Cause

The group datastore needed access to the auth provider registry to validate that referenced auth providers exist when creating/updating groups. This validation happens in the `verifyReferencedRoleAndProvider` method.

## Solution

Implemented a **lazy initialization pattern** using a function that returns the auth provider registry:

### Key Changes

1. **Modified Group Datastore Interface** (`central/group/datastore/datastore.go`):
   - Changed constructor to accept `func() authproviders.Registry` instead of `authproviders.Registry`
   - Updated `dataStoreImpl` to store the function instead of the registry directly

2. **Updated Group Datastore Implementation** (`central/group/datastore/datastore_impl.go`):
   - Changed `authProviderRegistry` field from `authproviders.Registry` to `func() authproviders.Registry`
   - Updated `verifyReferencedRoleAndProvider` to call `ds.authProviderRegistry()` to get the registry

3. **Modified Singleton Initialization** (`central/group/datastore/singleton.go`):
   - Added global variable `authProviderRegistryFunc` to store the registry function
   - Added `SetAuthProviderRegistryFunc()` to allow the auth provider registry to set this function
   - Updated `initialize()` to pass a function that returns the registry

4. **Updated Auth Provider Registry** (`central/authprovider/registry/singleton.go`):
   - Added call to `groupDataStore.SetAuthProviderRegistryFunc()` in `initialize()`
   - This breaks the circular dependency by setting the function after the registry is fully initialized

5. **Fixed Service Layer** (`central/group/service/service_impl.go`):
   - Removed auth provider registry parameter from datastore method calls
   - The datastore now handles getting the registry internally

6. **Updated Tests**:
   - Fixed test setup to pass registry function instead of registry directly
   - Removed auth provider registry parameter from all test method calls

## Why This Approach Works

The function-based approach breaks the circular dependency because:

1. **Lazy Evaluation**: The registry is only accessed when actually needed, not during initialization
2. **No Direct Import**: The group datastore doesn't need to import the auth provider registry package
3. **Dependency Injection**: The function is set by the auth provider registry after it's fully initialized
4. **Testability**: Easy to mock in tests by providing different functions

## Benefits

- ✅ Resolves import cycle
- ✅ Maintains existing functionality
- ✅ Preserves validation logic
- ✅ Easy to test and mock
- ✅ Follows Go idioms for dependency injection

## Testing

- All tests pass: `go test ./central/authprovider/service/... ./central/group/... ./pkg/auth/authproviders/...`
- Build succeeds: `go build ./central/...`