### PR TITLE
ROX-29711: Fix scanner-v4-install-tests suite

### DIFF
--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -975,7 +975,9 @@ EOT
     verify_scannerV2_deployed
     verify_no_scannerV4_deployed
     run ! verify_deployment_scannerV4_env_var_set "stackrox" "central"
-    run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor"
+    # Temporarily disabled, because 4.8.0 has been released with a bug where sensor has ROX_SCANNER_V4=true set.
+    # TODO(ROX-30062)
+    # run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor"
 
     _begin "upgrade-stackrox"
 
@@ -987,7 +989,9 @@ EOT
     verify_scannerV2_deployed
     verify_scannerV4_deployed
     verify_deployment_scannerV4_env_var_set "stackrox" "central"
-    run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor" # no Scanner V4 support in Sensor with roxctl
+    # Temporarily disabled, because 4.8.0 has been released with a bug where sensor has ROX_SCANNER_V4=true set.
+    # TODO(ROX-30062)
+    # run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor" # no Scanner V4 support in Sensor with roxctl
 
     _end
 }

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -462,24 +462,16 @@ central:
 EOT
     )
 
-    _begin "verify-scanner-V4-not-deployed"
+    _begin "verify-scanners-are-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
-    verify_no_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
+    verify_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
+    verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
 
     _begin "upgrade-to-HEAD-central"
     deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$MAIN_IMAGE_TAG" "" \
         --reuse-values
 
-    _begin "verify-scanner-V4-not-deployed"
-    verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
-    verify_no_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
-
-    _begin "enable-scanner-V4-in-central"
-    deploy_central_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$MAIN_IMAGE_TAG" "" \
-        --reuse-values \
-        --set scannerV4.disable=false
-
-    _begin "verify-scanners-deployed"
+    _begin "verify-scanners-are-deployed"
     verify_scannerV2_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_scannerV4_deployed "$CUSTOM_CENTRAL_NAMESPACE"
     verify_deployment_scannerV4_env_var_set "$CUSTOM_CENTRAL_NAMESPACE" "central"
@@ -492,36 +484,18 @@ EOT
         "$EARLIER_MAIN_IMAGE_TAG" "$old_sensor_chart" \
         "$secured_cluster_name" "$ROX_ADMIN_PASSWORD" "$central_endpoint"
 
-    _begin "verify-scanner-V2-not-deployed"
-    verify_no_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
-
-    _begin "verify-scanner-V4-not-deployed"
-    verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
+    _begin "verify-scanners-are-deployed"
+    verify_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
+    verify_scannerV4_indexer_deployed "$CUSTOM_SENSOR_NAMESPACE"
+    verify_deployment_scannerV4_env_var_set "$CUSTOM_SENSOR_NAMESPACE" "sensor"
 
     _begin "upgrade-to-HEAD-sensor"
     deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" "" "" "" "" ""
 
-    _begin "verify-scanner-V2-not-deployed"
-    verify_no_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
-
-    _begin "verify-scanner-V4-not-deployed"
-    verify_no_scannerV4_deployed "$CUSTOM_SENSOR_NAMESPACE"
-
-    _begin "enable-scanners-in-secured-cluster"
-    # Without creating the scanner-db-password secret manually Scanner V2 doesn't come up.
-    # Let's just reuse an existing password for this for simplicity.
-    "$ORCH_CMD" </dev/null -n "$CUSTOM_SENSOR_NAMESPACE" create secret generic scanner-db-password \
-        --from-file=password=<(echo "$ROX_ADMIN_PASSWORD")
-
-    deploy_sensor_with_helm "$CUSTOM_CENTRAL_NAMESPACE" "$CUSTOM_SENSOR_NAMESPACE" "" "" "" "" "" \
-        --set scannerV4.disable=false \
-        --set scanner.disable=false
-
-    _begin "verify-scanner-V2-deployed"
+    _begin "verify-scanners-are-deployed"
     verify_scannerV2_deployed "$CUSTOM_SENSOR_NAMESPACE"
-
-    _begin "verify-scanner-V4-deployed"
     verify_scannerV4_indexer_deployed "$CUSTOM_SENSOR_NAMESPACE"
+    verify_deployment_scannerV4_env_var_set "$CUSTOM_SENSOR_NAMESPACE" "sensor"
 
     _end
 }

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -967,6 +967,7 @@ EOT
     # Install using roxctl deployment bundles
     # shellcheck disable=SC2030,SC2031
     export OUTPUT_FORMAT=""
+    export SENSOR_HELM_DEPLOY="false" # Without this subtlety this test case would silently (and wrongly) use Helm for deploying sensor...
     info "Using roxctl executable ${EARLIER_ROXCTL_PATH}/roxctl for generating pre-Scanner V4 deployment bundles"
     PATH="${EARLIER_ROXCTL_PATH}:${PATH}" MAIN_IMAGE_TAG="${EARLIER_MAIN_IMAGE_TAG}" ROX_SCANNER_V4=false _deploy_stackrox
 


### PR DESCRIPTION
### Description

**This PR intends to fix the scanner-v4-install-tests on master.**

4.8.0 introduced different defaults for Scanner V4, which now cause CI failures in the scanner-v4-install-tests suite. One of these changes is expected behavior, which requires adjustments to the expectations of a test case which does Helm upgrade tests (-> commit 442cf85bd1530625cc08f34f846591323d0a01f0). A different change is actually a bug in 4.8.0, which causes the value of the `ROX_SCANNER_V4` environment variables to be wrongly set to `true` for sensor deployment bundles (-> commit a007167f16d56cbd245265a7a99586579908665f).

While analyzing the latter issue I figured out that the test logic for the upgrade test involving sensor bundles is actually broken in that it wrongly uses Helm charts under the hood instead of a sensor deployment bundle (-> commit cd6189fa722087014cb132dc8b9fe960c0b1d2d5).

### User-facing documentation

Just test changes, nothing user-facing.

### Testing and quality

- [x] the change is production ready
- [x] CI results are inspected

#### Automated testing

- [x] modified existing tests

#### How I validated my change

Locally executing the test suite + CI run.

