### PR TITLE
ROX-29784: Add stop-processing-context to sensor components

### DIFF
--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -1,6 +1,8 @@
 package admissioncontroller
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
@@ -55,7 +57,7 @@ func (h *alertHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (h *alertHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (h *alertHandlerImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/common/admissioncontroller/message_forwarder.go
+++ b/sensor/common/admissioncontroller/message_forwarder.go
@@ -1,6 +1,8 @@
 package admissioncontroller
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -70,10 +72,10 @@ func (h *admCtrlMsgForwarderImpl) Capabilities() []centralsensor.SensorCapabilit
 	return nil
 }
 
-func (h *admCtrlMsgForwarderImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (h *admCtrlMsgForwarderImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	errorList := errorhelpers.NewErrorList("ProcessMessage in AdmCtrlMsgForwarder")
 	for _, component := range h.components {
-		if err := component.ProcessMessage(msg); err != nil {
+		if err := component.ProcessMessage(ctx, msg); err != nil {
 			errorList.AddError(err)
 		}
 	}

--- a/sensor/common/admissioncontroller/mocks/alert_handler.go
+++ b/sensor/common/admissioncontroller/mocks/alert_handler.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -99,17 +100,17 @@ func (mr *MockAlertHandlerMockRecorder) ProcessAlerts(alerts any) *gomock.Call {
 }
 
 // ProcessMessage mocks base method.
-func (m *MockAlertHandler) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockAlertHandler) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockAlertHandlerMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockAlertHandlerMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockAlertHandler)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockAlertHandler)(nil).ProcessMessage), ctx, msg)
 }
 
 // ResponsesC mocks base method.

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"context"
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -72,7 +73,7 @@ func (a *auditLogCollectionManagerImpl) Capabilities() []centralsensor.SensorCap
 	return []centralsensor.SensorCapability{centralsensor.AuditLogEventsCap}
 }
 
-func (a *auditLogCollectionManagerImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (a *auditLogCollectionManagerImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	// This component doesn't actually process or handle any messages sent to Sensor. It uses the sensor component
 	// so that the lifecycle (start, stop) can be handled when Sensor starts up. The actual messages from central to
 	// enable/disable audit log collection is handled as part of the dynamic config in config.Handler which then calls

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -74,7 +74,7 @@ func (c *commandHandlerImpl) ProcessMessage(ctx context.Context, msg *central.Ms
 	}
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.Wrapf(ctx.Err(), "message processing in component %s", c.Name())
 	case c.commands <- command:
 		return nil
 	case <-c.stopper.Flow().StopRequested():

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -74,6 +74,7 @@ func (c *commandHandlerImpl) ProcessMessage(ctx context.Context, msg *central.Ms
 	}
 	select {
 	case <-ctx.Done():
+		// TODO(ROX-30333): Pass this context together with `msg` to `c.commands`
 		return errors.Wrapf(ctx.Err(), "message processing in component %s", c.Name())
 	case c.commands <- command:
 		return nil

--- a/sensor/common/compliance/mocks/auditlog_manager.go
+++ b/sensor/common/compliance/mocks/auditlog_manager.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -148,17 +149,17 @@ func (mr *MockAuditLogCollectionManagerMockRecorder) Notify(e any) *gomock.Call 
 }
 
 // ProcessMessage mocks base method.
-func (m *MockAuditLogCollectionManager) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockAuditLogCollectionManager) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockAuditLogCollectionManagerMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockAuditLogCollectionManagerMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).ProcessMessage), ctx, msg)
 }
 
 // RemoveEligibleComplianceNode mocks base method.

--- a/sensor/common/compliance/mocks/service.go
+++ b/sensor/common/compliance/mocks/service.go
@@ -176,17 +176,17 @@ func (mr *MockServiceMockRecorder) Output() *gomock.Call {
 }
 
 // ProcessMessage mocks base method.
-func (m *MockService) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockService) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockServiceMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockServiceMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockService)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockService)(nil).ProcessMessage), ctx, msg)
 }
 
 // RegisterServiceHandler mocks base method.

--- a/sensor/common/compliance/multiplexer.go
+++ b/sensor/common/compliance/multiplexer.go
@@ -1,6 +1,8 @@
 package compliance
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -70,7 +72,7 @@ func (c *Multiplexer) Capabilities() []centralsensor.SensorCapability {
 }
 
 // ProcessMessage is unimplemented, part of the component interface
-func (c *Multiplexer) ProcessMessage(_ *central.MsgToSensor) error {
+func (c *Multiplexer) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -108,7 +109,7 @@ func (c *nodeInventoryHandlerImpl) Notify(e common.SensorComponentEvent) {
 	}
 }
 
