### PR TITLE
fix: Take first of `$FUNCNAME` in `check-konflux-setup.sh`

### DIFF
--- a/scripts/ci/jobs/check-konflux-setup.sh
+++ b/scripts/ci/jobs/check-konflux-setup.sh
@@ -25,7 +25,7 @@ check_create_snapshot_runs_last() {
 1. Open ${pipeline_path} and locate the ${task_name} task
 2. Update the runAfter attribute of this task to the following list (all previous tasks in the pipeline, sorted alphabetically):
 ${expected_runafter}"
-        record_failure "${FUNCNAME}"
+        record_failure "${FUNCNAME[0]}"
     fi
 }
 
@@ -50,7 +50,7 @@ check_all_components_are_part_of_custom_snapshot() {
 1. Open ${pipeline_path} and locate the ${task_name} task
 2. Update the COMPONENTS parameter of this task to include entries for the missing components or delete references to removed components. COMPONENTS should include entries for (sorted alphabetically):
 ${expected_components}"
-        record_failure "${FUNCNAME}"
+        record_failure "${FUNCNAME[0]}"
     fi
 }
 
@@ -76,7 +76,7 @@ check_example_rpmdb_files_are_ignored() {
         echo >&2 "How to resolve:
 1. Open ${syft_config} and replace ${exclude_attribute} contents with the following.
 ${expected_excludes}"
-        record_failure "${FUNCNAME}"
+        record_failure "${FUNCNAME[0]}"
     fi
 }
 


### PR DESCRIPTION
### Description

In https://github.com/stackrox/stackrox/pull/15818, shellcheck that runs in CI [told me](https://github.com/stackrox/stackrox/actions/runs/15931806632/job/44942503640?pr=15818#step:10:182) that `FUNCNAME` is actually an array and it's no good to access its first element without explicitly telling so. Here's the fix for `master` (already applied for 4.6 in [`137338b` (#15818)](https://github.com/stackrox/stackrox/pull/15818/commits/137338b2350cb5aec6daaf76b0b2617dc4e2afd3)).

I'm a bit left wondering what happened to shellcheck after 4.6 because this issue was not revealed by CI when I was developing the script, but I'll leave this discovery for the future.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

No change.

#### How I validated my change

Tested manually. Broke things a bit in `.tekton/operator-bundle-pipeline.yaml`, ran `scripts/ci/jobs/check-konflux-setup.sh` and observed it still prints the failing function name at the end of the output.


