### PR TITLE
ROX-29885: Update ESlint 9.30.0 and Prettier 3.6.2 devDependencies

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -9,15 +9,15 @@ const pluginESLint = require('@eslint/js'); // eslint-disable-line import/no-ext
 const pluginJSON = require('@eslint/json').default;
 const pluginESLintComments = require('eslint-plugin-eslint-comments');
 const pluginImport = require('eslint-plugin-import');
-const pluginJest = require('eslint-plugin-jest');
 const pluginJestDOM = require('eslint-plugin-jest-dom');
 const pluginPrettier = require('eslint-plugin-prettier');
 const pluginReact = require('eslint-plugin-react');
 const pluginReactHooks = require('eslint-plugin-react-hooks');
 const pluginTestingLibrary = require('eslint-plugin-testing-library');
 const pluginTypeScriptESLint = require('@typescript-eslint/eslint-plugin');
+const pluginVitest = require('@vitest/eslint-plugin');
 
-const { browser: browserGlobals, jest: jestGlobals, node: nodeGlobals } = require('globals');
+const { browser: browserGlobals, node: nodeGlobals, vitest: vitestGlobals } = require('globals');
 
 const pluginAccessibility = require('./eslint-plugins/pluginAccessibility');
 const pluginGeneric = require('./eslint-plugins/pluginGeneric');
