### PR TITLE
ROX-29784: Name sensor components

### DIFF
--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -1,8 +1,6 @@
 package admissioncontroller
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
@@ -31,7 +29,7 @@ type alertHandlerImpl struct {
 }
 
 func (h *alertHandlerImpl) Name() string {
-	return fmt.Sprintf("%T", h)
+	return common.DefaultComponentName(h)
 }
 
 func (h *alertHandlerImpl) Start() error {

--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -1,6 +1,8 @@
 package admissioncontroller
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
@@ -26,6 +28,10 @@ type alertHandlerImpl struct {
 	output       chan *message.ExpiringMessage
 	stopSig      concurrency.Signal
 	centralReady concurrency.Signal
+}
+
+func (h *alertHandlerImpl) Name() string {
+	return fmt.Sprintf("%T", h)
 }
 
 func (h *alertHandlerImpl) Start() error {

--- a/sensor/common/admissioncontroller/message_forwarder.go
+++ b/sensor/common/admissioncontroller/message_forwarder.go
@@ -1,8 +1,6 @@
 package admissioncontroller
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -58,7 +56,7 @@ func (h *admCtrlMsgForwarderImpl) Stop() {
 }
 
 func (h *admCtrlMsgForwarderImpl) Name() string {
-	return fmt.Sprintf("%T", h)
+	return common.DefaultComponentName(h)
 }
 
 func (h *admCtrlMsgForwarderImpl) Notify(event common.SensorComponentEvent) {

--- a/sensor/common/admissioncontroller/message_forwarder.go
+++ b/sensor/common/admissioncontroller/message_forwarder.go
@@ -1,6 +1,8 @@
 package admissioncontroller
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -53,6 +55,10 @@ func (h *admCtrlMsgForwarderImpl) Stop() {
 	}
 
 	h.stopper.Client().Stop()
+}
+
+func (h *admCtrlMsgForwarderImpl) Name() string {
+	return fmt.Sprintf("%T", h)
 }
 
 func (h *admCtrlMsgForwarderImpl) Notify(event common.SensorComponentEvent) {

--- a/sensor/common/admissioncontroller/mocks/alert_handler.go
+++ b/sensor/common/admissioncontroller/mocks/alert_handler.go
@@ -58,6 +58,20 @@ func (mr *MockAlertHandlerMockRecorder) Capabilities() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockAlertHandler)(nil).Capabilities))
 }
 
