### PR TITLE
ROX-30087: implicit m2m token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 - ROX-27238: Central API for generating CRSs now supports custom expiration times, specified using the new fields "valid_until" or "valid_for".
   roxctl's "central crs generate" now supports specifying custom expiration times using the new parameters "--valid-until" or "--valid-for".
+- ROX-30087: Implicit exchange of OIDC tokens, accessing the API, with role mapping according to a M2M configuration matching the token issuer.
 
 ### Removed Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 - ROX-27238: Central API for generating CRSs now supports custom expiration times, specified using the new fields "valid_until" or "valid_for".
   roxctl's "central crs generate" now supports specifying custom expiration times using the new parameters "--valid-until" or "--valid-for".
-- ROX-30087: Implicit exchange of OIDC tokens, accessing the API, with role mapping according to a M2M configuration matching the token issuer.
+- ROX-30087: Implicit exchange of OIDC tokens, accessing the API, with a role mapping according to the M2M configuration that matches the token issuer.
 
 ### Removed Features
 

--- a/central/auth/m2m/mocks/set.go
+++ b/central/auth/m2m/mocks/set.go
@@ -57,6 +57,20 @@ func (mr *MockTokenExchangerSetMockRecorder) GetTokenExchanger(issuer any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTokenExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).GetTokenExchanger), issuer)
 }
 
+// HasExchangersConfigured mocks base method.
+func (m *MockTokenExchangerSet) HasExchangersConfigured() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasExchangersConfigured")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasExchangersConfigured indicates an expected call of HasExchangersConfigured.
+func (mr *MockTokenExchangerSetMockRecorder) HasExchangersConfigured() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasExchangersConfigured", reflect.TypeOf((*MockTokenExchangerSet)(nil).HasExchangersConfigured))
+}
+
 // RemoveTokenExchanger mocks base method.
 func (m *MockTokenExchangerSet) RemoveTokenExchanger(issuer string) error {
 	m.ctrl.T.Helper()

--- a/central/auth/m2m/set.go
+++ b/central/auth/m2m/set.go
@@ -27,6 +27,7 @@ type TokenExchangerSet interface {
 	RemoveTokenExchanger(issuer string) error
 	GetTokenExchanger(issuer string) (TokenExchanger, bool)
 	RollbackExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error
+	HasExchangersConfigured() bool
 }
 
 // TokenExchangerFactory factory for creating a new token exchanger.
@@ -126,4 +127,10 @@ func (t *tokenExchangerSet) RollbackExchanger(ctx context.Context, config *stora
 		return err
 	}
 	return t.UpsertTokenExchanger(ctx, config)
+}
+
+// HasExchangersConfigured returns true if there is at least one configured
+// exchanger.
+func (t *tokenExchangerSet) HasExchangersConfigured() bool {
+	return len(t.tokenExchangers) > 0
 }

--- a/central/jwt/jwt.go
+++ b/central/jwt/jwt.go
@@ -101,7 +101,7 @@ func create() (tokens.IssuerFactory, tokens.Validator, error) {
 		return nil, nil, errors.Wrap(err, "creating factory and validator")
 	}
 	validator = &m2mValidator{
-		m2m.TokenExchangerSetSingleton(roleDataStore.Singleton(), IssuerFactorySingleton()),
+		m2m.TokenExchangerSetSingleton(roleDataStore.Singleton(), factory),
 		validator,
 		issuerID,
 	}

