### PR TITLE
ROX-29650: bump go to 1.24

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 run:
   timeout: 240m
-  go: "1.23"
+  go: "1.24"
   build-tags:
     - integration
     - scanner_db_integration

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox
 
-go 1.23.4
-
-toolchain go1.23.6
+go 1.24
 
 require (
 	cloud.google.com/go/artifactregistry v1.17.1

--- a/operator/tools/controller-gen/go.mod
+++ b/operator/tools/controller-gen/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox/operator/tools/controller-gen
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24
 
 require sigs.k8s.io/controller-tools v0.16.5
 

--- a/operator/tools/envtest/go.mod
+++ b/operator/tools/envtest/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox/operator/tools/envtest
 
-go 1.23
-
-toolchain go1.23.2
+go 1.24
 
 require sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240215124517-56159419231e
 

--- a/operator/tools/kustomize/go.mod
+++ b/operator/tools/kustomize/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox/operator/tools/kustomize
 
-go 1.23
-
-toolchain go1.23.2
+go 1.24
 
 require sigs.k8s.io/kustomize/kustomize/v5 v5.7.0
 

--- a/operator/tools/kuttl/go.mod
+++ b/operator/tools/kuttl/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox/operator/tools/kuttl
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24
 
 require github.com/kudobuilder/kuttl v0.22.0
 

--- a/operator/tools/operator-sdk/go.mod
+++ b/operator/tools/operator-sdk/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/rox/operator/tools/operator-sdk
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24
 
 require (
 	github.com/operator-framework/operator-lifecycle-manager v0.30.0

--- a/scanner/hack/quay/go.mod
+++ b/scanner/hack/quay/go.mod
@@ -1,5 +1,5 @@
 module github.com/stackrox/rox/scanner/hack/quay
 
-go 1.23
+go 1.24
 
 toolchain go1.23.2

--- a/tests/performance/scale/go.mod
+++ b/tests/performance/scale/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/stackrox/performance-scale-tests
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24
 
 require (
 	github.com/cloud-bulldozer/go-commons v1.0.11

--- a/tools/check-workflow-run/go.mod
+++ b/tools/check-workflow-run/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/stackrox/tools/check-workflow-run
 
-go 1.23
-
-toolchain go1.23.2
+go 1.24
 
 require github.com/google/go-github/v61 v61.0.0
 

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/stackrox/tools/linters
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.24
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.2.1

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/stackrox/tools/test
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24
 
 require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0


### PR DESCRIPTION
This is the last PR in series and bumps go in go.mod to allow using all features of go 1.24

- https://github.com/openshift/release/pull/65929
- https://github.com/stackrox/stackrox/pull/15668