+// Name mocks base method.
+func (m *MockAlertHandler) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockAlertHandlerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockAlertHandler)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockAlertHandler) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -1,7 +1,6 @@
 package compliance
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -41,7 +40,7 @@ type auditLogCollectionManagerImpl struct {
 }
 
 func (a *auditLogCollectionManagerImpl) Name() string {
-	return fmt.Sprintf("%T", a)
+	return common.DefaultComponentName(a)
 }
 
 func (a *auditLogCollectionManagerImpl) Start() error {

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -37,6 +38,10 @@ type auditLogCollectionManagerImpl struct {
 
 	fileStateLock  sync.RWMutex
 	connectionLock sync.RWMutex
+}
+
+func (a *auditLogCollectionManagerImpl) Name() string {
+	return fmt.Sprintf("%T", a)
 }
 
 func (a *auditLogCollectionManagerImpl) Start() error {

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -1,7 +1,6 @@
 package compliance
 
 import (
-	"fmt"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -46,7 +45,7 @@ func (c *commandHandlerImpl) Start() error {
 }
 
 func (c *commandHandlerImpl) Name() string {
-	return fmt.Sprintf("%T", c)
+	return common.DefaultComponentName(c)
 }
 
 func (c *commandHandlerImpl) Stop() {

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -42,6 +43,10 @@ func (c *commandHandlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 func (c *commandHandlerImpl) Start() error {
 	go c.run()
 	return nil
+}
+
+func (c *commandHandlerImpl) Name() string {
+	return fmt.Sprintf("%T", c)
 }
 
 func (c *commandHandlerImpl) Stop() {

--- a/sensor/common/compliance/mocks/auditlog_manager.go
+++ b/sensor/common/compliance/mocks/auditlog_manager.go
@@ -121,6 +121,20 @@ func (mr *MockAuditLogCollectionManagerMockRecorder) ForceUpdate() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceUpdate", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).ForceUpdate))
 }
 
+// Name mocks base method.
+func (m *MockAuditLogCollectionManager) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockAuditLogCollectionManagerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockAuditLogCollectionManager) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()

--- a/sensor/common/compliance/mocks/service.go
+++ b/sensor/common/compliance/mocks/service.go
@@ -121,6 +121,20 @@ func (mr *MockServiceMockRecorder) IndexReportWraps() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexReportWraps", reflect.TypeOf((*MockService)(nil).IndexReportWraps))
 }
 
+// Name mocks base method.
+func (m *MockService) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockServiceMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockService)(nil).Name))
+}
+
 // NodeInventories mocks base method.
 func (m *MockService) NodeInventories() <-chan *storage.NodeInventory {
 	m.ctrl.T.Helper()

--- a/sensor/common/compliance/multiplexer.go
+++ b/sensor/common/compliance/multiplexer.go
@@ -1,8 +1,6 @@
 package compliance
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -24,7 +22,7 @@ type Multiplexer struct {
 }
 
 func (c *Multiplexer) Name() string {
-	return fmt.Sprintf("%T", c)
+	return common.DefaultComponentName(c)
 }
 
 // Stopped returns a signal allowing to check whether the component has been stopped

--- a/sensor/common/compliance/multiplexer.go
+++ b/sensor/common/compliance/multiplexer.go
@@ -1,6 +1,8 @@
 package compliance
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -19,6 +21,10 @@ type Multiplexer struct {
 	mp         channelmultiplexer.ChannelMultiplexer[common.MessageToComplianceWithAddress]
 	components []common.ComplianceComponent
 	stopper    concurrency.Stopper
+}
+
+func (c *Multiplexer) Name() string {
+	return fmt.Sprintf("%T", c)
 }
 
 // Stopped returns a signal allowing to check whether the component has been stopped

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -1,7 +1,6 @@
 package compliance
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -53,7 +52,7 @@ type nodeInventoryHandlerImpl struct {
 }
 
 func (c *nodeInventoryHandlerImpl) Name() string {
-	return fmt.Sprintf("%T", c)
+	return common.DefaultComponentName(c)
 }
 
 func (c *nodeInventoryHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -49,6 +50,10 @@ type nodeInventoryHandlerImpl struct {
 	// archCache stores an architecture per node, so that it can be used in the index report for
 	// the 'rhcos' package. The arch is discovered once and then reused for subsequent scans.
 	archCache map[string]string
+}
+
+func (c *nodeInventoryHandlerImpl) Name() string {
+	return fmt.Sprintf("%T", c)
 }
 
 func (c *nodeInventoryHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -47,6 +47,10 @@ type serviceImpl struct {
 	stopper     set.Set[concurrency.Stopper]
 }
 
+func (s *serviceImpl) Name() string {
+	return fmt.Sprintf("%T", s)
+}
+
 func (s *serviceImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
 	switch e {

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -48,7 +48,7 @@ type serviceImpl struct {
 }
 
 func (s *serviceImpl) Name() string {
-	return fmt.Sprintf("%T", s)
+	return common.DefaultComponentName(s)
 }
 
 func (s *serviceImpl) Notify(e common.SensorComponentEvent) {

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -54,6 +54,13 @@ func LogSensorComponentEvent(e SensorComponentEvent, optComponentName ...string)
 	}
 }
 
+func DefaultComponentName[T any](instance *T) string {
+	if instance == nil {
+		instance = new(T)
+	}
+	return fmt.Sprintf("%T", *instance)
+}
+
 // Notifiable is the interface used by Sensor to notify components of state changes in Central<->Sensor connectivity.
 type Notifiable interface {
 	Notify(e SensorComponentEvent)

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -69,6 +69,7 @@ type SensorComponent interface {
 
 	ProcessMessage(msg *central.MsgToSensor) error
 	ResponsesC() <-chan *message.ExpiringMessage
+	Name() string
 }
 
 // MessageToComplianceWithAddress adds the Hostname to sensor.MsgToCompliance so we know where to send it to.

--- a/sensor/common/config/handler.go
+++ b/sensor/common/config/handler.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -52,6 +54,10 @@ type configHandlerImpl struct {
 	admCtrlSettingsMgr        admissioncontroller.SettingsManager
 	auditLogCollectionManager compliance.AuditLogCollectionManager
 	stopC                     concurrency.ErrorSignal
+}
+
+func (c *configHandlerImpl) Name() string {
+	return fmt.Sprintf("%T", c)
 }
 
 func (c *configHandlerImpl) Start() error {

--- a/sensor/common/config/handler.go
+++ b/sensor/common/config/handler.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -57,7 +55,7 @@ type configHandlerImpl struct {
 }
 
 func (c *configHandlerImpl) Name() string {
-	return fmt.Sprintf("%T", c)
+	return common.DefaultComponentName(c)
 }
 
 func (c *configHandlerImpl) Start() error {

--- a/sensor/common/config/mocks/handler.go
+++ b/sensor/common/config/mocks/handler.go
@@ -100,6 +100,20 @@ func (mr *MockHandlerMockRecorder) GetHelmManagedConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHelmManagedConfig", reflect.TypeOf((*MockHandler)(nil).GetHelmManagedConfig))
 }
 
+// Name mocks base method.
+func (m *MockHandler) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHandlerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHandler)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockHandler) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()

--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -3,6 +3,7 @@ package delegatedregistry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -40,6 +41,10 @@ type delegatedRegistryImpl struct {
 	stopSig       concurrency.Signal
 	localScan     *scan.LocalScan
 	imageSvc      v1.ImageServiceClient
+}
+
+func (d *delegatedRegistryImpl) Name() string {
+	return fmt.Sprintf("%T", d)
 }
 
 // NewHandler returns a new instance of Handler.

--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -3,7 +3,6 @@ package delegatedregistry
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -44,7 +43,7 @@ type delegatedRegistryImpl struct {
 }
 
 func (d *delegatedRegistryImpl) Name() string {
-	return fmt.Sprintf("%T", d)
+	return common.DefaultComponentName(d)
 }
 
 // NewHandler returns a new instance of Handler.

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -2,6 +2,7 @@ package deploymentenhancer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -28,6 +29,10 @@ type DeploymentEnhancer struct {
 	storeProvider    store.Provider
 	ctx              context.Context
 	ctxCancel        context.CancelFunc
+}
+
+func (d *DeploymentEnhancer) Name() string {
+	return fmt.Sprintf("%T", d)
 }
 
 // CreateEnhancer creates a new Enhancer

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -2,7 +2,6 @@ package deploymentenhancer
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -32,7 +31,7 @@ type DeploymentEnhancer struct {
 }
 
 func (d *DeploymentEnhancer) Name() string {
-	return fmt.Sprintf("%T", d)
+	return common.DefaultComponentName(d)
 }
 
 // CreateEnhancer creates a new Enhancer

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -177,6 +178,10 @@ type detectorImpl struct {
 	networkFlowsQueue *queue.Queue[*queue.FlowQueueItem]
 	indicatorsQueue   *queue.Queue[*queue.IndicatorQueueItem]
 	deploymentsQueue  queue.SimpleQueue[*queue.DeploymentQueueItem]
+}
+
+func (d *detectorImpl) Name() string {
+	return fmt.Sprintf("%T", d)
 }
 
 func (d *detectorImpl) Start() error {

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -2,7 +2,6 @@ package detector
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 
@@ -181,7 +180,7 @@ type detectorImpl struct {
 }
 
 func (d *detectorImpl) Name() string {
-	return fmt.Sprintf("%T", d)
+	return common.DefaultComponentName(d)
 }
 
 func (d *detectorImpl) Start() error {

--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -60,6 +60,20 @@ func (mr *MockDetectorMockRecorder) Capabilities() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockDetector)(nil).Capabilities))
 }
 
+// Name mocks base method.
+func (m *MockDetector) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockDetectorMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockDetector)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockDetector) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -2,7 +2,6 @@ package enforcer
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -45,7 +44,7 @@ type enforcer struct {
 }
 
 func (e *enforcer) Name() string {
-	return fmt.Sprintf("%T", e)
+	return common.DefaultComponentName(e)
 }
 
 func (e *enforcer) Capabilities() []centralsensor.SensorCapability {

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -2,6 +2,7 @@ package enforcer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -41,6 +42,10 @@ type enforcer struct {
 	enforcementMap map[storage.EnforcementAction]EnforceFunc
 	actionsC       chan *central.SensorEnforcement
 	stopper        concurrency.Stopper
+}
+
+func (e *enforcer) Name() string {
+	return fmt.Sprintf("%T", e)
 }
 
 func (e *enforcer) Capabilities() []centralsensor.SensorCapability {

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -2,6 +2,7 @@ package externalsrcs
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -62,6 +63,10 @@ func (h *handlerImpl) Start() error {
 
 func (h *handlerImpl) Stop() {
 	h.stopSig.Signal()
+}
+
+func (h *handlerImpl) Name() string {
+	return fmt.Sprintf("%T", h)
 }
 
 func (h *handlerImpl) Notify(common.SensorComponentEvent) {}

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -2,7 +2,6 @@ package externalsrcs
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -66,7 +65,7 @@ func (h *handlerImpl) Stop() {
 }
 
 func (h *handlerImpl) Name() string {
-	return fmt.Sprintf("%T", h)
+	return common.DefaultComponentName(h)
 }
 
 func (h *handlerImpl) Notify(common.SensorComponentEvent) {}

--- a/sensor/common/externalsrcs/mocks/handler.go
+++ b/sensor/common/externalsrcs/mocks/handler.go
@@ -127,6 +127,20 @@ func (mr *MockHandlerMockRecorder) Capabilities() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockHandler)(nil).Capabilities))
 }
 
