### PR TITLE
fix(test): Operator e2e upgrade test

### DIFF
--- a/operator/tests/upgrade/upgrade/005-assert.yaml
+++ b/operator/tests/upgrade/upgrade/005-assert.yaml
@@ -1,1 +1,1 @@
-../../common/central-cr-without-scanner-v4-assert.yaml
+../../common/central-cr-assert.yaml

--- a/operator/tests/upgrade/upgrade/005-errors.yaml
+++ b/operator/tests/upgrade/upgrade/005-errors.yaml
@@ -1,1 +1,0 @@
-../../common/no-scanner-v4-deployment.yaml

--- a/operator/tests/upgrade/upgrade/010-assert.yaml
+++ b/operator/tests/upgrade/upgrade/010-assert.yaml
@@ -1,1 +1,1 @@
-../../common/secured-cluster-cr-assert-no-scanner-v4.yaml
+../../common/secured-cluster-cr-assert.yaml

--- a/operator/tests/upgrade/upgrade/010-errors.yaml
+++ b/operator/tests/upgrade/upgrade/010-errors.yaml
@@ -1,1 +1,0 @@
-../../common/no-scanner-v4-deployment.yaml

--- a/operator/tests/upgrade/upgrade/030-assert-central.yaml
+++ b/operator/tests/upgrade/upgrade/030-assert-central.yaml
@@ -1,1 +1,1 @@
-../../common/central-cr-without-scanner-v4-assert.yaml
+../../common/central-cr-assert.yaml

--- a/operator/tests/upgrade/upgrade/030-errors.yaml
+++ b/operator/tests/upgrade/upgrade/030-errors.yaml
@@ -1,1 +1,0 @@
-../../common/no-scanner-v4-deployment.yaml

--- a/operator/tests/upgrade/upgrade/031-assert-secured-cluster.yaml
+++ b/operator/tests/upgrade/upgrade/031-assert-secured-cluster.yaml
@@ -1,1 +1,1 @@
-../../common/secured-cluster-cr-assert-no-scanner-v4.yaml
+../../common/secured-cluster-cr-assert.yaml

--- a/operator/tests/upgrade/upgrade/031-errors.yaml
+++ b/operator/tests/upgrade/upgrade/031-errors.yaml
@@ -1,1 +1,0 @@
-../../common/no-scanner-v4-deployment.yaml

--- a/operator/tests/upgrade/upgrade/035-assert.yaml
+++ b/operator/tests/upgrade/upgrade/035-assert.yaml
@@ -1,1 +1,0 @@
-../../common/central-cr-assert.yaml

--- a/operator/tests/upgrade/upgrade/035-central-cr-with-scanner-v4.yaml
+++ b/operator/tests/upgrade/upgrade/035-central-cr-with-scanner-v4.yaml
@@ -1,1 +1,0 @@
-../../common/central-cr-with-scanner-v4-enabled-explicitly.yaml


### PR DESCRIPTION
### Description

Until recently the 'previous' version, which was installed as part of the upgrade tests, was installing a version which did not pull in scanner V4 by default. The upgrade test in its current form is based on this expected behaviour.

Now, 4.8.x has become the 'previous' version and that version installs scanner V4 by default, hence the test expectations need to be adjusted.

### User-facing documentation

Just test fixes, nothing user-facing.

### Testing and quality

- [x] the change is production ready
- [x] CI results are inspected (modified operator-e2e tests green)

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Just CI.
