### PR TITLE
ROX-30069: disable ui test failing in ocp4-19

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
@@ -66,7 +66,7 @@ describe('Vulnerability Management Dashboard', () => {
         );
     });
 
-    // ROX-19936: test perma-fails on OCP 4.19 after June 4, 2025
+    // ROX-30069: test perma-fails on OCP 4.19 after June 4, 2025
     it.skip('has item link to node component page from Top riskiest node components', () => {
         visitVulnerabilityManagementDashboard();
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -32,7 +32,7 @@ describe('Vulnerability Management Node Components', () => {
         ]);
     });
 
-    // ROX-19936: test perma-fails on OCP 4.19 after June 4, 2025
+    // ROX-30069: test perma-fails on OCP 4.19 after June 4, 2025
     it.skip('should sort the Risk Priority column', () => {
         visitVulnerabilityManagementEntities(entitiesKey);
 
@@ -118,12 +118,12 @@ describe('Vulnerability Management Node Components', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // ROX-19936: test perma-fails on OCP 4.19 after June 4, 2025
+    // ROX-30069: test perma-fails on OCP 4.19 after June 4, 2025
     it.skip('should display either links for node CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(entitiesKey, 'node-cves', 4, 'vulnCounter');
     });
 
-    // ROX-19936: test perma-fails on OCP 4.19 after June 4, 2025
+    // ROX-30069: test perma-fails on OCP 4.19 after June 4, 2025
     it.skip('should display links for nodes', () => {
         verifySecondaryEntities(entitiesKey, 'nodes', 6);
     });


### PR DESCRIPTION
A few tests are failing in ui-e2e on OCP 4.19 only. We need to fix the tests for 4.19. This PR is to skip those tests for now until fixed.

It may be related to the problem that the CoreOS image layers changed and ScannerV2 no longer supports scanning the CoreOS node images: ROX-29634 (related scannerV2 test disabled in https://github.com/stackrox/stackrox/pull/15598/files)

example failure (https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/14774/pull-ci-stackrox-stackrox-master-ocp-next-candidate-ui-e2e-tests/1942810144203083776):
1. Vulnerability Management Dashboard has item link to node component page from Top riskiest node components: has item link to node component page from Top riskiest node components
```
{Timed out retrying after 30000ms: Expected to find element: `[data-testid="widget"]:contains("Top riskiest node components") [data-testid="numbered-list-item-name"]:eq(0)`, but never found it. AssertionError - 2025-07-09T06:55:34.024Z AssertionError - 2025-07-09T06:55:34.024Z: Timed out retrying after 30000ms: Expected to find element: `[data-testid="widget"]:contains("Top riskiest node components") [data-testid="numbered-list-item-name"]:eq(0)`, but never found it.
AssertionError: Timed out retrying after 30000ms: Expected to find element: `[data-testid="widget"]:contains("Top riskiest node components") [data-testid="numbered-list-item-name"]:eq(0)`, but never found it.
    at verifyItemLinkToEntityPage (webpack://@stackrox/platform-app/./cypress/integration/vulnmanagement/dashboardToEntityPage.test.js:9:7)
    at Context.eval (webpack://@stackrox/platform-app/./cypress/integration/vulnmanagement/dashboardToEntityPage.test.js:76:8)}
```
2. Vulnerability Management Node Components should sort the Risk Priority column: should sort the Risk Priority column
```
{Timed out retrying after 30000ms: Expected to find element: `.rt-td:nth-child(7)`, but never found it. AssertionError - 2025-07-09T06:58:14.506Z AssertionError - 2025-07-09T06:58:14.506Z: Timed out retrying after 30000ms: Expected to find element: `.rt-td:nth-child(7)`, but never found it.
AssertionError: Timed out retrying after 30000ms: Expected to find element: `.rt-td:nth-child(7)`, but never found it.
    at Context.eval (webpack://@stackrox/platform-app/./cypress/integration/vulnmanagement/nodeComponents.test.js:43:11)}
```
3. Vulnerability Management Node Components should display either links for node CVEs or text for No CVEs: should display either links for node CVEs or text for No CVEs
```
{Timed out retrying after 30000ms: Expected to find element: `.rt-tbody .rt-td:nth-child(4)`, but never found it. AssertionError - 2025-07-09T06:59:17.252Z AssertionError - 2025-07-09T06:59:17.252Z: Timed out retrying after 30000ms: Expected to find element: `.rt-tbody .rt-td:nth-child(4)`, but never found it.
AssertionError: Timed out retrying after 30000ms: Expected to find element: `.rt-tbody .rt-td:nth-child(4)`, but never found it.
    at Context.eval (webpack://@stackrox/platform-app/./cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js:407:15)
    at getRet (https://central-lb/__cypress/runner/cypress_runner.js:120941:20)
    at tryCatcher (https://central-lb/__cypress/runner/cypress_runner.js:1777:23)
    at Promise.attempt.Promise.try (https://central-lb/__cypress/runner/cypress_runner.js:4285:29)
    at Context.thenFn (https://central-lb/__cypress/runner/cypress_runner.js:120952:66)
    at Context.then (https://central-lb/__cypress/runner/cypress_runner.js:121203:21)
    at wrapped (https://central-lb/__cypress/runner/cypress_runner.js:141524:19)}
```
4. Vulnerability Management Node Components should display links for nodes: should display links for nodes
```
{Timed out retrying after 30000ms: Expected to find element: `.rt-tbody .rt-td:nth-child(6)`, but never found it. AssertionError - 2025-07-09T07:00:19.959Z AssertionError - 2025-07-09T07:00:19.959Z: Timed out retrying after 30000ms: Expected to find element: `.rt-tbody .rt-td:nth-child(6)`, but never found it.
AssertionError: Timed out retrying after 30000ms: Expected to find element: `.rt-tbody .rt-td:nth-child(6)`, but never found it.
    at verifyTableLink (webpack://@stackrox/platform-app/./cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js:308:7)
    at verifySecondaryEntities (webpack://@stackrox/platform-app/./cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js:291:4)
    at Context.eval (webpack://@stackrox/platform-app/./cypress/integration/vulnmanagement/nodeComponents.test.js:125:32)}
```