### PR TITLE
fix(CI): free more space for build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,6 +119,7 @@ jobs:
 
       - uses: ./.github/actions/job-preamble
         with:
+          free-disk-space: 30
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
       - uses: ./.github/actions/cache-ui-dependencies
@@ -600,6 +601,7 @@ jobs:
 
       - uses: ./.github/actions/job-preamble
         with:
+          free-disk-space: 30
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
       - name: Cache Go dependencies

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -100,6 +100,7 @@ jobs:
 
       - uses: ./.github/actions/job-preamble
         with:
+          free-disk-space: '30'
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
       - name: Cache Go dependencies
@@ -134,6 +135,7 @@ jobs:
 
     - uses: ./.github/actions/job-preamble
       with:
+        free-disk-space: '30'
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Cache Go dependencies


### PR DESCRIPTION
By default we free only 24GB and this is not enought to build as observed in https://github.com/stackrox/stackrox/actions/runs/16038722150/job/45256004567
