### PR TITLE
ROX-29989: Allow for store generation of default sort

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/administration/events/datastore/internal/store/postgres/store.go
+++ b/central/administration/events/datastore/internal/store/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/administration/usage/store/postgres/store.go
+++ b/central/administration/usage/store/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/auth/store/postgres/store.go
+++ b/central/auth/store/postgres/store.go
@@ -69,6 +69,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		metricsSetCacheOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -80,6 +80,8 @@ func New(db postgres.DB) Store {
 		metricsSetCacheOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -63,6 +63,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		metricsSetCacheOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/integration/store/postgres/store.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/remediations/store/postgres/store.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/report/store/postgres/store.go
+++ b/central/complianceoperator/v2/report/store/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/rules/store/postgres/store.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/complianceoperator/v2/suites/store/postgres/store.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -63,6 +63,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -69,6 +69,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -81,6 +81,8 @@ func New(db postgres.DB) Store {
 		metricsSetCacheOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/discoveredclusters/datastore/internal/store/postgres/store.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/imagecomponent/v2/datastore/store/postgres/gen.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.ImageComponentV2 --references=storage.Image,imagesV2:storage.ImageV2 --search-category IMAGE_COMPONENTS_V2 --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,IMAGES,IMAGES_V2,DEPLOYMENTS,NAMESPACES,CLUSTERS --feature-flag FlattenCVEData
+//go:generate pg-table-bindings-wrapper --type=storage.ImageComponentV2 --references=storage.Image,imagesV2:storage.ImageV2 --search-category IMAGE_COMPONENTS_V2 --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,IMAGES,IMAGES_V2,DEPLOYMENTS,NAMESPACES,CLUSTERS --feature-flag FlattenCVEData --default-sort search.Component.String() --transform-sort-options ImagesSchema.OptionsMap

--- a/central/imagecomponent/v2/datastore/store/postgres/store.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		pgSearch.GetDefaultSort(search.Component.String(), false),
+		pkgSchema.ImagesSchema.OptionsMap,
 	)
 }
 

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -63,6 +63,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -63,6 +63,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		metricsSetCacheOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -69,6 +69,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/namespace/datastore/internal/store/postgres/store.go
+++ b/central/namespace/datastore/internal/store/postgres/store.go
@@ -80,6 +80,8 @@ func New(db postgres.DB) Store {
 		metricsSetCacheOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -69,6 +69,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -69,6 +69,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -63,6 +63,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -63,6 +63,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/pod/datastore/internal/store/postgres/store.go
+++ b/central/pod/datastore/internal/store/postgres/store.go
@@ -80,6 +80,8 @@ func New(db postgres.DB) Store {
 		metricsSetCacheOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -80,6 +80,8 @@ func New(db postgres.DB) Store {
 		metricsSetCacheOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/reports/config/store/postgres/store.go
+++ b/central/reports/config/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -69,6 +69,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -69,6 +69,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -77,6 +77,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -76,6 +76,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetPostgresOperationDurationTime,
 		metricsSetCacheOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -68,6 +68,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/previous/store.go
+++ b/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/previous/store.go
@@ -50,6 +50,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/updated/store.go
+++ b/migrator/migrations/m_189_to_m_190_vulnerability_requests_add_name/store/updated/store.go
@@ -51,6 +51,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/previous/store.go
+++ b/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/previous/store.go
@@ -50,6 +50,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/updated/store.go
+++ b/migrator/migrations/m_191_to_m_192_vulnerability_requests_searchable_scope/store/updated/store.go
@@ -55,6 +55,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/authproviders/store.go
+++ b/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/authproviders/store.go
@@ -46,6 +46,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/groups/store.go
+++ b/migrator/migrations/m_197_to_m_198_add_oidc_claim_mappings/store/groups/store.go
@@ -43,6 +43,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/stores/rules/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/stores/rules/store.go
@@ -41,6 +41,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/profiles/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/profiles/store.go
@@ -43,6 +43,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/results/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/results/store.go
@@ -44,6 +44,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/rules/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/rules/store.go
@@ -43,6 +43,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/scans/store.go
+++ b/migrator/migrations/m_200_to_m_201_compliance_v2_for_4_5/test/stores/scans/store.go
@@ -44,6 +44,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/store/store.go
+++ b/migrator/migrations/m_201_to_m_202_vuln_request_v1_to_v2/store/store.go
@@ -43,6 +43,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecveedges/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecveedges/store.go
@@ -39,6 +39,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecves/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/imagecves/store.go
@@ -39,6 +39,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/images/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/images/store.go
@@ -39,6 +39,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/vulnerabilityrequests/store.go
+++ b/migrator/migrations/m_202_to_m_203_vuln_requests_for_suppressed_cves/store/vulnerabilityrequests/store.go
@@ -39,6 +39,8 @@ func New(db postgres.DB) Store {
 		nil,
 		nil,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/store/previous/store.go
+++ b/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/store/previous/store.go
@@ -45,6 +45,8 @@ func New(db postgres.DB) Store {
 
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/store/updated/store.go
+++ b/migrator/migrations/m_204_to_m_205_clusters_platform_type_and_k8_version/store/updated/store.go
@@ -44,6 +44,8 @@ func New(db postgres.DB) Store {
 
 		isUpsertAllowed,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
+	"github.com/stackrox/rox/pkg/search/sortfields"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -91,6 +92,8 @@ type genericStore[T any, PT ClonedUnmarshaler[T]] struct {
 	setPostgresOperationDurationTime durationTimeSetter
 	upsertAllowed                    upsertChecker[T, PT]
 	targetResource                   permissions.ResourceMetadata
+	defaultSort                      *v1.QuerySortOption
+	transformOptionsMap              search.OptionsMap
 }
 
 // NewGenericStore returns new subStore implementation for given resource.
@@ -105,6 +108,8 @@ func NewGenericStore[T any, PT ClonedUnmarshaler[T]](
 	setPostgresOperationDurationTime durationTimeSetter,
 	upsertAllowed upsertChecker[T, PT],
 	targetResource permissions.ResourceMetadata,
+	defaultSort *v1.QuerySortOption,
+	transformOptionsMap search.OptionsMap,
 ) Store[T, PT] {
 	return &genericStore[T, PT]{
 		db:          db,
@@ -124,8 +129,10 @@ func NewGenericStore[T any, PT ClonedUnmarshaler[T]](
 			}
 			return setPostgresOperationDurationTime
 		}(),
-		upsertAllowed:  upsertAllowed,
-		targetResource: targetResource,
+		upsertAllowed:       upsertAllowed,
+		targetResource:      targetResource,
+		defaultSort:         defaultSort,
+		transformOptionsMap: transformOptionsMap,
 	}
 }
 
@@ -140,6 +147,8 @@ func NewGloballyScopedGenericStore[T any, PT ClonedUnmarshaler[T]](
 	setAcquireDBConnDuration durationTimeSetter,
 	setPostgresOperationDurationTime durationTimeSetter,
 	targetResource permissions.ResourceMetadata,
+	defaultSort *v1.QuerySortOption,
+	transformOptionsMap search.OptionsMap,
 ) Store[T, PT] {
 	return &genericStore[T, PT]{
 		db:          db,
@@ -159,8 +168,10 @@ func NewGloballyScopedGenericStore[T any, PT ClonedUnmarshaler[T]](
 			}
 			return setPostgresOperationDurationTime
 		}(),
-		upsertAllowed:  globallyScopedUpsertChecker[T, PT](targetResource),
-		targetResource: targetResource,
+		upsertAllowed:       globallyScopedUpsertChecker[T, PT](targetResource),
+		targetResource:      targetResource,
+		defaultSort:         defaultSort,
+		transformOptionsMap: transformOptionsMap,
 	}
 }
 
@@ -186,10 +197,13 @@ func (s *genericStore[T, PT]) Count(ctx context.Context, q *v1.Query) (int, erro
 func (s *genericStore[T, PT]) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.Search)
 
+	q = s.applyQueryDefaults(q)
+
 	return RunSearchRequestForSchema(ctx, s.schema, q, s.db)
 }
 
 func (s *genericStore[T, PT]) walkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
+	query = s.applyQueryDefaults(query)
 	return RunCursorQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
 }
 
@@ -227,6 +241,9 @@ func (s *genericStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, err
 // TODO(ROX-28999): merge with WalkByQuery if cursor is removed
 func (s *genericStore[T, PT]) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
+
+	query = s.applyQueryDefaults(query)
+
 	return RunQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
 }
 
@@ -234,6 +251,8 @@ func (s *genericStore[T, PT]) GetByQueryFn(ctx context.Context, query *v1.Query,
 // Deprecated: Use GetByQueryFn instead
 func (s *genericStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
+
+	query = s.applyQueryDefaults(query)
 
 	rows := make([]*T, 0, paginated.GetLimit(query.GetPagination().GetLimit(), batchAfter))
 	err := RunQueryForSchemaFn(ctx, s.schema, query, s.db, func(obj PT) error {
@@ -398,6 +417,19 @@ func (s *genericStore[T, PT]) UpsertMany(ctx context.Context, objs []PT) error {
 	})
 }
 
+func GetDefaultSort(sortOption string, reversed bool) *v1.QuerySortOption {
+	if sortOption == "" {
+		return nil
+	}
+
+	defaultSortOption := &v1.QuerySortOption{
+		Field:    sortOption,
+		Reversed: reversed,
+	}
+
+	return defaultSortOption
+}
+
 // region Helper functions
 
 func (s *genericStore[T, PT]) acquireConn(ctx context.Context, op ops.Op) (*postgres.Conn, error) {
@@ -510,6 +542,19 @@ func globallyScopedUpsertChecker[T any, PT ClonedUnmarshaler[T]](targetResource 
 		}
 		return nil
 	}
+}
+
+func (s *genericStore[T, PT]) applyQueryDefaults(q *v1.Query) *v1.Query {
+	if s.transformOptionsMap != nil {
+		q = sortfields.TransformSortOptions(q, s.transformOptionsMap)
+	}
+
+	if s.defaultSort == nil {
+		return q
+	}
+
+	// Add pagination sort order if needed.
+	return paginated.FillDefaultSortOption(q, s.defaultSort.CloneVT())
 }
 
 // endregion Helper functions

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -30,6 +30,8 @@ func NewGenericStoreWithCache[T any, PT ClonedUnmarshaler[T]](
 	setCacheOperationDurationTime durationTimeSetter,
 	upsertAllowed upsertChecker[T, PT],
 	targetResource permissions.ResourceMetadata,
+	defaultSort *v1.QuerySortOption,
+	transformOptionsMap search.OptionsMap,
 ) Store[T, PT] {
 	underlyingStore := NewGenericStore[T, PT](
 		db,
@@ -41,6 +43,8 @@ func NewGenericStoreWithCache[T any, PT ClonedUnmarshaler[T]](
 		setPostgresOperationDurationTime,
 		upsertAllowed,
 		targetResource,
+		defaultSort,
+		transformOptionsMap,
 	)
 	store := &cachedStore[T, PT]{
 		schema:          schema,
@@ -75,6 +79,8 @@ func NewGloballyScopedGenericStoreWithCache[T any, PT ClonedUnmarshaler[T]](
 	setPostgresOperationDurationTime durationTimeSetter,
 	setCacheOperationDurationTime durationTimeSetter,
 	targetResource permissions.ResourceMetadata,
+	defaultSort *v1.QuerySortOption,
+	transformOptionsMap search.OptionsMap,
 ) Store[T, PT] {
 	underlyingStore := NewGloballyScopedGenericStore[T, PT](
 		db,
@@ -85,6 +91,8 @@ func NewGloballyScopedGenericStoreWithCache[T any, PT ClonedUnmarshaler[T]](
 		setAcquireDBConnDuration,
 		setPostgresOperationDurationTime,
 		targetResource,
+		defaultSort,
+		transformOptionsMap,
 	)
 	store := &cachedStore[T, PT]{
 		schema:          schema,

--- a/pkg/search/postgres/store_cache_test.go
+++ b/pkg/search/postgres/store_cache_test.go
@@ -47,6 +47,8 @@ func TestNewGenericCachedStore(t *testing.T) {
 		doNothingDurationTimeSetter,
 		globallyScopedUpsertChecker[storage.TestSingleKeyStruct, *storage.TestSingleKeyStruct](resources.Namespace),
 		resources.Namespace,
+		nil,
+		nil,
 	))
 }
 
@@ -62,6 +64,8 @@ func TestNewGloballyScopedGenericCachedStore(t *testing.T) {
 		doNothingDurationTimeSetter,
 		doNothingDurationTimeSetter,
 		resources.Namespace,
+		nil,
+		nil,
 	))
 }
 
@@ -850,6 +854,8 @@ func newCachedStore(testDB *pgtest.TestPostgres) Store[storage.TestSingleKeyStru
 		doNothingDurationTimeSetter,
 		globallyScopedUpsertChecker[storage.TestSingleKeyStruct, *storage.TestSingleKeyStruct](resources.Namespace),
 		resources.Namespace,
+		nil,
+		nil,
 	)
 }
 

--- a/pkg/search/postgres/store_test.go
+++ b/pkg/search/postgres/store_test.go
@@ -45,6 +45,8 @@ func TestNewGenericStore(t *testing.T) {
 		doNothingDurationTimeSetter,
 		globallyScopedUpsertChecker[storage.TestSingleKeyStruct, *storage.TestSingleKeyStruct](resources.Namespace),
 		resources.Namespace,
+		nil,
+		nil,
 	))
 }
 
@@ -59,6 +61,8 @@ func TestNewGloballyScopedGenericStore(t *testing.T) {
 		doNothingDurationTimeSetter,
 		doNothingDurationTimeSetter,
 		resources.Namespace,
+		nil,
+		nil,
 	))
 }
 
