### PR TITLE
ROX-29902: Update mobx in dependencies

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -43,7 +43,7 @@
                 "jspdf": "^2.3.1",
                 "jspdf-autotable": "^3.5.14",
                 "lodash": "^4.17.21",
-                "mobx": "^6.9.0",
+                "mobx": "^6.13.7",
                 "mobx-react": "^7.6.0",
                 "object-resolve-path": "^1.1.1",
                 "pluralize": "^8.0.0",
@@ -12085,9 +12085,10 @@
             }
         },
         "node_modules/mobx": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.12.0.tgz",
-            "integrity": "sha1-crJoXKWvAxqqSed6TXbtZ/y/kTU= sha512-Mn6CN6meXEnMa0a5u6a5+RKrqRedHBhZGd15AWLk9O6uFY4KYHzImdt8JI8WODo1bjTSRnwXhJox+FCUZhCKCQ==",
+            "version": "6.13.7",
+            "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.7.tgz",
+            "integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mobx"

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -46,7 +46,7 @@
         "jspdf": "^2.3.1",
         "jspdf-autotable": "^3.5.14",
         "lodash": "^4.17.21",
-        "mobx": "^6.9.0",
+        "mobx": "^6.13.7",
         "mobx-react": "^7.6.0",
         "object-resolve-path": "^1.1.1",
         "pluralize": "^8.0.0",


### PR DESCRIPTION
### Description

Humble dependency is 15 months outdated.

### Analysis

Find in Files `mobx` in package-lock.json file has 2 relevant results:

* `"node_modules/@patternfly/react-topology"` has `dependencies`

    ```
    "mobx": "^6.9.0",
    "mobx-react": "^7.6.0",
    ```

* `"node_modules/redoc"` has `dependencies` and `peerDependencies`

    ```
    "mobx-react": "^9.1.1",
    "mobx": "^6.0.4",
    ```

### Solution

In package.json file:
* Update `"mobx": "^6.9.0",` because relevant for both packages.
* Leave `"mobx-react": "^7.6.0",` because that is latest y stream for `react-topology` requirement.

### Releases

Most changes reduce memory requirement. Every little bit helps, pardon pun.

https://github.com/mobxjs/mobx/releases/tag/mobx%406.13.6

> Improve observableset memory footprint and performance

https://github.com/mobxjs/mobx/releases/tag/mobx%406.13.1

> Shrink Atom and Reaction using a bitfield

https://github.com/mobxjs/mobx/releases/tag/mobx%406.13.0

> Added new Set methods

https://github.com/mobxjs/mobx/releases/tag/mobx%406.12.5

> Fix ES6 Map/Set checks for cross-window scripts

https://github.com/mobxjs/mobx/releases/tag/mobx%406.12.4

> Shrink ComputedValue using a bitfield

https://github.com/mobxjs/mobx/releases/tag/mobx%406.12.1

> Prevent `reaction` from heeping a Reference to the OldValue that would prevent GC
> Reduce memory overhead of tracking dependencies

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run start` in ui/apps/platform with staging demo as central

#### Manual testing

1. Visit /main/network-graph

2. Visit /main/apidocs

3. Visit /main/apidocs-v2
