### PR TITLE
ROX-26179: Update clusters sensor status

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
@@ -45,7 +45,7 @@ describe('Clusters Health Status', () => {
                 clusterName: 'epsilon-edison-5',
                 cloudProvider: 'AWS us-west1',
                 clusterStatus: 'Unhealthy',
-                sensorUpgrade: 'Upgrade availableUpgrade sensor',
+                sensorUpgrade: 'Upgrade available',
                 credentialExpiration: 'in 6 days on Monday',
                 clusterDeletion: 'in 90 days',
             },
@@ -211,7 +211,7 @@ describe('Clusters Health Status', () => {
             let n = 0;
             expectedClusters.forEach(({ expectedInListAndSide }) => {
                 Object.keys(expectedInListAndSide).forEach((key) => {
-                    if (key === 'clusterStatus') {
+                    if (key === 'clusterStatus' || key === 'sensorUpgrade') {
                         expect($tds.eq(n).text()).to.include(expectedInListAndSide[key]);
                     } else {
                         expect($tds.eq(n).text()).to.equal(expectedInListAndSide[key]);

--- a/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
@@ -45,7 +45,7 @@ describe('Clusters Health Status', () => {
                 clusterName: 'epsilon-edison-5',
                 cloudProvider: 'AWS us-west1',
                 clusterStatus: 'Unhealthy',
-                sensorUpgrade: 'Upgrade available',
+                sensorUpgrade: 'Upgrade availableUpgrade sensor',
                 credentialExpiration: 'in 6 days on Monday',
                 clusterDeletion: 'in 90 days',
             },

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -82,7 +82,6 @@ function ClustersTable({
                 <Thead>
                     <Tr>
                         <Th
-                            screenReaderText="Select all clusters"
                             select={{
                                 onSelect: () => toggleAllClusters(),
                                 isSelected:
@@ -164,16 +163,23 @@ function ClustersTable({
                                             </Td>
                                             <Td
                                                 dataLabel="Sensor upgrade status"
-                                                compoundExpand={{
-                                                    isExpanded: isCellExpanded(
-                                                        clusterId,
-                                                        EXPANDABLE_COLUMN.SENSOR
-                                                    ),
-                                                    onToggle: () =>
-                                                        toggle(clusterId, EXPANDABLE_COLUMN.SENSOR),
-                                                    rowIndex,
-                                                    columnIndex: 4,
-                                                }}
+                                                compoundExpand={
+                                                    clusterInfo?.status?.upgradeStatus
+                                                        ? {
+                                                              isExpanded: isCellExpanded(
+                                                                  clusterId,
+                                                                  EXPANDABLE_COLUMN.SENSOR
+                                                              ),
+                                                              onToggle: () =>
+                                                                  toggle(
+                                                                      clusterId,
+                                                                      EXPANDABLE_COLUMN.SENSOR
+                                                                  ),
+                                                              rowIndex,
+                                                              columnIndex: 4,
+                                                          }
+                                                        : undefined
+                                                }
                                             >
                                                 <SensorUpgrade
                                                     upgradeStatus={

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -24,6 +24,7 @@ import ClusterNameWithTypeIcon from './Components/ClusterNameWithTypeIcon';
 import ClusterStatus from './Components/ClusterStatus';
 import CredentialExpiration from './Components/CredentialExpiration';
 import SensorUpgrade from './Components/SensorUpgrade';
+import SensorUpgradePanel from './Components/SensorUpgradePanel';
 
 export type ClustersTableProps = {
     centralVersion: string;
@@ -81,6 +82,7 @@ function ClustersTable({
                 <Thead>
                     <Tr>
                         <Th
+                            screenReaderText="Select all clusters"
                             select={{
                                 onSelect: () => toggleAllClusters(),
                                 isSelected:
@@ -177,15 +179,6 @@ function ClustersTable({
                                                     upgradeStatus={
                                                         clusterInfo.status?.upgradeStatus
                                                     }
-                                                    centralVersion={centralVersion}
-                                                    sensorVersion={
-                                                        clusterInfo.status?.sensorVersion
-                                                    }
-                                                    isList
-                                                    actionProps={{
-                                                        clusterId: clusterInfo.id,
-                                                        upgradeSingleCluster,
-                                                    }}
                                                 />
                                             </Td>
                                             <Td dataLabel="Credential expiration">
@@ -239,9 +232,19 @@ function ClustersTable({
                                             <Tr isExpanded>
                                                 <Td colSpan={colSpan}>
                                                     <ExpandableRowContent>
-                                                        <div className="pf-v5-u-text-align-center">
-                                                            *sensor details*
-                                                        </div>
+                                                        <SensorUpgradePanel
+                                                            centralVersion={centralVersion}
+                                                            sensorVersion={
+                                                                clusterInfo.status?.sensorVersion
+                                                            }
+                                                            upgradeStatus={
+                                                                clusterInfo.status?.upgradeStatus
+                                                            }
+                                                            actionProps={{
+                                                                clusterId: clusterInfo.id,
+                                                                upgradeSingleCluster,
+                                                            }}
+                                                        />
                                                     </ExpandableRowContent>
                                                 </Td>
                                             </Tr>

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import {
     ActionsColumn,
     ExpandableRowContent,
+    InnerScrollContainer,
     Table,
     Tbody,
     Td,
@@ -33,6 +34,7 @@ export type ClustersTableProps = {
     onDeleteCluster: (cluster: Cluster) => (event: React.MouseEvent) => void;
     toggleAllClusters: () => void;
     toggleCluster: (clusterId) => void;
+    upgradeSingleCluster: (clusterId: string) => void;
 };
 
 export const EXPANDABLE_COLUMN = {
@@ -52,6 +54,7 @@ function ClustersTable({
     onDeleteCluster,
     toggleAllClusters,
     toggleCluster,
+    upgradeSingleCluster,
 }: ClustersTableProps) {
     const [expanded, setExpanded] = useState<ExpansionMap>({});
 
@@ -70,173 +73,187 @@ function ClustersTable({
         return expanded[clusterId] != null;
     }
 
-    const colSpan = 9;
+    const colSpan = 8;
 
     return (
-        <Table>
-            <Thead>
-                <Tr>
-                    <Th
-                        select={{
-                            onSelect: () => toggleAllClusters(),
-                            isSelected:
-                                tableState.type === 'COMPLETE' &&
-                                tableState.data.length === selectedClusterIds.length,
-                        }}
-                    />
-                    <Th>Cluster</Th>
-                    <Th>Provider (Region)</Th>
-                    <Th>Cluster Status</Th>
-                    <Th>Sensor upgrade status</Th>
-                    <Th>Credential expiration</Th>
-                    <Th>Cluster deletion</Th>
-                </Tr>
-            </Thead>
-            <TbodyUnified
-                tableState={tableState}
-                colSpan={colSpan}
-                emptyProps={{
-                    title: 'No clusters found',
-                }}
-                errorProps={{
-                    title: 'There was an error loading cluster information',
-                }}
-                filteredEmptyProps={{ onClearFilters }}
-                renderer={({ data }) => (
-                    <>
-                        {data.map((clusterInfo, rowIndex) => {
-                            const provider = formatCloudProvider(
-                                clusterInfo.status?.providerMetadata
-                            );
-                            const clusterId = clusterInfo.id;
+        <InnerScrollContainer>
+            <Table>
+                <Thead>
+                    <Tr>
+                        <Th
+                            select={{
+                                onSelect: () => toggleAllClusters(),
+                                isSelected:
+                                    tableState.type === 'COMPLETE' &&
+                                    tableState.data.length === selectedClusterIds.length,
+                            }}
+                        />
+                        <Th>Cluster</Th>
+                        <Th>Provider (Region)</Th>
+                        <Th>Cluster status</Th>
+                        <Th width={20}>Sensor upgrade status</Th>
+                        <Th>Credential expiration</Th>
+                        <Th>Cluster deletion</Th>
+                    </Tr>
+                </Thead>
+                <TbodyUnified
+                    tableState={tableState}
+                    colSpan={colSpan}
+                    emptyProps={{
+                        title: 'No clusters found',
+                    }}
+                    errorProps={{
+                        title: 'There was an error loading cluster information',
+                    }}
+                    filteredEmptyProps={{ onClearFilters }}
+                    renderer={({ data }) => (
+                        <>
+                            {data.map((clusterInfo, rowIndex) => {
+                                const provider = formatCloudProvider(
+                                    clusterInfo.status?.providerMetadata
+                                );
+                                const clusterId = clusterInfo.id;
 
-                            const isStatusUnavailable =
-                                !clusterInfo.healthStatus ||
-                                clusterInfo.healthStatus.overallHealthStatus === 'UNAVAILABLE';
+                                const isStatusUnavailable =
+                                    !clusterInfo.healthStatus ||
+                                    clusterInfo.healthStatus.overallHealthStatus === 'UNAVAILABLE';
 
-                            return (
-                                <Tbody isExpanded={isRowExpanded(clusterId)} key={clusterInfo.id}>
-                                    <Tr>
-                                        <Td
-                                            select={{
-                                                rowIndex,
-                                                onSelect: () => toggleCluster(clusterId),
-                                                isSelected: selectedClusterIds.includes(clusterId),
-                                            }}
-                                        />
-                                        <Td dataLabel="Cluster">
-                                            <ClusterNameWithTypeIcon cluster={clusterInfo} />
-                                        </Td>
-                                        <Td dataLabel="Provider (Region)">{provider}</Td>
-                                        <Td
-                                            dataLabel="Cluster Status"
-                                            compoundExpand={
-                                                !isStatusUnavailable
-                                                    ? {
-                                                          isExpanded: isCellExpanded(
-                                                              clusterId,
-                                                              EXPANDABLE_COLUMN.STATUS
-                                                          ),
-                                                          onToggle: () =>
-                                                              toggle(
+                                return (
+                                    <Tbody
+                                        isExpanded={isRowExpanded(clusterId)}
+                                        key={clusterInfo.id}
+                                    >
+                                        <Tr>
+                                            <Td
+                                                select={{
+                                                    rowIndex,
+                                                    onSelect: () => toggleCluster(clusterId),
+                                                    isSelected:
+                                                        selectedClusterIds.includes(clusterId),
+                                                }}
+                                            />
+                                            <Td dataLabel="Cluster" style={{ minWidth: '200px' }}>
+                                                <ClusterNameWithTypeIcon cluster={clusterInfo} />
+                                            </Td>
+                                            <Td dataLabel="Provider (Region)">{provider}</Td>
+                                            <Td
+                                                dataLabel="Cluster status"
+                                                compoundExpand={
+                                                    !isStatusUnavailable
+                                                        ? {
+                                                              isExpanded: isCellExpanded(
                                                                   clusterId,
                                                                   EXPANDABLE_COLUMN.STATUS
                                                               ),
-                                                          rowIndex,
-                                                          columnIndex: 3,
-                                                      }
-                                                    : undefined
-                                            }
-                                        >
-                                            <ClusterStatus
-                                                healthStatus={clusterInfo?.healthStatus}
-                                            />
-                                        </Td>
-                                        <Td
-                                            dataLabel="Sensor upgrade status"
-                                            compoundExpand={{
-                                                isExpanded: isCellExpanded(
-                                                    clusterId,
-                                                    EXPANDABLE_COLUMN.SENSOR
-                                                ),
-                                                onToggle: () =>
-                                                    toggle(clusterId, EXPANDABLE_COLUMN.SENSOR),
-                                                rowIndex,
-                                                columnIndex: 4,
-                                            }}
-                                        >
-                                            {/* TODO: needs update for upgrade */}
-                                            <SensorUpgrade
-                                                upgradeStatus={clusterInfo.status?.upgradeStatus}
-                                                centralVersion={centralVersion}
-                                                sensorVersion={clusterInfo.status?.sensorVersion}
-                                                isList
-                                            />
-                                        </Td>
-                                        <Td dataLabel="Credential expiration">
-                                            {/* TODO: needs update for upgrade */}
-                                            <CredentialExpiration
-                                                certExpiryStatus={
-                                                    clusterInfo.status
-                                                        ?.certExpiryStatus as CertExpiryStatus
+                                                              onToggle: () =>
+                                                                  toggle(
+                                                                      clusterId,
+                                                                      EXPANDABLE_COLUMN.STATUS
+                                                                  ),
+                                                              rowIndex,
+                                                              columnIndex: 3,
+                                                          }
+                                                        : undefined
                                                 }
-                                                autoRefreshEnabled={clusterInfo.sensorCapabilities?.includes(
-                                                    'SecuredClusterCertificatesRefresh'
-                                                )}
-                                                isList
-                                            />
-                                        </Td>
-                                        <Td dataLabel="Cluster deletion">
-                                            <ClusterDeletion
-                                                clusterRetentionInfo={
-                                                    clusterIdToRetentionInfo[clusterId] ?? null
-                                                }
-                                            />
-                                        </Td>
-                                        <Td isActionCell>
-                                            <ActionsColumn
-                                                items={[
-                                                    {
-                                                        title: 'Delete cluster',
-                                                        onClick: (event) => {
-                                                            onDeleteCluster(clusterInfo)(event);
+                                            >
+                                                <ClusterStatus
+                                                    healthStatus={clusterInfo?.healthStatus}
+                                                />
+                                            </Td>
+                                            <Td
+                                                dataLabel="Sensor upgrade status"
+                                                compoundExpand={{
+                                                    isExpanded: isCellExpanded(
+                                                        clusterId,
+                                                        EXPANDABLE_COLUMN.SENSOR
+                                                    ),
+                                                    onToggle: () =>
+                                                        toggle(clusterId, EXPANDABLE_COLUMN.SENSOR),
+                                                    rowIndex,
+                                                    columnIndex: 4,
+                                                }}
+                                            >
+                                                <SensorUpgrade
+                                                    upgradeStatus={
+                                                        clusterInfo.status?.upgradeStatus
+                                                    }
+                                                    centralVersion={centralVersion}
+                                                    sensorVersion={
+                                                        clusterInfo.status?.sensorVersion
+                                                    }
+                                                    isList
+                                                    actionProps={{
+                                                        clusterId: clusterInfo.id,
+                                                        upgradeSingleCluster,
+                                                    }}
+                                                />
+                                            </Td>
+                                            <Td dataLabel="Credential expiration">
+                                                {/* TODO: needs update for upgrade */}
+                                                <CredentialExpiration
+                                                    certExpiryStatus={
+                                                        clusterInfo.status
+                                                            ?.certExpiryStatus as CertExpiryStatus
+                                                    }
+                                                    autoRefreshEnabled={clusterInfo.sensorCapabilities?.includes(
+                                                        'SecuredClusterCertificatesRefresh'
+                                                    )}
+                                                    isList
+                                                />
+                                            </Td>
+                                            <Td dataLabel="Cluster deletion">
+                                                <ClusterDeletion
+                                                    clusterRetentionInfo={
+                                                        clusterIdToRetentionInfo[clusterId] ?? null
+                                                    }
+                                                />
+                                            </Td>
+                                            <Td isActionCell>
+                                                <ActionsColumn
+                                                    items={[
+                                                        {
+                                                            title: 'Delete cluster',
+                                                            onClick: (event) => {
+                                                                onDeleteCluster(clusterInfo)(event);
+                                                            },
                                                         },
-                                                    },
-                                                ]}
-                                            />
-                                        </Td>
-                                    </Tr>
-                                    {clusterInfo.healthStatus &&
-                                        isCellExpanded(clusterId, EXPANDABLE_COLUMN.STATUS) && (
+                                                    ]}
+                                                />
+                                            </Td>
+                                        </Tr>
+                                        {clusterInfo.healthStatus &&
+                                            isCellExpanded(clusterId, EXPANDABLE_COLUMN.STATUS) && (
+                                                <Tr isExpanded>
+                                                    <Td colSpan={colSpan}>
+                                                        <ExpandableRowContent>
+                                                            <ClusterStatusGrid
+                                                                healthStatus={
+                                                                    clusterInfo.healthStatus
+                                                                }
+                                                            />
+                                                        </ExpandableRowContent>
+                                                    </Td>
+                                                </Tr>
+                                            )}
+                                        {isCellExpanded(clusterId, EXPANDABLE_COLUMN.SENSOR) && (
                                             <Tr isExpanded>
                                                 <Td colSpan={colSpan}>
                                                     <ExpandableRowContent>
-                                                        <ClusterStatusGrid
-                                                            healthStatus={clusterInfo.healthStatus}
-                                                        />
+                                                        <div className="pf-v5-u-text-align-center">
+                                                            *sensor details*
+                                                        </div>
                                                     </ExpandableRowContent>
                                                 </Td>
                                             </Tr>
                                         )}
-
-                                    {isCellExpanded(clusterId, EXPANDABLE_COLUMN.SENSOR) && (
-                                        <Tr isExpanded>
-                                            <Td colSpan={colSpan}>
-                                                <ExpandableRowContent>
-                                                    <div className="pf-v5-u-text-align-center">
-                                                        *sensor details*
-                                                    </div>
-                                                </ExpandableRowContent>
-                                            </Td>
-                                        </Tr>
-                                    )}
-                                </Tbody>
-                            );
-                        })}
-                    </>
-                )}
-            />
-        </Table>
+                                    </Tbody>
+                                );
+                            })}
+                        </>
+                    )}
+                />
+            </Table>
+        </InnerScrollContainer>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -516,6 +516,7 @@ function ClustersTablePanel({
                         onDeleteCluster={onDeleteHandler}
                         toggleAllClusters={toggleAllClusters}
                         toggleCluster={toggleCluster}
+                        upgradeSingleCluster={upgradeSingleCluster}
                     />
                 ) : (
                     <CheckboxTable

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummary.jsx
@@ -11,7 +11,7 @@ import CollectorStatusLegacy from './Collector/CollectorStatusLegacy';
 import AdmissionControlStatusLegacy from './AdmissionControl/AdmissionControlStatusLegacy';
 import CredentialExpirationWidget from './CredentialExpirationWidget';
 import SensorStatusLegacy from './SensorStatusLegacy';
-import SensorUpgrade from './SensorUpgrade';
+import SensorUpgradeLegacy from './SensorUpgradeLegacy';
 
 import { formatBuildDate, formatCloudProvider, formatKubernetesVersion } from '../cluster.helpers';
 import ScannerStatusLegacy from './Scanner/ScannerStatusLegacy';
@@ -113,7 +113,7 @@ const ClusterSummary = ({
             </div>
             <div className="s-1">
                 <Widget header="Sensor Upgrade" bodyClassName="p-2">
-                    <SensorUpgrade
+                    <SensorUpgradeLegacy
                         upgradeStatus={status?.upgradeStatus}
                         sensorVersion={status?.sensorVersion}
                         centralVersion={centralVersion}

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
@@ -1,157 +1,28 @@
 import React, { ReactElement } from 'react';
-import { Tooltip } from '@patternfly/react-core';
 
 import HealthStatus from './HealthStatus';
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
-import { findUpgradeState, formatSensorVersion, sensorUpgradeStyles } from '../cluster.helpers';
+import { findUpgradeState, sensorUpgradeStyles } from '../cluster.helpers';
 import { SensorUpgradeStatus } from '../clusterTypes';
-
-const trClassName = 'align-top leading-normal';
-const thClassName = 'font-700 pl-0 pr-1 py-0 text-left';
-const tdClassName = 'p-0 text-left';
 
 const testId = 'sensorUpgrade';
 
-/*
- * Sensor Upgrade cell
- * - in Clusters list might have an action (for example, Upgrade available or Retry upgrade)
- * - in Cluster side panel does not have an action (but might have an action in the future)
- */
-
 type SensorUpgradeProps = {
     upgradeStatus?: SensorUpgradeStatus;
-    centralVersion: string;
-    sensorVersion?: string;
-    isList?: boolean;
-    actionProps?: {
-        clusterId: string;
-        upgradeSingleCluster: (clusterId) => void;
-    };
 };
 
-function SensorUpgrade({
-    upgradeStatus,
-    centralVersion,
-    sensorVersion = '',
-    isList = false,
-    actionProps,
-}: SensorUpgradeProps): ReactElement {
+function SensorUpgrade({ upgradeStatus }: SensorUpgradeProps): ReactElement {
     if (upgradeStatus) {
         const upgradeStateObject = findUpgradeState(upgradeStatus);
         if (upgradeStateObject) {
-            const { displayValue, type, actionText } = upgradeStateObject;
-
-            let displayElement: ReactElement | null = null;
-            let actionElement: ReactElement | null = null;
-
-            if (displayValue) {
-                displayElement = <span>{displayValue}</span>;
-            }
-
-            if (actionText) {
-                if (actionProps) {
-                    const { clusterId, upgradeSingleCluster } = actionProps;
-                    const onClick = (event) => {
-                        event.stopPropagation(); // so click in row does not open side panel
-                        upgradeSingleCluster(clusterId);
-                    };
-
-                    actionElement = (
-                        <button
-                            type="button"
-                            className="bg-transparent leading-normal m-0 p-0 pf-v5-u-link-color underline"
-                            onClick={onClick}
-                        >
-                            {actionText}
-                        </button>
-                    );
-                } else if (!displayElement) {
-                    // Upgrade available is not an action in Cluster side panel,
-                    // but it might become an action in the future.
-                    displayElement = <span>{actionText}</span>;
-                }
-            }
-
-            const upgradeElement = (
-                <div data-testid={testId}>
-                    {displayElement}
-                    {displayElement && actionElement && <br />}
-                    {actionElement}
-                </div>
-            );
+            const { displayValue, type } = upgradeStateObject;
 
             const { Icon, fgColor } = sensorUpgradeStyles[type];
             const icon = <Icon className="h-4 w-4" />;
 
-            // Use table instead of TooltipFieldValue to align version numbers.
-            const versionNumbers = (
-                <table>
-                    <tbody>
-                        <tr className={trClassName} key="sensorVersion">
-                            <th className={thClassName} scope="row">
-                                Sensor version:
-                            </th>
-                            <td className={tdClassName} data-testid="sensorVersion">
-                                {sensorVersion && type === 'current' ? (
-                                    <span>{sensorVersion}</span>
-                                ) : (
-                                    formatSensorVersion(sensorVersion)
-                                )}
-                            </td>
-                        </tr>
-                        <tr className={trClassName} key="centralVersion">
-                            <th className={thClassName} scope="row">
-                                Central version:
-                            </th>
-                            <td className={tdClassName} data-testid="centralVersion">
-                                {centralVersion}
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            );
-
-            let detailMessage = '';
-            if (type === 'failure') {
-                detailMessage = upgradeStatus?.mostRecentProcess?.progress?.upgradeStatusDetail;
-            } else if (type === 'intervention') {
-                detailMessage = upgradeStatus?.upgradabilityStatusReason;
-            }
-
-            const detailElement = detailMessage ? (
-                <div className="mb-2" data-testid="upgradeStatusDetail">
-                    {detailMessage}
-                </div>
-            ) : null;
-
-            if (isList) {
-                const overlayElement = detailElement ? (
-                    <div>
-                        {detailElement}
-                        {versionNumbers}
-                    </div>
-                ) : (
-                    versionNumbers
-                );
-
-                return (
-                    <Tooltip content={overlayElement}>
-                        <div>
-                            <HealthStatus icon={icon} iconColor={fgColor}>
-                                {upgradeElement}
-                            </HealthStatus>
-                        </div>
-                    </Tooltip>
-                );
-            }
-
             return (
                 <HealthStatus icon={icon} iconColor={fgColor}>
-                    <div>
-                        {upgradeElement}
-                        {detailElement}
-                        {versionNumbers}
-                    </div>
+                    <div data-testid={testId}>{displayValue}</div>
                 </HealthStatus>
             );
         }

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradeLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradeLegacy.tsx
@@ -1,0 +1,163 @@
+import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
+
+import HealthStatus from './HealthStatus';
+import HealthStatusNotApplicable from './HealthStatusNotApplicable';
+import { findUpgradeState, formatSensorVersion, sensorUpgradeStyles } from '../cluster.helpers';
+import { SensorUpgradeStatus } from '../clusterTypes';
+
+const trClassName = 'align-top leading-normal';
+const thClassName = 'font-700 pl-0 pr-1 py-0 text-left';
+const tdClassName = 'p-0 text-left';
+
+const testId = 'sensorUpgrade';
+
+/*
+ * Sensor Upgrade cell
+ * - in Clusters list might have an action (for example, Upgrade available or Retry upgrade)
+ * - in Cluster side panel does not have an action (but might have an action in the future)
+ */
+
+type SensorUpgradeLegacyProps = {
+    upgradeStatus?: SensorUpgradeStatus;
+    centralVersion: string;
+    sensorVersion?: string;
+    isList?: boolean;
+    actionProps?: {
+        clusterId: string;
+        upgradeSingleCluster: (clusterId) => void;
+    };
+};
+
+function SensorUpgradeLegacy({
+    upgradeStatus,
+    centralVersion,
+    sensorVersion = '',
+    isList = false,
+    actionProps,
+}: SensorUpgradeLegacyProps): ReactElement {
+    if (upgradeStatus) {
+        const upgradeStateObject = findUpgradeState(upgradeStatus);
+        if (upgradeStateObject) {
+            const { displayValue, type, actionText } = upgradeStateObject;
+
+            let displayElement: ReactElement | null = null;
+            let actionElement: ReactElement | null = null;
+
+            if (displayValue) {
+                displayElement = <span>{displayValue}</span>;
+            }
+
+            if (actionText) {
+                if (actionProps) {
+                    const { clusterId, upgradeSingleCluster } = actionProps;
+                    const onClick = (event) => {
+                        event.stopPropagation(); // so click in row does not open side panel
+                        upgradeSingleCluster(clusterId);
+                    };
+
+                    actionElement = (
+                        <button
+                            type="button"
+                            className="bg-transparent leading-normal m-0 p-0 pf-v5-u-link-color underline"
+                            onClick={onClick}
+                        >
+                            {actionText}
+                        </button>
+                    );
+                } else if (!displayElement) {
+                    // Upgrade available is not an action in Cluster side panel,
+                    // but it might become an action in the future.
+                    displayElement = <span>{actionText}</span>;
+                }
+            }
+
+            const upgradeElement = (
+                <div data-testid={testId}>
+                    {displayElement}
+                    {displayElement && actionElement && <br />}
+                    {actionElement}
+                </div>
+            );
+
+            const { Icon, fgColor } = sensorUpgradeStyles[type];
+            const icon = <Icon className="h-4 w-4" />;
+
+            // Use table instead of TooltipFieldValue to align version numbers.
+            const versionNumbers = (
+                <table>
+                    <tbody>
+                        <tr className={trClassName} key="sensorVersion">
+                            <th className={thClassName} scope="row">
+                                Sensor version:
+                            </th>
+                            <td className={tdClassName} data-testid="sensorVersion">
+                                {sensorVersion && type === 'current' ? (
+                                    <span>{sensorVersion}</span>
+                                ) : (
+                                    formatSensorVersion(sensorVersion)
+                                )}
+                            </td>
+                        </tr>
+                        <tr className={trClassName} key="centralVersion">
+                            <th className={thClassName} scope="row">
+                                Central version:
+                            </th>
+                            <td className={tdClassName} data-testid="centralVersion">
+                                {centralVersion}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            );
+
+            let detailMessage = '';
+            if (type === 'failure') {
+                detailMessage = upgradeStatus?.mostRecentProcess?.progress?.upgradeStatusDetail;
+            } else if (type === 'intervention') {
+                detailMessage = upgradeStatus?.upgradabilityStatusReason;
+            }
+
+            const detailElement = detailMessage ? (
+                <div className="mb-2" data-testid="upgradeStatusDetail">
+                    {detailMessage}
+                </div>
+            ) : null;
+
+            if (isList) {
+                const overlayElement = detailElement ? (
+                    <div>
+                        {detailElement}
+                        {versionNumbers}
+                    </div>
+                ) : (
+                    versionNumbers
+                );
+
+                return (
+                    <Tooltip content={overlayElement}>
+                        <div>
+                            <HealthStatus icon={icon} iconColor={fgColor}>
+                                {upgradeElement}
+                            </HealthStatus>
+                        </div>
+                    </Tooltip>
+                );
+            }
+
+            return (
+                <HealthStatus icon={icon} iconColor={fgColor}>
+                    <div>
+                        {upgradeElement}
+                        {detailElement}
+                        {versionNumbers}
+                    </div>
+                </HealthStatus>
+            );
+        }
+    }
+
+    return <HealthStatusNotApplicable testId={testId} />;
+}
+
+export default SensorUpgradeLegacy;

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
@@ -62,7 +62,7 @@ function SensorUpgradePanel({
                             </DescriptionListDescription>
                         </DescriptionListGroup>
                         <DescriptionListGroup>
-                            <DescriptionListTerm>Available actions</DescriptionListTerm>
+                            <DescriptionListTerm>Available action</DescriptionListTerm>
                             <DescriptionListDescription>
                                 {upgradeState?.actionText ? (
                                     <Button

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
@@ -58,7 +58,7 @@ function SensorUpgradePanel({
                         <DescriptionListGroup>
                             <DescriptionListTerm>Status reasoning</DescriptionListTerm>
                             <DescriptionListDescription>
-                                {statusReason || 'n/a'}
+                                {statusReason || 'Unknown'}
                             </DescriptionListDescription>
                         </DescriptionListGroup>
                         <DescriptionListGroup>
@@ -75,7 +75,7 @@ function SensorUpgradePanel({
                                         {upgradeState.actionText}
                                     </Button>
                                 ) : (
-                                    'n/a'
+                                    'None'
                                 )}
                             </DescriptionListDescription>
                         </DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {
+    DescriptionList,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    DescriptionListDescription,
+    Divider,
+    Panel,
+    PanelHeader,
+    PanelMain,
+    PanelMainBody,
+    Button,
+} from '@patternfly/react-core';
+import upperFirst from 'lodash/upperFirst';
+
+import { findUpgradeState } from '../cluster.helpers';
+import SensorUpgrade from './SensorUpgrade';
+import { SensorUpgradeStatus } from '../clusterTypes';
+
+export type SensorUpgradePanelProps = {
+    actionProps: {
+        clusterId: string;
+        upgradeSingleCluster: (clusterId: string) => void;
+    };
+    centralVersion: string;
+    sensorVersion: string;
+    upgradeStatus: SensorUpgradeStatus;
+};
+
+function SensorUpgradePanel({
+    centralVersion,
+    sensorVersion,
+    upgradeStatus,
+    actionProps,
+}: SensorUpgradePanelProps) {
+    const { upgradabilityStatusReason, mostRecentProcess } = upgradeStatus;
+
+    const upgradeState = findUpgradeState(upgradeStatus);
+
+    const statusReason =
+        upgradeState?.type === 'failure'
+            ? (mostRecentProcess?.progress?.upgradeStatusDetail ?? '')
+            : upperFirst(upgradabilityStatusReason);
+
+    return (
+        <Panel variant="bordered">
+            <PanelHeader>Sensor upgrade status</PanelHeader>
+            <Divider />
+            <PanelMain>
+                <PanelMainBody>
+                    <DescriptionList>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Status</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                <SensorUpgrade upgradeStatus={upgradeStatus} />
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Status reasoning</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {statusReason || 'n/a'}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Available actions</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {upgradeState?.actionText ? (
+                                    <Button
+                                        variant="link"
+                                        isInline
+                                        onClick={() => {
+                                            actionProps.upgradeSingleCluster(actionProps.clusterId);
+                                        }}
+                                    >
+                                        {upgradeState.actionText}
+                                    </Button>
+                                ) : (
+                                    'n/a'
+                                )}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Sensor version</DescriptionListTerm>
+                            <DescriptionListDescription>{sensorVersion}</DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Central version</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {centralVersion}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    </DescriptionList>
+                </PanelMainBody>
+            </PanelMain>
+        </Panel>
+    );
+}
+
+export default SensorUpgradePanel;

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -362,8 +362,9 @@ describe('cluster helpers', () => {
             const received = findUpgradeState(testUpgradeStatus);
 
             const expected = {
+                displayValue: 'Downgrade possible',
                 type: 'download',
-                actionText: 'Downgrade possible',
+                actionText: 'Downgrade sensor',
             };
             expect(received).toEqual(expected);
         });
@@ -376,8 +377,9 @@ describe('cluster helpers', () => {
             const received = findUpgradeState(testUpgradeStatus);
 
             const expected = {
+                displayValue: 'Upgrade available',
                 type: 'download',
-                actionText: 'Upgrade available',
+                actionText: 'Upgrade sensor',
             };
             expect(received).toEqual(expected);
         });
@@ -396,8 +398,9 @@ describe('cluster helpers', () => {
             const received = findUpgradeState(testUpgradeStatus);
 
             const expected = {
+                displayValue: 'Upgrade available',
                 type: 'download',
-                actionText: 'Upgrade available',
+                actionText: 'Upgrade sensor',
             };
             expect(received).toEqual(expected);
         });

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -197,7 +197,7 @@ export const sensorUpgradeStyles = {
 };
 
 type UpgradeState = {
-    displayValue?: string;
+    displayValue: string;
     type: string;
     actionText?: string;
 };
@@ -214,12 +214,14 @@ const upgradeStates: UpgradeStates = {
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {
+        displayValue: 'Upgrade available',
         type: 'download',
-        actionText: 'Upgrade available',
+        actionText: 'Upgrade sensor',
     },
     DOWNGRADE_POSSIBLE: {
+        displayValue: 'Downgrade possible',
         type: 'download',
-        actionText: 'Downgrade possible',
+        actionText: 'Downgrade sensor',
     },
     UPGRADE_INITIALIZING: {
         displayValue: 'Upgrade initializing',

--- a/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/clustersTableColumnDescriptors.jsx
@@ -14,7 +14,7 @@ import ClusterDeletion from './Components/ClusterDeletion';
 import ClusterNameWithTypeIcon from './Components/ClusterNameWithTypeIcon';
 import ClusterStatusLegacy from './Components/ClusterStatusLegacy';
 import CredentialExpiration from './Components/CredentialExpiration';
-import SensorUpgrade from './Components/SensorUpgrade';
+import SensorUpgradeLegacy from './Components/SensorUpgradeLegacy';
 
 export function getColumnsForClusters({
     clusterIdToRetentionInfo,
@@ -67,7 +67,7 @@ export function getColumnsForClusters({
         {
             Header: 'Sensor Upgrade',
             Cell: ({ original }) => (
-                <SensorUpgrade
+                <SensorUpgradeLegacy
                     upgradeStatus={original.status?.upgradeStatus}
                     centralVersion={metadata.version}
                     sensorVersion={original.status?.sensorVersion}


### PR DESCRIPTION
### Description

Introduces a Sensor Upgrade panel with version details, status details, and upgrade actions.

#### ClustersTable component
- Wrapped the table in `InnerScrollContainer` so it doesn’t overflow on smaller screens.
- Minor tweaks to headers:
  - Renamed to “Cluster status” (lowercase “status” for consistency).
  - Set `width={20}` on the sensor upgrade column to stabilize layout.

#### SensorUpgradePanel component
- Added a panel component with a description list showing:
  - Status
  - Reasoning
  - Actions
  - Sensor & Central versions

#### Component split
- `SensorUpgradeLegacy`: retains original tooltip table + inline action for legacy views and details page.
- `SensorUpgrade`: display-only, no action, no tooltip.

#### Type / style tweaks
- `UpgradeState.displayValue` is now required (instead of optional).
- Caveat: Legacy views now show both `displayValue` and `actionText` for upgrade/downgrade states.  
  This makes switching between legacy and new components easier without needing extra feature flag logic or conditionals for `upgradeState`.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

**Test 1:**
```
// backend response
{
  "upgradeStatus": {
    "upgradability": "UP_TO_DATE",
    "upgradabilityStatusReason": "sensor is running the same version as Central",
    "mostRecentProcess": null
  }
}
```
```
// ui state
{
  "displayValue": "Up to date with Central",
  "type": "current"
}
```
<img width="2176" height="715" alt="Screenshot 2025-07-21 at 11 59 39 AM" src="https://github.com/user-attachments/assets/dde5414f-d534-479a-bf13-f405e0a64649" />

---
**Test 2:**
```
// backend response
{
  "upgradeStatus": {
    "upgradability": "MANUAL_UPGRADE_REQUIRED",
    "upgradabilityStatusReason": "Helm controls the secured cluster version.",
    "mostRecentProcess": null
  }
}
```
```
// ui state
{
  "displayValue": "Secured cluster version is not managed by StackRox.",
  "type": "intervention"
}
```
<img width="2176" height="715" alt="Screenshot 2025-07-21 at 11 59 54 AM" src="https://github.com/user-attachments/assets/b7243234-cf7a-4422-9714-680cc25b43b4" />

---
**Test 3:**
```
// backend response
{
  "upgradeStatus": {
    "upgradability": "AUTO_UPGRADE_POSSIBLE",
    "upgradabilityStatusReason": "sensor is running an old version",
    "mostRecentProcess": null
  }
}
```
```
// ui state
{
  "type": "download",
  "actionText": "Upgrade sensor"
}
```
<img width="2176" height="715" alt="Screenshot 2025-07-21 at 12 00 04 PM" src="https://github.com/user-attachments/assets/6f713d66-1ca3-466c-bf78-88dac9d60ddc" />

---
**Test 4:**
```
// backend response
{
  "upgradeStatus": {
    "upgradability": "AUTO_UPGRADE_POSSIBLE",
    "upgradabilityStatusReason": "sensor is running an old version",
    "mostRecentProcess": {
      "active": false,
      "progress": {
        "upgradeState": "UPGRADE_INITIALIZATION_ERROR",
        "upgradeStatusDetail": "Pod terminated: (error)"
      },
      "type": "UPGRADE"
    }
  }
}
```
```
// ui state
{
  "displayValue": "Upgrade initialization error",
  "type": "failure",
  "actionText": "Retry upgrade"
}
```
<img width="2176" height="715" alt="Screenshot 2025-07-21 at 12 00 20 PM" src="https://github.com/user-attachments/assets/3fe1e1d2-73b5-4328-bf95-bbb1ec2c4161" />
