### PR TITLE
ROX-30003: Fix findCIDRNoLock

### DIFF
--- a/pkg/networkgraph/tree/radix.go
+++ b/pkg/networkgraph/tree/radix.go
@@ -461,16 +461,16 @@ func (t *nRadixTree) validateCardinality() bool {
 }
 
 func cloneIPNet(ipNet *net.IPNet) *net.IPNet {
-    ip := make(net.IP, len(ipNet.IP))
-    copy(ip, ipNet.IP)
+	ip := make(net.IP, len(ipNet.IP))
+	copy(ip, ipNet.IP)
 
-    mask := make(net.IPMask, len(ipNet.Mask))
-    copy(mask, ipNet.Mask)
+	mask := make(net.IPMask, len(ipNet.Mask))
+	copy(mask, ipNet.Mask)
 
-    return &net.IPNet{
-        IP:   ip,
-        Mask: mask,
-    }
+	return &net.IPNet{
+		IP:   ip,
+		Mask: mask,
+	}
 }
 
 func compareValueIpNet(value *storage.NetworkEntityInfo, ipNet *net.IPNet) bool {
@@ -524,7 +524,7 @@ func (t *nRadixTree) validateValues() bool {
 	mask := make(net.IPMask, 4)
 
 	ipNet := &net.IPNet{
-		IP:	ip,
+		IP:   ip,
 		Mask: mask,
 	}
 

--- a/pkg/networkgraph/tree/radix.go
+++ b/pkg/networkgraph/tree/radix.go
@@ -390,6 +390,10 @@ func (t *nRadixTree) findCIDRNoLock(ipNet *net.IPNet) (*nRadixNode, error) {
 			node = node.left
 		}
 
+		if node == nil {
+			break
+		}
+
 		// All network bits are traversed. If a supernet was found along the way, `ret` holds it,
 		// else there does not exist any supernet containing the search network/address.
 		if ipNet.Mask[i]&bit == 0 {
@@ -511,15 +515,7 @@ func (t *nRadixTree) Remove(key string) {
 	}
 
 	node.value = nil
-	parent := node.parent
-	if node.left == nil && node.right == nil {
-		if parent.right == node {
-			parent.right = nil
-		} else {
-			parent.left = nil
-		}
-		removeRecursively(parent)
-	}
+	removeRecursively(node)
 
 	delete(t.valueNodes, key)
 }

--- a/pkg/networkgraph/tree/radix.go
+++ b/pkg/networkgraph/tree/radix.go
@@ -414,6 +414,8 @@ func (t *nRadixTree) findCIDRNoLock(ipNet *net.IPNet) (*nRadixNode, error) {
 	return ret, nil
 }
 
+// Checks that all leaf nodes have values. All leaves
+// should have nodes since paths represent values.
 func validateLeavesHaveValues(node *nRadixNode) bool {
 	if node == nil {
 		return true
@@ -456,6 +458,8 @@ func getCardinalityByValues(node *nRadixNode) int {
 	return cardinality
 }
 
+// Checks that the number of values in the network tree
+// matches the number of keys in valueNodes.
 func (t *nRadixTree) validateCardinality() bool {
 	return getCardinalityByValues(t.root) == t.Cardinality()
 }
@@ -473,7 +477,7 @@ func cloneIPNet(ipNet *net.IPNet) *net.IPNet {
 	}
 }
 
-func compareValueIpNet(value *storage.NetworkEntityInfo, ipNet *net.IPNet) bool {
+func equalValueIpNet(value *storage.NetworkEntityInfo, ipNet *net.IPNet) bool {
 	valueCidr := value.GetExternalSource().GetCidr()
 	ipNetCidr := ipNet.String()
 	return valueCidr == ipNetCidr
@@ -481,7 +485,7 @@ func compareValueIpNet(value *storage.NetworkEntityInfo, ipNet *net.IPNet) bool 
 
 func validateValuesRecursive(ipNet *net.IPNet, octetIdx int, bit byte, node *nRadixNode) bool {
 	if node.value != nil {
-		if !compareValueIpNet(node.value, ipNet) {
+		if !equalValueIpNet(node.value, ipNet) {
 			return false
 		}
 	}
@@ -519,6 +523,8 @@ func validateValuesRecursive(ipNet *net.IPNet, octetIdx int, bit byte, node *nRa
 	return true
 }
 
+// Checks that the values of nodes correspond to the paths taken from
+// the root to the nodes.
 func (t *nRadixTree) validateValues() bool {
 	ip := make(net.IP, 4)
 	mask := make(net.IPMask, 4)

--- a/pkg/networkgraph/tree/radix_test.go
+++ b/pkg/networkgraph/tree/radix_test.go
@@ -157,6 +157,21 @@ func TestNRadixTreeFindCIDR(t *testing.T) {
 	protoassert.Equal(t, supernet.value, internetEntity)
 }
 
+func TestNRadixTreeFindCIDR_Depth31(t *testing.T) {
+	e := testutils.GetExtSrcNetworkEntityInfo("1", "1", "255.0.0.0/31", false, true)
+
+	cidr := "255.0.0.0/32"
+	_, ipNet, err := net.ParseCIDR(cidr)
+	assert.NoError(t, err)
+
+	tree, err := NewNRadixTree(pkgNet.IPv4, []*storage.NetworkEntityInfo{e})
+	assert.NoError(t, err)
+
+	supernet, err := tree.findCIDRNoLock(ipNet)
+	assert.NoError(t, err)
+	protoassert.Equal(t, supernet.value, e)
+}
+
 func TestNRadixTreeIPv6(t *testing.T) {
 	e1 := testutils.GetExtSrcNetworkEntityInfo("1", "1", "2001:db8:3333:4444:5555:6666:7777:8888/63", true, false)
 	e2 := testutils.GetExtSrcNetworkEntityInfo("2", "2", "2001:db8:3333:4444:5555:6666:7777:8888/64", false, false)

--- a/pkg/networkgraph/tree/radix_test.go
+++ b/pkg/networkgraph/tree/radix_test.go
@@ -149,7 +149,8 @@ func TestNRadixTreeFindCIDR(t *testing.T) {
 	_, ipNet, err := net.ParseCIDR(cidr)
 	assert.NoError(t, err)
 
-	tree, err := NewNRadixTree(pkgNet.IPv4, []*storage.NetworkEntityInfo{e1, e2, e3, e4})
+	tree := newDefaultNRadixTree(pkgNet.IPv4)
+	err = tree.build([]*storage.NetworkEntityInfo{e1, e2, e3, e4})
 	assert.NoError(t, err)
 
 	supernet, err := tree.findCIDRNoLock(ipNet)
@@ -164,7 +165,8 @@ func TestNRadixTreeFindCIDR_Depth31(t *testing.T) {
 	_, ipNet, err := net.ParseCIDR(cidr)
 	assert.NoError(t, err)
 
-	tree, err := NewNRadixTree(pkgNet.IPv4, []*storage.NetworkEntityInfo{e})
+	tree := newDefaultNRadixTree(pkgNet.IPv4)
+	err = tree.build([]*storage.NetworkEntityInfo{e})
 	assert.NoError(t, err)
 
 	supernet, err := tree.findCIDRNoLock(ipNet)

--- a/pkg/networkgraph/tree/types.go
+++ b/pkg/networkgraph/tree/types.go
@@ -1,6 +1,8 @@
 package tree
 
 import (
+	"net"
+
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -14,6 +16,7 @@ type NetworkTree interface {
 	// is equal to the cardinality. If there are multiple trees, the checks are done
 	// for each tree.
 	ValidateNetworkTree() bool
+	findCIDRNoLock(ipNet *net.IPNet) (*nRadixNode, error)
 }
 
 // ReadOnlyNetworkTree provides functionality to read network entities from a network tree.

--- a/pkg/networkgraph/tree/types.go
+++ b/pkg/networkgraph/tree/types.go
@@ -1,8 +1,6 @@
 package tree
 
 import (
-	"net"
-
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -16,7 +14,6 @@ type NetworkTree interface {
 	// is equal to the cardinality. If there are multiple trees, the checks are done
 	// for each tree.
 	ValidateNetworkTree() bool
-	findCIDRNoLock(ipNet *net.IPNet) (*nRadixNode, error)
 }
 
 // ReadOnlyNetworkTree provides functionality to read network entities from a network tree.

--- a/pkg/networkgraph/tree/types.go
+++ b/pkg/networkgraph/tree/types.go
@@ -10,8 +10,9 @@ type NetworkTree interface {
 
 	Insert(entity *storage.NetworkEntityInfo) error
 	Remove(key string)
-	// Checks that there are no leafs without values and that the number of values
-	// is equal to the cardinality. If there are multiple trees, the checks are done
+	// Checks that there are no leafs without values, that the number of values is equal to
+	// the cardinality, and that the values in the network tree corresponds to the paths needed
+	// to take from the root to their location. If there are multiple trees, the checks are done
 	// for each tree.
 	ValidateNetworkTree() bool
 }

--- a/pkg/networkgraph/tree/wrapper.go
+++ b/pkg/networkgraph/tree/wrapper.go
@@ -1,6 +1,8 @@
 package tree
 
 import (
+	"net"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	pkgNet "github.com/stackrox/rox/pkg/net"
@@ -47,6 +49,10 @@ func NewNetworkTreeWrapper(entities []*storage.NetworkEntityInfo) (NetworkTree, 
 	return &networkTreeWrapper{
 		trees: trees,
 	}, nil
+}
+
+func (t *networkTreeWrapper) findCIDRNoLock(ipNet *net.IPNet) (*nRadixNode, error) {
+	return nil, nil
 }
 
 func newDefaultNetworkTreeWrapper() *networkTreeWrapper {

--- a/pkg/networkgraph/tree/wrapper.go
+++ b/pkg/networkgraph/tree/wrapper.go
@@ -1,8 +1,6 @@
 package tree
 
 import (
-	"net"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	pkgNet "github.com/stackrox/rox/pkg/net"
@@ -49,10 +47,6 @@ func NewNetworkTreeWrapper(entities []*storage.NetworkEntityInfo) (NetworkTree, 
 	return &networkTreeWrapper{
 		trees: trees,
 	}, nil
-}
-
-func (t *networkTreeWrapper) findCIDRNoLock(ipNet *net.IPNet) (*nRadixNode, error) {
-	return nil, nil
 }
 
 func newDefaultNetworkTreeWrapper() *networkTreeWrapper {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Recently the following crash was reported.
```
goroutine 52206 [running]:
	runtime/debug.Stack()
		runtime/debug/stack.go:26 +0x5e
	github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).convertPanicToError(0xc0083c0e00?, {0x9a12ce0?, 0xfc72210?})
		github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:73 +0x3c
	github.com/stackrox/rox/pkg/grpc/metrics.(*grpcMetricsImpl).UnaryMonitoringInterceptor.func1()
		github.com/stackrox/rox/pkg/grpc/metrics/grpc_metrics_impl.go:85 +0x9b
	panic({0x9a12ce0?, 0xfc72210?})
		runtime/panic.go:792 +0x132
	github.com/stackrox/rox/pkg/networkgraph/tree.(*nRadixTree).findCIDRNoLock(0xc0083c12b0?, 0x10?)
		github.com/stackrox/rox/pkg/networkgraph/tree/radix.go:401 +0x79
	github.com/stackrox/rox/pkg/networkgraph/tree.(*nRadixTree).getMatchingSupernetForCIDRNoLock(0xc002975b80, {0xc0083c12b0, 0x10}, 0xaf1e630)
		github.com/stackrox/rox/pkg/networkgraph/tree/radix.go:228 +0x136
	github.com/stackrox/rox/pkg/networkgraph/tree.(*nRadixTree).GetMatchingSupernetForCIDR(0xc002975b80, {0xc0083c12b0, 0x10}, 0xaf1e630)
```

This crash may be related to the changes here https://github.com/stackrox/stackrox/pull/15724

I don't believe that there was an error in that PR, but changes in that PR may have made this error possible. The root of the bug is that there is not a check for if a node is nil before getting its value. More specifically the bug is triggered in there is a CIDR block with a mask of 31 and then the tree is searched for a CIDR block with the same IP address, but a mask of 32. The bug is fixed by adding a check for the node being nil before trying to get its value.


A unit test was created that triggers the bug

```
=== RUN   TestNRadixTreeFindCIDR_Depth31
--- FAIL: TestNRadixTreeFindCIDR_Depth31 (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x24e1579]

goroutine 69 [running]:
testing.tRunner.func1.2({0x2791460, 0x4709970})
	/usr/local/go/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1737 +0x35e
panic({0x2791460?, 0x4709970?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
github.com/stackrox/rox/pkg/networkgraph/tree.(*nRadixTree).findCIDRNoLock(0x2fbce00?, 0xc000602e00?)
	/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/networkgraph/tree/radix.go:406 +0x79
github.com/stackrox/rox/pkg/networkgraph/tree.TestNRadixTreeFindCIDR_Depth31(0xc000602e00)
	/home/jvirtane/go/src/github.com/stackrox/stackrox/pkg/networkgraph/tree/radix_test.go:174 +0x302
testing.tRunner(0xc000602e00, 0x2d91fb8)
	/usr/local/go/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1851 +0x413
exit status 2
FAIL	github.com/stackrox/rox/pkg/networkgraph/tree	0.022s
```

With the fix in this PR the unit test passes. The unit test does not use the `Remove` method, so it does not seem that the bug is caused by recent changes to `Remove`. However, it may be that recent changes made the bug more likely to occur. By removing nodes the tree may be more likely to enter into a state where the depth of the nodes is 31.

Unit tests are also added for `Remove` and it is refactored.

The `ValidateNetworkTree` method is improved, by checking that the values of nodes matches the values derived from the path to the values.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI is sufficient.
