### PR TITLE
ROX-29890: Disable no-nested-ternary lint rule in UI

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -426,7 +426,6 @@ module.exports = [
             'no-bitwise': 'error',
             'no-continue': 'error',
             'no-multi-assign': ['error'],
-            'no-nested-ternary': 'error',
             'no-plusplus': 'error',
             'no-restricted-syntax': [
                 'error',

--- a/ui/apps/platform/src/Components/TabNav/TabNav.tsx
+++ b/ui/apps/platform/src/Components/TabNav/TabNav.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import {

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
@@ -120,7 +120,6 @@ function AuthProvidersList({ entityId, authProviders }: AuthProvidersListProps):
                                                     id === currentUser?.authProvider?.id ||
                                                     isImmutable,
                                                 description:
-                                                    // eslint-disable-next-line no-nested-ternary
                                                     id === currentUser?.authProvider?.id
                                                         ? 'Cannot delete current auth provider'
                                                         : isImmutable

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import {

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import {

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventHint.tsx
@@ -40,7 +40,6 @@ export type AdministrationEventHintProps = {
 };
 
 function AdministrationEventHint({ hint }: AdministrationEventHintProps): ReactElement {
-    /* eslint-disable no-nested-ternary */
     /* eslint-disable react/no-array-index-key */
     // Remove default PatternFly margin-top for li + li to conserve vertical space.
     return (
@@ -63,7 +62,6 @@ function AdministrationEventHint({ hint }: AdministrationEventHintProps): ReactE
         </div>
     );
     /* eslint-enable react/no-array-index-key */
-    /* eslint-enable no-nested-ternary */
 }
 
 export default AdministrationEventHint;

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventPage.tsx
@@ -46,7 +46,6 @@ function AdministrationEventPage({ id }: AdministrationEventPageProps): ReactEle
 
     const h1 = event ? event.domain : 'Administration event';
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <PageTitle title={`Administration events - ${h1}`} />
@@ -82,7 +81,6 @@ function AdministrationEventPage({ id }: AdministrationEventPageProps): ReactEle
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default AdministrationEventPage;

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsPage.tsx
@@ -89,7 +89,6 @@ function AdministrationEventsPage(): ReactElement {
             .catch(() => {});
     }, 60000); // 60 seconds corresponds to backend reprocessing events.
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <PageTitle title="Administration Events" />
@@ -139,7 +138,6 @@ function AdministrationEventsPage(): ReactElement {
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default AdministrationEventsPage;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
@@ -55,7 +55,6 @@ function ClusterRegistrationSecretPage({
             </Button>
         ) : null;
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <ClusterRegistrationSecretsHeader
@@ -99,7 +98,6 @@ function ClusterRegistrationSecretPage({
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default ClusterRegistrationSecretPage;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
@@ -58,7 +58,6 @@ function ClusterRegistrationSecretsPage({
         }
     }
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <ClusterRegistrationSecretsHeader
@@ -106,7 +105,6 @@ function ClusterRegistrationSecretsPage({
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default ClusterRegistrationSecretsPage;

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
@@ -23,14 +23,13 @@ function ClusterDeletion({ clusterRetentionInfo }: ClusterDeletionProps): ReactE
         const { daysUntilDeletion } = clusterRetentionInfo;
         // const healthStatus = getClusterDeletionStatus(daysUntilDeletion);
         // TODO IconText with something like SystemHealth/CardHeaderIcons? But what about Not applicable? MinusIcon?
-        /* eslint-disable no-nested-ternary */
+
         const text =
             daysUntilDeletion < 1
                 ? 'Imminent'
                 : daysUntilDeletion === 1
                   ? 'in 1 day'
                   : `in ${daysUntilDeletion} days`;
-        /* eslint-enable no-nested-ternary */
 
         return <span>{text}</span>;
     }

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -70,7 +70,6 @@ function DelegateScanningPage() {
         setIsEditing(false); // either Cancel or successful Save
     }
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <PageTitle title={displayedPageTitle} />
@@ -131,7 +130,6 @@ function DelegateScanningPage() {
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default DelegateScanningPage;

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/cluster.ts
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/cluster.ts
@@ -1,6 +1,5 @@
 import { DelegatedRegistryCluster } from 'services/DelegatedRegistryConfigService';
 
-/* eslint-disable no-nested-ternary */
 // Caller is responsible to handle special case of empty string.
 export function getClusterName(clusters: DelegatedRegistryCluster[], clusterId: string) {
     const cluster = clusters.find((cluster) => cluster.id === clusterId);
@@ -10,4 +9,3 @@ export function getClusterName(clusters: DelegatedRegistryCluster[], clusterId: 
           ? cluster.name
           : `${cluster.name} (Not available for scanning)`;
 }
-/* eslint-enable no-nested-ternary */

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -84,7 +84,6 @@ function DiscoveredClustersPage(): ReactElement {
             });
     }, [page, perPage, searchFilter, sortOption]);
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <PageSection component="div" variant="light">
@@ -143,7 +142,6 @@ function DiscoveredClustersPage(): ReactElement {
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default DiscoveredClustersPage;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -52,7 +52,6 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
             </Button>
         ) : null;
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <InitBundlesHeader headerActions={headerActions} title="Cluster init bundle" />
@@ -91,7 +90,6 @@ function InitBundlePage({ hasWriteAccessForInitBundles, id }: InitBundlePageProp
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default InitBundlePage;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -49,7 +49,6 @@ function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps)
         }
     }
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <InitBundlesHeader headerActions={headerActions} title={titleInitBundles} />
@@ -85,7 +84,6 @@ function InitBundlesPage({ hasWriteAccessForInitBundles }: InitBundlesPageProps)
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default InitBundlesPage;

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -89,7 +89,6 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
     // Because  Button is inside, it has same width at the text :(
 
     // TODO after 4.4 release add hasAdminRole to conditional rendering.
-
     return (
         <>
             <Alert

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -89,7 +89,7 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
     // Because  Button is inside, it has same width at the text :(
 
     // TODO after 4.4 release add hasAdminRole to conditional rendering.
-    /* eslint-disable no-nested-ternary */
+
     return (
         <>
             <Alert
@@ -212,7 +212,6 @@ function NoClustersPage({ isModalOpen, setIsModalOpen }): ReactElement {
             </PageSection>
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default NoClustersPage;

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -127,7 +127,6 @@ function ComplianceDashboardPage(): ReactElement {
         setIsManageStandardsModalOpen(false);
     }
 
-    /* eslint-disable no-nested-ternary */
     return (
         <>
             <PageHeader header="Compliance" subHeader="Dashboard">
@@ -251,7 +250,6 @@ function ComplianceDashboardPage(): ReactElement {
             ) : null}
         </>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default ComplianceDashboardPage;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -41,13 +41,11 @@ function ComplianceByStandards({
         );
     }
 
-    /* eslint-disable no-nested-ternary */
     const standards = !data?.results
         ? []
         : !entityType
           ? data.results
           : data.results.filter(({ scopes }) => scopes.includes(entityType));
-    /* eslint-enable no-nested-ternary */
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -63,7 +63,6 @@ function ClusterDetailsTable({
     onCheckStatusSelect,
     onClearFilters,
 }: ClusterDetailsTableProps) {
-    /* eslint-disable no-nested-ternary */
     const { page, perPage, setPage, setPerPage } = pagination;
     const { generatePathWithScanConfig } = useScanConfigRouter();
     const [expandedRows, setExpandedRows] = useState<number[]>([]);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -54,7 +54,6 @@ function ProfileChecksTable({
     getSortParams,
     onClearFilters,
 }: ProfileChecksTableProps) {
-    /* eslint-disable no-nested-ternary */
     const { generatePathWithScanConfig } = useScanConfigRouter();
     const [expandedRows, setExpandedRows] = useState<number[]>([]);
     const { searchFilter } = useURLSearch();

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
@@ -38,7 +38,6 @@ function ScanConfigsPage() {
                 <Route
                     index
                     element={
-                        // eslint-disable-next-line no-nested-ternary
                         pageAction === 'create' && hasWriteAccessForCompliance ? (
                             <CreateScanConfigPage />
                         ) : !pageAction ? (

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -173,7 +173,6 @@ function getCategoriesUtils<
     ];
 
     // For robust behavior in case of unexpected response, provide ternary fallback even though categories limited to Category0 and Category1.
-
     return {
         categoriesAlternatives,
 

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -173,7 +173,7 @@ function getCategoriesUtils<
     ];
 
     // For robust behavior in case of unexpected response, provide ternary fallback even though categories limited to Category0 and Category1.
-    /* eslint-disable no-nested-ternary */
+
     return {
         categoriesAlternatives,
 
@@ -194,7 +194,6 @@ function getCategoriesUtils<
 
         validCategories: [category0, category1],
     };
-    /* eslint-enable no-nested-ternary */
 }
 
 export const categoriesUtilsForClairifyScanner = getCategoriesUtils(

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
@@ -88,7 +88,6 @@ function ReviewPolicyForm({
      * alignSelfStretch so columns have equal height for border.
      */
 
-    /* eslint-disable no-nested-ternary */
     return (
         <Flex
             spaceItems={{ default: 'spaceItemsNone' }}
@@ -193,7 +192,6 @@ function ReviewPolicyForm({
             )}
         </Flex>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default ReviewPolicyForm;

--- a/ui/apps/platform/src/Containers/Risk/KeyValuePairs.jsx
+++ b/ui/apps/platform/src/Containers/Risk/KeyValuePairs.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -87,7 +87,6 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
      */
     const isFetchingInitialRequest = isFetching && pollingCount === 0;
 
-    /* eslint-disable no-nested-ternary */
     const icon = isFetchingInitialRequest
         ? SpinnerIcon
         : !expirationDate || !currentDatetime
@@ -177,7 +176,6 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
             </CardBody>
         </Card>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default CertificateCard;

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -54,7 +54,6 @@ function ClusterStatusCard({
      * for table of countsOverall if not healthy: HEALTHY === 0 || UNHEALTHY !== 0 || DEGRADED !== 0
      */
 
-    /* eslint-disable no-nested-ternary */
     return (
         <Card isCompact>
             <ClustersHealthCardHeader
@@ -119,7 +118,6 @@ function ClusterStatusCard({
             ) : null}
         </Card>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default ClusterStatusCard;

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealth.utils.ts
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealth.utils.ts
@@ -64,14 +64,14 @@ export function getSensorUpgradeCounts(clusters: Cluster[]): ClusterStatusCounts
                 default: {
                     const { upgradeStatus } = cluster.status || {};
                     const upgradeState = findUpgradeState(upgradeStatus);
-                    /* eslint-disable no-nested-ternary */
+
                     const key =
                         upgradeState?.type === 'current'
                             ? 'HEALTHY'
                             : upgradeState?.type === 'failure'
                               ? 'UNHEALTHY'
                               : 'DEGRADED';
-                    /* eslint-enable no-nested-ternary */
+
                     counts[key] += 1;
                 }
             }

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
@@ -23,13 +23,11 @@ function ClustersHealthCardHeader({
     isFetchingInitialRequest,
     title,
 }: ClustersHealthCardHeaderProps): ReactElement {
-    /* eslint-disable no-nested-ternary */
     const icon = isFetchingInitialRequest
         ? SpinnerIcon
         : !counts
           ? ErrorIcon
           : healthIconMap[getClustersHealthVariant(counts)];
-    /* eslint-enable no-nested-ternary */
 
     const phrase = counts === null ? '' : getClustersHealthPhrase(counts);
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -47,7 +47,6 @@ function CredentialExpirationCard({
      * for table of counts if not healthy: HEALTHY === 0 || UNHEALTHY !== 0 || DEGRADED !== 0
      */
 
-    /* eslint-disable no-nested-ternary */
     return (
         <Card isCompact>
             <ClustersHealthCardHeader
@@ -87,7 +86,6 @@ function CredentialExpirationCard({
             ) : null}
         </Card>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default CredentialExpirationCard;

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
@@ -46,7 +46,6 @@ function SensorUpgradeCard({
      * for table of counts if not healthy: HEALTHY === 0 || UNHEALTHY !== 0 || DEGRADED !== 0
      */
 
-    /* eslint-disable no-nested-ternary */
     return (
         <Card isCompact>
             <ClustersHealthCardHeader
@@ -86,7 +85,6 @@ function SensorUpgradeCard({
             ) : null}
         </Card>
     );
-    /* eslint-enable no-nested-ternary */
 }
 
 export default SensorUpgradeCard;

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
@@ -30,13 +30,13 @@ const IntegrationHealthWidgetVisual = ({
     const integrations = integrationsMerged.filter((integrationMergedItem) => {
         return integrationMergedItem.status === 'UNHEALTHY';
     });
-    /* eslint-disable no-nested-ternary */
+
     const icon = isFetchingInitialRequest
         ? SpinnerIcon
         : errorMessageFetching
           ? ErrorIcon
           : healthIconMap[integrations.length === 0 ? 'success' : 'danger'];
-    /* eslint-enable no-nested-ternary */
+
     const hasCount = !isFetchingInitialRequest && !errorMessageFetching;
 
     return (

--- a/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
@@ -54,13 +54,11 @@ function DeclarativeConfigurationHealthCard({
     const unhealthyItems = items.filter(({ status }) => status === 'UNHEALTHY');
     const unhealthyCount = unhealthyItems.length;
 
-    /* eslint-disable no-nested-ternary */
     const icon = isFetchingInitialRequest
         ? SpinnerIcon
         : errorMessageFetching
           ? ErrorIcon
           : healthIconMap[unhealthyCount === 0 ? 'success' : 'danger'];
-    /* eslint-enable no-nested-ternary */
 
     return (
         <Card isFullHeight isCompact>

--- a/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
@@ -70,13 +70,11 @@ const VulnerabilityDefinitionsHealthCard = ({
         currentDatetime &&
         differenceInMinutes(currentDatetime, lastUpdatedTimestamp) < dayInMinutes;
 
-    /* eslint-disable no-nested-ternary */
     const icon = isFetchingInitialRequest
         ? SpinnerIcon
         : errorMessageFetching
           ? ErrorIcon
           : healthIconMap[isUpToDate ? 'success' : 'danger'];
-    /* eslint-enable no-nested-ternary */
 
     return (
         <Card isCompact>

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -19,7 +19,6 @@ function ContainerConfiguration({ deployment }: ContainerConfigurationProps): Re
 
     const hasPlatformWorkloadCveLink = deployment && deployment.platformComponent;
 
-    // eslint-disable-next-line no-nested-ternary
     const vulnMgmtBasePath = !isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
         ? vulnerabilitiesWorkloadCvesPath
         : hasPlatformWorkloadCveLink

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -33,7 +33,6 @@ function DeploymentOverview({
                 desc={
                     <Link
                         to={
-                            // eslint-disable-next-line no-nested-ternary
                             !isFeatureFlagEnabled('ROX_PLATFORM_CVE_SPLIT')
                                 ? `${vulnerabilitiesWorkloadCvesPath}/deployments/${alertDeployment.id}`
                                 : hasPlatformWorkloadCveLink

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -79,13 +79,13 @@ function ViolationDetailsPage(): ReactElement {
 
     const { policy, enforcement } = alert;
     const title = policy.name || 'Unknown violation';
-    /* eslint-disable no-nested-ternary */
+
     const entityName = isResourceAlert(alert)
         ? alert.resource.clusterName
         : isDeploymentAlert(alert)
           ? alert.deployment.name
           : '';
-    /* eslint-enable no-nested-ternary */
+
     const resourceType = isResourceAlert(alert) ? alert.resource.resourceType : 'deployment';
 
     const displayedResourceType = startCase(resourceType.toLowerCase());

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 
 import CollapsibleSection from 'Components/CollapsibleSection';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import {
     Bullseye,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import {
     Bullseye,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React, { useEffect, useState } from 'react';
 import {
     Button,

--- a/ui/apps/platform/src/services/ComplianceService.ts
+++ b/ui/apps/platform/src/services/ComplianceService.ts
@@ -33,9 +33,7 @@ function compareStandardsByName(
     const { name: namePrev } = standardPrev;
     const { name: nameNext } = standardNext;
 
-    /* eslint-disable no-nested-ternary */
     return namePrev < nameNext ? -1 : namePrev > nameNext ? 1 : 0;
-    /* eslint-enable no-nested-ternary */
 }
 
 export function fetchComplianceStandardsSortedByName(): Promise<ComplianceStandardMetadata[]> {


### PR DESCRIPTION
### Description

After change to eslint.config.js file, remember to quit and then restart Visual Studio Code.

Team agreed some time ago, but waited until after 4.8 release.

Pattern to conditionally render is especially clear and concise:

```tsx
{isLoading ? (…) : errorMessage ? (…) : (…)}
```

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run lint:fix` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
3. `npm run tsc` in ui/apps/platform folder.
