### PR TITLE
fix(dev): Map protoc download for aarch64

### DIFF
--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -57,7 +57,7 @@ endif
 ifeq ($(UNAME_S),Darwin)
 PROTOC_OS = osx
 endif
-PROTOC_ARCH=$(shell case $$(uname -m) in (arm64) echo aarch_64 ;; (s390x) echo s390_64 ;; (*) uname -m ;; esac)
+PROTOC_ARCH=$(shell case $$(uname -m) in (arm64|aarch64) echo aarch_64 ;; (s390x) echo s390_64 ;; (*) uname -m ;; esac)
 
 PROTO_PRIVATE_DIR := $(BASE_PATH)/.proto
 


### PR DESCRIPTION
I'm running on a system where `uname -m` returns `aarch64` instead of `arm64`, so I added that to the architecture mapping for downloading `protoc`.