### PR TITLE
ROX-29185: Refactor heritage to allow better unit-testing

### DIFF
--- a/sensor/common/heritage/heritage.go
+++ b/sensor/common/heritage/heritage.go
@@ -9,15 +9,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/version"
-	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -72,19 +68,19 @@ func sensorMetadataString(data []*SensorMetadata) string {
 	return str.String()
 }
 
-// Using this as one cannot import the client.Interface from 'sensor/kubernetes/client' directly
-type k8sClient interface {
-	Kubernetes() kubernetes.Interface
+type configMapWriter interface {
+	Write(ctx context.Context, data ...*SensorMetadata) error
+	Read(ctx context.Context) ([]*SensorMetadata, error)
 }
 
 type Manager struct {
-	k8sClient k8sClient
 	namespace string
 
 	// Cache the data for the current instance of Sensor
 	currentSensor SensorMetadata
 
-	// Timestamp of the latest update to the config map. Used to limit the number of updates to the cm.
+	cmWriter configMapWriter
+	// Timestamp of the latest update to the config map. Used to rate-limit the number of updates to the cm.
 	lastCmWrite time.Time
 	// Time that defines a window where only a single write to config map should happen in case of cache hit.
 	writeCmFrequency time.Duration
@@ -102,13 +98,17 @@ type Manager struct {
 func NewHeritageManager(ns string, client k8sClient, start time.Time) *Manager {
 	return &Manager{
 		cacheIsPopulated: atomic.Bool{},
-		k8sClient:        client,
 		cache:            []*SensorMetadata{},
 		namespace:        ns,
 		currentSensor: SensorMetadata{
 			SensorVersion: version.GetMainVersion(),
 			SensorStart:   start,
 		},
+		cmWriter: &cmWriter{
+			k8sClient: client,
+			namespace: ns,
+		},
+		lastCmWrite:      time.Unix(0, 0),
 		writeCmFrequency: 5 * time.Minute,
 		maxSize:          env.PastSensorsMaxEntries.IntegerSetting(), // Setting value is already validated
 		minSize:          heritageMinSize,                            // Keep in sync with minimum of `env.PastSensorsMaxEntries`
@@ -117,7 +117,7 @@ func NewHeritageManager(ns string, client k8sClient, start time.Time) *Manager {
 }
 
 func (h *Manager) populateCacheFromConfigMapNoLock(ctx context.Context) error {
-	data, err := h.readConfigMap(ctx)
+	data, err := h.cmWriter.Read(ctx)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			h.cacheIsPopulated.Store(true)
@@ -182,60 +182,33 @@ func (h *Manager) upsertConfigMap(ctx context.Context, now time.Time) error {
 			log.Warnf("%v", err)
 		}
 	}
+	wrote, err := h.write(ctx, now)
+	if wrote {
+		log.Debugf("Wrote heritage data %s to ConfigMap %s/%s", sensorMetadataString(h.cache), h.namespace, cmName)
+	}
+	return err
+}
 
+func (h *Manager) write(ctx context.Context, now time.Time) (wrote bool, err error) {
 	if cacheHit := h.updateCachedTimestampNoLock(now); !cacheHit {
 		h.currentSensor.LatestUpdate = now
 		h.cache = append(h.cache, &h.currentSensor)
 	} else {
-		// On cache-hit, we would update only the `LatestUpdate` field. Let's not do this too often.
+		// On cache-hit, we would update the `LatestUpdate` field, which should not happen too often to save on IO load.
 		timeSinceLastWrite := now.Sub(h.lastCmWrite)
 		if timeSinceLastWrite < h.writeCmFrequency {
-			return nil
+			return false, nil
 		}
 	}
+
 	h.cache = pruneOldHeritageData(h.cache, now, h.maxAge, h.minSize, h.maxSize)
 
-	log.Debugf("Writing Heritage data %s to ConfigMap %s/%s", sensorMetadataString(h.cache), h.namespace, cmName)
-	return h.write(ctx, now, h.cache...)
-}
-
-func (h *Manager) write(ctx context.Context, now time.Time, data ...*SensorMetadata) error {
-	cm, err := pastSensorDataToConfigMap(data...)
-	if err != nil {
-		return errors.Wrap(err, "converting past sensor data to config map")
+	err = h.cmWriter.Write(ctx, h.cache...)
+	if err == nil {
+		h.lastCmWrite = now
+		return true, nil
 	}
-
-	if err := h.ensureConfigMapExists(ctx, cm); err != nil {
-		return errors.Wrap(err, "preparing configMap for writing")
-	}
-	if _, err := h.k8sClient.Kubernetes().CoreV1().ConfigMaps(h.namespace).
-		Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
-		return errors.Wrapf(err, "writing to config map %s/%s", h.namespace, cmName)
-	}
-	h.lastCmWrite = now
-	return nil
-}
-
-func (h *Manager) ensureConfigMapExists(ctx context.Context, cm *v1.ConfigMap) error {
-	if _, errCr := h.k8sClient.Kubernetes().CoreV1().ConfigMaps(h.namespace).
-		Create(ctx, cm, metav1.CreateOptions{}); errCr != nil {
-		if !apiErrors.IsAlreadyExists(errCr) {
-			return errors.Wrapf(errCr, "creating config map %s/%s", h.namespace, cmName)
-		}
-	}
-	return nil
-}
-
-func (h *Manager) readConfigMap(ctx context.Context) ([]*SensorMetadata, error) {
-	cm, err := h.k8sClient.Kubernetes().CoreV1().ConfigMaps(h.namespace).Get(ctx, cmName, metav1.GetOptions{})
-	if err != nil {
-		return []*SensorMetadata{}, errors.Wrapf(err, "retrieving config map %s/%s", h.namespace, cmName)
-	}
-	data, err := configMapToPastSensorData(cm)
-	if err != nil {
-		return []*SensorMetadata{}, errors.Wrap(err, "converting config map to past sensor data")
-	}
-	return data, nil
+	return false, err
 }
 
 // pruneOldHeritageData reduces the number of elements in the []*PastSensor slice by removing

--- a/sensor/common/heritage/heritage_test.go
+++ b/sensor/common/heritage/heritage_test.go
@@ -1,9 +1,13 @@
 package heritage
 
 import (
+	"context"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_cleanupHeritageData(t *testing.T) {
@@ -348,5 +352,94 @@ func Test_cleanupHeritageData(t *testing.T) {
 				t.Errorf("\ngot  = %v\nwant = %v", sensorMetadataString(got), tt.want)
 			}
 		})
+	}
+}
+
+type dummyWriter struct{}
+
+func (d *dummyWriter) Write(_ context.Context, _ ...*SensorMetadata) error {
+	return nil
+}
+
+func (d *dummyWriter) Read(_ context.Context) ([]*SensorMetadata, error) {
+	return []*SensorMetadata{}, nil
+}
+
+func Test_writeRateLimiter(t *testing.T) {
+	data := []*SensorMetadata{
+		{
+			ContainerID:  "a",
+			PodIP:        "1.1.1.1",
+			SensorStart:  time.Unix(0, 0),
+			LatestUpdate: time.Unix(10, 0),
+		},
+		{
+			ContainerID:  "b",
+			PodIP:        "1.1.1.2",
+			SensorStart:  time.Unix(100, 0),
+			LatestUpdate: time.Unix(110, 0),
+		},
+	}
+	tests := map[string]struct {
+		lastWrite     time.Time
+		frequency     time.Duration
+		now           time.Time
+		cacheHit      bool
+		writeExpected bool
+	}{
+		"Write after 5s should not trigger 1s rate limit": {
+			lastWrite:     time.Unix(0, 0),
+			frequency:     time.Second,
+			now:           time.Unix(5, 0),
+			cacheHit:      true,
+			writeExpected: true,
+		},
+		"Write after 5s should trigger 10s rate limit": {
+			lastWrite:     time.Unix(0, 0),
+			frequency:     10 * time.Second,
+			now:           time.Unix(5, 0),
+			cacheHit:      true,
+			writeExpected: false,
+		},
+		"Write after 5s should not trigger 10s rate limit on cache-miss": {
+			lastWrite:     time.Unix(0, 0),
+			frequency:     10 * time.Second,
+			now:           time.Unix(5, 0),
+			cacheHit:      false,
+			writeExpected: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hm := newManager(t, &dummyWriter{}, data, tt.lastWrite, tt.frequency)
+			if tt.cacheHit {
+				hm.currentSensor.PodIP = "1.1.1.1"
+				hm.currentSensor.ContainerID = "a"
+			} else {
+				hm.currentSensor.PodIP = "1.1.1.199"
+				hm.currentSensor.ContainerID = "z"
+			}
+			gotWrite, gotErr := hm.write(context.Background(), tt.now)
+			assert.NoError(t, gotErr)
+			assert.Equal(t, tt.writeExpected, gotWrite)
+		})
+	}
+}
+
+func newManager(_ *testing.T, writer configMapWriter, cache []*SensorMetadata, lastWrite time.Time, freq time.Duration) *Manager {
+	return &Manager{
+		cacheIsPopulated: atomic.Bool{},
+		cache:            cache,
+		namespace:        "test",
+		currentSensor: SensorMetadata{
+			SensorVersion: "1.0.0-test",
+			SensorStart:   time.Unix(0, 0),
+		},
+		cmWriter:         writer,
+		lastCmWrite:      lastWrite,
+		writeCmFrequency: freq,
+		maxSize:          10,
+		minSize:          2,
+		maxAge:           heritageMaxAge,
 	}
 }

--- a/sensor/common/heritage/writer.go
+++ b/sensor/common/heritage/writer.go
@@ -1,0 +1,61 @@
+package heritage
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Using this as one cannot import the client.Interface from 'sensor/kubernetes/client' directly
+type k8sClient interface {
+	Kubernetes() kubernetes.Interface
+}
+
+type cmWriter struct {
+	// namespace to write the configmap to
+	namespace string
+	// k8sClient to use fro writing
+	k8sClient k8sClient
+}
+
+func (h *cmWriter) Write(ctx context.Context, data ...*SensorMetadata) error {
+	cm, err := pastSensorDataToConfigMap(data...)
+	if err != nil {
+		return errors.Wrap(err, "converting past sensor data to config map")
+	}
+
+	if err := h.ensureConfigMapExists(ctx, cm); err != nil {
+		return errors.Wrap(err, "preparing configMap for writing")
+	}
+	if _, err := h.k8sClient.Kubernetes().CoreV1().ConfigMaps(h.namespace).
+		Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return errors.Wrapf(err, "writing to config map %s/%s", h.namespace, cmName)
+	}
+	return nil
+}
+
+func (h *cmWriter) ensureConfigMapExists(ctx context.Context, cm *v1.ConfigMap) error {
+	if _, errCr := h.k8sClient.Kubernetes().CoreV1().ConfigMaps(h.namespace).
+		Create(ctx, cm, metav1.CreateOptions{}); errCr != nil {
+		if !apiErrors.IsAlreadyExists(errCr) {
+			return errors.Wrapf(errCr, "creating config map %s/%s", h.namespace, cmName)
+		}
+	}
+	return nil
+}
+
+func (h *cmWriter) Read(ctx context.Context) ([]*SensorMetadata, error) {
+	cm, err := h.k8sClient.Kubernetes().CoreV1().ConfigMaps(h.namespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return []*SensorMetadata{}, errors.Wrapf(err, "retrieving config map %s/%s", h.namespace, cmName)
+	}
+	data, err := configMapToPastSensorData(cm)
+	if err != nil {
+		return []*SensorMetadata{}, errors.Wrap(err, "converting config map to past sensor data")
+	}
+	return data, nil
+}


### PR DESCRIPTION
### Description

Before this PR, writing and reading of the configmap was embedded into the HeritageManager which made the testing difficult as a real (or fake) k8s client was required. In this PR, I extract all k8s-related functions to a separate object, so that it can be mocked in the unit-tests.

Fixes https://github.com/stackrox/stackrox/pull/16085#pullrequestreview-3033186822

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

- CI
