### PR TITLE
ROX-29724: Fix network tree remove backport 4.8

### DIFF
--- a/pkg/networkgraph/tree/types.go
+++ b/pkg/networkgraph/tree/types.go
@@ -10,6 +10,10 @@ type NetworkTree interface {
 
 	Insert(entity *storage.NetworkEntityInfo) error
 	Remove(key string)
+	// Checks that there are no leafs without values and that the number of values
+	// is equal to the cardinality. If there are multiple trees, the checks are done
+	// for each tree.
+	ValidateNetworkTree() bool
 }
 
 // ReadOnlyNetworkTree provides functionality to read network entities from a network tree.

--- a/pkg/networkgraph/tree/wrapper.go
+++ b/pkg/networkgraph/tree/wrapper.go
@@ -88,6 +88,19 @@ func (t *networkTreeWrapper) Insert(entity *storage.NetworkEntityInfo) error {
 	return t.trees[ipNet.Family()].Insert(entity)
 }
 
+func (t *networkTreeWrapper) ValidateNetworkTree() bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	for _, tree := range t.trees {
+		if !tree.ValidateNetworkTree() {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Remove removes the network entity from a tree for given key, if present.
 func (t *networkTreeWrapper) Remove(key string) {
 	t.lock.Lock()


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR is a backport of the following PR https://github.com/stackrox/stackrox/pull/15724. The testing was done there and has not been done for the backport.

The `Remove` method of the network tree does not actually fully remove a network entity from the tree. It merely removes the key for the network entity from the tree. It does not actually remove any of the nodes associated with the entity in the network tree. This leads to a continual increase in memory when external IPs is enabled.

To fix this problem, when a network entity is removed from the tree, the end node of the path representing that network entity is removed, if it has no children. Its parent is then removed if that parent has no children and has no value (I.e is not the endpoint of another network entity). This is done recursively.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

I created some long running clusters

![image](https://github.com/user-attachments/assets/3817d5cd-929c-4d44-965a-c7a97b6d7304)

"Memory leak fix" refers to a PR in which network entities are filtered out before being added to the database if the flow which they are a part of involves a recently deleted deployment. That PR is here https://github.com/stackrox/stackrox/pull/15693

"Memory leak fix 4" refers to the changes in this PR but based on a recent master.

"Memory leak fix 5" refers to the changes in the PR but based on https://github.com/stackrox/stackrox/pull/15693

When both memory fixes are applied, there is not a noticeable memory increase compared to when external IPs is disabled.