### PR TITLE
ROX-30143: Enable typescript-eslint consistent-type-exports rule

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -706,6 +706,7 @@ module.exports = [
             '@typescript-eslint/require-await': 'off', // about 20 errors
 
             '@typescript-eslint/array-type': 'error',
+            '@typescript-eslint/consistent-type-exports': 'error',
         },
     },
     {


### PR DESCRIPTION
### Description

https://typescript-eslint.io/rules/consistent-type-exports

> TypeScript allows specifying a `type` keyword on exports to indicate that the export exists only in the type system, not at runtime.

> This allows transpilers to drop exports without knowing the types of the dependencies.

No errors, because team already uses `export type` idiom.

However, close the door to errors by part-time contributors.

### Residue

Easy warm up before we start to enable rule for `import type` idiom (thatks to **David Vail** for introducing it) in batches via opt-in and opt-out for folders.

https://typescript-eslint.io/rules/consistent-type-imports

TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime.

> This allows transpilers to drop imports without knowing the types of the dependencies.

https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how

Published on 2023-02-24 but better late than never to apply it.

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [x] enabled lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.