### PR TITLE
chore: free to 25gb in gha runner

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -4,7 +4,7 @@ inputs:
   free-disk-space:
     description: 'Free disk space desired in GB (2025-06 ubuntu-24.04 runner starts with 20GB free and we can delete and reach 40GB)'
     required: false
-    default: 22
+    default: 25
   gcp-account:
     description: 'Account to be used to upload tests data'
     required: true


### PR DESCRIPTION
I had adjusted the job-preamble to only clear to 22gb but we're approaching that limit now. Now changing the default to 25gb to give us some breathing room and avoid intermittent out of disk space failures:

https://redhat-internal.slack.com/archives/CC5UHD0KA/p1751876843337599?thread_ts=1751620264.920839&cid=CC5UHD0KA

Related to the increase to 30gb for builds: https://github.com/stackrox/stackrox/pull/15909