@@ -524,7 +524,7 @@ module.exports = [
         // Key of plugin is namespace of its rules.
         plugins: {
             cypress: pluginCypress,
-            jest: pluginJest,
+            vitest: pluginVitest,
         },
         rules: {
             // Turn off rules from ESLint recommended configuration.
@@ -541,7 +541,7 @@ module.exports = [
             'cypress/no-chained-get': 'error',
             // 'cypress/no-force': 'error', // TODO fix errors
 
-            'jest/no-focused-tests': 'error',
+            'vitest/no-focused-tests': 'error',
         },
     },
     {
@@ -744,17 +744,16 @@ module.exports = [
         languageOptions: {
             ...parserAndOptions,
             globals: {
-                vi: false,
-                ...jestGlobals,
+                ...vitestGlobals,
             },
         },
 
         // Key of plugin is namespace of its rules.
         plugins: {
             import: pluginImport,
-            jest: pluginJest,
             'jest-dom': pluginJestDOM,
             'testing-library': pluginTestingLibrary,
+            vitest: pluginVitest,
         },
         rules: {
             'import/no-extraneous-dependencies': [
@@ -764,9 +763,9 @@ module.exports = [
                 },
             ],
 
-            ...pluginJest.configs.recommended.rules,
+            ...pluginVitest.configs.recommended.rules,
 
-            'jest/expect-expect': [
+            'vitest/expect-expect': [
                 'error',
                 {
                     assertFunctionNames: ['expect', 'expectSaga'], // authSagas.test.js integrationSagas.test.js

--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -114,22 +114,22 @@
                 "@types/react-dom": "^18.3.7",
                 "@types/react-redux": "^7.1.34",
                 "@types/segment-analytics": "^0.0.38",
-                "@typescript-eslint/eslint-plugin": "^8.34.1",
-                "@typescript-eslint/parser": "^8.34.1",
+                "@typescript-eslint/eslint-plugin": "^8.35.0",
+                "@typescript-eslint/parser": "^8.35.0",
                 "@vitejs/plugin-basic-ssl": "^1.1.0",
                 "@vitejs/plugin-react": "^4.4.0",
                 "@vitest/coverage-v8": "^3.1.1",
+                "@vitest/eslint-plugin": "^1.3.3",
                 "axe-core": "^4.10.0",
                 "cypress": "^13.16.1",
                 "cypress-axe": "^1.5.0",
-                "eslint": "^9.29.0",
+                "eslint": "^9.30.0",
                 "eslint-import-resolver-typescript": "^4.2.6",
                 "eslint-plugin-cypress": "^5.1.0",
                 "eslint-plugin-eslint-comments": "^3.2.0",
-                "eslint-plugin-import": "^2.31.0",
-                "eslint-plugin-jest": "^28.11.0",
+                "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-jest-dom": "^5.5.0",
-                "eslint-plugin-prettier": "^5.5.0",
+                "eslint-plugin-prettier": "^5.5.1",
                 "eslint-plugin-react": "^7.37.5",
                 "eslint-plugin-react-hooks": "^5.2.0",
                 "eslint-plugin-testing-library": "^7.5.3",
@@ -143,7 +143,7 @@
                 "node-fetch": "^2.6.1",
                 "postcss": "^8.4.47",
                 "postcss-cli": "^8.3.1",
-                "prettier": "^3.5.3",
+                "prettier": "^3.6.2",
                 "react-test-renderer": "^17.0.2",
                 "redux-immutable-state-invariant": "^2.1.0",
                 "redux-saga-test-plan": "^3.7.0",
@@ -164,12 +164,12 @@
                 "@esbuild/linux-ppc64": "^0.25.5",
                 "@esbuild/linux-s390x": "^0.25.5",
                 "@esbuild/linux-x64": "^0.25.5",
-                "@rollup/rollup-darwin-arm64": "^4.41.1",
-                "@rollup/rollup-darwin-x64": "^4.41.1",
-                "@rollup/rollup-linux-arm64-gnu": "^4.41.1",
-                "@rollup/rollup-linux-powerpc64le-gnu": "^4.41.1",
-                "@rollup/rollup-linux-s390x-gnu": "^4.41.1",
-                "@rollup/rollup-linux-x64-gnu": "^4.41.1"
+                "@rollup/rollup-darwin-arm64": "^4.44.0",
+                "@rollup/rollup-darwin-x64": "^4.44.0",
+                "@rollup/rollup-linux-arm64-gnu": "^4.44.0",
+                "@rollup/rollup-linux-powerpc64le-gnu": "^4.44.0",
+                "@rollup/rollup-linux-s390x-gnu": "^4.44.0",
+                "@rollup/rollup-linux-x64-gnu": "^4.44.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -3029,9 +3029,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
-            "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3044,9 +3044,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
-            "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+            "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3124,9 +3124,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.29.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
-            "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.0.tgz",
+            "integrity": "sha512-Wzw3wQwPvc9sHM+NjakWTcPx11mbZyiYHuwWa/QfZ7cIRX7WK54PSk7bdyXDaoaopUcMatv1zaQvOAAO8hCdww==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5298,17 +5298,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.1.tgz",
-            "integrity": "sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.0.tgz",
+            "integrity": "sha512-ijItUYaiWuce0N1SoSMrEd0b6b6lYkYt99pqCPfybd+HKVXtEvYhICfLdwp42MhiI5mp0oq7PKEL+g1cNiz/Eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.34.1",
-                "@typescript-eslint/type-utils": "8.34.1",
-                "@typescript-eslint/utils": "8.34.1",
-                "@typescript-eslint/visitor-keys": "8.34.1",
+                "@typescript-eslint/scope-manager": "8.35.0",
+                "@typescript-eslint/type-utils": "8.35.0",
+                "@typescript-eslint/utils": "8.35.0",
+                "@typescript-eslint/visitor-keys": "8.35.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -5322,7 +5322,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.34.1",
+                "@typescript-eslint/parser": "^8.35.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
             }
@@ -5338,16 +5338,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.1.tgz",
-            "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
+            "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.34.1",
-                "@typescript-eslint/types": "8.34.1",
-                "@typescript-eslint/typescript-estree": "8.34.1",
-                "@typescript-eslint/visitor-keys": "8.34.1",
+                "@typescript-eslint/scope-manager": "8.35.0",
+                "@typescript-eslint/types": "8.35.0",
+                "@typescript-eslint/typescript-estree": "8.35.0",
+                "@typescript-eslint/visitor-keys": "8.35.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -5363,14 +5363,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.1.tgz",
-            "integrity": "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
+            "integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.34.1",
-                "@typescript-eslint/types": "^8.34.1",
+                "@typescript-eslint/tsconfig-utils": "^8.35.0",
+                "@typescript-eslint/types": "^8.35.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -5385,14 +5385,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.1.tgz",
-            "integrity": "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
+            "integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.34.1",
-                "@typescript-eslint/visitor-keys": "8.34.1"
+                "@typescript-eslint/types": "8.35.0",
+                "@typescript-eslint/visitor-keys": "8.35.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5403,9 +5403,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz",
-            "integrity": "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
+            "integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5420,14 +5420,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.1.tgz",
-            "integrity": "sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.0.tgz",
+            "integrity": "sha512-ceNNttjfmSEoM9PW87bWLDEIaLAyR+E6BoYJQ5PfaDau37UGca9Nyq3lBk8Bw2ad0AKvYabz6wxc7DMTO2jnNA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.34.1",
-                "@typescript-eslint/utils": "8.34.1",
+                "@typescript-eslint/typescript-estree": "8.35.0",
+                "@typescript-eslint/utils": "8.35.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -5444,9 +5444,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.1.tgz",
-            "integrity": "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
+            "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5458,16 +5458,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
-            "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
+            "integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.34.1",
-                "@typescript-eslint/tsconfig-utils": "8.34.1",
-                "@typescript-eslint/types": "8.34.1",
-                "@typescript-eslint/visitor-keys": "8.34.1",
+                "@typescript-eslint/project-service": "8.35.0",
+                "@typescript-eslint/tsconfig-utils": "8.35.0",
+                "@typescript-eslint/types": "8.35.0",
+                "@typescript-eslint/visitor-keys": "8.35.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -5526,16 +5526,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
-            "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
+            "integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.34.1",
-                "@typescript-eslint/types": "8.34.1",
-                "@typescript-eslint/typescript-estree": "8.34.1"
+                "@typescript-eslint/scope-manager": "8.35.0",
+                "@typescript-eslint/types": "8.35.0",
+                "@typescript-eslint/typescript-estree": "8.35.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5569,13 +5569,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.34.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.1.tgz",
-            "integrity": "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==",
+            "version": "8.35.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
+            "integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.34.1",
+                "@typescript-eslint/types": "8.35.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -5985,6 +5985,29 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@vitest/eslint-plugin": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.3.3.tgz",
+            "integrity": "sha512-zOB4T5f80JXfP5DC2yQl7azRYq8PmGqYle3uxh3a0NnbKc+EaSYSpEcrVAh2r5W97pi3BVv7oRb5NdEQy0cCXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "^8.24.1"
+            },
+            "peerDependencies": {
+                "eslint": ">= 8.57.0",
+                "typescript": ">= 5.0.0",
+                "vitest": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                },
+                "vitest": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@vitest/expect": {
@@ -6430,17 +6453,20 @@
             }
         },
         "node_modules/array-includes": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
-            "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+            "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.2",
-                "es-object-atoms": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
-                "is-string": "^1.0.7"
+                "es-abstract": "^1.24.0",
+                "es-object-atoms": "^1.1.1",
+                "get-intrinsic": "^1.3.0",
+                "is-string": "^1.1.1",
+                "math-intrinsics": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6491,17 +6517,19 @@
             }
         },
         "node_modules/array.prototype.findlastindex": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
-            "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+            "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.2",
+                "es-abstract": "^1.23.9",
                 "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
-                "es-shim-unscopables": "^1.0.2"
+                "es-object-atoms": "^1.1.1",
+                "es-shim-unscopables": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6511,15 +6539,16 @@
             }
         },
         "node_modules/array.prototype.flat": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-            "integrity": "sha1-FHYhffjP8X1y7o87oGc421s4fRg= sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+            "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "es-shim-unscopables": "^1.0.0"
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.5",
+                "es-shim-unscopables": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9229,9 +9258,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.23.9",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-            "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+            "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9239,18 +9268,18 @@
                 "arraybuffer.prototype.slice": "^1.0.4",
                 "available-typed-arrays": "^1.0.7",
                 "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
