### PR TITLE
ROX-29844: Add configuration of base URL in plugin requests

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@apollo/client": "^3.6.3",
         "@lifeomic/axios-fetch": "^3.1.0",
+        "@openshift-console/dynamic-plugin-sdk": "4.19.0",
         "@patternfly/react-charts": "^7.2.2",
         "@patternfly/react-component-groups": "^5.2.0",
         "@patternfly/react-core": "^5.2.2",
@@ -124,7 +125,6 @@
         "@babel/preset-typescript": "^7.27.1",
         "@babel/runtime": "^7.27.6",
         "@eslint/json": "^0.12.0",
-        "@openshift-console/dynamic-plugin-sdk": "4.19.0",
         "@openshift-console/dynamic-plugin-sdk-webpack": "4.19.0",
         "@tailwindcss/forms": "^0.2.1",
         "@testing-library/cypress": "^10.0.3",

--- a/ui/apps/platform/scripts/start-ocp-console.sh
+++ b/ui/apps/platform/scripts/start-ocp-console.sh
@@ -6,10 +6,17 @@ CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}
 CONSOLE_PORT=${CONSOLE_PORT:=9000}
 CONSOLE_IMAGE_PLATFORM=${CONSOLE_IMAGE_PLATFORM:="linux/amd64"}
 
+# The ACS backend service URL that will receive the console's proxied requests.
+ACS_API_SERVICE_URL=${ACS_API_SERVICE_URL:=https://$(oc -n stackrox get route central -o jsonpath='{.spec.host}')}
+
+# Whether to inject the OCP auth token into the ACS backend service.
+ACS_INJECT_OCP_AUTH_TOKEN=${ACS_INJECT_OCP_AUTH_TOKEN:=true}
+
 # Plugin metadata is declared in package.json
 PLUGIN_NAME="advanced-cluster-security"
 
-echo "Starting local OpenShift console..."
+echo "Starting local OpenShift console using ACS API Service URL: $ACS_API_SERVICE_URL"
+echo "Injecting OCP auth token: $ACS_INJECT_OCP_AUTH_TOKEN"
 
 export BRIDGE_USER_AUTH="disabled"
 export BRIDGE_K8S_MODE="off-cluster"
@@ -32,6 +39,8 @@ set -e
 if [ -n "$GITOPS_HOSTNAME" ]; then
     export BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS="https://$GITOPS_HOSTNAME"
 fi
+
+export BRIDGE_PLUGIN_PROXY='{"services":[{"consoleAPIPath":"/api/proxy/plugin/advanced-cluster-security/api-service/","endpoint":"'$ACS_API_SERVICE_URL'", "authorize":'$ACS_INJECT_OCP_AUTH_TOKEN'}]}'
 
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ApolloProvider } from '@apollo/client';
+
+import axios from 'services/instance';
+import configureApolloClient from '../init/configureApolloClient';
+
+const baseURL = '/api/proxy/plugin/advanced-cluster-security/api-service/';
+
+const apolloClient = configureApolloClient();
+
+axios.interceptors.request.use((config) => {
+    const updatedConfig = { ...config, baseURL };
+
+    // Note - in production authorization is handled in-cluster by the console and will overwrite this header. When
+    // running locally, we need to inject the token manually to allow API requests to the ACS API.
+    if (process.env.NODE_ENV === 'development' && process.env.ACS_CONSOLE_DEV_TOKEN) {
+        updatedConfig.headers.Authorization = `Bearer ${process.env.ACS_CONSOLE_DEV_TOKEN}`;
+    }
+
+    return updatedConfig;
+});
+
+export default function PluginProvider({ children }) {
+    return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>;
+}

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -3,22 +3,15 @@ import { ApolloProvider } from '@apollo/client';
 
 import axios from 'services/instance';
 import configureApolloClient from '../init/configureApolloClient';
+import consoleFetchAxiosAdapter from './consoleFetchAxiosAdapter';
 
