### PR TITLE
chore(ui): Handle encoded and unencoded params in horizontal nav

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.cy.jsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.cy.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import ComponentTestProviders from 'test-utils/ComponentProviders';
+
+import HorizontalSubnav from './HorizontalSubnav';
+
+// Mock the permission and feature flag hooks
+const mockRoutePredicates = {
+    hasReadAccess: () => true,
+    isFeatureFlagEnabled: () => true,
+};
+
+function setup(pathname) {
+    window.history.pushState({}, document.title, pathname);
+
+    cy.mount(
+        <ComponentTestProviders>
+            <HorizontalSubnav
+                hasReadAccess={mockRoutePredicates.hasReadAccess}
+                isFeatureFlagEnabled={mockRoutePredicates.isFeatureFlagEnabled}
+            />
+        </ComponentTestProviders>
+    );
+}
+
+describe(Cypress.spec.relative, () => {
+    it('should render the violations subnav when on violations page', () => {
+        setup('/main/violations');
+
+        // Verify that the violations subnav items are rendered
+        cy.contains('User Workloads').should('exist');
+        cy.contains('Platform').should('exist');
+        cy.contains('All Violations').should('exist');
+    });
+
+    it('should not render subnav when not on a violations or vulnerabilities page', () => {
+        setup('/main/dashboard');
+
+        // The component should not render anything when not on a relevant page
+        cy.get('nav').should('not.exist');
+    });
+
+    describe('Violations active state behavior', () => {
+        it('should default User Workloads to active when no filter is present', () => {
+            setup('/main/violations');
+
+            // Verify User Workloads is active by default when no filter is present
+            cy.findByRole('link', { name: 'User Workloads' }).should('have.class', 'pf-m-current');
+
+            // Verify other links are not active
+            cy.findByRole('link', { name: 'Platform' }).should('not.have.class', 'pf-m-current');
+            cy.findByRole('link', { name: 'All Violations' }).should(
+                'not.have.class',
+                'pf-m-current'
+            );
+        });
+
+        it('should work with additional URL parameters', () => {
+            setup(
+                '/main/violations?someParam=value&filteredWorkflowView=Applications view&anotherParam=test'
+            );
+
+            // Check that User Workloads link is still active with additional params
+            cy.findByRole('link', { name: 'User Workloads' }).should('have.class', 'pf-m-current');
+        });
+
+        it('should update active state when clicking through navigation items', () => {
+            setup('/main/violations');
+
+            // Initially User Workloads should be active by default
+            cy.findByRole('link', { name: 'User Workloads' }).should('have.class', 'pf-m-current');
+            cy.findByRole('link', { name: 'Platform' }).should('not.have.class', 'pf-m-current');
+            cy.findByRole('link', { name: 'All Violations' }).should(
+                'not.have.class',
+                'pf-m-current'
+            );
+
+            // Click on Platform and verify it becomes active
+            cy.findByRole('link', { name: 'Platform' }).click();
+            cy.findByRole('link', { name: 'Platform' }).should('have.class', 'pf-m-current');
+            cy.findByRole('link', { name: 'User Workloads' }).should(
+                'not.have.class',
+                'pf-m-current'
+            );
+            cy.findByRole('link', { name: 'All Violations' }).should(
+                'not.have.class',
+                'pf-m-current'
+            );
+
+            // Click on All Violations and verify it becomes active
+            cy.findByRole('link', { name: 'All Violations' }).click();
+            cy.findByRole('link', { name: 'All Violations' }).should('have.class', 'pf-m-current');
+            cy.findByRole('link', { name: 'User Workloads' }).should(
+                'not.have.class',
+                'pf-m-current'
+            );
+            cy.findByRole('link', { name: 'Platform' }).should('not.have.class', 'pf-m-current');
+
+            // Click back on User Workloads (first item) and verify it becomes active again
+            cy.findByRole('link', { name: 'User Workloads' }).click();
+            cy.findByRole('link', { name: 'User Workloads' }).should('have.class', 'pf-m-current');
+            cy.findByRole('link', { name: 'Platform' }).should('not.have.class', 'pf-m-current');
+            cy.findByRole('link', { name: 'All Violations' }).should(
+                'not.have.class',
+                'pf-m-current'
+            );
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -26,6 +26,7 @@ import {
 } from 'routePaths';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
+import { hasSearchKeyValue } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import NavigationItem from './NavigationItem';
 import { filterNavDescriptions, isActiveLink, NavDescription } from './utils';
@@ -50,8 +51,13 @@ function getSubnavDescriptionGroups(
                       path: violationsUserWorkloadsViewPath,
                       isActive: (location) => {
                           const search: string = location.search || '';
-                          const encodedValue = encodeURIComponent('Applications view');
-                          return search.includes(`filteredWorkflowView=${encodedValue}`);
+                          return (
+                              hasSearchKeyValue(
+                                  search,
+                                  'filteredWorkflowView',
+                                  'Applications view'
+                              ) || hasSearchKeyValue(search, 'filteredWorkflowView', null)
+                          );
                       },
                       routeKey: 'violations',
                   },
@@ -61,8 +67,7 @@ function getSubnavDescriptionGroups(
                       path: violationsPlatformViewPath,
                       isActive: (location) => {
                           const search: string = location.search || '';
-                          const encodedValue = encodeURIComponent('Platform view');
-                          return search.includes(`filteredWorkflowView=${encodedValue}`);
+                          return hasSearchKeyValue(search, 'filteredWorkflowView', 'Platform view');
                       },
                       routeKey: 'violations',
                   },
@@ -72,8 +77,7 @@ function getSubnavDescriptionGroups(
                       path: violationsFullViewPath,
                       isActive: (location) => {
                           const search: string = location.search || '';
-                          const encodedValue = encodeURIComponent('Full view');
-                          return search.includes(`filteredWorkflowView=${encodedValue}`);
+                          return hasSearchKeyValue(search, 'filteredWorkflowView', 'Full view');
                       },
                       routeKey: 'violations',
                   },

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -68,7 +68,7 @@ export const systemHealthPath = `${mainPath}/system-health`;
 export const userBasePath = `${mainPath}/user`;
 export const userRolePath = `${userBasePath}/roles/:roleName`;
 export const violationsBasePath = `${mainPath}/violations`;
-export const violationsUserWorkloadsViewPath = `${mainPath}/violations?filteredWorkflowView=Application view`;
+export const violationsUserWorkloadsViewPath = `${mainPath}/violations?filteredWorkflowView=Applications view`;
 export const violationsPlatformViewPath = `${mainPath}/violations?filteredWorkflowView=Platform view`;
 export const violationsFullViewPath = `${mainPath}/violations?filteredWorkflowView=Full view`;
 export const violationsPath = `${violationsBasePath}/:alertId?`;

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -7,6 +7,7 @@ import {
     getPaginationParams,
     searchValueAsArray,
     convertToExactMatch,
+    hasSearchKeyValue,
 } from './searchUtils';
 
 describe('searchUtils', () => {
@@ -351,6 +352,26 @@ describe('searchUtils', () => {
 
         it('returns a string value wrapped in bespoke regex for exact match', () => {
             expect(convertToExactMatch('cluster')).toEqual('r/^cluster$');
+        });
+    });
+
+    describe('hasSearchKeyValue', () => {
+        it('returns true when the key and value are present in the search string regardless of encoding', () => {
+            expect(hasSearchKeyValue('?key=a value', 'key', 'a value')).toBe(true);
+            expect(hasSearchKeyValue('?key=a%20value', 'key', 'a value')).toBe(true);
+            expect(hasSearchKeyValue('?key=a+value', 'key', 'a value')).toBe(true);
+            // negative cases
+            expect(hasSearchKeyValue('?key=a value', 'key', 'a')).toBe(false);
+            expect(hasSearchKeyValue('?key=a%20value', 'key', 'a')).toBe(false);
+            expect(hasSearchKeyValue('?key=a+value', 'key', 'a')).toBe(false);
+        });
+
+        it('returns true when the key and value are present with other key-value pairs', () => {
+            expect(hasSearchKeyValue('?a=s&key=a value&b=t', 'key', 'a value')).toBe(true);
+            expect(hasSearchKeyValue('?a=s%20s&key=a%20value&b=t%20x', 'key', 'a value')).toBe(
+                true
+            );
+            expect(hasSearchKeyValue('?a=s+s&key=a+value&b=t+x', 'key', 'a value')).toBe(true);
         });
     });
 });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -302,3 +302,10 @@ export const generatePathWithQuery = (
 
     return queryParams ? `${path}?${queryParams}` : path;
 };
+
+export function hasSearchKeyValue(search: string, key: string, value: string | null) {
+    const urlSearchParams = new URLSearchParams(search);
+    const encodedValue = encodeURIComponent(value ?? '');
+
+    return urlSearchParams.get(key) === value || urlSearchParams.get(key) === encodedValue;
+}


### PR DESCRIPTION
### Description

In the react-router v5->v6 change the handling of active states in the Violations page navigation was broken and caught during a bug bash. Since this will be an issue again when moving to the rr-compat library, I've made these checks independent of parameter encoding and added tests to prevent breaking again during the next change.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

`npm run test`
`npm run test-component`