### PR TITLE
ROX-29792: Clarify cluster status for scan config

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -639,11 +639,9 @@ func (suite *complianceManagerTestSuite) TestProcessRescanRequest() {
 			setMocks: func() {
 				suite.scanConfigDS.EXPECT().GetScanConfiguration(gomock.Any(), mockScanID).Return(multiCluster, true, nil).Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster1, gomock.Any()).Return(errors.New("Failed to send message to sensor")).Times(1)
-				suite.clusterDatastore.EXPECT().GetClusterName(gomock.Any(), gomock.Any()).Return("test_cluster", true, nil).Times(1)
-				suite.scanConfigDS.EXPECT().UpdateClusterStatus(gomock.Any(), mockScanID, testconsts.Cluster1, "Failed to send message to sensor", "test_cluster").Times(1)
 				suite.connectionMgr.EXPECT().SendMessage(testconsts.Cluster3, gomock.Any()).Return(nil).Times(1)
 			},
-			isErrorTest: false,
+			isErrorTest: true,
 		},
 	}
 	for _, tc := range cases {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigClustersTable.tsx
@@ -111,7 +111,7 @@ function ScanConfigClustersTable({
                     <Tr>
                         <Th sort={getSortParams(0)}>Cluster</Th>
                         <Th sort={getSortParams(1)} width={20}>
-                            Operator status
+                            Scan schedule status
                         </Th>
                     </Tr>
                 </Thead>
@@ -120,7 +120,7 @@ function ScanConfigClustersTable({
                         return (
                             <Tr key={cluster.clusterId}>
                                 <Td dataLabel="Cluster">{cluster.clusterName}</Td>
-                                <Td dataLabel="Operator status">
+                                <Td dataLabel="Scan schedule status">
                                     <ComplianceClusterStatus errors={cluster.errors} />
                                 </Td>
                             </Tr>


### PR DESCRIPTION
### Description

Current problem (way to reproduce can be found in the ticket):
- if manual scan trigger "fails" (i.e. sensor not connected)
- we will save the state of failure with he scan config
- it can be cleared only by scan config update
- user will not get an error message returned from "trigger" API call

Anothe problem:
- broken scan config state on secured cluster does not represent unhealthy cluster
- cluster can be healthy and work properly for other scan configs
- representation in UI is confusing in misleading

A proposal for this issue:
- errors that occur during manual scan trigger will be collected for each cluster and returned to UI to be displayed to the user
- cluster scan config state - will not be updated if manual trigger scan fails
- in UI we will show "Scan schedule status". Cluster status - will be visible only on create/edit scan schedule

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

#### How I validated my change

- [x] trigger manual scan with disconnected sensor
- [x] test UI error message display/format
- [ ] (not sure how) - broken bindings should be shown as not healthy scan schedule state
