### PR TITLE
ROX-29570: Give same RBAC to Flows as Baseline in Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
@@ -2,19 +2,41 @@ import React from 'react';
 import pluralize from 'pluralize';
 import { Button } from '@patternfly/react-core';
 
+import useInterval from 'hooks/useInterval';
+import { fetchNodeUpdates } from 'services/NetworkService';
+
 type NodeUpdateSectionProps = {
     isLoading: boolean;
     lastUpdatedTime: string;
+    namespacesFromUrl: string[];
     nodeUpdatesCount: number;
+    selectedClusterId: string;
+    setCurrentEpochCount: (number) => void;
     updateNetworkNodes: () => void;
 };
 
 const NodeUpdateSection = ({
     isLoading,
     lastUpdatedTime,
+    namespacesFromUrl,
     nodeUpdatesCount,
+    selectedClusterId,
+    setCurrentEpochCount,
     updateNetworkNodes,
 }: NodeUpdateSectionProps) => {
+    // Update the poll epoch after 30 seconds to update the node count for a cluster.
+    useInterval(() => {
+        if (selectedClusterId && namespacesFromUrl.length > 0) {
+            fetchNodeUpdates(selectedClusterId)
+                .then((result) => {
+                    setCurrentEpochCount(result?.response?.epoch ?? 0);
+                })
+                .catch(() => {
+                    // failure to update the node count is not critical
+                });
+        }
+    }, 30000);
+
     if (!isLoading && nodeUpdatesCount > 0) {
         return (
             <Button
@@ -27,7 +49,7 @@ const NodeUpdateSection = ({
         );
     }
 
-    return <em>Last updated {lastUpdatedTime ? `at ${lastUpdatedTime}` : 'never'}</em>;
+    return <>Last updated {lastUpdatedTime ? `at ${lastUpdatedTime}` : 'never'}</>;
 };
 
 export default NodeUpdateSection;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousFlows.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { FlexItem, Label } from '@patternfly/react-core';
+import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import pluralize from 'pluralize';
+
+import { Flow } from '../types/flow.type';
+import {
+    getNumAnomalousExternalFlows,
+    getNumAnomalousInternalFlows,
+} from '../utils/networkGraphUtils';
+
+export type AnomalousFlowsProps = {
+    networkFlows: Flow[];
+};
+
+function AnomalousFlows({ networkFlows }: AnomalousFlowsProps) {
+    const numAnomalousExternalFlows = getNumAnomalousExternalFlows(networkFlows);
+    const numAnomalousInternalFlows = getNumAnomalousInternalFlows(networkFlows);
+
+    if (numAnomalousExternalFlows === 0 && numAnomalousInternalFlows === 0) {
+        return <>None</>;
+    }
+
+    return (
+        <>
+            {numAnomalousExternalFlows !== 0 && (
+                <FlexItem>
+                    <Label variant="outline" color="red" icon={<ExclamationCircleIcon />}>
+                        {numAnomalousExternalFlows} external{' '}
+                        {pluralize('flow', numAnomalousExternalFlows)}
+                    </Label>
+                </FlexItem>
+            )}
+            {numAnomalousInternalFlows !== 0 && (
+                <FlexItem>
+                    <Label variant="outline" color="gold" icon={<ExclamationTriangleIcon />}>
+                        {numAnomalousInternalFlows} internal{' '}
+                        {pluralize('flow', numAnomalousInternalFlows)}
+                    </Label>
+                </FlexItem>
+            )}
+        </>
+    );
+}
+
+export default AnomalousFlows;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousTraffic.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousTraffic.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+    Alert,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    Spinner,
+} from '@patternfly/react-core';
+
+import useFetchNetworkFlows from '../api/useFetchNetworkFlows';
+import { EdgeState } from '../components/EdgeStateSelect';
+import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+
+import AnomalousFlows from './AnomalousFlows';
+
+export type AnomalousTrafficProps = {
+    deploymentId: string;
+    edgeState: EdgeState;
+    edges: CustomEdgeModel[];
+    nodes: CustomNodeModel[];
+};
+
+function AnomalousTraffic({ deploymentId, edgeState, edges, nodes }: AnomalousTrafficProps) {
+    const {
+        isLoading,
+        error,
+        data: { networkFlows },
+    } = useFetchNetworkFlows({ deploymentId, edgeState, edges, nodes });
+
+    return (
+        <DescriptionListGroup>
+            <DescriptionListTerm>Anomalous traffic</DescriptionListTerm>
+            <DescriptionListDescription>
+                <Flex
+                    direction={{ default: 'row' }}
+                    justifyContent={{ default: 'justifyContentCenter' }}
+                >
+                    {isLoading ? (
+                        <Spinner />
+                    ) : error ? (
+                        <Alert
+                            variant="warning"
+                            title="Unable to fetch network flows"
+                            isInline
+                            component="p"
+                            className="pf-v5-u-w-100"
+                        >
+                            {error}
+                        </Alert>
+                    ) : (
+                        <AnomalousFlows networkFlows={networkFlows} />
+                    )}
+                </Flex>
+            </DescriptionListDescription>
+        </DescriptionListGroup>
+    );
+}
+
+export default AnomalousTraffic;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
@@ -19,6 +19,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 
 import download from 'utils/download';
+import usePermissions from 'hooks/usePermissions';
 import { Deployment } from 'types/deployment.proto';
 import { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
@@ -44,6 +45,9 @@ type DeploymentBaselineProps = {
 };
 
 function DeploymentBaseline({ deployment, deploymentId, onNodeSelect }: DeploymentBaselineProps) {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForActions = hasReadWriteAccess('DeploymentExtension');
+
     // component state
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
@@ -208,15 +212,17 @@ function DeploymentBaseline({ deployment, deploymentId, onNodeSelect }: Deployme
                             <ToolbarItem>
                                 <FlowsTableHeaderText type="baseline" numFlows={numBaselines} />
                             </ToolbarItem>
-                            <ToolbarItem align={{ default: 'alignRight' }}>
-                                <FlowsBulkActions
-                                    type="baseline"
-                                    selectedRows={selectedRows}
-                                    onClearSelectedRows={() => setSelectedRows([])}
-                                    markSelectedAsAnomalous={markSelectedAsAnomalous}
-                                    addSelectedToBaseline={addSelectedToBaseline}
-                                />
-                            </ToolbarItem>
+                            {hasWriteAccessForActions && (
+                                <ToolbarItem align={{ default: 'alignRight' }}>
+                                    <FlowsBulkActions
+                                        type="baseline"
+                                        selectedRows={selectedRows}
+                                        onClearSelectedRows={() => setSelectedRows([])}
+                                        markSelectedAsAnomalous={markSelectedAsAnomalous}
+                                        addSelectedToBaseline={addSelectedToBaseline}
+                                    />
+                                </ToolbarItem>
+                            )}
                         </ToolbarContent>
                     </Toolbar>
                 </StackItem>
@@ -231,7 +237,7 @@ function DeploymentBaseline({ deployment, deploymentId, onNodeSelect }: Deployme
                         setSelectedRows={setSelectedRows}
                         addToBaseline={addToBaseline}
                         markAsAnomalous={markAsAnomalous}
-                        isEditable
+                        isEditable={hasWriteAccessForActions}
                         onSelectFlow={onSelectFlow}
                     />
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import {
-    Button,
     DescriptionList,
     DescriptionListDescription,
     DescriptionListGroup,
@@ -18,13 +17,11 @@ import {
     Title,
     EmptyStateHeader,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
-import pluralize from 'pluralize';
 
+import usePermissions from 'hooks/usePermissions';
 import { Deployment } from 'types/deployment.proto';
 import { ListenPort } from 'types/networkFlow.proto';
 import { getDateTime } from 'utils/dateUtils';
-import { NetworkPolicyState } from 'Containers/NetworkGraph/types/topology.type';
 
 import DeploymentPortConfig from 'Components/DeploymentPortConfig';
 import DeploymentContainerConfig from 'Components/DeploymentContainerConfig';
@@ -34,16 +31,21 @@ import EgressOnly from 'images/network-graph/egress-only.svg?react';
 import IngressOnly from 'images/network-graph/ingress-only.svg?react';
 import NoPolicyRules from 'images/network-graph/no-policy-rules.svg?react';
 
-import { useSidePanelTab } from '../NetworkGraphURLStateContext';
+import { EdgeState } from '../components/EdgeStateSelect';
+import { CustomEdgeModel, CustomNodeModel, NetworkPolicyState } from '../types/topology.type';
+
+import AnomalousTraffic from './AnomalousTraffic';
 
 import './DeploymentDetails.css';
 
 type DeploymentDetailsProps = {
     deployment: Deployment;
-    numAnomalousExternalFlows: number;
-    numAnomalousInternalFlows: number;
+    deploymentId: string;
+    edgeState: EdgeState;
+    edges: CustomEdgeModel[];
     listenPorts: ListenPort[];
     networkPolicyState: NetworkPolicyState;
+    nodes: CustomNodeModel[];
 };
 
 function DetailSection({ title, children }) {
@@ -71,23 +73,18 @@ function DetailSection({ title, children }) {
 
 function DeploymentDetails({
     deployment,
-    numAnomalousExternalFlows,
-    numAnomalousInternalFlows,
+    deploymentId,
+    edgeState,
+    edges,
     listenPorts,
     networkPolicyState,
+    nodes,
 }: DeploymentDetailsProps) {
     const labelKeys = Object.keys(deployment.labels);
     const annotationKeys = Object.keys(deployment.annotations);
 
-    const { setSelectedTabSidePanel } = useSidePanelTab();
-
-    const onNetworkFlowsTabSelect = () => {
-        setSelectedTabSidePanel('FLOWS');
-    };
-
-    const onNetworkPoliciesTabSelect = () => {
-        setSelectedTabSidePanel('NETWORK_POLICIES');
-    };
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForNetworkPolicy = hasReadAccess('NetworkPolicy');
 
     return (
         <div className="pf-v5-u-h-100 pf-v5-u-p-md">
@@ -95,159 +92,68 @@ function DeploymentDetails({
                 <li>
                     <DetailSection title="Network security">
                         <DescriptionList columnModifier={{ default: '1Col' }}>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Anomalous traffic</DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Flex
-                                        direction={{ default: 'row' }}
-                                        alignItems={{ default: 'alignItemsCenter' }}
-                                    >
-                                        {numAnomalousExternalFlows === 0 &&
-                                            numAnomalousInternalFlows === 0 &&
-                                            'None'}
-                                        {numAnomalousExternalFlows !== 0 && (
-                                            <FlexItem>
-                                                <Button
-                                                    variant="link"
-                                                    isInline
-                                                    onClick={onNetworkFlowsTabSelect}
-                                                >
-                                                    <Label
-                                                        variant="outline"
-                                                        color="red"
-                                                        icon={<ExclamationCircleIcon />}
-                                                    >
-                                                        {numAnomalousExternalFlows} external{' '}
-                                                        {pluralize(
-                                                            'flow',
-                                                            numAnomalousExternalFlows
-                                                        )}
-                                                    </Label>
-                                                </Button>
-                                            </FlexItem>
-                                        )}
-                                        {numAnomalousInternalFlows !== 0 && (
-                                            <FlexItem>
-                                                <Button
-                                                    variant="link"
-                                                    isInline
-                                                    onClick={onNetworkFlowsTabSelect}
-                                                >
-                                                    <Label
-                                                        variant="outline"
-                                                        color="gold"
-                                                        icon={<ExclamationTriangleIcon />}
-                                                    >
-                                                        {numAnomalousInternalFlows} internal{' '}
-                                                        {pluralize(
-                                                            'flow',
-                                                            numAnomalousInternalFlows
-                                                        )}
-                                                    </Label>
-                                                </Button>
-                                            </FlexItem>
-                                        )}
-                                    </Flex>
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
+                            {hasReadAccessForNetworkPolicy && (
+                                <AnomalousTraffic
+                                    deploymentId={deploymentId}
+                                    edgeState={edgeState}
+                                    edges={edges}
+                                    nodes={nodes}
+                                />
+                            )}
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Network policy rules</DescriptionListTerm>
                                 <DescriptionListDescription>
                                     {networkPolicyState === 'both' && (
-                                        <Button
-                                            variant="link"
-                                            isInline
-                                            onClick={onNetworkPoliciesTabSelect}
+                                        <Label
+                                            variant="outline"
+                                            color="blue"
+                                            icon={<BothPolicyRules width="22px" height="22px" />}
                                         >
-                                            <Label
-                                                variant="outline"
-                                                color="blue"
-                                                icon={
-                                                    <BothPolicyRules width="22px" height="22px" />
-                                                }
-                                            >
-                                                1 or more policies regulating bidirectional traffic
-                                            </Label>
-                                        </Button>
+                                            1 or more policies regulating bidirectional traffic
+                                        </Label>
                                     )}
                                     {networkPolicyState === 'egress' && (
                                         <LabelGroup>
-                                            <Button
-                                                variant="link"
-                                                isInline
-                                                onClick={onNetworkPoliciesTabSelect}
+                                            <Label
+                                                variant="outline"
+                                                color="red"
+                                                icon={<NoPolicyRules width="22px" height="22px" />}
                                             >
-                                                <Label
-                                                    variant="outline"
-                                                    color="red"
-                                                    icon={
-                                                        <NoPolicyRules width="22px" height="22px" />
-                                                    }
-                                                >
-                                                    A missing policy is allowing all ingress traffic
-                                                </Label>
-                                            </Button>
-                                            <Button
-                                                variant="link"
-                                                isInline
-                                                onClick={onNetworkPoliciesTabSelect}
+                                                A missing policy is allowing all ingress traffic
+                                            </Label>
+                                            <Label
+                                                variant="outline"
+                                                color="blue"
+                                                icon={<EgressOnly width="22px" height="22px" />}
                                             >
-                                                <Label
-                                                    variant="outline"
-                                                    color="blue"
-                                                    icon={<EgressOnly width="22px" height="22px" />}
-                                                >
-                                                    1 or more policies regulating egress traffic
-                                                </Label>
-                                            </Button>
+                                                1 or more policies regulating egress traffic
+                                            </Label>
                                         </LabelGroup>
                                     )}
                                     {networkPolicyState === 'ingress' && (
                                         <LabelGroup>
-                                            <Button
-                                                variant="link"
-                                                isInline
-                                                onClick={onNetworkPoliciesTabSelect}
-                                            >
-                                                <Label
-                                                    variant="outline"
-                                                    icon={
-                                                        <NoPolicyRules width="22px" height="22px" />
-                                                    }
-                                                >
-                                                    A missing policy is allowing all egress traffic
-                                                </Label>
-                                            </Button>
-                                            <Button
-                                                variant="link"
-                                                isInline
-                                                onClick={onNetworkPoliciesTabSelect}
-                                            >
-                                                <Label
-                                                    variant="outline"
-                                                    color="blue"
-                                                    icon={
-                                                        <IngressOnly width="22px" height="22px" />
-                                                    }
-                                                >
-                                                    1 or more policies regulating ingress traffic
-                                                </Label>
-                                            </Button>
-                                        </LabelGroup>
-                                    )}
-                                    {networkPolicyState === 'none' && (
-                                        <Button
-                                            variant="link"
-                                            isInline
-                                            onClick={onNetworkPoliciesTabSelect}
-                                        >
                                             <Label
                                                 variant="outline"
                                                 icon={<NoPolicyRules width="22px" height="22px" />}
                                             >
-                                                A missing policy is allowing all network traffic
+                                                A missing policy is allowing all egress traffic
                                             </Label>
-                                        </Button>
+                                            <Label
+                                                variant="outline"
+                                                color="blue"
+                                                icon={<IngressOnly width="22px" height="22px" />}
+                                            >
+                                                1 or more policies regulating ingress traffic
+                                            </Label>
+                                        </LabelGroup>
+                                    )}
+                                    {networkPolicyState === 'none' && (
+                                        <Label
+                                            variant="outline"
+                                            icon={<NoPolicyRules width="22px" height="22px" />}
+                                        >
+                                            A missing policy is allowing all network traffic
+                                        </Label>
                                     )}
                                 </DescriptionListDescription>
                             </DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -5,12 +5,13 @@ import useAnalytics, { DEPLOYMENT_FLOWS_TOGGLE_CLICKED } from 'hooks/useAnalytic
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { QueryValue } from 'hooks/useURLParameter';
 
-import { CustomNodeModel } from '../types/topology.type';
+import useFetchNetworkFlows from '../api/useFetchNetworkFlows';
 import { EdgeState } from '../components/EdgeStateSelect';
-import { Flow } from '../types/flow.type';
+import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import { isInternalFlow } from '../utils/networkGraphUtils';
+
 import InternalFlows from './InternalFlows';
 import ExternalFlows from './ExternalFlows';
-import { isInternalFlow } from '../utils/networkGraphUtils';
 
 import {
     usePagination,
@@ -32,24 +33,18 @@ export function isValidDeploymentFlowsToggle(value: QueryValue): value is Deploy
 
 type DeploymentFlowsProps = {
     deploymentId: string;
-    nodes: CustomNodeModel[];
     edgeState: EdgeState;
+    edges: CustomEdgeModel[];
+    nodes: CustomNodeModel[];
     onNodeSelect: (id: string) => void;
-    isLoadingNetworkFlows: boolean;
-    networkFlowsError: string;
-    networkFlows: Flow[];
-    refetchFlows: () => void;
 };
 
 function DeploymentFlows({
     deploymentId,
     nodes,
     edgeState,
+    edges,
     onNodeSelect,
-    isLoadingNetworkFlows,
-    networkFlowsError,
-    networkFlows,
-    refetchFlows,
 }: DeploymentFlowsProps) {
     const { analyticsTrack } = useAnalytics();
     const { isFeatureFlagEnabled } = useFeatureFlags();
@@ -95,6 +90,13 @@ function DeploymentFlows({
             setSelectedToggleSidePanel,
         ]
     );
+
+    const {
+        isLoading: isLoadingNetworkFlows,
+        error: networkFlowsError,
+        data: { networkFlows },
+        refetchFlows,
+    } = useFetchNetworkFlows({ deploymentId, edgeState, edges, nodes });
 
     if (!isNetworkGraphExternalIpsEnabled) {
         return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -18,6 +18,8 @@ import {
 import useFetchDeployment from 'hooks/useFetchDeployment';
 import usePermissions, { HasReadAccess } from 'hooks/usePermissions';
 import { QueryValue } from 'hooks/useURLParameter';
+import { ensureExhaustive } from 'utils/type.utils';
+
 import { getListenPorts, getNodeById } from '../utils/networkGraphUtils';
 import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
@@ -52,8 +54,10 @@ function hasReadAccessForDeploymentTab(hasReadAccess: HasReadAccess, tabKey: Dep
             return hasReadAccess('DeploymentExtension');
         case 'NETWORK_POLICIES':
             return hasReadAccess('NetworkPolicy');
-        default:
+        case 'DETAILS':
             return true;
+        default:
+            return ensureExhaustive(tabKey);
     }
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/InternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/InternalFlows.tsx
@@ -16,6 +16,7 @@ import {
 } from '@patternfly/react-core';
 import pluralize from 'pluralize';
 
+import usePermissions from 'hooks/usePermissions';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useModifyBaselineStatuses from '../api/useModifyBaselineStatuses';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
@@ -61,6 +62,9 @@ function InternalFlows({
     networkFlows,
     refetchFlows,
 }: InternalFlowsProps) {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForActions = hasReadWriteAccess('DeploymentExtension');
+
     // component state
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
     const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
@@ -178,18 +182,20 @@ function InternalFlows({
                         <ToolbarItem>
                             <FlowsTableHeaderText type={edgeState} numFlows={totalFlows} />
                         </ToolbarItem>
-                        <ToolbarItem align={{ default: 'alignRight' }}>
-                            <FlowsBulkActions
-                                type="active"
-                                selectedRows={selectedRows}
-                                onClearSelectedRows={() => {
-                                    setSelectedAnomalousRows([]);
-                                    setSelectedBaselineRows([]);
-                                }}
-                                markSelectedAsAnomalous={markSelectedAsAnomalous}
-                                addSelectedToBaseline={addSelectedToBaseline}
-                            />
-                        </ToolbarItem>
+                        {hasWriteAccessForActions && (
+                            <ToolbarItem align={{ default: 'alignRight' }}>
+                                <FlowsBulkActions
+                                    type="active"
+                                    selectedRows={selectedRows}
+                                    onClearSelectedRows={() => {
+                                        setSelectedAnomalousRows([]);
+                                        setSelectedBaselineRows([]);
+                                    }}
+                                    markSelectedAsAnomalous={markSelectedAsAnomalous}
+                                    addSelectedToBaseline={addSelectedToBaseline}
+                                />
+                            </ToolbarItem>
+                        )}
                     </ToolbarContent>
                 </Toolbar>
             </StackItem>
@@ -217,7 +223,7 @@ function InternalFlows({
                                     markAsAnomalous={markAsAnomalous}
                                     numExtraneousEgressFlows={numExtraneousEgressFlows}
                                     numExtraneousIngressFlows={numExtraneousIngressFlows}
-                                    isEditable
+                                    isEditable={hasWriteAccessForActions}
                                     onSelectFlow={onSelectFlow}
                                 />
                             ) : (
@@ -247,7 +253,7 @@ function InternalFlows({
                                     markAsAnomalous={markAsAnomalous}
                                     numExtraneousEgressFlows={numExtraneousEgressFlows}
                                     numExtraneousIngressFlows={numExtraneousIngressFlows}
-                                    isEditable
+                                    isEditable={hasWriteAccessForActions}
                                     onSelectFlow={onSelectFlow}
                                 />
                             ) : (


### PR DESCRIPTION
### Description

**Hide space** for review to reduce changed lines because of indentation.

### Problems

Read requests have 403 **Forbidden** status:
* Node updates at upper right
* **Details** tab of deployment side panel
* **Flows** tab of deployment side panel

Write requests have 403 **Forbidden** status:
* Bulk or row actions on **Flows** and **Baseline** tabs

Rendering of empty tab in deployment side panel:
* Link from label in **Details** tab to **Network Policies** tab
* After excellent improvement by **Brad** to include tab in page address query string, link shared by sender who has permission **Flows**, **Baseline**, or **Network policies** tabs, but recipient does not

### Analysis

Some hooks make requests have been added to `InternalFlows` and `ExternalFlows` compoents for External IPs effort, since I added conditional rendering for **Baseline** tab in #8335

* `NetworkGraphPage` makes `fetchNodesUpdate` request which requires `NetworkPolicy` resource.
* `DeploymentSideBar` has `useFetchNetworkFlows` hook which requires `NetworkPolicy` resource.
* `DeploymentFlows` component renders `ExternalFlows` element which has `useNetworkBaselineStatus` hook and `InternalFlows` element which has `useModifyBaselineStatuses` hook.
* `InternalFlows` does not conditionally render `FlowsBulkAction` and unconditionally sets `isEditable` prop

### Solution

1. Move requests into conditionally rendered elements.
1. Provide same conditional rendering for `Tab` and `TabContent` elements.
    Add sister predicate `hasReadAccessForDeploymentTab` to `isValidDeploymentTab` that Brad added recently, to fall back to **Details** tab.
3. Delete unique `Button` like for `Label` idiom to switch tab.

### Residue

1. Add `'no-Button-Label'` lint rule.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform
2. `npm run lint` in ui/apps/platform
3. `npm run start` in ui/apps/platform

#### Manual testing

Thank you **David Vail** for recipe to test user role permissions: `'NetworkGraph'` and `'Deployment'`, but not `'DeploymentExtension'` nor  `'NetworkPolicy'`

1. Visit /main/network-graph select cluster and namespace

    Before changes without conditional rendering, **Last updated** at upper right plus request every 30 seconds:

    GET /v1/networkpolicies/graph/epoch?clusterId=id has 403 **Forbidden** status

    ![epoch_403_Forbidden](https://github.com/user-attachments/assets/ceff48d6-1316-47c8-a8e7-8e9180c71284)

    After changes with conditional rendering, see absence of **Last updated** at upper right
    ![NodeUpdateSection](https://github.com/user-attachments/assets/b3fa20ab-29b1-4617-982a-dd2033a18adc)

2. Click a deployment to open sidebar.

    Before changes without conditional rendering, see absence of **Baseline** tab but presence of **Flows** tab, also presence of **Anomalous traffic** heading on **Details** tab, plus request:

    POST /v1/networkbaseline/id/status has 403 **Forbidden** status


    After changes with conditional rendering, see absence of **Baseline** and **Flows** tabs, also **Anomalous traffic** heading on **Details** tab.
    ![Details_without_conditional_rendering](https://github.com/user-attachments/assets/ae6a45c6-fb66-45d4-b836-6c4791cf6184)

    See absence of **Network policy** tab.

    Before changes without conditional rendering, see presence of **Network policy rules** heading on **Details** tab and click label to see empty sidebar, because calls handler to change tab.
    ![Network_policies_empty](https://github.com/user-attachments/assets/ad2e5d22-72ac-47eb-947a-8728281fb0a4)

3. Add `DeploymentExtension` resource with `READ_ACCESS` level

    Before changes, click **Bulk actions** item or row action
    PATCH /v1/networkbaseline/id/peers has 403 **Forbidden** status