+// Name mocks base method.
+func (m *MockHandler) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHandlerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHandler)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockHandler) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
@@ -63,7 +62,7 @@ type serviceImpl struct {
 }
 
 func (s *serviceImpl) Name() string {
-	return fmt.Sprintf("%T", s)
+	return common.DefaultComponentName(s)
 }
 
 func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
@@ -59,6 +60,10 @@ type serviceImpl struct {
 	registryStore registryStore
 	localScan     localScan
 	centralReady  concurrency.Signal
+}
+
+func (s *serviceImpl) Name() string {
+	return fmt.Sprintf("%T", s)
 }
 
 func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -365,6 +365,10 @@ type networkFlowManager struct {
 	pubSub  *internalmessage.MessageSubscriber
 }
 
+func (m *networkFlowManager) Name() string {
+	return fmt.Sprintf("%T", m)
+}
+
 func (m *networkFlowManager) ProcessMessage(_ *central.MsgToSensor) error {
 	return nil
 }

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -366,7 +366,7 @@ type networkFlowManager struct {
 }
 
 func (m *networkFlowManager) Name() string {
-	return fmt.Sprintf("%T", m)
+	return common.DefaultComponentName(m)
 }
 
 func (m *networkFlowManager) ProcessMessage(_ *central.MsgToSensor) error {

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -1,8 +1,6 @@
 package reprocessor
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -46,7 +44,7 @@ type handlerImpl struct {
 }
 
 func (h *handlerImpl) Name() string {
-	return fmt.Sprintf("%T", h)
+	return common.DefaultComponentName(h)
 }
 
 func (h *handlerImpl) Start() error {

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -1,6 +1,8 @@
 package reprocessor
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -41,6 +43,10 @@ type handlerImpl struct {
 	detector           detector.Detector
 	imageCache         cache.Image
 	stopSig            concurrency.ErrorSignal
+}
+
+func (h *handlerImpl) Name() string {
+	return fmt.Sprintf("%T", h)
 }
 
 func (h *handlerImpl) Start() error {

--- a/sensor/common/reprocessor/mocks/handler.go
+++ b/sensor/common/reprocessor/mocks/handler.go
@@ -57,6 +57,20 @@ func (mr *MockHandlerMockRecorder) Capabilities() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockHandler)(nil).Capabilities))
 }
 
