### PR TITLE
ROX-29311: Use retrying dial TLS wrapper functions

### DIFF
--- a/pkg/tlsutils/dial_context.go
+++ b/pkg/tlsutils/dial_context.go
@@ -26,26 +26,10 @@ func DialContextWithRetries(ctx context.Context, network, addr string, tlsConfig
 }
 
 func isPermanentError(err error) bool {
-	permanentErrorChecks := []func(error) bool{
-		func(err error) bool {
-			return errors.As(err, &x509.CertificateInvalidError{})
-		},
-		func(err error) bool {
-			return errors.As(err, &x509.HostnameError{})
-		},
-		func(err error) bool {
-			return errors.As(err, &x509.UnknownAuthorityError{})
-		},
-		func(err error) bool {
-			return errors.As(err, &x509.SystemRootsError{})
-		},
-	}
-	for _, isPermanent := range permanentErrorChecks {
-		if isPermanent(err) {
-			return true
-		}
-	}
-	return false
+	return errors.As(err, &x509.CertificateInvalidError{}) ||
+		errors.As(err, &x509.HostnameError{}) ||
+		errors.As(err, &x509.UnknownAuthorityError{}) ||
+		errors.As(err, &x509.SystemRootsError{})
 }
 
 func DialContextWithRetriesWithDialer(ctx context.Context, dialer tls.Dialer, network, addr string) (*tls.Conn, error) {

--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -190,8 +190,11 @@ func (c *endpointsTestCase) runConnectionTest(t *testing.T, testCtx *endpointsTe
 	invalidServerNames.RemoveAll(c.validServerNames...)
 	nameErr := &x509.HostnameError{}
 	for serverName := range invalidServerNames {
-		tlsConf := testCtx.tlsConfig(c.clientCert, serverName, true)
-		conn, err := tls.DialWithDialer(&dialer, "tcp", c.endpoint(), tlsConf)
+		testDialer := tls.Dialer{
+			NetDialer: &dialer,
+			Config:    testCtx.tlsConfig(c.clientCert, serverName, true),
+		}
+		conn, err := tlsutils.DialContextWithRetriesWithDialer(context.Background(), testDialer, "tcp", c.endpoint())
 		if conn != nil {
 			_ = conn.Close()
 		}


### PR DESCRIPTION
### Description

Small test stability improvement, very similar to https://github.com/stackrox/stackrox/pull/15844.

Tracking JIRA: https://issues.redhat.com/browse/ROX-29311

### User-facing documentation

Just test changes, nothing user-facing.

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Just CI.