--- a/central/jwt/jwt.go
+++ b/central/jwt/jwt.go
@@ -25,7 +25,7 @@ var (
 const (
 	privateKeyPath    = "/run/secrets/stackrox.io/jwt/jwt-key.der"
 	privateKeyPathPEM = "/run/secrets/stackrox.io/jwt/jwt-key.pem"
-	issuerID          = "https://stackrox.io/jwt"
+	roxIssuer         = "https://stackrox.io/jwt"
 
 	keyID = "jwtk0"
 )
@@ -74,7 +74,7 @@ func (v *m2mValidator) Validate(ctx context.Context, token string) (*tokens.Toke
 		return nil, err
 	}
 	// If this is a stackrox.io token, let's just validate it.
-	if iss == issuerID {
+	if iss == roxIssuer {
 		return v.roxValidator.Validate(ctx, token)
 	}
 	// Otherwise, let's exchange the token according to an M2M configuration for
@@ -103,7 +103,7 @@ func create() (tokens.IssuerFactory, tokens.Validator, error) {
 		return nil, nil, errors.Wrap(err, "parsing private key")
 	}
 
-	factory, validator, err := tokens.CreateIssuerFactoryAndValidator(issuerID, privateKey, keyID)
+	factory, validator, err := tokens.CreateIssuerFactoryAndValidator(roxIssuer, privateKey, keyID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating factory and validator")
 	}

--- a/central/jwt/jwt_test.go
+++ b/central/jwt/jwt_test.go
@@ -103,6 +103,7 @@ func TestM2MValidator(t *testing.T) {
 			if c.setupExchangerSet != nil {
 				c.setupExchangerSet(exchangerSet)
 			}
+			exchangerSet.EXPECT().HasExchangersConfigured().Times(1).Return(true)
 
 			validator := &m2mValidator{
 				TokenExchangerSet: exchangerSet,

--- a/central/jwt/jwt_test.go
+++ b/central/jwt/jwt_test.go
@@ -46,12 +46,12 @@ func TestM2MValidator(t *testing.T) {
 		expectedErr         error
 	}{
 		"rox issuer": {
-			token: tokenWithIssuer(issuerID),
+			token: tokenWithIssuer(roxIssuer),
 			mockRoxValidator: func(ctx context.Context, token string) (*tokens.TokenInfo, error) {
-				assert.Equal(t, tokenWithIssuer(issuerID), token)
+				assert.Equal(t, tokenWithIssuer(roxIssuer), token)
 				return &tokens.TokenInfo{Token: token}, nil
 			},
-			expectedTokenToPass: tokenWithIssuer(issuerID),
+			expectedTokenToPass: tokenWithIssuer(roxIssuer),
 		},
 		"non-rox issuer with exchanger": {
 			token: tokenWithIssuer("other-issuer"),

--- a/central/jwt/jwt_test.go
+++ b/central/jwt/jwt_test.go
@@ -1,0 +1,122 @@
+package jwt
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/auth/m2m/mocks"
+	"github.com/stackrox/rox/pkg/auth/tokens"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	testRoxIssuerID = "test-issuer"
+)
+
+var (
+	errTest = errors.New("test error")
+)
+
+type mockRoxValidator func(ctx context.Context, token string) (*tokens.TokenInfo, error)
+
+func (v mockRoxValidator) Validate(ctx context.Context, token string) (*tokens.TokenInfo, error) {
+	if v != nil {
+		return v(ctx, token)
+	}
+	return nil, nil
+}
+
+func tokenWithIssuer(issuer string) string {
+	claims := fmt.Sprintf(`{"iss":"%s"}`, issuer)
+	return fmt.Sprintf("%s.%s.signature",
+		base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`)),
+		base64.RawURLEncoding.EncodeToString([]byte(claims)))
+}
+
+func TestM2MValidator(t *testing.T) {
+	ctx := context.Background()
+	mockCtrl := gomock.NewController(t)
+
+	cases := map[string]struct {
+		token               string
+		mockRoxValidator    mockRoxValidator
+		setupExchangerSet   func(*mocks.MockTokenExchangerSet)
+		expectedTokenToPass string
+		expectedErr         error
+	}{
+		"rox issuer": {
+			token: tokenWithIssuer(testRoxIssuerID),
+			mockRoxValidator: func(ctx context.Context, token string) (*tokens.TokenInfo, error) {
+				assert.Equal(t, tokenWithIssuer(testRoxIssuerID), token)
+				return &tokens.TokenInfo{Token: token}, nil
+			},
+			expectedTokenToPass: tokenWithIssuer(testRoxIssuerID),
+		},
+		"non-rox issuer with exchanger": {
+			token: tokenWithIssuer("other-issuer"),
+			mockRoxValidator: func(ctx context.Context, token string) (*tokens.TokenInfo, error) {
+				assert.Equal(t, "exchanged-token", token)
+				return &tokens.TokenInfo{Token: token}, nil
+			},
+			setupExchangerSet: func(mes *mocks.MockTokenExchangerSet) {
+				mockExchanger := mocks.NewMockTokenExchanger(mockCtrl)
+				mockExchanger.EXPECT().ExchangeToken(gomock.Any(), tokenWithIssuer("other-issuer")).
+					Return("exchanged-token", nil)
+				mes.EXPECT().GetTokenExchanger("other-issuer").
+					Return(mockExchanger, true)
+			},
+			expectedTokenToPass: "exchanged-token",
+		},
+		"non-rox issuer, no exchanger": {
+			token: tokenWithIssuer("unknown-issuer"),
+			setupExchangerSet: func(mes *mocks.MockTokenExchangerSet) {
+				mes.EXPECT().GetTokenExchanger("unknown-issuer").
+					Return(nil, false)
+			},
+			expectedErr: errox.NoCredentials,
+		},
+		"issuer mismatch exchanger error": {
+			token: tokenWithIssuer("failing-issuer"),
+			setupExchangerSet: func(mes *mocks.MockTokenExchangerSet) {
+				mockExchanger := mocks.NewMockTokenExchanger(mockCtrl)
+				mockExchanger.EXPECT().ExchangeToken(gomock.Any(), tokenWithIssuer("failing-issuer")).
+					Return("", errTest)
+				mes.EXPECT().GetTokenExchanger("failing-issuer").
+					Return(mockExchanger, true)
+			},
+			expectedErr: errTest,
+		},
+		"invalid token": {
+			token:       "invalid-token",
+			expectedErr: errox.InvalidArgs,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			exchangerSet := mocks.NewMockTokenExchangerSet(mockCtrl)
+			if c.setupExchangerSet != nil {
+				c.setupExchangerSet(exchangerSet)
+			}
+
+			validator := &m2mValidator{
+				TokenExchangerSet: exchangerSet,
+				roxValidator:      c.mockRoxValidator,
+				issuerID:          testRoxIssuerID,
+			}
+
+			token, err := validator.Validate(ctx, c.token)
+
+			if assert.ErrorIs(t, err, c.expectedErr) {
+				if c.expectedTokenToPass != "" && assert.NotNil(t, token) {
+					assert.Equal(t, c.expectedTokenToPass, token.Token)
+				}
+			}
+		})
+	}
+}

--- a/central/jwt/jwt_test.go
+++ b/central/jwt/jwt_test.go
@@ -14,10 +14,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-const (
-	testRoxIssuerID = "test-issuer"
-)
-
 var (
 	errTest = errors.New("test error")
 )
@@ -50,12 +46,12 @@ func TestM2MValidator(t *testing.T) {
 		expectedErr         error
 	}{
 		"rox issuer": {
-			token: tokenWithIssuer(testRoxIssuerID),
+			token: tokenWithIssuer(issuerID),
 			mockRoxValidator: func(ctx context.Context, token string) (*tokens.TokenInfo, error) {
-				assert.Equal(t, tokenWithIssuer(testRoxIssuerID), token)
+				assert.Equal(t, tokenWithIssuer(issuerID), token)
 				return &tokens.TokenInfo{Token: token}, nil
 			},
-			expectedTokenToPass: tokenWithIssuer(testRoxIssuerID),
+			expectedTokenToPass: tokenWithIssuer(issuerID),
 		},
 		"non-rox issuer with exchanger": {
 			token: tokenWithIssuer("other-issuer"),
@@ -108,7 +104,6 @@ func TestM2MValidator(t *testing.T) {
 			validator := &m2mValidator{
 				TokenExchangerSet: exchangerSet,
 				roxValidator:      c.mockRoxValidator,
-				issuerID:          testRoxIssuerID,
 			}
 
 			token, err := validator.Validate(ctx, c.token)


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR implements an implicit JWT token exchange to allow for authorizing requests from clients, which do not support full m2m flow. E.g., Prometheus server, OpenShift console.

The idea is to identify the issuer of the token before validation, and if it is not a rox token, try to exchange the token using m2m, and then process the request using the exchanged token.

This change adds some _overhead in the token processing_, as it has to be parsed one more time to extract the issuer. Possible optimization would be to parse the token once, and pass the parsed JWT instead of the raw token string. This may be addressed in a separate PR, as such refactoring doesn't seem to be trivial.

Other optimization opportunities (to check if not already implemented):
- cache the issuer certificates;
- cache the exchanged tokens.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Test accessing API with a `sm-inspector` **service account** token. M2M is configured to map `sub: system:serviceaccount:stackrox:sm-inspector` to the `Network Graph Viewer` role:

```console
sh$ curl -ks https://mp0626bendpersonalwriti.demos.rox.systems/v1/auth/status \
  -H "Authorization: Bearer $(kubectl create token sm-inspector)" | \
  jq '.userInfo.roles'
[
  {
    "name": "Network Graph Viewer",
    "resourceToAccess": {
      "Deployment": "READ_ACCESS",
      "NetworkGraph": "READ_ACCESS",
      "NetworkPolicy": "READ_ACCESS"
    }
  }
]
```

Test with **Google ID** token and a generic M2M configuration for `https://accounts.google.com` issuer:
```console
sh$ curl -ks https://mp0626bendpersonalwriti.demos.rox.systems/v1/auth/status \
  -H "Authorization: Bearer $(gcloud --format=json auth print-identity-token | jq -r .id_token)" | \
  jq '.userInfo.roles[0].name'
"Analyst"
```

Test with an expired Google ID token:
```console
sh$ echo $M2M_TOKEN | cut -d . -f 2 | base64 -d | jq
{
  "iss": "https://accounts.google.com",
...
  "email_verified": true,
...
  "iat": 1752243141, // Fri, 11 Jul 2025 16:12:21 +0200
  "exp": 1752246741  // Fri, 11 Jul 2025 17:12:21 +0200
}

sh$ curl https://mp0626bendpersonalwriti.demos.rox.systems/v1/auth/status \
    -H "Authorization: Bearer $M2M_TOKEN" -ks
{"userId":"sso:77e865de-a69c-49bd-b325-a507c9c85ea3:114422582258483333622| ...

sh$ curl "https://oauth2.googleapis.com/tokeninfo?id_token=$M2M_TOKEN"
{
  "iss": "https://accounts.google.com",
...
  "iat": "1752243141",
  "exp": "1752246741", // Fri, 11 Jul 2025 17:12:21 +0200
  "alg": "RS256",
...
}

sh$ date -R
Fri, 11 Jul 2025 17:25:14 +0200

sh$ curl "https://oauth2.googleapis.com/tokeninfo?id_token=$M2M_TOKEN"
{
  "error": "invalid_token",
  "error_description": "Invalid Value"
}

sh$ curl https://mp0626bendpersonalwriti.demos.rox.systems/v1/auth/status \
    -H "Authorization: Bearer $M2M_TOKEN" -ks
{"code":16,"message":"credentials not found: token-based: cannot extract identity: token validation failed","details":[],"error":"credentials not found: token-based: cannot extract identity: token validation failed"}
```