+// Name mocks base method.
+func (m *MockHandler) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHandlerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHandler)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockHandler) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -508,6 +508,10 @@ type fakeSensorComponent struct {
 	responsesC chan *message.ExpiringMessage
 }
 
+func (f fakeSensorComponent) Name() string {
+	return fmt.Sprintf("%T", f)
+}
+
 func (f fakeSensorComponent) Notify(common.SensorComponentEvent) {
 	panic("implement me")
 }

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -509,7 +509,7 @@ type fakeSensorComponent struct {
 }
 
 func (f fakeSensorComponent) Name() string {
-	return fmt.Sprintf("%T", f)
+	return "sensor.fakeSensorComponent"
 }
 
 func (f fakeSensorComponent) Notify(common.SensorComponentEvent) {

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -2,12 +2,12 @@ package signal
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
@@ -62,6 +62,10 @@ type serviceImpl struct {
 	processPipeline  Pipeline
 	writer           io.Writer
 	authFuncOverride func(context.Context, string) (context.Context, error)
+}
+
+func (s *serviceImpl) Name() string {
+	return fmt.Sprintf("%T", s)
 }
 
 func authFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -2,7 +2,6 @@ package signal
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"strings"
 
@@ -65,7 +64,7 @@ type serviceImpl struct {
 }
 
 func (s *serviceImpl) Name() string {
-	return fmt.Sprintf("%T", s)
+	return common.DefaultComponentName(s)
 }
 
 func authFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {

--- a/sensor/kubernetes/admissioncontroller/config_map_persister.go
+++ b/sensor/kubernetes/admissioncontroller/config_map_persister.go
@@ -3,7 +3,6 @@ package admissioncontroller
 import (
 	"compress/gzip"
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -42,7 +41,7 @@ type configMapPersister struct {
 }
 
 func (p *configMapPersister) Name() string {
-	return fmt.Sprintf("%T", p)
+	return common.DefaultComponentName(p)
 }
 
 // NewConfigMapSettingsPersister creates a config persister object for the admission controller.

--- a/sensor/kubernetes/admissioncontroller/config_map_persister.go
+++ b/sensor/kubernetes/admissioncontroller/config_map_persister.go
@@ -3,6 +3,7 @@ package admissioncontroller
 import (
 	"compress/gzip"
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,6 +39,10 @@ type configMapPersister struct {
 	client v1client.ConfigMapInterface
 
 	settingsStreamIt concurrency.ValueStreamIter[*sensor.AdmissionControlSettings]
+}
+
+func (p *configMapPersister) Name() string {
+	return fmt.Sprintf("%T", p)
 }
 
 // NewConfigMapSettingsPersister creates a config persister object for the admission controller.

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -113,7 +113,7 @@ type tlsIssuerImpl struct {
 }
 
 func (i *tlsIssuerImpl) Name() string {
-	return fmt.Sprintf("%T", i)
+	return common.DefaultComponentName(i)
 }
 
 // Start starts the Sensor component and launches a certificate refresher that:

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -112,6 +112,10 @@ type tlsIssuerImpl struct {
 	activateLock                 sync.Mutex
 }
 
+func (i *tlsIssuerImpl) Name() string {
+	return fmt.Sprintf("%T", i)
+}
+
 // Start starts the Sensor component and launches a certificate refresher that:
 // * checks the state of the certificates whenever Sensor connects to Central, and several months before they expire
 // * updates the certificates if needed

--- a/sensor/kubernetes/clusterhealth/updater.go
+++ b/sensor/kubernetes/clusterhealth/updater.go
@@ -55,6 +55,10 @@ type updaterImpl struct {
 	cancelCtx      context.CancelFunc
 }
 
+func (u *updaterImpl) Name() string {
+	return fmt.Sprintf("%T", u)
+}
+
 func (u *updaterImpl) Start() error {
 	go u.run(u.updateTicker.C)
 	return nil

--- a/sensor/kubernetes/clusterhealth/updater.go
+++ b/sensor/kubernetes/clusterhealth/updater.go
@@ -56,7 +56,7 @@ type updaterImpl struct {
 }
 
 func (u *updaterImpl) Name() string {
-	return fmt.Sprintf("%T", u)
+	return common.DefaultComponentName(u)
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -2,7 +2,6 @@ package clustermetrics
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -72,7 +71,7 @@ type clusterMetricsImpl struct {
 }
 
 func (cm *clusterMetricsImpl) Name() string {
-	return fmt.Sprintf("%T", cm)
+	return common.DefaultComponentName(cm)
 }
 
 func (cm *clusterMetricsImpl) Start() error {

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -2,6 +2,7 @@ package clustermetrics
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -68,6 +69,10 @@ type clusterMetricsImpl struct {
 	pollingTimeout  time.Duration
 	k8sClient       kubernetes.Interface
 	pollTicker      *time.Ticker
+}
+
+func (cm *clusterMetricsImpl) Name() string {
+	return fmt.Sprintf("%T", cm)
 }
 
 func (cm *clusterMetricsImpl) Start() error {

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -3,7 +3,6 @@ package clusterstatus
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"slices"
 	"sync/atomic"
 	"time"
@@ -55,7 +54,7 @@ type updaterImpl struct {
 }
 
 func (u *updaterImpl) Name() string {
-	return fmt.Sprintf("%T", u)
+	return common.DefaultComponentName(u)
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -3,6 +3,7 @@ package clusterstatus
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"slices"
 	"sync/atomic"
 	"time"
@@ -51,6 +52,10 @@ type updaterImpl struct {
 	// This function is needed to be able to mock in test
 	getProviders                     func(context.Context) *storage.ProviderMetadata
 	getProviderMetadataFromOpenShift providerMetadataFromOpenShift
+}
+
+func (u *updaterImpl) Name() string {
+	return fmt.Sprintf("%T", u)
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -41,6 +41,10 @@ type handlerImpl struct {
 	complianceIsReady *concurrency.Signal
 }
 
+func (m *handlerImpl) Name() string {
+	return fmt.Sprintf("%T", m)
+}
+
 type scanScheduleConfiguration struct {
 	Suspend        *bool
 	Schedule       *string

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -42,7 +42,7 @@ type handlerImpl struct {
 }
 
 func (m *handlerImpl) Name() string {
-	return fmt.Sprintf("%T", m)
+	return common.DefaultComponentName(m)
 }
 
 type scanScheduleConfiguration struct {

--- a/sensor/kubernetes/complianceoperator/mocks/types.go
+++ b/sensor/kubernetes/complianceoperator/mocks/types.go
@@ -109,6 +109,20 @@ func (mr *MockInfoUpdaterMockRecorder) GetNamespace() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockInfoUpdater)(nil).GetNamespace))
 }
 
+// Name mocks base method.
+func (m *MockInfoUpdater) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockInfoUpdaterMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockInfoUpdater)(nil).Name))
+}
+
 // Notify mocks base method.
 func (m *MockInfoUpdater) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -2,7 +2,6 @@ package complianceoperator
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -101,7 +100,7 @@ type updaterImpl struct {
 }
 
 func (u *updaterImpl) Name() string {
-	return fmt.Sprintf("%T", u)
+	return common.DefaultComponentName(u)
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -2,6 +2,7 @@ package complianceoperator
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -97,6 +98,10 @@ type updaterImpl struct {
 	stopSig              concurrency.Signal
 	complianceOperatorNS string
 	isReady              *concurrency.Signal
+}
+
+func (u *updaterImpl) Name() string {
+	return fmt.Sprintf("%T", u)
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -2,7 +2,6 @@ package eventpipeline
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -43,7 +42,7 @@ type eventPipeline struct {
 }
 
 func (p *eventPipeline) Name() string {
-	return fmt.Sprintf("%T", p)
+	return common.DefaultComponentName(p)
 }
 
 // Capabilities implements common.SensorComponent

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -2,10 +2,10 @@ package eventpipeline
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
-
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -40,6 +40,10 @@ type eventPipeline struct {
 	contextMtx    sync.Mutex
 	context       context.Context
 	cancelContext context.CancelFunc
+}
+
+func (p *eventPipeline) Name() string {
+	return fmt.Sprintf("%T", p)
 }
 
 // Capabilities implements common.SensorComponent

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -29,6 +29,10 @@ type commandHandler struct {
 	stopSig concurrency.Signal
 }
 
+func (h *commandHandler) Name() string {
+	return fmt.Sprintf("%T", h)
+}
+
 // NewCommandHandler creates a new network policies command handler.
 func NewCommandHandler(client kubernetes.Interface) common.SensorComponent {
 	return newCommandHandler(client.NetworkingV1())

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -30,7 +30,7 @@ type commandHandler struct {
 }
 
 func (h *commandHandler) Name() string {
-	return fmt.Sprintf("%T", h)
+	return common.DefaultComponentName(h)
 }
 
 // NewCommandHandler creates a new network policies command handler.

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"runtime/pprof"
 	"sync/atomic"
@@ -54,7 +53,7 @@ type commandHandler struct {
 }
 
 func (h *commandHandler) Name() string {
-	return fmt.Sprintf("%T", h)
+	return common.DefaultComponentName(h)
 }
 
 // DiagnosticConfigurationFunc is a function that modifies the diagnostic configuration.

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"runtime/pprof"
 	"sync/atomic"
@@ -50,6 +51,10 @@ type commandHandler struct {
 
 	pendingContextCancels      map[string]context.CancelFunc
 	pendingContextCancelsMutex sync.Mutex
+}
+
+func (h *commandHandler) Name() string {
+	return fmt.Sprintf("%T", h)
 }
 
 // DiagnosticConfigurationFunc is a function that modifies the diagnostic configuration.

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -39,6 +40,10 @@ type commandHandler struct {
 	checkInClient       central.SensorUpgradeControlServiceClient
 
 	configHandler config.Handler
+}
+
+func (h *commandHandler) Name() string {
+	return fmt.Sprintf("%T", h)
 }
 
 // NewCommandHandler returns a new upgrade command handler for Kubernetes.

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -2,7 +2,6 @@ package upgrade
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -43,7 +42,7 @@ type commandHandler struct {
 }
 
 func (h *commandHandler) Name() string {
-	return fmt.Sprintf("%T", h)
+	return common.DefaultComponentName(h)
 }
 
 // NewCommandHandler returns a new upgrade command handler for Kubernetes.


### PR DESCRIPTION
### Description

Split from #16013 as it contained three changes, from which some were raising discussions. Here is the first change out of the three, so that we can approach them one-by-one.

Naming Sensor Components would make it easier to produce  meaningful metrics and logs when some components are misbehaving. The initial name is generated out of the type, but can be changed to something more friendly later if needed.
Note that the names are unused at the moment, but there are few places where they can be used out-of-the box (e.g., log about transitioning between the online/offline states). The PRs to use the new `Name()` will follow.

Reviewers, please let me know if you want me to manually go over the list of components and name them using human-brain power instead of the type name.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing


- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- existing CI only
