### PR TITLE
fix: free more disk space for definitions update

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -131,6 +131,7 @@ jobs:
 
     - uses: ./.github/actions/job-preamble
       with:
+        free-disk-space: 50
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Checkout specific reference
@@ -198,6 +199,7 @@ jobs:
 
     - uses: ./.github/actions/job-preamble
       with:
+        free-disk-space: 50
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Checkout specific reference


### PR DESCRIPTION
### Description

Since https://github.com/stackrox/stackrox/pull/15634 was merged, we've observed failures in the `Scanner versioned vulnerabilities update` workflow, specifically the `build-and-run v1` job. Example: https://github.com/stackrox/stackrox/actions/runs/15973303950/job/45049313708#logs.

These changes attempt to mitigate these errors by freeing more disk space. I suspect we'll hit a warning about not being able to free the requested amount of space, but it shouldn't cause an error.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

N/A

#### How I validated my change

Tested the general flow with the `pr-update-scanner-vulns` label, but we won't know if these changes work for the v1 jobs until this PR is merged.