-const baseURL = '/api/proxy/plugin/advanced-cluster-security/api-service/';
+// The console requires a custom fetch implementation via `consoleFetch` to correctly pass headers such
+// as X-CSRFToken to API requests. All of our current code uses `axios` to make API requests, so we need
+// to override the default adapter to use `consoleFetch` instead of XMLHttpRequest.
+const proxyBaseURL = '/api/proxy/plugin/advanced-cluster-security/api-service';
+axios.defaults.adapter = (config) => consoleFetchAxiosAdapter(proxyBaseURL, config);
 
 const apolloClient = configureApolloClient();
-
-axios.interceptors.request.use((config) => {
-    const updatedConfig = { ...config, baseURL };
-
-    // Note - in production authorization is handled in-cluster by the console and will overwrite this header. When
-    // running locally, we need to inject the token manually to allow API requests to the ACS API.
-    if (process.env.NODE_ENV === 'development' && process.env.ACS_CONSOLE_DEV_TOKEN) {
-        updatedConfig.headers.Authorization = `Bearer ${process.env.ACS_CONSOLE_DEV_TOKEN}`;
-    }
-
-    return updatedConfig;
-});
 
 export default function PluginProvider({ children }) {
     return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>;

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/Index.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/Index.tsx
@@ -2,20 +2,26 @@ import * as React from 'react';
 import { PageSection, Title } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 
-import SeverityCountLabels from 'Containers/Vulnerabilities/components/SeverityCountLabels';
+import SummaryCounts from 'Containers/Dashboard/SummaryCounts';
+import ViolationsByPolicyCategory from 'Containers/Dashboard/Widgets/ViolationsByPolicyCategory';
+import PluginProvider from '../PluginProvider';
 
 export function Index() {
     return (
-        <>
+        <PluginProvider>
             <PageSection>
                 <Title headingLevel="h1">{'Hello, Plugin!'}</Title>
-                <SeverityCountLabels
-                    criticalCount={10}
-                    importantCount={20}
-                    moderateCount={30}
-                    lowCount={40}
-                    unknownCount={50}
+                <SummaryCounts
+                    hasReadAccessForResource={{
+                        Cluster: true,
+                        Node: true,
+                        Alert: true,
+                        Deployment: true,
+                        Image: true,
+                        Secret: true,
+                    }}
                 />
+                <ViolationsByPolicyCategory />
             </PageSection>
             <PageSection>
                 <p>
@@ -25,6 +31,6 @@ export function Index() {
                     {'Your plugin is working.'}
                 </p>
             </PageSection>
-        </>
+        </PluginProvider>
     );
 }

--- a/ui/apps/platform/src/ConsolePlugin/consoleFetchAxiosAdapter.ts
+++ b/ui/apps/platform/src/ConsolePlugin/consoleFetchAxiosAdapter.ts
@@ -1,0 +1,46 @@
+import { ApolloError } from '@apollo/client';
+import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+import { AxiosError, InternalAxiosRequestConfig } from 'axios';
+
+export default function consoleFetchAxiosAdapter(
+    baseUrl: string,
+    config: InternalAxiosRequestConfig
+) {
+    const updatedHeaders = { ...config.headers };
+    // Note - in production authorization is handled in-cluster by the console and will overwrite this header. When
+    // running locally, we need to inject the token manually to allow API requests to the ACS API.
+    if (process.env.NODE_ENV === 'development' && process.env.ACS_CONSOLE_DEV_TOKEN) {
+        updatedHeaders.Authorization = `Bearer ${process.env.ACS_CONSOLE_DEV_TOKEN}`;
+    }
+
+    return consoleFetch(`${baseUrl}${config.url}`, {
+        method: config.method?.toUpperCase() ?? 'GET',
+        body: config.data,
+        headers: updatedHeaders,
+    })
+        .then(async (response) => {
+            const data = await response.text();
+
+            // GraphQL request errors are JSON objects with an `errors` field an a HTTP status code of 200, so we
+            // need to check for that and throw an ApolloError
+            if (config.url?.startsWith('/api/graphql')) {
+                const json = JSON.parse(data);
+                if ('errors' in json) {
+                    throw new ApolloError({ graphQLErrors: json.errors });
+                }
+            }
+
+            return {
+                ...response,
+                config,
+                data,
+                // Converts `fetch` headers to an `axios` compatible headers object
+                headers: Object.fromEntries(response.headers.entries()),
+                request: response,
+                statusText: response.statusText,
+            };
+        })
+        .catch((error) => {
+            throw new AxiosError(error.message);
+        });
+}

--- a/ui/apps/platform/src/ConsolePlugin/consoleFetchAxiosAdapter.ts
+++ b/ui/apps/platform/src/ConsolePlugin/consoleFetchAxiosAdapter.ts
@@ -41,6 +41,17 @@ export default function consoleFetchAxiosAdapter(
             };
         })
         .catch((error) => {
-            throw new AxiosError(error.message);
+            // Preserve original error context by passing the original error object and stack trace
+            const axiosError: AxiosError & { originalError?: Error } = new AxiosError(
+                error.message,
+                undefined,
+                config,
+                undefined,
+                error.response
+            );
+            axiosError.stack = error.stack;
+            // Attach the original error for further debugging if needed
+            axiosError.originalError = error;
+            throw axiosError;
         });
 }

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { DefinePlugin } = require('webpack');
 const { ConsoleRemotePlugin } = require('@openshift-console/dynamic-plugin-sdk-webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
@@ -15,7 +16,7 @@ const config = {
         chunkFilename: isProd ? '[name]-chunk-[chunkhash].min.js' : '[name]-chunk.js',
     },
     resolve: {
-        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         alias: {
             Containers: path.resolve(__dirname, 'src/Containers'),
             Components: path.resolve(__dirname, 'src/Components'),
@@ -33,6 +34,7 @@ const config = {
             'test-utils': path.resolve(__dirname, 'src/test-utils'),
             images: path.resolve(__dirname, 'src/images'),
             css: path.resolve(__dirname, 'src/css'),
+            routePaths: path.resolve(__dirname, 'src/routePaths.ts'),
         },
     },
     module: {
@@ -130,6 +132,15 @@ const config = {
                     noErrorOnMissing: true,
                 },
             ],
+        }),
+        new DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+            'process.env.ACS_CONSOLE_DEV_TOKEN': JSON.stringify(
+                // Do not inject the token when building for production
+                process.env.NODE_ENV === 'development'
+                    ? process.env.ACS_CONSOLE_DEV_TOKEN
+                    : undefined
+            ),
         }),
     ],
     devtool: isProd ? false : 'source-map',