@@ -548,6 +552,8 @@ func newStore(testDB *pgtest.TestPostgres) Store[storage.TestSingleKeyStruct, *s
 		doNothingDurationTimeSetter,
 		globallyScopedUpsertChecker[storage.TestSingleKeyStruct, *storage.TestSingleKeyStruct](resources.Namespace),
 		resources.Namespace,
+		nil,
+		nil,
 	)
 }
 

--- a/pkg/search/sortfields/transformer.go
+++ b/pkg/search/sortfields/transformer.go
@@ -8,7 +8,7 @@ import (
 // TransformSortOptions applies transformation to specially handled sort fields e.g. multi-word fields.
 func TransformSortOptions(q *v1.Query, optionsMap search.OptionsMap) *v1.Query {
 	// If pagination not set, just skip.
-	if q.GetPagination() == nil || optionsMap == nil {
+	if q == nil || q.GetPagination() == nil || optionsMap == nil {
 		return q
 	}
 

--- a/pkg/search/sortfields/transformer.go
+++ b/pkg/search/sortfields/transformer.go
@@ -1,0 +1,48 @@
+package sortfields
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+// TransformSortOptions applies transformation to specially handled sort fields e.g. multi-word fields.
+func TransformSortOptions(q *v1.Query, optionsMap search.OptionsMap) *v1.Query {
+	// If pagination not set, just skip.
+	if q.GetPagination() == nil || optionsMap == nil {
+		return q
+	}
+
+	// Local copy to avoid changing input.
+	local := q.CloneVT()
+
+	sortOptions := make([]*v1.QuerySortOption, 0, len(local.GetPagination().GetSortOptions()))
+	// replace the multi-word fields with the correct multi-word sort field, if present.
+	for _, sortOption := range local.GetPagination().GetSortOptions() {
+		sortFieldMapperFunc, ok := SortFieldsMap[search.FieldLabel(sortOption.GetField())]
+		if !ok {
+			sortOptions = append(sortOptions, sortOption)
+			continue
+		}
+
+		transformedFields := sortFieldMapperFunc(sortOption)
+
+		var anyTransformedFieldNotFound bool
+		for _, transformedField := range transformedFields {
+			if _, exists := optionsMap.Get(transformedField.GetField()); !exists {
+				anyTransformedFieldNotFound = true
+				break
+			}
+		}
+
+		if anyTransformedFieldNotFound {
+			sortOptions = append(sortOptions, sortOption)
+		} else {
+			sortOptions = append(sortOptions, transformedFields...)
+		}
+	}
+
+	// update query pagination
+	local.Pagination.SortOptions = sortOptions
+
+	return local
+}

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -127,6 +127,16 @@ func New(db postgres.DB) Store {
             isUpsertAllowed,
             {{- end }}
             targetResource,
+            {{- if .DefaultSortStore }}
+            pgSearch.GetDefaultSort({{.DefaultSort}}, {{.ReverseDefaultSort}}),
+            {{- else }}
+            nil,
+            {{- end }}
+            {{- if .DefaultTransform }}
+            pkgSchema.{{.TransformSortOptions}},
+            {{- else }}
+            nil,
+            {{- end }}
     )
 }
 

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -72,6 +72,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -71,6 +71,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -73,6 +73,8 @@ func New(db postgres.DB) Store {
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
+		nil,
+		nil,
 	)
 }
 


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The Searchers apply default sort options (which is a good thing to have in general) and in some cases transform sort options from a single field to multiple fields.  For example, a sort on Component Name gets transformed to a sort on Component Name and Component Version to ensure the data is sorted as desired.  (One could argue such things are unnecessary, but since they exist we should allow for them.)

So the changes in this PR allows for 2 things (I combined them into 1 PR because I chose to generate them and they encompass changes to a broad swath of the code base.  So I felt 1 PR was appropriate.

- adds generation of a default sort if provided.  default-sort -- maps to a sort field and reverse-default-sort is a boolean that will reverse the sort order if desired.
- transform-sort-options provides a schema that allows stores to transform certain sort options to account for multi column sorts if desired.  For example Image component may include the image schema sort options to sort on image name and version.  

For reviewers:
- central/imagecomponent/v2/datastore/store/postgres/gen.go was the only `gen.go` updated at this time as an example.  So please review that and its store.
- Need Reviewed:
 - pkg/search/postgres/store.go
 - pkg/search/postgres/store_cache.go
 - pkg/search/postgres/store_cache_test.go
 - pkg/search/postgres/store_test.go
 - pkg/search/sortfields/transformer.go
 - tools/generate-helpers/pg-table-bindings/main.go
 - tools/generate-helpers/pg-table-bindings/store.go.tpl 
- The other stores were just generated because I changed the generic store signature.  So all other stores were updated to pass nil to the 2 new fields
- Migrators had to be updated because for some reason we are using the generic store in those.  That was annoying.
- 

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

No changes yet as the generated code uses nil for these things.  These features will be utilized and tested later in the stack.