+                "call-bound": "^1.0.4",
                 "data-view-buffer": "^1.0.2",
                 "data-view-byte-length": "^1.0.2",
                 "data-view-byte-offset": "^1.0.1",
                 "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
+                "es-object-atoms": "^1.1.1",
                 "es-set-tostringtag": "^2.1.0",
                 "es-to-primitive": "^1.3.0",
                 "function.prototype.name": "^1.1.8",
-                "get-intrinsic": "^1.2.7",
-                "get-proto": "^1.0.0",
+                "get-intrinsic": "^1.3.0",
+                "get-proto": "^1.0.1",
                 "get-symbol-description": "^1.1.0",
                 "globalthis": "^1.0.4",
                 "gopd": "^1.2.0",
@@ -9262,21 +9291,24 @@
                 "is-array-buffer": "^3.0.5",
                 "is-callable": "^1.2.7",
                 "is-data-view": "^1.0.2",
+                "is-negative-zero": "^2.0.3",
                 "is-regex": "^1.2.1",
+                "is-set": "^2.0.3",
                 "is-shared-array-buffer": "^1.0.4",
                 "is-string": "^1.1.1",
                 "is-typed-array": "^1.1.15",
-                "is-weakref": "^1.1.0",
+                "is-weakref": "^1.1.1",
                 "math-intrinsics": "^1.1.0",
