### PR TITLE
chore(ci): do not cache go.mod in style

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -125,25 +125,13 @@ jobs:
   golangci-lint:
     timeout-minutes: 240
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.9
-      volumes:
-        - /usr:/mnt/usr
-        - /opt:/mnt/opt
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: ./.github/actions/job-preamble
+    - uses: actions/setup-go@v5
       with:
-        free-disk-space: '30'
-        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
-
-    - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+        go-version-file: 'tools/linters/go.mod'
 
     - name: Check Cache golangci-lint
       run: make golangci-lint-cache-status


### PR DESCRIPTION
### Description

It looks like golangci-lint job does not require build cache. Also it does not need the whole repo and our container test image.
- https://github.com/stackrox/stackrox/actions/runs/16056787996/job/45313084517#step:10:79
- https://github.com/stackrox/stackrox/actions/runs/16040905043/job/45262077119#step:10:29
- https://github.com/stackrox/stackrox/actions/runs/16035742781/job/45246957256#step:10:47
