### PR TITLE
ROX-29846: Reverts the UI to rr5 compat layer for OCP compatibility

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -22,6 +22,7 @@
                 "@patternfly/react-user-feedback": "^5.0.0",
                 "axios": "^1.10.0",
                 "computed-style-to-inline-style": "^3.0.0",
+                "connected-react-router": "^6.9.3",
                 "core-js": "^3.43.0",
                 "d3-axis": "^1.0.12",
                 "d3-brush": "^3.0.0",
@@ -36,7 +37,7 @@
                 "formik": "^2.2.9",
                 "framer-motion": "^10.0.0",
                 "graphql": "^16.11.0",
-                "history": "^5.3.0",
+                "history": "^4.10.1",
                 "html2canvas": "1.0.0-rc.7",
                 "initials": "^3.1.2",
                 "js-base64": "^3.7.2",
@@ -65,7 +66,8 @@
                 "react-popper": "0.9.0",
                 "react-redux": "^7.2.6",
                 "react-responsive": "^9.0.2",
-                "react-router-dom": "^6.28.0",
+                "react-router-dom": "^5.3.4",
+                "react-router-dom-v5-compat": "^6.30.0",
                 "react-router-hash-link": "^2.4.3",
                 "react-select": "^2.0.0",
                 "react-spinners": "^0.10.4",
@@ -77,7 +79,6 @@
                 "react-vis": "^1.12.1",
                 "redoc": "^2.5.0",
                 "redux": "^4.1.2",
-                "redux-first-history": "^5.2.0",
                 "redux-form": "^8.3.10",
                 "redux-saga": "^0.16.0",
                 "redux-thunk": "^2.4.1",
@@ -3649,9 +3650,10 @@
             }
         },
         "node_modules/@remix-run/router": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
-            "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+            "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -6904,6 +6906,27 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "node_modules/connected-react-router": {
+            "version": "6.9.3",
+            "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.3.tgz",
+            "integrity": "sha512-4ThxysOiv/R2Dc4Cke1eJwjKwH1Y51VDwlOrOfs1LjpdYOVvCNjNkZDayo7+sx42EeGJPQUNchWkjAIJdXGIOQ==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.isequalwith": "^4.4.0",
+                "prop-types": "^15.7.2"
+            },
+            "optionalDependencies": {
+                "immutable": "^3.8.1 || ^4.0.0",
+                "seamless-immutable": "^7.1.3"
+            },
+            "peerDependencies": {
+                "history": "^4.7.2",
+                "react": "^16.4.0 || ^17.0.0",
+                "react-redux": "^6.0.0 || ^7.1.0",
+                "react-router": "^4.3.1 || ^5.0.0",
+                "redux": "^3.6.0 || ^4.0.0"
+            }
         },
         "node_modules/convert-source-map": {
             "version": "1.7.0",
@@ -10161,12 +10184,17 @@
             "license": "CC0-1.0"
         },
         "node_modules/history": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-            "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.6"
+                "@babel/runtime": "^7.1.2",
+                "loose-envify": "^1.2.0",
+                "resolve-pathname": "^3.0.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0",
+                "value-equal": "^1.0.1"
             }
         },
         "node_modules/hoist-non-react-statics": {
@@ -10317,8 +10345,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
             "integrity": "sha1-uG943mre82CDle+yaakUYnl+LCM= sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/import-cwd": {
             "version": "3.0.0",
@@ -11019,8 +11046,7 @@
         "node_modules/isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-            "dev": true
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -11698,6 +11724,12 @@
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
             "dev": true
+        },
+        "node_modules/lodash.isequalwith": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
+            "integrity": "sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ==",
+            "license": "MIT"
         },
         "node_modules/lodash.ismatch": {
             "version": "4.4.0",
@@ -13034,6 +13066,15 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/path-to-regexp": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+            "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "0.0.1"
+            }
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -14010,33 +14051,84 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.28.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
-            "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+            "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.21.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "hoist-non-react-statics": "^3.1.0",
+                "loose-envify": "^1.3.1",
+                "path-to-regexp": "^1.7.0",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8"
+                "react": ">=15"
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.28.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
-            "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+            "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.21.0",
-                "react-router": "6.28.0"
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.2",
+                "react-router": "5.3.4",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=15"
+            }
+        },
+        "node_modules/react-router-dom-v5-compat": {
+            "version": "6.30.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.0.tgz",
+            "integrity": "sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==",
+            "license": "MIT",
+            "dependencies": {
+                "@remix-run/router": "1.23.0",
+                "history": "^5.3.0",
+                "react-router": "6.30.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
                 "react": ">=16.8",
-                "react-dom": ">=16.8"
+                "react-dom": ">=16.8",
+                "react-router-dom": "4 || 5"
+            }
+        },
+        "node_modules/react-router-dom-v5-compat/node_modules/history": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+            "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.7.6"
+            }
+        },
+        "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+            "version": "6.30.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
+            "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@remix-run/router": "1.23.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
             }
         },
         "node_modules/react-router-hash-link": {
@@ -14388,15 +14480,6 @@
                 "@babel/runtime": "^7.9.2"
             }
         },
-        "node_modules/redux-first-history": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/redux-first-history/-/redux-first-history-5.2.0.tgz",
-            "integrity": "sha512-7kLqtSXGPZIgvEhl3B+3wRvzePvvZggpVqg+jpR2ZVqu2ESGj9DF6hMHpoEP7bGHqddljjKYjnRmtSetYEiG2Q==",
-            "peerDependencies": {
-                "history": "^4.7.2 || ^5.0",
-                "redux": "^3.6.0 || ^4.0.0 || ^5.0.0"
-            }
-        },
         "node_modules/redux-form": {
             "version": "8.3.10",
             "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-8.3.10.tgz",
@@ -14689,6 +14772,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/resolve-pathname": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+            "license": "MIT"
+        },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -14914,6 +15003,13 @@
             "engines": {
                 "node": ">=v12.22.7"
             }