-                "object-inspect": "^1.13.3",
+                "object-inspect": "^1.13.4",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.7",
                 "own-keys": "^1.0.1",
-                "regexp.prototype.flags": "^1.5.3",
+                "regexp.prototype.flags": "^1.5.4",
                 "safe-array-concat": "^1.1.3",
                 "safe-push-apply": "^1.0.0",
                 "safe-regex-test": "^1.1.0",
                 "set-proto": "^1.0.0",
+                "stop-iteration-iterator": "^1.1.0",
                 "string.prototype.trim": "^1.2.10",
                 "string.prototype.trimend": "^1.0.9",
                 "string.prototype.trimstart": "^1.0.8",
@@ -9285,7 +9317,7 @@
                 "typed-array-byte-offset": "^1.0.4",
                 "typed-array-length": "^1.0.7",
                 "unbox-primitive": "^1.1.0",
-                "which-typed-array": "^1.1.18"
+                "which-typed-array": "^1.1.19"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9375,12 +9407,16 @@
             }
         },
         "node_modules/es-shim-unscopables": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-            "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+            "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.0"
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/es-to-primitive": {
@@ -9490,19 +9526,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.29.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
-            "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
+            "version": "9.30.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.0.tgz",
+            "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.20.1",
-                "@eslint/config-helpers": "^0.2.1",
+                "@eslint/config-array": "^0.21.0",
+                "@eslint/config-helpers": "^0.3.0",
                 "@eslint/core": "^0.14.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.29.0",
+                "@eslint/js": "9.30.0",
                 "@eslint/plugin-kit": "^0.3.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -9605,9 +9641,9 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