### PR DESCRIPTION
### Description

Adds the ability to configure the following:
1. Whether or not the local console instance injects OpenShift auth headers
2. The endpoint of `central` where API requests should be proxied to
3. An optional ACS auth token that should be added to all API requests

This change will allow us to develop the dynamic plugin frontend with or without a working ACS-side implementation of authn, and against a central instance of our choosing. See more in the provided README docs.

In addition, in order to prevent request failures for POST requests, we need to use the console API's `consoleFetch` implementation to ensure the correct headers are set. Since we already use axios directly throughout, a wrapper around `consoleFetch` was added as an axios adapter to avoid changing application code.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

Load the development console. The following should be displayed with both
```
ACS_INJECT_OCP_AUTH_TOKEN=false ./scripts/start-ocp-console.sh
ACS_CONSOLE_DEV_TOKEN="somelongtokenstring" npm run start:ocp-plugin
```
and the default values (made explicit here)
```
ACS_INJECT_OCP_AUTH_TOKEN=true ./scripts/start-ocp-console.sh
ACS_CONSOLE_DEV_TOKEN="" npm run start:ocp-plugin
```
<img width="1673" height="923" alt="image" src="https://github.com/user-attachments/assets/caa6a1ac-3f3a-4c61-a839-2e97bab1fa9d" />
