### PR TITLE
ROX-29794: Sensor status to scan config cluster status

### DIFF
--- a/central/complianceoperator/v2/integration/service/service_impl.go
+++ b/central/complianceoperator/v2/integration/service/service_impl.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/cluster/datastore"
 	complianceDS "github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
 	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authz"
@@ -21,6 +23,10 @@ import (
 
 const (
 	maxPaginationLimit = 1000
+
+	fmtGetClusterErr       = "Unable to get information for cluster %q."
+	fmtGetClusterNotFound  = "Cluster %q not found."
+	fmtGetClusterUnhealthy = "Sensor connection to cluster %q is not healthy."
 )
 
 var (
@@ -82,6 +88,22 @@ func (s *serviceImpl) ListComplianceIntegrations(ctx context.Context, req *v2.Ra
 	apiIntegrations, err := convertStorageProtos(ctx, integrations, s.complianceMetaDataStore)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert compliance integrations.")
+	}
+
+	// Enrich cluster status with sensor connection status.
+	for _, apiIntegration := range apiIntegrations {
+		cluster, found, err := s.clusterDS.GetCluster(ctx, apiIntegration.GetClusterId())
+		if err != nil {
+			apiIntegration.StatusErrors = append(apiIntegration.StatusErrors, fmt.Sprintf(fmtGetClusterErr, apiIntegration.GetClusterName()))
+			continue
+		}
+		if !found {
+			apiIntegration.StatusErrors = append(apiIntegration.StatusErrors, fmt.Sprintf(fmtGetClusterNotFound, apiIntegration.GetClusterName()))
+			continue
+		}
+		if cluster.GetHealthStatus().GetSensorHealthStatus() != storage.ClusterHealthStatus_HEALTHY {
+			apiIntegration.StatusErrors = append(apiIntegration.StatusErrors, fmt.Sprintf(fmtGetClusterUnhealthy, apiIntegration.GetClusterName()))
+		}
 	}
 
 	integrationCount, err := s.complianceMetaDataStore.CountIntegrations(ctx, countQuery)

--- a/central/complianceoperator/v2/integration/service/service_impl_test.go
+++ b/central/complianceoperator/v2/integration/service/service_impl_test.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	"github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore"
 	"github.com/stackrox/rox/central/complianceoperator/v2/integration/datastore/mocks"
@@ -58,19 +60,31 @@ func (s *ComplianceIntegrationServiceTestSuite) SetupSuite() {
 	s.service = New(s.complianceIntegrationDataStore, s.clusterDatastore)
 }
 
+type sensorHealthStateReturn struct {
+	healthStatus storage.ClusterHealthStatus_HealthStatusLabel
+	found        bool
+	err          error
+}
+
 func (s *ComplianceIntegrationServiceTestSuite) TestListComplianceIntegrations() {
 	allAccessContext := sac.WithAllAccess(context.Background())
 	testCases := []struct {
-		desc           string
-		query          *apiV2.RawQuery
-		expectedQ      *v1.Query
-		expectedCountQ *v1.Query
+		desc              string
+		query             *apiV2.RawQuery
+		expectedQ         *v1.Query
+		expectedCountQ    *v1.Query
+		sensorHealthState sensorHealthStateReturn
 	}{
 		{
 			desc:           "Empty query",
 			query:          &apiV2.RawQuery{Query: ""},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
+			sensorHealthState: sensorHealthStateReturn{
+				healthStatus: storage.ClusterHealthStatus_HEALTHY,
+				found:        true,
+				err:          nil,
+			},
 		},
 		{
 			desc:  "Query with search field",
@@ -78,6 +92,11 @@ func (s *ComplianceIntegrationServiceTestSuite) TestListComplianceIntegrations()
 			expectedQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").
 				WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").ProtoQuery(),
+			sensorHealthState: sensorHealthStateReturn{
+				healthStatus: storage.ClusterHealthStatus_HEALTHY,
+				found:        true,
+				err:          nil,
+			},
 		},
 		{
 			desc: "Query with custom pagination",
@@ -87,6 +106,41 @@ func (s *ComplianceIntegrationServiceTestSuite) TestListComplianceIntegrations()
 			},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(1)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
+			sensorHealthState: sensorHealthStateReturn{
+				healthStatus: storage.ClusterHealthStatus_HEALTHY,
+				found:        true,
+				err:          nil,
+			},
+		},
+		{
+			desc:           "Fetch cluster failed",
+			query:          &apiV2.RawQuery{Query: ""},
+			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
+			expectedCountQ: search.EmptyQuery(),
+			sensorHealthState: sensorHealthStateReturn{
+				err: errors.New("DB error"),
+			},
+		},
+		{
+			desc:           "Cluster not found",
+			query:          &apiV2.RawQuery{Query: ""},
+			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
+			expectedCountQ: search.EmptyQuery(),
+			sensorHealthState: sensorHealthStateReturn{
+				found: false,
+				err:   nil,
+			},
+		},
+		{
+			desc:           "Sensor connection is not established",
+			query:          &apiV2.RawQuery{Query: ""},
+			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
+			expectedCountQ: search.EmptyQuery(),
+			sensorHealthState: sensorHealthStateReturn{
+				healthStatus: storage.ClusterHealthStatus_DEGRADED,
+				found:        true,
+				err:          nil,
+			},
 		},
 	}
 
@@ -110,6 +164,15 @@ func (s *ComplianceIntegrationServiceTestSuite) TestListComplianceIntegrations()
 				TotalCount: 6,
 			}
 
+			// Adjust expected response for sensor connection status
+			if tc.sensorHealthState.err != nil {
+				expectedResp.Integrations[0].StatusErrors = append(expectedResp.Integrations[0].StatusErrors, fmt.Sprintf(fmtGetClusterErr, mockClusterName))
+			} else if !tc.sensorHealthState.found {
+				expectedResp.Integrations[0].StatusErrors = append(expectedResp.Integrations[0].StatusErrors, fmt.Sprintf(fmtGetClusterNotFound, mockClusterName))
+			} else if tc.sensorHealthState.healthStatus != storage.ClusterHealthStatus_HEALTHY {
+				expectedResp.Integrations[0].StatusErrors = append(expectedResp.Integrations[0].StatusErrors, fmt.Sprintf(fmtGetClusterUnhealthy, mockClusterName))
+			}
+
 			s.complianceIntegrationDataStore.EXPECT().GetComplianceIntegration(gomock.Any(), gomock.Any()).Return(&storage.ComplianceIntegration{
 				Id:                  uuid.NewDummy().String(),
 				Version:             "22",
@@ -117,6 +180,8 @@ func (s *ComplianceIntegrationServiceTestSuite) TestListComplianceIntegrations()
 				ComplianceNamespace: fixtureconsts.Namespace1,
 				StatusErrors:        []string{"Error 1", "Error 2", "Error 3"},
 			}, true, nil).Times(1)
+
+			s.clusterDatastore.EXPECT().GetCluster(gomock.Any(), gomock.Any()).Return(&storage.Cluster{HealthStatus: &storage.ClusterHealthStatus{SensorHealthStatus: tc.sensorHealthState.healthStatus}}, tc.sensorHealthState.found, tc.sensorHealthState.err).Times(1)
 
 			s.complianceIntegrationDataStore.EXPECT().GetComplianceIntegrationsView(allAccessContext, tc.expectedQ).
 				Return([]*datastore.IntegrationDetails{{


### PR DESCRIPTION
### Description

This PR is adding sensor connection status to cluster status during scan config creation.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] unit tests
- [x] tested UI in deployed QA demo cluster