-func (c *nodeInventoryHandlerImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (c *nodeInventoryHandlerImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	ackMsg := msg.GetNodeInventoryAck()
 	if ackMsg == nil {
 		return nil

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -324,7 +324,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerCentralACKsToCompliance() {
 			result := consumeAndCountCompliance(s.T(), handler.ComplianceC(), tc.expectedACKCount+tc.expectedNACKCount)
 
 			for _, reply := range tc.centralReplies {
-				s.NoError(mockCentralReply(handler, reply))
+				s.NoError(mockCentralReply(s.T().Context(), handler, reply))
 			}
 
 			s.NoError(result.sc.Stopped().Wait())
@@ -376,7 +376,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerOfflineACKNACK() {
 		result := consumeAndCountCompliance(s.T(), h.ComplianceC(), state.expectedACKCount+state.expectedNACKCount)
 
 		if state.event == common.SensorComponentEventCentralReachable {
-			s.NoError(mockCentralReply(h, central.NodeInventoryACK_ACK))
+			s.NoError(mockCentralReply(s.T().Context(), h, central.NodeInventoryACK_ACK))
 		}
 		s.NoError(result.sc.Stopped().Wait())
 		s.Equal(state.expectedACKCount, result.ACKCount)
@@ -388,10 +388,10 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerOfflineACKNACK() {
 	s.NoError(h.Stopped().Wait())
 }
 
-func mockCentralReply(h *nodeInventoryHandlerImpl, ackType central.NodeInventoryACK_Action) error {
+func mockCentralReply(ctx context.Context, h *nodeInventoryHandlerImpl, ackType central.NodeInventoryACK_Action) error {
 	select {
 	case <-h.ResponsesC():
-		return h.ProcessMessage(context.TODO(), &central.MsgToSensor{
+		return h.ProcessMessage(ctx, &central.MsgToSensor{
 			Msg: &central.MsgToSensor_NodeInventoryAck{NodeInventoryAck: &central.NodeInventoryACK{
 				ClusterId: "4",
 				NodeName:  "4",

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -390,7 +391,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerOfflineACKNACK() {
 func mockCentralReply(h *nodeInventoryHandlerImpl, ackType central.NodeInventoryACK_Action) error {
 	select {
 	case <-h.ResponsesC():
-		return h.ProcessMessage(&central.MsgToSensor{
+		return h.ProcessMessage(context.TODO(), &central.MsgToSensor{
 			Msg: &central.MsgToSensor_NodeInventoryAck{NodeInventoryAck: &central.NodeInventoryACK{
 				ClusterId: "4",
 				NodeName:  "4",

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -78,7 +78,7 @@ func (s *serviceImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (s *serviceImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (s *serviceImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -67,7 +68,9 @@ type SensorComponent interface {
 	Stop()
 	Capabilities() []centralsensor.SensorCapability
 
-	ProcessMessage(msg *central.MsgToSensor) error
+	// ProcessMessage processes the `msg` message from Central.
+	// The `ctx` is used to cancel processing of the message being currently processed.
+	ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error
 	ResponsesC() <-chan *message.ExpiringMessage
 	Name() string
 }

--- a/sensor/common/config/handler.go
+++ b/sensor/common/config/handler.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -76,7 +78,7 @@ func (c *configHandlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return nil
 }
 
-func (c *configHandlerImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (c *configHandlerImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	if msg.GetAuditLogSync() != nil {
 		err := c.parseMessage(func() {
 			log.Infof("Received audit log sync state from Central: %s", protoutils.NewWrapper(msg.GetAuditLogSync()))

--- a/sensor/common/config/mocks/handler.go
+++ b/sensor/common/config/mocks/handler.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -127,17 +128,17 @@ func (mr *MockHandlerMockRecorder) Notify(e any) *gomock.Call {
 }
 
 // ProcessMessage mocks base method.
-func (m *MockHandler) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockHandler) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockHandlerMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockHandlerMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockHandler)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockHandler)(nil).ProcessMessage), ctx, msg)
 }
 
 // ResponsesC mocks base method.

--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -65,7 +65,7 @@ func (d *delegatedRegistryImpl) Capabilities() []centralsensor.SensorCapability 
 
 func (d *delegatedRegistryImpl) Notify(_ common.SensorComponentEvent) {}
 
-func (d *delegatedRegistryImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (d *delegatedRegistryImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	if !enabled {
 		return nil
 	}

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -48,7 +48,7 @@ func CreateEnhancer(provider store.Provider) common.SensorComponent {
 }
 
 // ProcessMessage takes an incoming message and queues it for enhancement
-func (d *DeploymentEnhancer) ProcessMessage(msg *central.MsgToSensor) error {
+func (d *DeploymentEnhancer) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	toEnhance := msg.GetDeploymentEnhancementRequest()
 	if toEnhance == nil {
 		return nil

--- a/sensor/common/deploymentenhancer/component_test.go
+++ b/sensor/common/deploymentenhancer/component_test.go
@@ -1,6 +1,7 @@
 package deploymentenhancer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -112,10 +113,10 @@ func (s *ComponentTestSuite) TestMsgQueueOverfill() {
 		deploymentsQueue: make(chan *central.DeploymentEnhancementRequest, 1),
 		storeProvider:    s.mockStoreProvider,
 	}
-	s.NoError(de.ProcessMessage(generateMsgToSensor()))
+	s.NoError(de.ProcessMessage(context.TODO(), generateMsgToSensor()))
 
 	// As there is no reader, the second call has to error out
-	s.ErrorContains(de.ProcessMessage(generateMsgToSensor()), "DeploymentEnhancer queue has reached its limit of")
+	s.ErrorContains(de.ProcessMessage(context.TODO(), generateMsgToSensor()), "DeploymentEnhancer queue has reached its limit of")
 }
 
 func generateMsgToSensor() *central.MsgToSensor {

--- a/sensor/common/deploymentenhancer/component_test.go
+++ b/sensor/common/deploymentenhancer/component_test.go
@@ -1,7 +1,6 @@
 package deploymentenhancer
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -113,10 +112,10 @@ func (s *ComponentTestSuite) TestMsgQueueOverfill() {
 		deploymentsQueue: make(chan *central.DeploymentEnhancementRequest, 1),
 		storeProvider:    s.mockStoreProvider,
 	}
-	s.NoError(de.ProcessMessage(context.TODO(), generateMsgToSensor()))
+	s.NoError(de.ProcessMessage(s.T().Context(), generateMsgToSensor()))
 
 	// As there is no reader, the second call has to error out
-	s.ErrorContains(de.ProcessMessage(context.TODO(), generateMsgToSensor()), "DeploymentEnhancer queue has reached its limit of")
+	s.ErrorContains(de.ProcessMessage(s.T().Context(), generateMsgToSensor()), "DeploymentEnhancer queue has reached its limit of")
 }
 
 func generateMsgToSensor() *central.MsgToSensor {

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -360,7 +360,7 @@ func (d *detectorImpl) ProcessReprocessDeployments() error {
 	return nil
 }
 
-func (d *detectorImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (d *detectorImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	switch {
 	case msg.GetBaselineSync() != nil:
 		return d.processBaselineSync(msg.GetBaselineSync())

--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -111,17 +111,17 @@ func (mr *MockDetectorMockRecorder) ProcessIndicator(ctx, indicator any) *gomock
 }
 
 // ProcessMessage mocks base method.
-func (m *MockDetector) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockDetector) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockDetectorMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockDetectorMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockDetector)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockDetector)(nil).ProcessMessage), ctx, msg)
 }
 
 // ProcessNetworkFlow mocks base method.

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -104,7 +104,7 @@ func (e *enforcer) ProcessAlertResults(action central.ResourceAction, stage stor
 	}
 }
 
-func (e *enforcer) ProcessMessage(msg *central.MsgToSensor) error {
+func (e *enforcer) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	enforcement := msg.GetEnforcement()
 	if enforcement == nil {
 		return nil

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -82,7 +82,7 @@ func (h *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSens
 	}
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.Wrapf(ctx.Err(), "message processing in component %s", h.Name())
 	case <-h.stopSig.Done():
 		return errors.New("could not process external network entities request")
 	default:

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -2,6 +2,7 @@ package externalsrcs
 
 import (
 	"bytes"
+	"context"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -74,12 +75,14 @@ func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.NetworkGraphExternalSrcsCap}
 }
 
-func (h *handlerImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (h *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	request := msg.GetPushNetworkEntitiesRequest()
 	if request == nil {
 		return nil
 	}
 	select {
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-h.stopSig.Done():
 		return errors.New("could not process external network entities request")
 	default:

--- a/sensor/common/externalsrcs/handler_test.go
+++ b/sensor/common/externalsrcs/handler_test.go
@@ -48,7 +48,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
+	require.NoError(t, handler.ProcessMessage(t.Context(), req))
 
 	require.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	vs = vs.TryNext()
@@ -90,7 +90,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
+	require.NoError(t, handler.ProcessMessage(t.Context(), req))
 
 	require.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	vs = vs.TryNext()
@@ -132,7 +132,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
+	require.NoError(t, handler.ProcessMessage(t.Context(), req))
 
 	require.False(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	require.Nil(t, vs.TryNext())
@@ -169,7 +169,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
+	require.NoError(t, handler.ProcessMessage(t.Context(), req))
 
 	assert.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	vs = vs.TryNext()
@@ -188,7 +188,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
+	require.NoError(t, handler.ProcessMessage(t.Context(), req))
 
 	assert.False(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	assert.Nil(t, vs.TryNext())
@@ -261,7 +261,7 @@ func TestExternalSourcesLookup(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
+	require.NoError(t, handler.ProcessMessage(t.Context(), req))
 	require.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 
 	expected := req.GetPushNetworkEntitiesRequest().GetEntities()[1]

--- a/sensor/common/externalsrcs/handler_test.go
+++ b/sensor/common/externalsrcs/handler_test.go
@@ -48,7 +48,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(req))
+	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
 
 	require.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	vs = vs.TryNext()
@@ -90,7 +90,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(req))
+	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
 
 	require.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	vs = vs.TryNext()
@@ -132,7 +132,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(req))
+	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
 
 	require.False(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	require.Nil(t, vs.TryNext())
@@ -169,7 +169,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(req))
+	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
 
 	assert.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	vs = vs.TryNext()
@@ -188,7 +188,7 @@ func TestExternalSrcsHandler(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(req))
+	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
 
 	assert.False(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 	assert.Nil(t, vs.TryNext())
@@ -261,7 +261,7 @@ func TestExternalSourcesLookup(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, handler.ProcessMessage(req))
+	require.NoError(t, handler.ProcessMessage(context.TODO(), req))
 	require.True(t, concurrency.WaitWithTimeout(vs, 100*time.Millisecond))
 
 	expected := req.GetPushNetworkEntitiesRequest().GetEntities()[1]

--- a/sensor/common/externalsrcs/mocks/handler.go
+++ b/sensor/common/externalsrcs/mocks/handler.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -154,17 +155,17 @@ func (mr *MockHandlerMockRecorder) Notify(e any) *gomock.Call {
 }
 
 // ProcessMessage mocks base method.
-func (m *MockHandler) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockHandler) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockHandlerMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockHandlerMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockHandler)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockHandler)(nil).ProcessMessage), ctx, msg)
 }
 
 // ResponsesC mocks base method.

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -161,7 +161,7 @@ func (s *serviceImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (s *serviceImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (s *serviceImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -369,7 +369,7 @@ func (m *networkFlowManager) Name() string {
 	return "networkflow.manager.networkFlowManager"
 }
 
-func (m *networkFlowManager) ProcessMessage(_ *central.MsgToSensor) error {
+func (m *networkFlowManager) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -1,6 +1,8 @@
 package reprocessor
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -63,7 +65,7 @@ func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (h *handlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (h *handlerImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/common/reprocessor/mocks/handler.go
+++ b/sensor/common/reprocessor/mocks/handler.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -98,17 +99,17 @@ func (mr *MockHandlerMockRecorder) ProcessInvalidateImageCache(arg0 any) *gomock
 }
 
 // ProcessMessage mocks base method.
-func (m *MockHandler) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockHandler) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockHandlerMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockHandlerMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockHandler)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockHandler)(nil).ProcessMessage), ctx, msg)
 }
 
 // ProcessReprocessDeployments mocks base method.

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -342,7 +342,7 @@ func (s *centralCommunicationImpl) initialConfigSync(stream central.SensorServic
 		return errors.Errorf("initial message received from Sensor was not a cluster config: %T", msg.Msg)
 	}
 	// Send the initial cluster config to the config handler
-	if err := handler.ProcessMessage(msg); err != nil {
+	if err := handler.ProcessMessage(context.TODO(), msg); err != nil {
 		return errors.Wrap(err, "processing initial cluster config")
 	}
 	return nil
@@ -368,7 +368,7 @@ func (s *centralCommunicationImpl) initialPolicySync(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "receiving initial baselines")
 	}
-	if err := detector.ProcessMessage(msg); err != nil {
+	if err := detector.ProcessMessage(context.TODO(), msg); err != nil {
 		return errors.Wrap(err, "process baselines could not be successfully processed")
 	}
 
@@ -380,7 +380,7 @@ func (s *centralCommunicationImpl) initialPolicySync(ctx context.Context,
 	if msg.GetNetworkBaselineSync() == nil {
 		return errors.Errorf("expected NetworkBaseline message but received %t", msg.Msg)
 	}
-	if err := detector.ProcessMessage(msg); err != nil {
+	if err := detector.ProcessMessage(context.TODO(), msg); err != nil {
 		return errors.Wrap(err, "network baselines could not be successfully processed")
 	}
 	return nil

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -268,7 +268,7 @@ func (s *centralCommunicationImpl) initialSync(ctx context.Context, stream centr
 	}
 
 	// DO NOT CHANGE THE ORDER. Please refer to `Run()` at `central/sensor/service/connection/connection_impl.go`
-	if err := s.initialConfigSync(stream, configHandler); err != nil {
+	if err := s.initialConfigSync(ctx, stream, configHandler); err != nil {
 		return err
 	}
 
@@ -333,7 +333,7 @@ func (s *centralCommunicationImpl) initialDeduperSync(stream central.SensorServi
 	return nil
 }
 
-func (s *centralCommunicationImpl) initialConfigSync(stream central.SensorService_CommunicateClient, handler config.Handler) error {
+func (s *centralCommunicationImpl) initialConfigSync(ctx context.Context, stream central.SensorService_CommunicateClient, handler config.Handler) error {
 	msg, err := stream.Recv()
 	if err != nil {
 		return errors.Wrap(err, "receiving initial cluster config")
@@ -342,7 +342,7 @@ func (s *centralCommunicationImpl) initialConfigSync(stream central.SensorServic
 		return errors.Errorf("initial message received from Sensor was not a cluster config: %T", msg.Msg)
 	}
 	// Send the initial cluster config to the config handler
-	if err := handler.ProcessMessage(context.TODO(), msg); err != nil {
+	if err := handler.ProcessMessage(ctx, msg); err != nil {
 		return errors.Wrap(err, "processing initial cluster config")
 	}
 	return nil

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -368,7 +368,7 @@ func (s *centralCommunicationImpl) initialPolicySync(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "receiving initial baselines")
 	}
-	if err := detector.ProcessMessage(context.TODO(), msg); err != nil {
+	if err := detector.ProcessMessage(ctx, msg); err != nil {
 		return errors.Wrap(err, "process baselines could not be successfully processed")
 	}
 
@@ -380,7 +380,7 @@ func (s *centralCommunicationImpl) initialPolicySync(ctx context.Context,
 	if msg.GetNetworkBaselineSync() == nil {
 		return errors.Errorf("expected NetworkBaseline message but received %t", msg.Msg)
 	}
-	if err := detector.ProcessMessage(context.TODO(), msg); err != nil {
+	if err := detector.ProcessMessage(ctx, msg); err != nil {
 		return errors.Wrap(err, "network baselines could not be successfully processed")
 	}
 	return nil

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -528,7 +528,7 @@ func (f fakeSensorComponent) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{}
 }
 
-func (f fakeSensorComponent) ProcessMessage(*central.MsgToSensor) error {
+func (f fakeSensorComponent) ProcessMessage(context.Context, *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -60,8 +60,8 @@ func (c *centralCommunicationSuite) SetupTest() {
 	// Setup Mocks:
 	c.mockHandler.EXPECT().GetDeploymentIdentification().AnyTimes().Return(nil)
 	c.mockHandler.EXPECT().GetHelmManagedConfig().AnyTimes().Return(nil)
-	c.mockHandler.EXPECT().ProcessMessage(gomock.Any()).AnyTimes().Return(nil)
-	c.mockDetector.EXPECT().ProcessMessage(gomock.Any()).AnyTimes().Return(nil)
+	c.mockHandler.EXPECT().ProcessMessage(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	c.mockDetector.EXPECT().ProcessMessage(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	c.mockDetector.EXPECT().ProcessPolicySync(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 }
 

--- a/sensor/common/sensor/central_receiver_impl.go
+++ b/sensor/common/sensor/central_receiver_impl.go
@@ -1,6 +1,7 @@
 package sensor
 
 import (
+	"context"
 	"io"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -59,7 +60,7 @@ func (s *centralReceiverImpl) receive(stream central.SensorService_CommunicateCl
 				return
 			}
 			for _, r := range s.receivers {
-				if err := r.ProcessMessage(msg); err != nil {
+				if err := r.ProcessMessage(context.TODO(), msg); err != nil {
 					log.Error(err)
 				}
 			}

--- a/sensor/common/sensor/central_receiver_impl.go
+++ b/sensor/common/sensor/central_receiver_impl.go
@@ -1,7 +1,6 @@
 package sensor
 
 import (
-	"context"
 	"io"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -60,7 +59,7 @@ func (s *centralReceiverImpl) receive(stream central.SensorService_CommunicateCl
 				return
 			}
 			for _, r := range s.receivers {
-				if err := r.ProcessMessage(context.TODO(), msg); err != nil {
+				if err := r.ProcessMessage(stream.Context(), msg); err != nil {
 					log.Error(err)
 				}
 			}

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -89,7 +89,7 @@ func (s *serviceImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (s *serviceImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (s *serviceImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/kubernetes/admissioncontroller/config_map_persister.go
+++ b/sensor/kubernetes/admissioncontroller/config_map_persister.go
@@ -71,7 +71,7 @@ func (p *configMapPersister) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (p *configMapPersister) ProcessMessage(_ *central.MsgToSensor) error {
+func (p *configMapPersister) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -220,7 +220,7 @@ func (i *tlsIssuerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 // ProcessMessage dispatches Central's messages to Sensor received via the Central receiver.
 // This method must not block as it would prevent centralReceiverImpl from sending messages
 // to other SensorComponents.
-func (i *tlsIssuerImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (i *tlsIssuerImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	if i.getResponseFn == nil {
 		return errors.New("getResponseFn is not set")
 	}

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -272,7 +272,7 @@ func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessage
 	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
 	s.Require().NoError(fixture.tlsIssuer.Start())
 
-	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(msg))
+	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(context.TODO(), msg))
 	assert.Eventually(s.T(), func() bool {
 		response := fixture.tlsIssuer.responseQueue.Pull()
 		return response != nil
@@ -289,7 +289,7 @@ func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessage
 	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
 	s.Require().NoError(fixture.tlsIssuer.Start())
 
-	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(msg))
+	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(context.TODO(), msg))
 	assert.Never(s.T(), func() bool {
 		response := fixture.tlsIssuer.responseQueue.Pull()
 		return response != nil
@@ -433,13 +433,13 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSuccessfulRefresh() {
 			for i := 0; i < tc.numFailedResponses; i++ {
 				request := s.waitForRequest(ctx, tlsIssuer)
 				response := getSecuredClusterIssueCertsFailureResponse(request.GetRequestId())
-				err = tlsIssuer.ProcessMessage(response)
+				err = tlsIssuer.ProcessMessage(context.TODO(), response)
 				s.Require().NoError(err)
 			}
 
 			request := s.waitForRequest(ctx, tlsIssuer)
 			response := getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
-			err = tlsIssuer.ProcessMessage(response)
+			err = tlsIssuer.ProcessMessage(context.TODO(), response)
 			s.Require().NoError(err)
 
 			verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)
@@ -470,7 +470,7 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSensorOnlineOfflineModes()
 
 	request := s.waitForRequest(ctx, tlsIssuer)
 	response := getSecuredClusterIssueCertsFailureResponse(request.GetRequestId())
-	err = tlsIssuer.ProcessMessage(response)
+	err = tlsIssuer.ProcessMessage(context.TODO(), response)
 	s.Require().NoError(err)
 
 	tlsIssuer.Notify(common.SensorComponentEventOfflineMode)
@@ -481,7 +481,7 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSensorOnlineOfflineModes()
 
 	request = s.waitForRequest(ctx, tlsIssuer)
 	response = getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
-	err = tlsIssuer.ProcessMessage(response)
+	err = tlsIssuer.ProcessMessage(context.TODO(), response)
 	s.Require().NoError(err)
 
 	verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)
@@ -497,7 +497,7 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSensorOnlineOfflineModes()
 
 	request = s.waitForRequest(ctx, tlsIssuer)
 	response = getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
-	err = tlsIssuer.ProcessMessage(response)
+	err = tlsIssuer.ProcessMessage(context.TODO(), response)
 	s.Require().NoError(err)
 
 	verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -272,7 +272,7 @@ func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessage
 	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
 	s.Require().NoError(fixture.tlsIssuer.Start())
 
-	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(context.TODO(), msg))
+	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(s.T().Context(), msg))
 	assert.Eventually(s.T(), func() bool {
 		response := fixture.tlsIssuer.responseQueue.Pull()
 		return response != nil
@@ -289,7 +289,7 @@ func (s *securedClusterTLSIssuerTests) TestSecuredClusterTLSIssuerProcessMessage
 	fixture.tlsIssuer.Notify(common.SensorComponentEventCentralReachable)
 	s.Require().NoError(fixture.tlsIssuer.Start())
 
-	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(context.TODO(), msg))
+	assert.NoError(s.T(), fixture.tlsIssuer.ProcessMessage(s.T().Context(), msg))
 	assert.Never(s.T(), func() bool {
 		response := fixture.tlsIssuer.responseQueue.Pull()
 		return response != nil
@@ -433,13 +433,13 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSuccessfulRefresh() {
 			for i := 0; i < tc.numFailedResponses; i++ {
 				request := s.waitForRequest(ctx, tlsIssuer)
 				response := getSecuredClusterIssueCertsFailureResponse(request.GetRequestId())
-				err = tlsIssuer.ProcessMessage(context.TODO(), response)
+				err = tlsIssuer.ProcessMessage(s.T().Context(), response)
 				s.Require().NoError(err)
 			}
 
 			request := s.waitForRequest(ctx, tlsIssuer)
 			response := getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
-			err = tlsIssuer.ProcessMessage(context.TODO(), response)
+			err = tlsIssuer.ProcessMessage(s.T().Context(), response)
 			s.Require().NoError(err)
 
 			verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)
@@ -470,7 +470,7 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSensorOnlineOfflineModes()
 
 	request := s.waitForRequest(ctx, tlsIssuer)
 	response := getSecuredClusterIssueCertsFailureResponse(request.GetRequestId())
-	err = tlsIssuer.ProcessMessage(context.TODO(), response)
+	err = tlsIssuer.ProcessMessage(s.T().Context(), response)
 	s.Require().NoError(err)
 
 	tlsIssuer.Notify(common.SensorComponentEventOfflineMode)
@@ -481,7 +481,7 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSensorOnlineOfflineModes()
 
 	request = s.waitForRequest(ctx, tlsIssuer)
 	response = getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
-	err = tlsIssuer.ProcessMessage(context.TODO(), response)
+	err = tlsIssuer.ProcessMessage(s.T().Context(), response)
 	s.Require().NoError(err)
 
 	verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)
@@ -497,7 +497,7 @@ func (s *securedClusterTLSIssuerIntegrationTests) TestSensorOnlineOfflineModes()
 
 	request = s.waitForRequest(ctx, tlsIssuer)
 	response = getSecuredClusterIssueCertsSuccessResponse(request.GetRequestId(), ca.CertPEM(), secretsCerts)
-	err = tlsIssuer.ProcessMessage(context.TODO(), response)
+	err = tlsIssuer.ProcessMessage(s.T().Context(), response)
 	s.Require().NoError(err)
 
 	verifySecrets(ctx, s.T(), k8sClient, sensorNamespace, ca, secretsCerts)

--- a/sensor/kubernetes/clusterhealth/updater.go
+++ b/sensor/kubernetes/clusterhealth/updater.go
@@ -84,7 +84,7 @@ func (u *updaterImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.HealthMonitoringCap}
 }
 
-func (u *updaterImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (u *updaterImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -99,7 +99,7 @@ func (cm *clusterMetricsImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{}
 }
 
-func (cm *clusterMetricsImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (cm *clusterMetricsImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -105,7 +105,7 @@ func (u *updaterImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (u *updaterImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (u *updaterImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -106,7 +106,7 @@ func (m *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSens
 
 	select {
 	case <-ctx.Done():
-		// TODO(ROX-): Pass this context together with `req` to `m.request`
+		// TODO(ROX-30333): Pass this context together with `req` to `m.request`
 		return errors.Wrapf(ctx.Err(), "message processing in component %s", m.Name())
 	case m.request <- req:
 		return nil

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -89,7 +89,7 @@ func (m *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (m *handlerImpl) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	req := msg.GetComplianceRequest()
 	if req == nil {
 		return nil
@@ -105,6 +105,8 @@ func (m *handlerImpl) ProcessMessage(msg *central.MsgToSensor) error {
 	}
 
 	select {
+	case <-ctx.Done():
+		return ctx.Err() // TODO(ROX-): Pass this context together with `req` to `m.request`
 	case m.request <- req:
 		return nil
 	case <-m.stopSignal.Done():

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -106,7 +106,8 @@ func (m *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSens
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err() // TODO(ROX-): Pass this context together with `req` to `m.request`
+		// TODO(ROX-): Pass this context together with `req` to `m.request`
+		return errors.Wrapf(ctx.Err(), "message processing in component %s", m.Name())
 	case m.request <- req:
 		return nil
 	case <-m.stopSignal.Done():

--- a/sensor/kubernetes/complianceoperator/handler_impl_test.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl_test.go
@@ -411,7 +411,7 @@ func (s *HandlerTestSuite) sendMessage(times int, msg *central.MsgToSensor) *cen
 	var ret *central.ComplianceResponse
 
 	for i := 0; i < times; i++ {
-		s.NoError(s.requestHandler.ProcessMessage(context.TODO(), msg))
+		s.NoError(s.requestHandler.ProcessMessage(s.T().Context(), msg))
 
 		select {
 		case response := <-s.requestHandler.ResponsesC():

--- a/sensor/kubernetes/complianceoperator/handler_impl_test.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl_test.go
@@ -411,7 +411,7 @@ func (s *HandlerTestSuite) sendMessage(times int, msg *central.MsgToSensor) *cen
 	var ret *central.ComplianceResponse
 
 	for i := 0; i < times; i++ {
-		s.NoError(s.requestHandler.ProcessMessage(msg))
+		s.NoError(s.requestHandler.ProcessMessage(context.TODO(), msg))
 
 		select {
 		case response := <-s.requestHandler.ResponsesC():

--- a/sensor/kubernetes/complianceoperator/mocks/types.go
+++ b/sensor/kubernetes/complianceoperator/mocks/types.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
@@ -136,17 +137,17 @@ func (mr *MockInfoUpdaterMockRecorder) Notify(e any) *gomock.Call {
 }
 
 // ProcessMessage mocks base method.
-func (m *MockInfoUpdater) ProcessMessage(msg *central.MsgToSensor) error {
+func (m *MockInfoUpdater) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessMessage", msg)
+	ret := m.ctrl.Call(m, "ProcessMessage", ctx, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessMessage indicates an expected call of ProcessMessage.
-func (mr *MockInfoUpdaterMockRecorder) ProcessMessage(msg any) *gomock.Call {
+func (mr *MockInfoUpdaterMockRecorder) ProcessMessage(ctx, msg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockInfoUpdater)(nil).ProcessMessage), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessMessage", reflect.TypeOf((*MockInfoUpdater)(nil).ProcessMessage), ctx, msg)
 }
 
 // ResponsesC mocks base method.

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -131,7 +131,7 @@ func (u *updaterImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.HealthMonitoringCap}
 }
 
-func (u *updaterImpl) ProcessMessage(_ *central.MsgToSensor) error {
+func (u *updaterImpl) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
 	return nil
 }
 

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -51,7 +51,7 @@ func (*eventPipeline) Capabilities() []centralsensor.SensorCapability {
 }
 
 // ProcessMessage implements common.SensorComponent
-func (p *eventPipeline) ProcessMessage(msg *central.MsgToSensor) error {
+func (p *eventPipeline) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	switch {
 	case msg.GetPolicySync() != nil:
 		return p.processPolicySync(msg.GetPolicySync())

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -1,7 +1,6 @@
 package eventpipeline
 
 import (
-	"context"
 	"sync/atomic"
 	"testing"
 
@@ -184,7 +183,7 @@ func (s *eventPipelineSuite) Test_ReprocessDeployments() {
 		assert.True(s.T(), resourceEvent.DeploymentReferences[0].ForceDetection)
 	})
 
-	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
+	err := s.pipeline.ProcessMessage(s.T().Context(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -205,7 +204,7 @@ func (s *eventPipelineSuite) Test_PolicySync() {
 		defer messageReceived.Done()
 	})
 
-	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
+	err := s.pipeline.ProcessMessage(s.T().Context(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -234,7 +233,7 @@ func (s *eventPipelineSuite) Test_UpdatedImage() {
 		assertResourceEvent(s.T(), resourceEvent)
 	})
 
-	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
+	err := s.pipeline.ProcessMessage(s.T().Context(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -263,7 +262,7 @@ func (s *eventPipelineSuite) Test_ReprocessDeployment() {
 		assertResourceEvent(s.T(), resourceEvent)
 	})
 
-	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
+	err := s.pipeline.ProcessMessage(s.T().Context(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -292,7 +291,7 @@ func (s *eventPipelineSuite) Test_InvalidateImageCache() {
 		assertResourceEvent(s.T(), resourceEvent)
 	})
 
-	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
+	err := s.pipeline.ProcessMessage(s.T().Context(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -1,6 +1,7 @@
 package eventpipeline
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 
@@ -183,7 +184,7 @@ func (s *eventPipelineSuite) Test_ReprocessDeployments() {
 		assert.True(s.T(), resourceEvent.DeploymentReferences[0].ForceDetection)
 	})
 
-	err := s.pipeline.ProcessMessage(msgFromCentral)
+	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -204,7 +205,7 @@ func (s *eventPipelineSuite) Test_PolicySync() {
 		defer messageReceived.Done()
 	})
 
-	err := s.pipeline.ProcessMessage(msgFromCentral)
+	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -233,7 +234,7 @@ func (s *eventPipelineSuite) Test_UpdatedImage() {
 		assertResourceEvent(s.T(), resourceEvent)
 	})
 
-	err := s.pipeline.ProcessMessage(msgFromCentral)
+	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -262,7 +263,7 @@ func (s *eventPipelineSuite) Test_ReprocessDeployment() {
 		assertResourceEvent(s.T(), resourceEvent)
 	})
 
-	err := s.pipeline.ProcessMessage(msgFromCentral)
+	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()
@@ -291,7 +292,7 @@ func (s *eventPipelineSuite) Test_InvalidateImageCache() {
 		assertResourceEvent(s.T(), resourceEvent)
 	})
 
-	err := s.pipeline.ProcessMessage(msgFromCentral)
+	err := s.pipeline.ProcessMessage(context.TODO(), msgFromCentral)
 	s.NoError(err)
 
 	messageReceived.Wait()

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -92,7 +92,8 @@ func (h *commandHandler) ProcessMessage(ctx context.Context, msg *central.MsgToS
 	}
 	select {
 	case <-ctx.Done():
-		return ctx.Err() // TODO(ROX-): pass the context together with `cmd` to `h.commandsC`
+		// TODO(ROX-): pass the context together with `cmd` to `h.commandsC`
+		return errors.Wrapf(ctx.Err(), "message processing in component %s", h.Name())
 	case h.commandsC <- cmd:
 		return nil
 	case <-h.stopSig.Done():

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -92,7 +92,7 @@ func (h *commandHandler) ProcessMessage(ctx context.Context, msg *central.MsgToS
 	}
 	select {
 	case <-ctx.Done():
-		// TODO(ROX-): pass the context together with `cmd` to `h.commandsC`
+		// TODO(ROX-30333): pass the context together with `cmd` to `h.commandsC`
 		return errors.Wrapf(ctx.Err(), "message processing in component %s", h.Name())
 	case h.commandsC <- cmd:
 		return nil

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -85,12 +85,14 @@ func (h *commandHandler) run() {
 	}
 }
 
-func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
+func (h *commandHandler) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	cmd := msg.GetNetworkPoliciesCommand()
 	if cmd == nil {
 		return nil
 	}
 	select {
+	case <-ctx.Done():
+		return ctx.Err() // TODO(ROX-): pass the context together with `cmd` to `h.commandsC`
 	case h.commandsC <- cmd:
 		return nil
 	case <-h.stopSig.Done():

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -109,7 +109,7 @@ func (h *commandHandler) Notify(e common.SensorComponentEvent) {
 	}
 }
 
-func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
+func (h *commandHandler) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	switch m := msg.GetMsg().(type) {
 	case *central.MsgToSensor_TelemetryDataRequest:
 		return h.processRequest(m.TelemetryDataRequest)

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -110,7 +110,7 @@ func (h *commandHandler) waitForTermination(proc *process) {
 	}
 }
 
-func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
+func (h *commandHandler) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	trigger := msg.GetSensorUpgradeTrigger()
 	if trigger == nil {
 		return nil


### PR DESCRIPTION
### Description

The context is meant to stop processing of the current message. The next message passed to `ProcessMessage` will be processed as usual. In contrast, the component's `Stop()` method is meant to stop all the processing in a component and shut it down.

Note that this PR merely adds the new `ctx` parameter and regenerates the mocks.

⚠️ There are few places where handling of the new context was trivial - I added the handling. In order to make those places easier to spot in the review, I am adding comments in those places. Please give those a look.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

#### How I validated my change

- CI only
