### PR TITLE
ROX-29878: improve vuln deduplication

### DIFF
--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -2693,6 +2693,61 @@ func Test_sortBySeverity(t *testing.T) {
 	}
 }
 
+func Test_dedupeVulns(t *testing.T) {
+	testcases := []struct {
+		name string
+		vulnIDs []string
+		vulns   map[string]*claircore.Vulnerability
+		expected []string
+	}{
+		{
+			name: "no dupes",
+			vulnIDs: []string{"0", "1", "2"},
+			vulns: map[string]*claircore.Vulnerability{
+				"0": {
+					ID: "0",
+					Name: "a",
+				},
+				"1": {
+					ID: "1",
+					Name: "b",
+				},
+				"2": {
+					ID: "2",
+					Name: "c",
+				},
+			},
+			expected: []string{"0", "1", "2"},
+		},
+		{
+			name: "dupes - FixedInVersion",
+			vulnIDs: []string{"0", "1"},
+			vulns: map[string]*claircore.Vulnerability{
+				"0": {
+					ID: "0",
+					Name: "a",
+					FixedInVersion: "fixed=2.1.8&introduced=2.0.0",
+					Updater: "osv/maven",
+				},
+				"1": {
+					ID: "1",
+					Name: "a",
+					FixedInVersion: "fixed=2.1.8&introduced=2.1.0",
+					Updater: "osv/maven",
+				},
+			},
+			expected: []string{"0"},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dedupeVulns(tt.vulnIDs, tt.vulns)
+			assert.ElementsMatch(t, tt.expected, got)
+		})
+	}
+}
+
 func Test_dedupeAdvisories(t *testing.T) {
 	now := timestamppb.Now()
 


### PR DESCRIPTION
### Description

This is meant to cover the case we may see with https://osv.dev/vulnerability/GHSA-xggx-fx6w-v7ch.

Note: though this change will deduplicate that particular entry, Scanner V4 still potentially outputs two vulnerabilities with the same name for the same package. This was always theoretical, but it may be in Central's best interest to allow this, as it is always possible. For example, since Scanner V4 attempts to rename vulnerabilities to their equivalent CVE ID, if possible, the theoretical possibility of seeing two vulns with the same name for the same package becomes a little less theoretical.

The changes in this PR are just meant to help alleviate this one odd case.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] added unit tests

#### How I validated my change

CI + TODO
