### PR TITLE
chore(sensor): use string for component name

### DIFF
--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -29,7 +29,7 @@ type alertHandlerImpl struct {
 }
 
 func (h *alertHandlerImpl) Name() string {
-	return common.DefaultComponentName(h)
+	return "admissioncontroller.alertHandlerImpl"
 }
 
 func (h *alertHandlerImpl) Start() error {

--- a/sensor/common/admissioncontroller/message_forwarder.go
+++ b/sensor/common/admissioncontroller/message_forwarder.go
@@ -56,7 +56,7 @@ func (h *admCtrlMsgForwarderImpl) Stop() {
 }
 
 func (h *admCtrlMsgForwarderImpl) Name() string {
-	return common.DefaultComponentName(h)
+	return "admissioncontroller.admCtrlMsgForwarderImpl"
 }
 
 func (h *admCtrlMsgForwarderImpl) Notify(event common.SensorComponentEvent) {

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -40,7 +40,7 @@ type auditLogCollectionManagerImpl struct {
 }
 
 func (a *auditLogCollectionManagerImpl) Name() string {
-	return common.DefaultComponentName(a)
+	return "compliance.auditLogCollectionManagerImpl"
 }
 
 func (a *auditLogCollectionManagerImpl) Start() error {

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -45,7 +45,7 @@ func (c *commandHandlerImpl) Start() error {
 }
 
 func (c *commandHandlerImpl) Name() string {
-	return common.DefaultComponentName(c)
+	return "compliance.commandHandlerImpl"
 }
 
 func (c *commandHandlerImpl) Stop() {

--- a/sensor/common/compliance/multiplexer.go
+++ b/sensor/common/compliance/multiplexer.go
@@ -22,7 +22,7 @@ type Multiplexer struct {
 }
 
 func (c *Multiplexer) Name() string {
-	return common.DefaultComponentName(c)
+	return "compliance.Multiplexer"
 }
 
 // Stopped returns a signal allowing to check whether the component has been stopped

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -52,7 +52,7 @@ type nodeInventoryHandlerImpl struct {
 }
 
 func (c *nodeInventoryHandlerImpl) Name() string {
-	return common.DefaultComponentName(c)
+	return "compliance.nodeInventoryHandlerImpl"
 }
 
 func (c *nodeInventoryHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -48,7 +48,7 @@ type serviceImpl struct {
 }
 
 func (s *serviceImpl) Name() string {
-	return common.DefaultComponentName(s)
+	return "compliance.serviceImpl"
 }
 
 func (s *serviceImpl) Notify(e common.SensorComponentEvent) {

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -54,13 +54,6 @@ func LogSensorComponentEvent(e SensorComponentEvent, optComponentName ...string)
 	}
 }
 
-func DefaultComponentName[T any](instance *T) string {
-	if instance == nil {
-		instance = new(T)
-	}
-	return fmt.Sprintf("%T", *instance)
-}
-
 // Notifiable is the interface used by Sensor to notify components of state changes in Central<->Sensor connectivity.
 type Notifiable interface {
 	Notify(e SensorComponentEvent)

--- a/sensor/common/config/handler.go
+++ b/sensor/common/config/handler.go
@@ -55,7 +55,7 @@ type configHandlerImpl struct {
 }
 
 func (c *configHandlerImpl) Name() string {
-	return common.DefaultComponentName(c)
+	return "config.configHandlerImpl"
 }
 
 func (c *configHandlerImpl) Start() error {

--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -43,7 +43,7 @@ type delegatedRegistryImpl struct {
 }
 
 func (d *delegatedRegistryImpl) Name() string {
-	return common.DefaultComponentName(d)
+	return "delegatedregistry.delegatedRegistryImpl"
 }
 
 // NewHandler returns a new instance of Handler.

--- a/sensor/common/deploymentenhancer/component.go
+++ b/sensor/common/deploymentenhancer/component.go
@@ -31,7 +31,7 @@ type DeploymentEnhancer struct {
 }
 
 func (d *DeploymentEnhancer) Name() string {
-	return common.DefaultComponentName(d)
+	return "deploymentenhancer.DeploymentEnhancer"
 }
 
 // CreateEnhancer creates a new Enhancer

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -180,7 +180,7 @@ type detectorImpl struct {
 }
 
 func (d *detectorImpl) Name() string {
-	return common.DefaultComponentName(d)
+	return "detector.detectorImpl"
 }
 
 func (d *detectorImpl) Start() error {

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -44,7 +44,7 @@ type enforcer struct {
 }
 
 func (e *enforcer) Name() string {
-	return common.DefaultComponentName(e)
+	return "enforcer.enforcer"
 }
 
 func (e *enforcer) Capabilities() []centralsensor.SensorCapability {

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -65,7 +65,7 @@ func (h *handlerImpl) Stop() {
 }
 
 func (h *handlerImpl) Name() string {
-	return common.DefaultComponentName(h)
+	return "externalsrcs.handlerImpl"
 }
 
 func (h *handlerImpl) Notify(common.SensorComponentEvent) {}

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -62,7 +62,7 @@ type serviceImpl struct {
 }
 
 func (s *serviceImpl) Name() string {
-	return common.DefaultComponentName(s)
+	return "image.serviceImpl"
 }
 
 func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -366,7 +366,7 @@ type networkFlowManager struct {
 }
 
 func (m *networkFlowManager) Name() string {
-	return common.DefaultComponentName(m)
+	return "networkflow.manager.networkFlowManager"
 }
 
 func (m *networkFlowManager) ProcessMessage(_ *central.MsgToSensor) error {

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -44,7 +44,7 @@ type handlerImpl struct {
 }
 
 func (h *handlerImpl) Name() string {
-	return common.DefaultComponentName(h)
+	return "reprocessor.handlerImpl"
 }
 
 func (h *handlerImpl) Start() error {

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -64,7 +64,7 @@ type serviceImpl struct {
 }
 
 func (s *serviceImpl) Name() string {
-	return common.DefaultComponentName(s)
+	return "signal.serviceImpl"
 }
 
 func authFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {

--- a/sensor/kubernetes/admissioncontroller/config_map_persister.go
+++ b/sensor/kubernetes/admissioncontroller/config_map_persister.go
@@ -41,7 +41,7 @@ type configMapPersister struct {
 }
 
 func (p *configMapPersister) Name() string {
-	return common.DefaultComponentName(p)
+	return "admissioncontroller.configMapPersister"
 }
 
 // NewConfigMapSettingsPersister creates a config persister object for the admission controller.

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -113,7 +113,7 @@ type tlsIssuerImpl struct {
 }
 
 func (i *tlsIssuerImpl) Name() string {
-	return common.DefaultComponentName(i)
+	return "certrefresh.tlsIssuerImpl"
 }
 
 // Start starts the Sensor component and launches a certificate refresher that:

--- a/sensor/kubernetes/clusterhealth/updater.go
+++ b/sensor/kubernetes/clusterhealth/updater.go
@@ -56,7 +56,7 @@ type updaterImpl struct {
 }
 
 func (u *updaterImpl) Name() string {
-	return common.DefaultComponentName(u)
+	return "clusterhealth.updaterImpl"
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -71,7 +71,7 @@ type clusterMetricsImpl struct {
 }
 
 func (cm *clusterMetricsImpl) Name() string {
-	return common.DefaultComponentName(cm)
+	return "clustermetrics.clusterMetricsImpl"
 }
 
 func (cm *clusterMetricsImpl) Start() error {

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -54,7 +54,7 @@ type updaterImpl struct {
 }
 
 func (u *updaterImpl) Name() string {
-	return common.DefaultComponentName(u)
+	return "clusterstatus.updaterImpl"
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -42,7 +42,7 @@ type handlerImpl struct {
 }
 
 func (m *handlerImpl) Name() string {
-	return common.DefaultComponentName(m)
+	return "complianceoperator.handlerImpl"
 }
 
 type scanScheduleConfiguration struct {

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -100,7 +100,7 @@ type updaterImpl struct {
 }
 
 func (u *updaterImpl) Name() string {
-	return common.DefaultComponentName(u)
+	return "complianceoperator.updaterImpl"
 }
 
 func (u *updaterImpl) Start() error {

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -42,7 +42,7 @@ type eventPipeline struct {
 }
 
 func (p *eventPipeline) Name() string {
-	return common.DefaultComponentName(p)
+	return "eventpipeline.eventPipeline"
 }
 
 // Capabilities implements common.SensorComponent

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -30,7 +30,7 @@ type commandHandler struct {
 }
 
 func (h *commandHandler) Name() string {
-	return common.DefaultComponentName(h)
+	return "networkpolicies.commandHandler"
 }
 
 // NewCommandHandler creates a new network policies command handler.

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -53,7 +53,7 @@ type commandHandler struct {
 }
 
 func (h *commandHandler) Name() string {
-	return common.DefaultComponentName(h)
+	return "telemetry.commandHandler"
 }
 
 // DiagnosticConfigurationFunc is a function that modifies the diagnostic configuration.

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -42,7 +42,7 @@ type commandHandler struct {
 }
 
 func (h *commandHandler) Name() string {
-	return common.DefaultComponentName(h)
+	return "upgrade.commandHandler"
 }
 
 // NewCommandHandler returns a new upgrade command handler for Kubernetes.


### PR DESCRIPTION
Since `Name()` always return the same value there is no need to generate it every time it's called and use generics for that. We can replace it with a const. 

Fixes:
- https://github.com/stackrox/stackrox/pull/16028#discussion_r2207015680
- https://github.com/stackrox/stackrox/pull/16028#pullrequestreview-3025489768


Assisted-by: Claude (Anthropic AI assistant)