+        },
+        "node_modules/seamless-immutable": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
+            "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
+            "license": "BSD-3-Clause",
+            "optional": true
         },
         "node_modules/semver": {
             "version": "6.3.1",
@@ -15843,6 +15939,12 @@
             "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
             "integrity": "sha1-2YDWa8crXVqcqG+3yf/bnImN3QM= sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/tiny-warning": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -16491,6 +16593,12 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/value-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+            "license": "MIT"
         },
         "node_modules/verror": {
             "version": "1.10.0",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -24,6 +24,7 @@
         "@patternfly/react-topology": "^5.2.1",
         "@patternfly/react-user-feedback": "^5.0.0",
         "axios": "^1.10.0",
+        "connected-react-router": "^6.9.3",
         "computed-style-to-inline-style": "^3.0.0",
         "core-js": "^3.43.0",
         "d3-axis": "^1.0.12",
@@ -39,7 +40,7 @@
         "formik": "^2.2.9",
         "framer-motion": "^10.0.0",
         "graphql": "^16.11.0",
-        "history": "^5.3.0",
+        "history": "^4.10.1",
         "html2canvas": "1.0.0-rc.7",
         "initials": "^3.1.2",
         "js-base64": "^3.7.2",
@@ -68,7 +69,8 @@
         "react-popper": "0.9.0",
         "react-redux": "^7.2.6",
         "react-responsive": "^9.0.2",
-        "react-router-dom": "^6.28.0",
+        "react-router-dom": "^5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0",
         "react-router-hash-link": "^2.4.3",
         "react-select": "^2.0.0",
         "react-spinners": "^0.10.4",
@@ -80,7 +82,6 @@
         "react-vis": "^1.12.1",
         "redoc": "^2.5.0",
         "redux": "^4.1.2",
-        "redux-first-history": "^5.2.0",
         "redux-form": "^8.3.10",
         "redux-saga": "^0.16.0",
         "redux-thunk": "^2.4.1",
@@ -139,7 +140,7 @@
         "@vitejs/plugin-basic-ssl": "^1.1.0",
         "@vitejs/plugin-react": "^4.4.0",
         "@vitest/coverage-v8": "^3.1.1",
-        "@vitest/eslint-plugin" : "^1.3.3",
+        "@vitest/eslint-plugin": "^1.3.3",
         "axe-core": "^4.10.3",
         "cypress": "^14.5.0",
         "cypress-axe": "^1.6.0",
@@ -187,7 +188,10 @@
         "autoprefixer": "10.4.5",
         "nth-check": "^2.1.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "connected-react-router": {
+            "react": "^18.0.0"
+        }
     },
     "browserslist": [
         "Chrome >= 80"

--- a/ui/apps/platform/src/Components/BreadcrumbItemLink.tsx
+++ b/ui/apps/platform/src/Components/BreadcrumbItemLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BreadcrumbItem, BreadcrumbItemProps } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 export type BreadcrumbItemLinkProps = {
     children: React.ReactNode;

--- a/ui/apps/platform/src/Components/ButtonLink/ButtonLink.jsx
+++ b/ui/apps/platform/src/Components/ButtonLink/ButtonLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 const ButtonLink = ({ children, dataTestId, extraClassNames, icon, linkTo }) => {
     return (

--- a/ui/apps/platform/src/Components/ContainerImageInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerImageInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';

--- a/ui/apps/platform/src/Components/CountWidget.jsx
+++ b/ui/apps/platform/src/Components/CountWidget.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import Widget from 'Components/Widget';
 
 const CountWidget = ({ title, count, description, linkUrl }) => {

--- a/ui/apps/platform/src/Components/FixableCVECount/FixableCVECount.jsx
+++ b/ui/apps/platform/src/Components/FixableCVECount/FixableCVECount.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 const orientations = ['horizontal', 'vertical'];
 

--- a/ui/apps/platform/src/Components/GroupedTabs.jsx
+++ b/ui/apps/platform/src/Components/GroupedTabs.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import upperFirst from 'lodash/upperFirst';
 
 const GroupedTab = ({ text, index, active, to }) => (

--- a/ui/apps/platform/src/Components/IconWidget.jsx
+++ b/ui/apps/platform/src/Components/IconWidget.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import Widget from 'Components/Widget';
 import Loader from 'Components/Loader';
 

--- a/ui/apps/platform/src/Components/InfoWidget.jsx
+++ b/ui/apps/platform/src/Components/InfoWidget.jsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import Widget from 'Components/Widget';
 import Loader from 'Components/Loader';
 

--- a/ui/apps/platform/src/Components/Menu.tsx
+++ b/ui/apps/platform/src/Components/Menu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { ChevronDown, ChevronUp } from 'react-feather';
 import { Tooltip } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
+++ b/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     Bullseye,
     Button,

--- a/ui/apps/platform/src/Components/PatternFly/Charts/LinkableChartLabel.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/Charts/LinkableChartLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { ChartLabel, ChartLabelProps } from '@patternfly/react-charts';
 
 export type LinkableChartLabelProps = ChartLabelProps & {

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import Raven from 'raven-js';
 
 import ErrorBoundaryPage from './ErrorBoundaryPage';

--- a/ui/apps/platform/src/Components/PatternFly/LinkShim/LinkShim.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/LinkShim/LinkShim.tsx
@@ -1,5 +1,5 @@
 import React, { AnchorHTMLAttributes, ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 /*
  * Given href prop, return React Router Link element with to prop.

--- a/ui/apps/platform/src/Components/RelatedEntity.jsx
+++ b/ui/apps/platform/src/Components/RelatedEntity.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import Widget from 'Components/Widget';
 import EntityIcon from 'Components/EntityIcon';

--- a/ui/apps/platform/src/Components/RelatedEntityListCount.jsx
+++ b/ui/apps/platform/src/Components/RelatedEntityListCount.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 
 import Widget from 'Components/Widget';

--- a/ui/apps/platform/src/Components/TabNav/TabNav.tsx
+++ b/ui/apps/platform/src/Components/TabNav/TabNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 type TabNavProps = {
     tabLinks: {

--- a/ui/apps/platform/src/Components/TableCellLink/TableCellLink.tsx
+++ b/ui/apps/platform/src/Components/TableCellLink/TableCellLink.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 export type TableCellLinkProps = {
     children: ReactNode;

--- a/ui/apps/platform/src/Components/TileLink/TileLink.jsx
+++ b/ui/apps/platform/src/Components/TileLink/TileLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import Loader from 'Components/Loader';
 import TileContent from 'Components/TileContent';

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.jsx
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import { components } from 'react-select';
 import queryString from 'qs';

--- a/ui/apps/platform/src/Components/visuals/SunburstDetailSection.jsx
+++ b/ui/apps/platform/src/Components/visuals/SunburstDetailSection.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
 import Truncate from 'react-truncate';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 class SunburstDetailSection extends Component {
     static propTypes = {

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 
 import { entityPathSegment } from './accessControlPaths';
 import AccessControlRouteNotFound from './AccessControlRouteNotFound';

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlLinks.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlLinks.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import { AccessControlEntityType } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import { useSelector, useDispatch } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { useFormik, FormikProvider, FieldArray } from 'formik';

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { selectors } from 'reducers';
-import { useLocation, useNavigate, useParams, Link } from 'react-router-dom';
+import { useLocation, useNavigate, useParams, Link } from 'react-router-dom-v5-compat';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsRoute.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsRoute.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import AdministrationEventPage from './AdministrationEventPage';
 import AdministrationEventsPage from './AdministrationEventsPage';

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import IconText from 'Components/PatternFly/IconText/IconText';

--- a/ui/apps/platform/src/Containers/AppPage.tsx
+++ b/ui/apps/platform/src/Containers/AppPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import {
     loginPath,

--- a/ui/apps/platform/src/Containers/AppPageTitle.tsx
+++ b/ui/apps/platform/src/Containers/AppPageTitle.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Location, useLocation } from 'react-router-dom';
+import { Location, useLocation } from 'react-router-dom-v5-compat';
 import capitalize from 'lodash/capitalize';
 
 import { basePathToLabelMap } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Card, Text } from '@patternfly/react-core';
 import { Tbody, Tr, Td, Table, Th, Thead } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Alert, Button, Flex, FlexItem } from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     ActionGroup,
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 
 import useAuthStatus from 'hooks/useAuthStatus'; // TODO after 4.4 release

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { ClusterRegistrationSecret } from 'services/ClustersService';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';
 
 import { searchCategories } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState, useReducer } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex } from '@patternfly/react-core';
 import { Cluster } from 'types/cluster.proto';
 import HelmIndicator from './HelmIndicator';

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpirationWidget.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpirationWidget.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 import useAuthStatus from 'hooks/useAuthStatus';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     ActionGroup,
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 
 import useAuthStatus from 'hooks/useAuthStatus'; // TODO after 4.4 release

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { ClusterInitBundle } from 'services/ClustersService';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     Alert,
     Bullseye,

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import usePermissions from 'hooks/usePermissions';
 import useURLParameter from 'hooks/useURLParameter';

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import {
     Button,
     Pagination,

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { DocumentNode, gql, useQuery } from '@apollo/client';
 
 import { complianceBasePath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Page.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import URLService from 'utils/URLService';
 import entityTypes from 'constants/entityTypes';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { resourceLabels } from 'messages/common';
 import URLService from 'utils/URLService';

--- a/ui/apps/platform/src/Containers/Compliance/List/List.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/List.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import lowerCase from 'lodash/lowerCase';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import lowerCase from 'lodash/lowerCase';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import Query from 'Components/CacheFirstQuery';
 import CloseButton from 'Components/CloseButton';

--- a/ui/apps/platform/src/Containers/Compliance/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Page.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import capitalize from 'lodash/capitalize';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 
 import URLService from 'utils/URLService';
 import entityTypes, { standardBaseTypes } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.jsx
@@ -6,7 +6,7 @@ import useCases from 'constants/useCaseTypes';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { AGGREGATED_RESULTS as QUERY } from 'queries/controls';
 import queryService from 'utils/queryService';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom-v5-compat';
 import searchContext from 'Containers/searchContext';
 
 import { entityNounOrdinaryCase } from '../entitiesForCompliance';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import Widget from 'Components/Widget';
 import ArcSingle from 'Components/visuals/ArcSingle';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.jsx
@@ -7,7 +7,7 @@ import {
     HorizontalBarSeries,
     LabelSeries,
 } from 'react-vis';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import merge from 'deepmerge';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/LinkListWidget.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/LinkListWidget.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Alert } from '@patternfly/react-core';
 
 import Widget from 'Components/Widget';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.jsx
@@ -12,7 +12,7 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { SEARCH_WITH_CONTROLS as QUERY } from 'queries/search';
 import queryService from 'utils/queryService';
 import { getResourceCountFromAggregatedResults } from 'utils/complianceUtils';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import useCases from 'constants/useCaseTypes';
 import searchContext from 'Containers/searchContext';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';
 import merge from 'lodash/merge';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';
 import capitalize from 'lodash/capitalize';
 import sortBy from 'lodash/sortBy';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/VerticalClusterBar.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/VerticalClusterBar.jsx
@@ -8,7 +8,7 @@ import {
     VerticalBarSeries,
 } from 'react-vis';
 import PropTypes from 'prop-types';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
 import merge from 'deepmerge';
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsPage.tsx
@@ -7,7 +7,7 @@ import {
     Tab,
     Tabs,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import { CompoundSearchFilterConfig, OnSearchPayload } from 'Components/CompoundSearchFilter/types';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     Pagination,
     Toolbar,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import {
     Alert,
     Breadcrumb,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     Pagination,
     Text,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoverageEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoverageEmptyState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Text, Bullseye, Flex, FlexItem, PageSection } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragePage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
 
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
-import { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router-dom-v5-compat';
 import {
     Bullseye,
     Divider,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     Divider,
     Pagination,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileClustersTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Divider, Pagination, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { InnerScrollContainer, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfilesTableToggleGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
 import useURLSearch from 'hooks/useURLSearch';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/hooks/useScanConfigRouter.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { generatePathWithQuery } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionDropdown.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Divider, DropdownItem } from '@patternfly/react-core';
-import { generatePath, useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom-v5-compat';
 
 import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigActionsColumn.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { generatePath, useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom-v5-compat';
 import { ActionsColumn } from '@patternfly/react-table';
 
 import { ComplianceScanConfigurationStatus } from 'services/ComplianceScanConfigurationService';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigDetailPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigDetailPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useCallback } from 'react';
-import { generatePath, Link, useParams } from 'react-router-dom';
+import { generatePath, Link, useParams } from 'react-router-dom-v5-compat';
 
 import usePageAction from 'hooks/usePageAction';
 import useRestQuery from 'hooks/useRestQuery';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 import { Banner } from '@patternfly/react-core';
 
 import usePageAction from 'hooks/usePageAction';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ScanConfigsTablePage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { generatePath, Link } from 'react-router-dom';
+import { generatePath, Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/ViewScanConfigDetail.tsx
@@ -15,7 +15,7 @@ import {
     TabTitleText,
     Title,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import { complianceEnhancedSchedulesPath } from 'routePaths';
 import useAlert from 'hooks/useAlert';

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ClusterSelection.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ClusterSelection.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, RefObject, useCallback } from 'react';
 import { FormikContextType, useFormikContext } from 'formik';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     Alert,
     Bullseye,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useCallback, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Button,
     Modal,

--- a/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 import PageNotFound from 'Components/PageNotFound';
 import searchContext from 'Containers/searchContext';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/AppMenu.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/AppMenu.jsx
@@ -4,7 +4,7 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import pluralize from 'pluralize';
 import entityLabels from 'messages/entity';
 import URLService from 'utils/URLService';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 import DashboardMenu from 'Components/DashboardMenu';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/CISControlsTile.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/CISControlsTile.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import URLService from 'utils/URLService';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import entityTypes from 'constants/entityTypes';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { gql, useQuery } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/PoliciesTile.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/PoliciesTile.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { gql } from '@apollo/client';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import entityTypes from 'constants/entityTypes';
 import Query from 'Components/ThrowingQuery';
 import EntityTileLink from 'Components/EntityTileLink';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/RBACMenu.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/RBACMenu.jsx
@@ -3,7 +3,7 @@ import entityTypes from 'constants/entityTypes';
 import pluralize from 'pluralize';
 import entityLabels from 'messages/entity';
 import URLService from 'utils/URLService';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 import DashboardMenu from 'Components/DashboardMenu';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.jsx
@@ -2,7 +2,7 @@ import React, { useState, useContext } from 'react';
 import { Alert } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 import queryService from 'utils/queryService';
 import entityTypes, { standardEntityTypes, standardBaseTypes } from 'constants/entityTypes';
 import { COMPLIANCE_FAIL_COLOR, COMPLIANCE_PASS_COLOR } from 'constants/severityColors';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/Lollipop.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/Lollipop.jsx
@@ -10,7 +10,7 @@ import {
     GradientDefs,
 } from 'react-vis';
 import max from 'lodash/max';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import BarGradient from 'Components/visuals/BarGradient';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.jsx
@@ -6,7 +6,7 @@ import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
 import networkStatuses from 'constants/networkStatuses';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import max from 'lodash/max';
 import { severityValues, severities } from 'constants/severities';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import dateFns from 'date-fns';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { gql } from '@apollo/client';
 import Loader from 'Components/Loader';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 import URLService from 'utils/URLService';
 import entityTypes from 'constants/entityTypes';
 import networkStatuses from 'constants/networkStatuses';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityControl.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityControl.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';
 import Query from 'Components/ThrowingQuery';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPage.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityTabs.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityTabs.jsx
@@ -5,7 +5,7 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import entityLabels from 'messages/entity';
 import pluralize from 'pluralize';
 import URLService from 'utils/URLService';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import GroupedTabs from 'Components/GroupedTabs';
 import entityTabsMap from '../entityTabRelationships';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/ConfigManagementEntityPolicy.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/ConfigManagementEntityPolicy.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.jsx
@@ -16,7 +16,7 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
 import Table, { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import TableWidget from './TableWidget';
 
 const getDeploymentsGroupedByPolicies = (data) => {

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/TableWidget.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/TableWidget.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import resolvePath from 'object-resolve-path';
 
 import Widget from 'Components/Widget';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListClusters.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListClusters.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListDeployments.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListDeployments.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNamespaces.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNamespaces.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import uniq from 'lodash/uniq';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListServiceAccounts.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListServiceAccounts.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/List.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/List.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom'; // Updated imports
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat'; // Updated imports
 import pluralize from 'pluralize';
 import resolvePath from 'object-resolve-path';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import resolvePath from 'object-resolve-path';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';
 import startCase from 'lodash/startCase';

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 import URLService from 'utils/URLService';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';
 import { ChevronRight } from 'react-feather';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom-v5-compat';
 
 import useEntityName from 'hooks/useEntityName';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate, Link } from 'react-router-dom';
+import { useLocation, useNavigate, Link } from 'react-router-dom-v5-compat';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import CloseButton from 'Components/CloseButton';

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import {
     Flex,
     FlexItem,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Chart,
     ChartAxis,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import {
     Button,
     EmptyState,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandardChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Chart,
     ChartAxis,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Truncate } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 import {
     Button,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, Title, Truncate } from '@patternfly/react-core';
 import { Table, Tbody, Tr, Td } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import {
     Flex,
     FlexItem,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Chart,
     ChartAxis,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, ReactElement, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { isUserResource } from 'Containers/AccessControl/traits';
 import useCentralCapabilities from 'hooks/useCentralCapabilities';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationTile.tsx
@@ -9,7 +9,7 @@ import {
     GalleryItem,
     Truncate,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';
 

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -8,7 +8,7 @@ import {
     Divider,
     Flex,
 } from '@patternfly/react-core';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom-v5-compat';
 import { connect } from 'react-redux';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -9,7 +9,7 @@ import {
     Title,
 } from '@patternfly/react-core';
 import { ActionsColumn, Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import IntegrationsNotFoundPage from './IntegrationsNotFoundPage';
 import IntegrationTilesPage from './IntegrationTiles/IntegrationTilesPage';

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { integrationsPath } from 'routePaths';
 
 import {

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationPermissions.test.jsx
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationPermissions.test.jsx
@@ -2,10 +2,12 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { HistoryRouter as Router } from 'redux-first-history/rr6';
+import { createBrowserHistory as createHistory } from 'history';
 
 import configureStore from 'init/configureStore';
 import useIntegrationPermissions from './useIntegrationPermissions';
+
+const history = createHistory();
 
 const initialStoreWrite = {
     app: {
@@ -43,14 +45,10 @@ const initialStoreNone = {
 
 describe('useIntegrationPermissions', () => {
     it('should return write permissions', () => {
-        const { store, history } = configureStore(initialStoreWrite);
+        const store = configureStore(initialStoreWrite, history);
 
         const { result } = renderHook(() => useIntegrationPermissions(), {
-            wrapper: ({ children }) => (
-                <Router history={history}>
-                    <Provider store={store}>{children}</Provider>
-                </Router>
-            ),
+            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
         });
 
         expect(result.current.authProviders.write).toEqual(true);
@@ -64,14 +62,10 @@ describe('useIntegrationPermissions', () => {
     });
 
     it('should return read permissions', () => {
-        const { store, history } = configureStore(initialStoreRead);
+        const store = configureStore(initialStoreRead, history);
 
         const { result } = renderHook(() => useIntegrationPermissions(), {
-            wrapper: ({ children }) => (
-                <Router history={history}>
-                    <Provider store={store}>{children}</Provider>
-                </Router>
-            ),
+            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
         });
 
         expect(result.current.authProviders.write).toEqual(false);
@@ -85,14 +79,10 @@ describe('useIntegrationPermissions', () => {
     });
 
     it('should return no permissions', () => {
-        const { store, history } = configureStore(initialStoreNone);
+        const store = configureStore(initialStoreNone, history);
 
         const { result } = renderHook(() => useIntegrationPermissions(), {
-            wrapper: ({ children }) => (
-                <Router history={history}>
-                    <Provider store={store}>{children}</Provider>
-                </Router>
-            ),
+            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
         });
 
         expect(result.current.authProviders.write).toEqual(false);

--- a/ui/apps/platform/src/Containers/Integrations/hooks/usePageState.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/usePageState.ts
@@ -1,4 +1,4 @@
-import { useLocation, useMatch } from 'react-router-dom';
+import { useLocation, useMatch } from 'react-router-dom-v5-compat';
 import {
     integrationCreatePath,
     integrationDetailsPath,

--- a/ui/apps/platform/src/Containers/Login/LoginPage.jsx
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { ClipLoader } from 'react-spinners';

--- a/ui/apps/platform/src/Containers/MainPage/AuthenticatedRoutes.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AuthenticatedRoutes.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom-v5-compat';
 import { createStructuredSelector } from 'reselect';
 
 import LoadingSection from 'Components/PatternFly/LoadingSection';

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -1,6 +1,6 @@
 import React, { ElementType, ReactElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 
 // Import path variables in alphabetical order to minimize merge conflicts when multiple people add routes.

--- a/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusButton.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusButton.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 import { Activity } from 'react-feather';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Tooltip } from '@patternfly/react-core';
 
 import { clustersBasePath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/MainPage/Header/GlobalSearchButton.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/GlobalSearchButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { useDispatch } from 'react-redux';
 import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Divider, DropdownItem } from '@patternfly/react-core';
 import initials from 'initials';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import useAnalytics, { INVITE_USERS_MODAL_OPENED } from 'hooks/useAnalytics';

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Alert, ClipboardCopy, Text } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import { accessControlBasePath } from 'routePaths';
 import { BucketsForNewAndExistingEmails } from './InviteUsers.utils';

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Alert, Button, Modal, ModalBoxBody, ModalBoxFooter, Text } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Page, Button } from '@patternfly/react-core';
 import { OutlinedCommentsIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { matchPath, useLocation, useNavigate } from 'react-router-dom';
+import { matchPath, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {
     Nav,
     Dropdown,

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationItem.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationItem.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom-v5-compat';
 import { NavItem } from '@patternfly/react-core';
 
 export type NavigationItemProps = {

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Location, matchPath, useLocation } from 'react-router-dom';
+import { Location, matchPath, useLocation } from 'react-router-dom-v5-compat';
 import {
     Nav,
     NavExpandable,

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { Location, matchPath } from 'react-router-dom';
+import { Location, matchPath } from 'react-router-dom-v5-compat';
 
 import { isRouteEnabled, RouteKey } from 'routePaths';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import relatedEntitySVG from 'images/network-graph/related-entity.svg';
 import filteredEntitySVG from 'images/network-graph/filtered-entity.svg';

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useRef } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { Popover } from '@patternfly/react-core';
 import {
     SELECTION_EVENT,

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { networkBasePath } from 'routePaths';
 import useAnalytics, { CLUSTER_LEVEL_SIMULATOR_OPENED } from 'hooks/useAnalytics';

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONSuccess.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONSuccess.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Button, Flex, FlexItem, ModalBoxBody, ModalBoxFooter } from '@patternfly/react-core';
 
 import { ListPolicy } from 'types/policy.proto';

--- a/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import usePermissions from 'hooks/usePermissions';
 import useURLSearch from 'hooks/useURLSearch';

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import {
     Button,
     Divider,

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     PageSection,
     Bullseye,

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { FormikProvider, useFormik } from 'formik';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     Button,
     Modal,

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { Form } from '@patternfly/react-core';
 import { useField } from 'formik';

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 
 import PoliciesPage from 'Containers/Policies/PoliciesPage';
 import PolicyCategoriesPage from 'Containers/PolicyCategories/PolicyCategoriesPage';

--- a/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.jsx
+++ b/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import lowerCase from 'lodash/lowerCase';
 import capitalize from 'lodash/capitalize';
 

--- a/ui/apps/platform/src/Containers/Risk/CreatePolicyFromSearch.jsx
+++ b/ui/apps/platform/src/Containers/Risk/CreatePolicyFromSearch.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { connect } from 'react-redux';
 import { Button } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Risk/KeyValuePairs.jsx
+++ b/ui/apps/platform/src/Containers/Risk/KeyValuePairs.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import isObject from 'lodash/isObject';
 import isArray from 'lodash/isArray';

--- a/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';
 
 import { PageBody } from 'Components/Panel';

--- a/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Alert } from '@patternfly/react-core';
 
 import Tabs from 'Components/Tabs';

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Bullseye } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.jsx
+++ b/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import find from 'lodash/find';
 import { Tooltip } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 import { SearchResultCategory } from 'services/SearchService';

--- a/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem, Nav, NavItem, NavList, Split, SplitItem } from '@patternfly/react-core';
 
 import { SearchResponse } from 'services/SearchService';

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, ReactElement } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {
     Alert,
     Bullseye,

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 import { SearchResult } from 'services/SearchService';

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
 import { clustersBasePath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
+++ b/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, Icon } from '@patternfly/react-core';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/User/UserPage.jsx
+++ b/ui/apps/platform/src/Containers/User/UserPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavLink, Route, Routes, useMatch, useParams } from 'react-router-dom';
+import { NavLink, Route, Routes, useMatch, useParams } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector, createSelector } from 'reselect';

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Divider } from '@patternfly/react-core';
 
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import startCase from 'lodash/startCase';
 import {
     Bullseye,

--- a/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import ViolationsTablePage from './ViolationsTablePage';
 import ViolationDetailsPage from './Details/ViolationDetailsPage';

--- a/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import startCase from 'lodash/startCase';
 import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import usePermissions from 'hooks/usePermissions';
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/WorkflowDashboardLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/WorkflowDashboardLayout.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import URLService from 'utils/URLService';
 import useCaseTypes from 'constants/useCaseTypes';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import parseURL from 'utils/URLParser';
 import workflowStateContext from 'Containers/workflowStateContext';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import Metadata from 'Components/Metadata';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import RiskScore from 'Components/RiskScore';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import Metadata from 'Components/Metadata';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import resolvePath from 'object-resolve-path';
 
 import workflowStateContext from 'Containers/workflowStateContext';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import startCase from 'lodash/startCase';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumb.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumb.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import useEntityName from 'hooks/useEntityName';
 import { VulnerabilityManagementEntityType } from 'utils/entityRelationships';

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { ChevronRight, ArrowLeft } from 'react-feather';
 
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import * as Icon from 'react-feather';
 import { connect } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import {
     defaultHeaderClassName,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useRef, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import resolvePath from 'object-resolve-path';
 import workflowStateContext from 'Containers/workflowStateContext';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd, PanelTitle } from 'Components/Panel';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPage.jsx
@@ -4,7 +4,7 @@ import { Bullseye } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
 import Raven from 'raven-js';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import startCase from 'lodash/startCase';
 
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';

--- a/ui/apps/platform/src/Containers/VulnMgmt/WorkflowLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/WorkflowLayout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom-v5-compat';
 
 import CloseButton from 'Components/CloseButton';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/LabeledBarGraph.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/LabeledBarGraph.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import max from 'lodash/max';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import {
     FlexibleXYPlot,

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedGrid.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedGrid.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 const NumberedGrid = ({ data }) => {
     const stacked = data.length < 4;

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedList.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Tooltip } from '@patternfly/react-core';
 
 import DetailedTooltipContent from 'Components/DetailedTooltipContent';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/Scatterplot.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/Scatterplot.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     FlexibleXYPlot,
     XAxis,

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 const ViewAllButton = ({ url }: { url: string }): ReactElement => {
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionManagementPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import ExceptionRequestsPage from './ExceptionRequestsPage';
 import ExceptionRequestDetailsPage from './ExceptionRequestDetailsPage';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -17,7 +17,7 @@ import {
     Title,
     pluralize,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import { exceptionManagementPath } from 'routePaths';
 import useSet from 'hooks/useSet';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -8,7 +8,7 @@ import {
     Tabs,
     Title,
 } from '@patternfly/react-core';
-import { Route, Routes, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Route, Routes, Navigate, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import { exceptionManagementPath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import {
     Button,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql, useQuery } from '@apollo/client';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { pluralize } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Td, ExpandableRowContent, Tbody } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 import {
     PageSection,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Truncate, pluralize } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import { TableUIState } from 'utils/getTableUIState';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -12,7 +12,7 @@ import {
     Title,
     pluralize,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Text } from '@patternfly/react-core';
 import {
     ActionsColumn,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Truncate } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { Text } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Td, ExpandableRowContent, Tbody } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import {
     PageSection,
     Breadcrumb,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Text } from '@patternfly/react-core';
 import {
     ActionsColumn,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { pluralize } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Td, Tbody } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { Truncate } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -15,7 +15,7 @@ import {
     Title,
     pluralize,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CloneVulnReportPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
     PageSection,
     Title,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/CreateVulnReportPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     PageSection,
     Title,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/EditVulnReportPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
     PageSection,
     Title,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Button, Modal, Wizard, WizardStep } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
 import isEmpty from 'lodash/isEmpty';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { useNavigate, useParams, generatePath } from 'react-router-dom';
+import { useNavigate, useParams, generatePath } from 'react-router-dom-v5-compat';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 
 import usePageAction from 'hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, generatePath, useNavigate } from 'react-router-dom';
+import { Link, generatePath, useNavigate } from 'react-router-dom-v5-compat';
 import isEmpty from 'lodash/isEmpty';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PageSection, Title, Tabs, Tab } from '@patternfly/react-core';
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import PageTitle from 'Components/PageTitle';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -9,7 +9,7 @@ import {
     TabTitleText,
     Tabs,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 
 import PageTitle from 'Components/PageTitle';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -18,7 +18,7 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 import isEmpty from 'lodash/isEmpty';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -11,7 +11,7 @@ import {
     Split,
     SplitItem,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import NotFoundMessage from 'Components/NotFoundMessage';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { pluralize } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 
 import { getQueryString } from 'utils/queryStringUtils';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, pluralize, Truncate } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { gql } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import {
     ActionsColumn,
     ExpandableRowContent,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import {
     ActionsColumn,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Td } from '@patternfly/react-table';
 
 import { exceptionManagementPath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Button, Flex, FlexItem, Tooltip, Truncate } from '@patternfly/react-core';
 import { OutlinedCopyIcon } from '@patternfly/react-icons';
 import useClipboardCopy from 'hooks/useClipboardCopy';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/PendingExceptionLabelLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/PendingExceptionLabelLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem, Label } from '@patternfly/react-core';
 import { OutlinedClockIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, generatePath } from 'react-router-dom';
+import { Link, generatePath } from 'react-router-dom-v5-compat';
 import { Flex, List, ListItem, Text, Button, FlexItem, Alert } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/hooks/useURLPagination.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLPagination.test.tsx
@@ -1,12 +1,39 @@
-import React from 'react';
-import { createMemoryHistory } from 'history';
-import { HistoryRouter as Router } from 'redux-first-history/rr6';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import React, { ReactNode } from 'react';
+// import { createMemoryHistory } from 'history';
+import { MemoryRouter as Router, Route, RouteComponentProps } from 'react-router-dom';
+// import { HistoryRouter as Router } from 'redux-first-history/rr6';
+import { CompatRouter, MemoryRouter, useLocation } from 'react-router-dom-v5-compat';
 import { renderHook } from '@testing-library/react';
 
 import actAndFlushTaskQueue from 'test-utils/flushTaskQueue';
 import { URLSearchParams } from 'url';
 import useURLPagination from './useURLPagination';
+
+type WrapperProps = {
+    children: ReactNode;
+    onRouteRender: (renderResult: RouteComponentProps) => void;
+    initialEntries: string[];
+};
+
+function Wrapper({ children, onRouteRender, initialEntries = [] }: WrapperProps) {
+    return (
+        <Router
+            initialEntries={initialEntries}
+            initialIndex={Math.max(0, initialEntries.length - 1)}
+        >
+            <CompatRouter>
+                <Route path="*" render={onRouteRender} />
+                {children}
+            </CompatRouter>
+        </Router>
+    );
+}
+
+const createWrapper = (props) => {
+    return function CreatedWrapper({ children }) {
+        return <Wrapper {...props}>{children}</Wrapper>;
+    };
+};
 
 test('should update pagination parameters in the URL', async () => {
     let params;
@@ -57,23 +84,22 @@ test('should update pagination parameters in the URL', async () => {
 
 test('should not add history states when setting values with a "replace" action', async () => {
     let params;
+    let historyLength;
+    let testLocation;
 
-    const history = createMemoryHistory({
-        initialEntries: [''],
+    const { result } = renderHook(() => useURLPagination(10), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ location, history }) => {
+                testLocation = location;
+                historyLength = history.length;
+            },
+            initialEntries: [''],
+        }),
     });
-
-    const { result } = renderHook(
-        () => {
-            return useURLPagination(10);
-        },
-        {
-            wrapper: ({ children }) => <Router history={history}>{children}</Router>,
-        }
-    );
-
     // Check the length of the initial history stack
-    params = new URLSearchParams(history.location.search);
-    expect(history.index).toBe(0);
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
     expect(params.get('page')).toBe(null);
     expect(params.get('perPage')).toBe(null);
 
@@ -84,8 +110,8 @@ test('should not add history states when setting values with a "replace" action'
     });
 
     // Check the length of the history stack after updating the page parameter
-    params = new URLSearchParams(history.location.search);
-    expect(history.index).toBe(0);
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
     expect(params.get('page')).toBe('2');
     expect(params.get('perPage')).toBe(null);
 
@@ -96,31 +122,31 @@ test('should not add history states when setting values with a "replace" action'
     });
 
     // Check the length of the history stack after updating the perPage parameter
-    params = new URLSearchParams(history.location.search);
-    expect(history.index).toBe(0);
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
     expect(params.get('page')).toBe(null);
     expect(params.get('perPage')).toBe('20');
 });
 
 test('should only add a single history state when setting perPage without an action parameter', async () => {
     let params;
+    let historyLength;
+    let testLocation;
 
-    const history = createMemoryHistory({
-        initialEntries: [''],
+    const { result } = renderHook(() => useURLPagination(10), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ location, history }) => {
+                testLocation = location;
+                historyLength = history.length;
+            },
+            initialEntries: [''],
+        }),
     });
 
-    const { result } = renderHook(
-        () => {
-            return useURLPagination(10);
-        },
-        {
-            wrapper: ({ children }) => <Router history={history}>{children}</Router>,
-        }
-    );
-
     // Check the length of the initial history stack
-    params = new URLSearchParams(history.location.search);
-    expect(history.index).toBe(0);
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(1);
     expect(params.get('page')).toBe(null);
     expect(params.get('perPage')).toBe(null);
 
@@ -131,8 +157,8 @@ test('should only add a single history state when setting perPage without an act
     });
 
     // Check the length of the history stack after updating the page parameter
-    params = new URLSearchParams(history.location.search);
-    expect(history.index).toBe(1);
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(2);
     expect(params.get('page')).toBe('2');
     expect(params.get('perPage')).toBe(null);
 
@@ -143,8 +169,8 @@ test('should only add a single history state when setting perPage without an act
     });
 
     // Check the length of the history stack after updating the perPage parameter
-    params = new URLSearchParams(history.location.search);
-    expect(history.index).toBe(2);
+    params = new URLSearchParams(testLocation.search);
+    expect(historyLength).toBe(3);
     expect(params.get('page')).toBe(null);
     expect(params.get('perPage')).toBe('20');
 });

--- a/ui/apps/platform/src/hooks/useURLParameter.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLParameter.test.tsx
@@ -1,28 +1,60 @@
-import React from 'react';
-import { createMemoryHistory } from 'history';
-import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
-import { HistoryRouter as Router } from 'redux-first-history/rr6';
+import React, { ReactNode } from 'react';
+// import { createMemoryHistory } from 'history';
+import { MemoryRouter as Router, Route, RouteComponentProps } from 'react-router-dom';
+// import { HistoryRouter as Router } from 'redux-first-history/rr6';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 import { renderHook } from '@testing-library/react';
 
-import actAndFlushTaskQueue from 'test-utils/flushTaskQueue';
 import { URLSearchParams } from 'url';
+import actAndFlushTaskQueue from 'test-utils/flushTaskQueue';
+
 import useURLParameter from './useURLParameter';
+
+type WrapperProps = {
+    children: ReactNode;
+    onRouteRender: (renderResult: RouteComponentProps) => void;
+    initialEntries: string[];
+};
+
+// This Wrapper component allows the `useURLParameter` hook to simulate the browser's
+// URL bar in JSDom via the MemoryRouter
+function Wrapper({ children, onRouteRender, initialEntries = [] }: WrapperProps) {
+    return (
+        <Router
+            initialEntries={initialEntries}
+            initialIndex={Math.max(0, initialEntries.length - 1)}
+        >
+            <CompatRouter>
+                <Route path="*" render={onRouteRender} />
+                {children}
+            </CompatRouter>
+        </Router>
+    );
+}
+
+const createWrapper = (props) => {
+    return function CreatedWrapper({ children }) {
+        return <Wrapper {...props}>{children}</Wrapper>;
+    };
+};
+
+beforeAll(() => {
+    vitest.useFakeTimers();
+});
 
 test('should read/write scoped string value in URL parameter without changing existing URL parameters', async () => {
     let params;
     let testLocation;
 
-    const { result } = renderHook(
-        () => {
-            testLocation = useLocation();
-            return useURLParameter('testKey', undefined);
-        },
-        {
-            wrapper: ({ children }) => (
-                <MemoryRouter initialEntries={['?oldKey=test']}>{children}</MemoryRouter>
-            ),
-        }
-    );
+    const { result } = renderHook(() => useURLParameter('testKey', undefined), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ location }) => {
+                testLocation = location;
+            },
+            initialEntries: ['?oldKey=test'],
+        }),
+    });
 
     // Check new and existing values before setter function is called
     params = new URLSearchParams(testLocation.search);
@@ -59,14 +91,15 @@ test('should allow multiple sequential parameter updates without data loss', asy
     let testLocation;
 
     const { result } = renderHook(
-        () => {
-            testLocation = useLocation();
-            return [useURLParameter('key1', 'oldValue1'), useURLParameter('key2', undefined)];
-        },
+        () => [useURLParameter('key1', 'oldValue1'), useURLParameter('key2', undefined)],
         {
-            wrapper: ({ children }) => (
-                <MemoryRouter initialEntries={['?key1=oldValue1']}>{children}</MemoryRouter>
-            ),
+            wrapper: createWrapper({
+                children: [],
+                onRouteRender: ({ location }) => {
+                    testLocation = location;
+                },
+                initialEntries: ['?key1=oldValue1'],
+            }),
         }
     );
 
@@ -102,18 +135,15 @@ test('should read/write scoped complex object in URL parameter without changing 
     };
 
     const emptyState: StateObject = { clusters: [] };
-
-    const { result } = renderHook(
-        () => {
-            testLocation = useLocation();
-            return useURLParameter('testKey', emptyState);
-        },
-        {
-            wrapper: ({ children }) => (
-                <MemoryRouter initialEntries={['?oldKey=test']}>{children}</MemoryRouter>
-            ),
-        }
-    );
+    const { result } = renderHook(() => useURLParameter('testKey', emptyState), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ location }) => {
+                testLocation = location;
+            },
+            initialEntries: ['?oldKey=test'],
+        }),
+    });
 
     function isStateObject(obj: unknown): obj is StateObject {
         return typeof obj === 'object' && obj !== null && 'clusters' in obj;
@@ -171,27 +201,21 @@ test('should read/write scoped complex object in URL parameter without changing 
     expect(Array.from(params.entries())).toHaveLength(1);
 });
 
-test('should implement push and replace state for navigate', async () => {
-    let testNavigate;
+test('should implement push and replace state for history', async () => {
+    let testHistory;
     let testLocation;
 
-    const { result } = renderHook(
-        () => {
-            testLocation = useLocation();
-            testNavigate = useNavigate();
-            return useURLParameter('testKey', undefined);
-        },
-        {
-            wrapper: ({ children }) => (
-                <MemoryRouter
-                    initialEntries={['/main/dashboard', '/main/clusters?oldKey=test']}
-                    initialIndex={1}
-                >
-                    {children}
-                </MemoryRouter>
-            ),
-        }
-    );
+    const { result } = renderHook(() => useURLParameter('testKey', undefined), {
+        wrapper: createWrapper({
+            children: [],
+            onRouteRender: ({ history, location }) => {
+                testHistory = history;
+                testLocation = location;
+            },
+            initialIndex: 1,
+            initialEntries: ['/main/dashboard', '/main/clusters?oldKey=test'],
+        }),
+    });
 
     // Test the the default behavior is to push URL parameter changes to the history stack
     await actAndFlushTaskQueue(() => {
@@ -201,7 +225,7 @@ test('should implement push and replace state for navigate', async () => {
     expect(testLocation.pathname).toBe('/main/clusters');
     expect(testLocation.search).toBe('?oldKey=test&testKey=testValue');
     await actAndFlushTaskQueue(() => {
-        testNavigate(-1);
+        testHistory.goBack();
     });
     expect(testLocation.pathname).toBe('/main/clusters');
     expect(testLocation.search).toBe('?oldKey=test');
@@ -214,7 +238,7 @@ test('should implement push and replace state for navigate', async () => {
     expect(testLocation.pathname).toBe('/main/clusters');
     expect(testLocation.search).toBe('?oldKey=test&testKey=newTestValue');
     await actAndFlushTaskQueue(() => {
-        testNavigate(-1);
+        testHistory.goBack();
     });
     expect(testLocation.pathname).toBe('/main/dashboard');
     expect(testLocation.search).toBe('');
@@ -223,26 +247,28 @@ test('should implement push and replace state for navigate', async () => {
 test('should batch URL parameter updates', async () => {
     let params;
     let testLocation;
-
-    const history = createMemoryHistory({
-        initialEntries: [''],
-    });
+    let testHistory;
 
     const { result } = renderHook(
-        () => {
-            testLocation = useLocation();
-            return {
-                hook1: useURLParameter('testKey1', undefined),
-                hook2: useURLParameter('testKey2', undefined),
-            };
-        },
+        () => ({
+            hook1: useURLParameter('testKey1', undefined),
+            hook2: useURLParameter('testKey2', undefined),
+        }),
         {
-            wrapper: ({ children }) => <Router history={history}>{children}</Router>,
+            wrapper: createWrapper({
+                children: [],
+                onRouteRender: ({ history, location }) => {
+                    testHistory = history;
+                    testLocation = location;
+                },
+                initialIndex: 1,
+                initialEntries: [''],
+            }),
         }
     );
 
     params = new URLSearchParams(testLocation.search);
-    expect(history.index).toBe(0);
+    expect(testHistory.length).toBe(1);
     expect(params.get('testKey1')).toBeNull();
     expect(params.get('testKey2')).toBeNull();
     expect(result.current.hook1[0]).toBeUndefined();
@@ -255,7 +281,7 @@ test('should batch URL parameter updates', async () => {
     });
 
     params = new URLSearchParams(testLocation.search);
-    expect(history.index).toBe(1);
+    expect(testHistory.length).toBe(2);
     expect(params.get('testKey1')).toBe('testValue');
     expect(params.get('testKey2')).toBeNull();
     expect(result.current.hook1[0]).toBe('testValue');
@@ -271,7 +297,7 @@ test('should batch URL parameter updates', async () => {
     });
 
     params = new URLSearchParams(testLocation.search);
-    expect(history.index).toBe(2);
+    expect(testHistory.length).toBe(3);
     expect(params.get('testKey1')).toBe('newValue1');
     expect(params.get('testKey2')).toBe('newValue3');
     expect(result.current.hook1[0]).toBe('newValue1');
@@ -284,7 +310,7 @@ test('should batch URL parameter updates', async () => {
     });
 
     params = new URLSearchParams(testLocation.search);
-    expect(history.index).toBe(2);
+    expect(testHistory.length).toBe(3);
     expect(params.get('testKey1')).toBe('newTestValue');
     expect(params.get('testKey2')).toBe('newValue3');
     expect(result.current.hook1[0]).toBe('newTestValue');
@@ -299,7 +325,7 @@ test('should batch URL parameter updates', async () => {
     });
 
     params = new URLSearchParams(testLocation.search);
-    expect(history.index).toBe(3);
+    expect(testHistory.length).toBe(4);
     expect(params.get('testKey1')).toBe('newValue4');
     expect(params.get('testKey2')).toBe('newValue5');
     expect(result.current.hook1[0]).toBe('newValue4');

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import type { NavigateFunction } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import type { NavigateFunction } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';

--- a/ui/apps/platform/src/hooks/useURLSort.test.jsx
+++ b/ui/apps/platform/src/hooks/useURLSort.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
 import cloneDeep from 'lodash/cloneDeep';
 
 import actAndFlushTaskQueue from 'test-utils/flushTaskQueue';

--- a/ui/apps/platform/src/hooks/useURLStringUnion.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLStringUnion.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom-v5-compat';
 import { renderHook } from '@testing-library/react';
 import actAndFlushTaskQueue from 'test-utils/flushTaskQueue';
 

--- a/ui/apps/platform/src/hooks/useWorkflowMatch.js
+++ b/ui/apps/platform/src/hooks/useWorkflowMatch.js
@@ -1,4 +1,4 @@
-import { useLocation, matchPath } from 'react-router-dom';
+import { useLocation, matchPath } from 'react-router-dom-v5-compat';
 
 import { workflowPaths, validPageEntityListTypes, validPageEntityTypes } from 'routePaths';
 

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -6,7 +6,17 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import { HistoryRouter as Router } from 'redux-first-history/rr6';
+
+// We needed to backpedal to the react-router-v5-compat layer in order to be compatible with the console plugin API.
+// To reverse this change once the console plugin API is updated to support react-router-dom@v6 we need to:
+// 1. Remove the react-router-dom-v5-compat dependency and the <CompatRouter> wrapper below
+// 2. Remove the react-router-dom dependency and the <Router> wrapper below, uncommenting the redux-first-history/rr6 import
+// 3. Replace imports from react-router-dom-v5-compat with react-router-dom throughout the codebase
+// import { HistoryRouter as Router } from 'redux-first-history/rr6';
+import { CompatRouter } from 'react-router-dom-v5-compat';
+import { ConnectedRouter } from 'connected-react-router';
+import { createBrowserHistory as createHistory } from 'history';
+
 import { AnyAction } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { ApolloProvider } from '@apollo/client';
@@ -35,7 +45,8 @@ installRaven();
 const rootNode = document.getElementById('root');
 /* @ts-expect-error `createRoot` expects a non-null argument */
 const root = createRoot(rootNode);
-const { store, history } = configureStore();
+const history = createHistory();
+const store = configureStore(undefined, history);
 const apolloClient = configureApollo();
 
 const dispatch = (action) =>
@@ -50,11 +61,13 @@ dispatch(fetchCentralCapabilitiesThunk());
 root.render(
     <Provider store={store}>
         <ApolloProvider client={apolloClient}>
-            <Router history={history}>
-                <ErrorBoundary>
-                    <AppPage />
-                </ErrorBoundary>
-            </Router>
+            <ConnectedRouter history={history}>
+                <CompatRouter>
+                    <ErrorBoundary>
+                        <AppPage />
+                    </ErrorBoundary>
+                </CompatRouter>
+            </ConnectedRouter>
         </ApolloProvider>
     </Provider>
 );

--- a/ui/apps/platform/src/init/configureStore.js
+++ b/ui/apps/platform/src/init/configureStore.js
@@ -1,6 +1,6 @@
 import { createStore, applyMiddleware, compose } from 'redux';
-import { createReduxHistoryContext } from 'redux-first-history';
-import { createBrowserHistory } from 'history';
+import { routerMiddleware } from 'connected-react-router';
+
 import createSagaMiddleware from 'redux-saga';
 import createRavenMiddleware from 'raven-for-redux';
 import Raven from 'raven-js';
@@ -12,19 +12,16 @@ import { actions as authActions } from 'reducers/auth';
 import * as AuthService from 'services/AuthService';
 import registerServerErrorHandler from 'services/serverErrorHandler';
 
-const { createReduxHistory, routerMiddleware, routerReducer } = createReduxHistoryContext({
-    history: createBrowserHistory(),
-});
-
 const sagaMiddleware = createSagaMiddleware({
     onError: (error) => Raven.captureException(error),
 });
 
 // Omit Redux state to reduce size of payload in /api/logimbue request.
+
 const ravenMiddleware = createRavenMiddleware(Raven, { stateTransformer: () => null });
 
-export default function configureStore(initialState = {}) {
-    const middlewares = [sagaMiddleware, routerMiddleware, ravenMiddleware, thunk];
+export default function configureStore(initialState = {}, history) {
+    const middlewares = [sagaMiddleware, routerMiddleware(history), ravenMiddleware, thunk];
     const enhancers = [applyMiddleware(...middlewares)];
 
     const composeEnhancers =
@@ -34,7 +31,8 @@ export default function configureStore(initialState = {}) {
             ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ shouldHotReload: false })
             : compose;
 
-    const rootReducer = createRootReducer(routerReducer);
+    const rootReducer = createRootReducer(history);
+
     const store = createStore(rootReducer, initialState, composeEnhancers(...enhancers));
 
     AuthService.addAuthInterceptors((error) =>
@@ -48,7 +46,5 @@ export default function configureStore(initialState = {}) {
 
     sagaMiddleware.run(rootSaga);
 
-    const history = createReduxHistory(store);
-
-    return { store, history };
+    return store;
 }

--- a/ui/apps/platform/src/reducers/index.js
+++ b/ui/apps/platform/src/reducers/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
+import { connectRouter } from 'connected-react-router';
 
 import bindSelectors from 'utils/bindSelectors';
 import apiTokens, { selectors as apiTokenSelectors } from './apitokens';
@@ -54,9 +55,9 @@ const appReducer = combineReducers({
     cloudSources,
 });
 
-const createRootReducer = (routerReducer) => {
+const createRootReducer = (history) => {
     return combineReducers({
-        router: routerReducer,
+        router: connectRouter(history),
         form: formReducer,
         app: appReducer,
     });

--- a/ui/apps/platform/src/sagas/authSagas.js
+++ b/ui/apps/platform/src/sagas/authSagas.js
@@ -2,7 +2,7 @@ import { all, take, call, fork, put, takeLatest, takeEvery, select } from 'redux
 import { delay } from 'redux-saga';
 import queryString from 'qs';
 import Raven from 'raven-js';
-import { LOCATION_CHANGE, push } from 'redux-first-history';
+import { LOCATION_CHANGE, push } from 'connected-react-router';
 import { Base64 } from 'js-base64';
 
 import { loginPath, testLoginResultsPath, authResponsePrefix } from 'routePaths';

--- a/ui/apps/platform/src/sagas/authSagas.test.js
+++ b/ui/apps/platform/src/sagas/authSagas.test.js
@@ -1,5 +1,5 @@
 import { select, call } from 'redux-saga/effects';
-import { push } from 'redux-first-history';
+import { push } from 'connected-react-router';
 import { expectSaga } from 'redux-saga-test-plan';
 import { dynamic, throwError } from 'redux-saga-test-plan/providers';
 

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -1,4 +1,4 @@
-import { generatePath } from 'react-router-dom';
+import { generatePath } from 'react-router-dom-v5-compat';
 
 import type { ApiSortOption, SearchFilter } from 'types/search';
 import type { SlimUser } from 'types/user.proto';

--- a/ui/apps/platform/src/test-utils/ComponentProviders.tsx
+++ b/ui/apps/platform/src/test-utils/ComponentProviders.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Store, createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+// import { HistoryRouter as Router } from 'redux-first-history/rr6';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 import { ApolloProvider } from '@apollo/client';
 
 import configureApolloClient from 'init/configureApolloClient';
@@ -20,9 +22,11 @@ export default function ComponentTestProviders({
 }: ComponentTestProviderProps) {
     return (
         <Provider store={reduxStore}>
-            <BrowserRouter>
-                <ApolloProvider client={configureApolloClient()}>{children}</ApolloProvider>
-            </BrowserRouter>
+            <Router>
+                <CompatRouter>
+                    <ApolloProvider client={configureApolloClient()}>{children}</ApolloProvider>
+                </CompatRouter>
+            </Router>
         </Provider>
     );
 }

--- a/ui/apps/platform/src/test-utils/renderWithRouter.jsx
+++ b/ui/apps/platform/src/test-utils/renderWithRouter.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
 import { render } from '@testing-library/react';
 
 function renderWithRouter(ui, { route = '/' } = {}) {

--- a/ui/apps/platform/src/utils/URLGenerator.js
+++ b/ui/apps/platform/src/utils/URLGenerator.js
@@ -1,5 +1,5 @@
 import qs from 'qs';
-import { generatePath } from 'react-router-dom';
+import { generatePath } from 'react-router-dom-v5-compat';
 
 import pageTypes from 'constants/pageTypes';
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';

--- a/ui/apps/platform/src/utils/URLParser.ts
+++ b/ui/apps/platform/src/utils/URLParser.ts
@@ -1,4 +1,4 @@
-import { Location, matchPath } from 'react-router-dom';
+import { Location, matchPath } from 'react-router-dom-v5-compat';
 import qs, { ParsedQs } from 'qs';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/utils/URLService.js
+++ b/ui/apps/platform/src/utils/URLService.js
@@ -1,7 +1,7 @@
 import qs from 'qs';
 import pageTypes from 'constants/pageTypes';
 import useCases from 'constants/useCaseTypes';
-import { generatePath } from 'react-router-dom';
+import { generatePath } from 'react-router-dom-v5-compat';
 import { entityParamNames, listParamNames } from 'constants/url';
 import entityTypes from 'constants/entityTypes';
 import merge from 'deepmerge';

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -1,4 +1,4 @@
-import { NavigateFunction } from 'react-router-dom';
+import { NavigateFunction } from 'react-router-dom-v5-compat';
 import {
     ChartBarProps,
     ChartLabelProps,

--- a/ui/apps/platform/src/utils/sagaEffects.js
+++ b/ui/apps/platform/src/utils/sagaEffects.js
@@ -1,6 +1,7 @@
-import { LOCATION_CHANGE } from 'redux-first-history';
+// import { LOCATION_CHANGE } from 'redux-first-history';
+import { LOCATION_CHANGE } from 'connected-react-router';
 import { take, fork } from 'redux-saga/effects';
-import { matchPath } from 'react-router-dom';
+import { matchPath } from 'react-router-dom-v5-compat';
 
 /**
  * The location match object.

--- a/ui/apps/platform/src/utils/urlUtils.ts
+++ b/ui/apps/platform/src/utils/urlUtils.ts
@@ -1,4 +1,4 @@
-import { generatePath } from 'react-router-dom';
+import { generatePath } from 'react-router-dom-v5-compat';
 
 import logError from './logError';
 


### PR DESCRIPTION
### Description

Moves from `react-router` v6 to `react-router-dom-v5-compat` in order to have compatibility as an OCP plugin. Fortunately, as the compat layer uses react-router v6 under the hood, we do not need to change any of the existing v6 APIs that were implemented in https://github.com/stackrox/stackrox/pull/13628. Instead, we just need to change the main Router wrapping components at the top level, and revert to the `connected-react-router` library to wire the history up to context.

The core changes:
- Replace `import ... from 'react-router-dom';` with `import ... from 'react-router-dom-v5-compat';` in all files. This is the vast majority of file diffs, but is a superficial change.
- Revert the use of `redux-first-history` back to `connected-react-router`. Primarily changing https://github.com/stackrox/stackrox/pull/16055/files#diff-17b63ecf711b742a7a122239cda060614dd22df1c31fa64cca750d83ae1f2dbd and https://github.com/stackrox/stackrox/pull/16055/files#diff-a9b7b8ed21a6d16377e9fbf2442ec7bcfa40b6f2df96e3ccf19b7a78c7074dc6
- Reintroduce `ConnectedRouter` as the main router provider, and then wrap this around a `<CompatRouter>` from the compatibility library in https://github.com/stackrox/stackrox/pull/16055/files#diff-64c2528d02a317cf6976a2b62b1f7959a7533009d976ade7210696ffe3ae260b

### Follow ups

1. It would be great to fully remove auth and integrations from sagas
2. If/when we can reverse this change it should be as straightforward as reverting this PR

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

CI

Manual smoke testing of behavior throughout the app.
