### PR TITLE
ROX-29613: No extips for gone depl backport 4.8

### DIFF
--- a/central/deployment/cache/cache.go
+++ b/central/deployment/cache/cache.go
@@ -7,7 +7,11 @@ import (
 )
 
 const (
-	deletedDeploymentsRetentionPeriod = 2 * time.Minute
+	// 30 seconds for collector to send a message to sensor
+	// 30 seconds for sensor to send a message to central
+	// 5 minutes for afterglow
+	// 1 minute for a safety margin
+	deletedDeploymentsRetentionPeriod = 7 * time.Minute
 )
 
 var (

--- a/central/networkbaseline/service/service_impl_sql_test.go
+++ b/central/networkbaseline/service/service_impl_sql_test.go
@@ -136,7 +136,7 @@ func (s *networkBaselineServiceSuite) setupTablesExternalFlowsWithDefaultEntity(
 	fs, err := s.flowDataStore.GetFlowStore(allAllowedCtx, fixtureconsts.Cluster1)
 	s.NoError(err)
 
-	err = fs.UpsertFlows(allAllowedCtx, []*storage.NetworkFlow{flow}, timestamp.FromGoTime(ts))
+	_, err = fs.UpsertFlows(allAllowedCtx, []*storage.NetworkFlow{flow}, timestamp.FromGoTime(ts))
 	s.NoError(err)
 }
 
@@ -200,7 +200,7 @@ func (s *networkBaselineServiceSuite) setupTablesExternalFlows() {
 	fs, err := s.flowDataStore.GetFlowStore(allAllowedCtx, fixtureconsts.Cluster1)
 	s.NoError(err)
 
-	err = fs.UpsertFlows(allAllowedCtx, flows, timestamp.FromGoTime(ts))
+	_, err = fs.UpsertFlows(allAllowedCtx, flows, timestamp.FromGoTime(ts))
 	s.NoError(err)
 }
 

--- a/central/networkgraph/flow/datastore/flow.go
+++ b/central/networkgraph/flow/datastore/flow.go
@@ -21,7 +21,8 @@ type FlowDataStore interface {
 
 	// UpsertFlows upserts the given flows to the store. The flows slice might be modified by this function, so if you
 	// need to use it afterwards, create a copy.
-	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error
+	// Returns the flows actually upserted.
+	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) ([]*storage.NetworkFlow, error)
 	RemoveFlowsForDeployment(ctx context.Context, id string) error
 	RemoveStaleFlows(ctx context.Context) error
 	// RemoveOrphanedFlows - remove flows that have been orphaned by deployments

--- a/central/networkgraph/flow/datastore/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/mocks/flow.go
@@ -148,11 +148,12 @@ func (mr *MockFlowDataStoreMockRecorder) RemoveStaleFlows(ctx any) *gomock.Call 
 }
 
 // UpsertFlows mocks base method.
-func (m *MockFlowDataStore) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error {
+func (m *MockFlowDataStore) UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) ([]*storage.NetworkFlow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertFlows", ctx, flows, lastUpdateTS)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]*storage.NetworkFlow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpsertFlows indicates an expected call of UpsertFlows.

--- a/central/networkgraph/service/service_impl_postgres_benchmark_test.go
+++ b/central/networkgraph/service/service_impl_postgres_benchmark_test.go
@@ -127,7 +127,7 @@ func (s *networkGraphServiceBenchmarks) setupTables(b *testing.B, numFlows int) 
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, fixtureconsts.Cluster1)
 	require.NoError(b, err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
 	require.NoError(b, err)
 
 	return id.String()
@@ -198,7 +198,7 @@ func (s *networkGraphServiceBenchmarks) setupTablesForMetadata(b *testing.B) {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, fixtureconsts.Cluster1)
 	require.NoError(b, err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
 	require.NoError(b, err)
 }
 

--- a/central/networkgraph/service/service_impl_postgres_test.go
+++ b/central/networkgraph/service/service_impl_postgres_test.go
@@ -183,7 +183,7 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraph() {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
 	s.NoError(err)
 
 	request := &v1.NetworkGraphRequest{
@@ -295,7 +295,7 @@ func (s *networkGraphServiceSuite) TestGetNetworkGraphNormalizedAndUnformalized(
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, entityFlows, timeNow)
 	s.NoError(err)
 
 	request := &v1.NetworkGraphRequest{
@@ -407,7 +407,7 @@ func (s *networkGraphServiceSuite) TestGetExternalNetworkFlows() {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, allFlows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, allFlows, timestamp.FromGoTime(time.Now()))
 	s.NoError(err)
 
 	for _, tc := range []struct {
@@ -565,7 +565,7 @@ func (s *networkGraphServiceSuite) TestGetExternalNetworkFlowsMetadata() {
 	flowStore, err := s.flowDataStore.CreateFlowStore(globalWriteAccessCtx, testCluster)
 	s.NoError(err)
 
-	err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
+	_, err = flowStore.UpsertFlows(globalWriteAccessCtx, flows, timestamp.FromGoTime(time.Now()))
 	s.NoError(err)
 
 	for _, tc := range []struct {


### PR DESCRIPTION
### Description

This is a backport for 4.8. While the original PR was tested, this PR has not been tested. Find the original PR here https://github.com/stackrox/stackrox/pull/15693

Please note that https://github.com/stackrox/stackrox/pull/15714 builds upon this PR. The change there is small, but that PR contains information about testing this PR.

When flows are received from Sensor, they are filtered before being inserted into the database, and in particular, flows for deleted deployments are ignored. However, there is no such check for 'discovered' network entities. Thus when a flow arrives in central for a deployment that has been deleted, the flow will not be inserted into the database, but the external entity will be inserted into the database. This causes 'already orphaned' entities to be stored and never destroyed.

#### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- [x] The reproducer was manually replayed and no entities were inserted after the deployment was destroyed.