-            "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+            "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9625,8 +9661,9 @@
         "node_modules/eslint-module-utils/node_modules/debug": {
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o= sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -9664,30 +9701,30 @@
             }
         },
         "node_modules/eslint-plugin-import": {
-            "version": "2.31.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-            "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+            "version": "2.32.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+            "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
-                "array-includes": "^3.1.8",
-                "array.prototype.findlastindex": "^1.2.5",
-                "array.prototype.flat": "^1.3.2",
-                "array.prototype.flatmap": "^1.3.2",
+                "array-includes": "^3.1.9",
+                "array.prototype.findlastindex": "^1.2.6",
+                "array.prototype.flat": "^1.3.3",
+                "array.prototype.flatmap": "^1.3.3",
                 "debug": "^3.2.7",
                 "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.9",
-                "eslint-module-utils": "^2.12.0",
+                "eslint-module-utils": "^2.12.1",
                 "hasown": "^2.0.2",
-                "is-core-module": "^2.15.1",
+                "is-core-module": "^2.16.1",
                 "is-glob": "^4.0.3",
                 "minimatch": "^3.1.2",
                 "object.fromentries": "^2.0.8",
                 "object.groupby": "^1.0.3",
-                "object.values": "^1.2.0",
+                "object.values": "^1.2.1",
                 "semver": "^6.3.1",
-                "string.prototype.trimend": "^1.0.8",
+                "string.prototype.trimend": "^1.0.9",
                 "tsconfig-paths": "^3.15.0"
             },
             "engines": {
@@ -9704,44 +9741,6 @@
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
-            }
-        },
-        "node_modules/eslint-plugin-import/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s= sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/eslint-plugin-jest": {
-            "version": "28.11.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
-            "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "engines": {
-                "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0",
-                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
-                "jest": "*"
-            },
-            "peerDependenciesMeta": {
-                "@typescript-eslint/eslint-plugin": {
-                    "optional": true
-                },
-                "jest": {
-                    "optional": true
-                }
             }
         },
         "node_modules/eslint-plugin-jest-dom": {
@@ -9770,9 +9769,9 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.0.tgz",
-            "integrity": "sha512-8qsOYwkkGrahrgoUv76NZi23koqXOGiiEzXMrT8Q7VcYaUISR+5MorIUxfWqYXN0fN/31WbSrxCxFkVQ43wwrA==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
+            "integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11699,9 +11698,10 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -11865,6 +11865,19 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
             "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -15367,9 +15380,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -17366,6 +17379,20 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
             "integrity": "sha1-OUE/7p0CXHSn5ZzuyyN4TMDxfwI="
+        },
+        "node_modules/stop-iteration-iterator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "internal-slot": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/store": {
             "version": "2.0.12",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -135,22 +135,22 @@
         "@types/react-dom": "^18.3.7",
         "@types/react-redux": "^7.1.34",
         "@types/segment-analytics": "^0.0.38",
-        "@typescript-eslint/eslint-plugin": "^8.34.1",
-        "@typescript-eslint/parser": "^8.34.1",
+        "@typescript-eslint/eslint-plugin": "^8.35.0",
+        "@typescript-eslint/parser": "^8.35.0",
         "@vitejs/plugin-basic-ssl": "^1.1.0",
         "@vitejs/plugin-react": "^4.4.0",
         "@vitest/coverage-v8": "^3.1.1",
+        "@vitest/eslint-plugin" : "^1.3.3",
         "axe-core": "^4.10.0",
         "cypress": "^13.16.1",
         "cypress-axe": "^1.5.0",
-        "eslint": "^9.29.0",
+        "eslint": "^9.30.0",
         "eslint-import-resolver-typescript": "^4.2.6",
         "eslint-plugin-cypress": "^5.1.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jest": "^28.11.0",
+        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest-dom": "^5.5.0",
-        "eslint-plugin-prettier": "^5.5.0",
+        "eslint-plugin-prettier": "^5.5.1",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-testing-library": "^7.5.3",
@@ -164,7 +164,7 @@
         "node-fetch": "^2.6.1",
         "postcss": "^8.4.47",
         "postcss-cli": "^8.3.1",
-        "prettier": "^3.5.3",
+        "prettier": "^3.6.2",
         "react-test-renderer": "^17.0.2",
         "redux-immutable-state-invariant": "^2.1.0",
         "redux-saga-test-plan": "^3.7.0",
@@ -190,27 +190,10 @@
         "@rollup/rollup-linux-x64-gnu": "^4.44.0"
     },
     "overrides": {
-        "@jest/types": "^29.6.3",
-        "@typescript-eslint/eslint-plugin": "^8.34.1",
-        "@typescript-eslint/parser": "^8.34.1",
         "autoprefixer": "10.4.5",
-        "babel-jest": "^29.7.0",
-        "eslint": "^9.29.0",
-        "eslint-plugin-jest": "^28.11.0",
-        "eslint-plugin-jest-dom": {
-            "@testing-library/dom": "^10.4.0"
-        },
-        "eslint-plugin-react-hooks": "^5.2.0",
-        "eslint-plugin-testing-library": "^7.5.3",
-        "jest": "^29.7.0",
-        "jest-resolve": "^29.7.0",
-        "jest-watch-typeahead": "^2.2.2",
         "nth-check": "^2.1.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-scripts": {
-            "typescript": "5.8.2"
-        }
+        "react-dom": "^18.2.0"
     },
     "jest": {
         "moduleNameMapper": {

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/authProviders.utils.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/authProviders.utils.ts
@@ -187,8 +187,8 @@ export function mergeGroupsWithAuthProviders(
         item.groups = [];
 
         // comma operator is much faster than spread in a reduce loop
-        // eslint-disable-next-line no-return-assign, no-param-reassign, no-sequences
-        return (obj[item.id] = item), obj;
+        // eslint-disable-next-line no-return-assign, no-param-reassign
+        return ((obj[item.id] = item), obj);
     }, {});
 
     if (authProviders.length) {

--- a/ui/apps/platform/src/Containers/Compliance/List/tableColumns.test.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/tableColumns.test.js
@@ -1,4 +1,4 @@
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expectColumnsToContain", "expectColumnsNotToContain"] }] */
+/* eslint vitest/expect-expect: ["error", { "assertFunctionNames": ["expectColumnsToContain", "expectColumnsNotToContain"] }] */
 
 import { resourceTypes, standardTypes } from 'constants/entityTypes';
 import { getColumnsByEntity, getColumnsByStandard } from './tableColumns';


### PR DESCRIPTION
### Description

ESLint releases a minor update every other Friday.

Although update from 9.29.0 to 9.30.0 is sooner than usual:
* Update Prettier from 3.5.3 to 3.6.2
* Replace `eslint-plugin-jest` with `@vitest/eslint-plugin` as prerequisite to remove `jest` and `ts-jest` devDependencies.
    For visibility, `eslint-plugin-jest-dom` is from testing-library, does not has `jest` dependency, is still relevant, and has not been superseded.

### Procedure

Remember to update some packages in `overrides` if needed.

* For contribution: `npm install` to update package-lock.json file according to changes in package.json file.
* For team: `npm ci` to delete and recreate ui/apps/platform/node_modules folder.

### eslint

https://eslint.org/blog/2025/06/eslint-v9.30.0-released/

https://eslint.org/blog/2025/06/eslint-v9.30.0-released/#new-allowseparatetypeimports-option-in-no-duplicate-imports

> With the new option `allowSeparateTypeImports`, the `no-duplicate-imports` rule can now be configured to treat `import` and `import type` as separate usages, even if they specify the same module.

Aha, I had to read this twice. The pattern that the team discussed recently to distinguish `import` and `import type` is allowed by default. This option allows people to disallow it (pardon pun).

For visibility, the following do not seem to be relevant for our project.

Having said that, it might become relevant if plugin causes return of (or revenge of) the mono-repo.

https://eslint.org/blog/2025/06/eslint-v9.30.0-released/#basepath-property-in-config-objects

> Config objects can now include the new `basePath` property to specify the path to a subdirectory to which the `config` object should apply to. If a config object has a `basePath` property, patterns specified in `files` and `ignores` are evaluated relative to the subdirectory represented by basePath. This makes it easier to write config objects that target a particular directory inside your project.

https://eslint.org/blog/2025/06/eslint-v9.30.0-released/#stable-feature-flag-v10_config_lookup_from_file

> With the addition of the `basePath` property in `config` objects, the experimental configuration file resolution introduced in ESLint v9.12.0 has been finalized. It will become the default behavior in the next major release of ESLint.

### prettier

https://prettier.io/blog/2025/06/23/3.6.0

> First, we're shipping a new experimental high-performance CLI behind a feature flag.

Nice, but not relevant to us, because we run prettier via ESLint plugin.

https://prettier.io/blog/2025/06/23/3.6.0#change-17145

> Previously we only add parentheses to `AssignmentExpression` in object keys, but not in class property keys.

Sonehow it affected assignment within sequence, which is a unique idiom that is new to me.

### vitest

Follow up replacement of `jest` with `vitest` in #13281

1. Remove need for `"jest": "*"` in `peerDependencies` of `eslint-plugin-jest` package.
2. Replace `jest` with `vitest` from `globals` package.

### overrides

Override for `eslint` reminded me:
* One side of coin: delete obsolete related to lint or test, plus `react-script` of course, that I can test by compile and lint only.
* Other side of coin: defer deletion of versions that might affect product dependencies.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint` in ui/apps/platform
2. `npm run tsc` in ui/apps/platform
3. `npm run test` in ui/apps/platform