### PR TITLE
feat(m2m): exchange opaque k8s tokens

### DIFF
--- a/central/auth/m2m/exchanger.go
+++ b/central/auth/m2m/exchanger.go
@@ -133,6 +133,12 @@ func mapToStringClaims(claims map[string]interface{}) map[string][]string {
 			stringClaims[key] = []string{value}
 		case []string:
 			stringClaims[key] = value
+		case []any:
+			for _, v := range value {
+				if s, ok := v.(string); ok {
+					stringClaims[key] = append(stringClaims[key], s)
+				}
+			}
 		default:
 			log.Debugf("Dropping value %v for claim %s since its a nested claim or a non-string type %T", value, key, value)
 		}

--- a/central/auth/m2m/exchanger_test.go
+++ b/central/auth/m2m/exchanger_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMapStringToClaims(t *testing.T) {
+func TestMapToStringClaims(t *testing.T) {
 	claims := map[string]interface{}{
 		"sub":          "my-subject",
 		"aud":          []string{"audience-1", "audience-2", "audience-3"},
@@ -22,10 +22,12 @@ func TestMapStringToClaims(t *testing.T) {
 				[]string{"four", "five", "six"},
 			},
 		},
+		"groups": []any{"group1", "group2"},
 	}
 	expectedResult := map[string][]string{
-		"sub": {"my-subject"},
-		"aud": {"audience-1", "audience-2", "audience-3"},
+		"sub":    {"my-subject"},
+		"aud":    {"audience-1", "audience-2", "audience-3"},
+		"groups": {"group1", "group2"},
 	}
 
 	result := mapToStringClaims(claims)

--- a/central/auth/m2m/id_token.go
+++ b/central/auth/m2m/id_token.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 )
 
+//nolint:gosec // G101
 const KubernetesTokenIssuer = "https://kubernetes"
 
 // IssuerFromRawIDToken retrieves the issuer from a raw ID token. If the token

--- a/central/auth/m2m/id_token.go
+++ b/central/auth/m2m/id_token.go
@@ -1,16 +1,26 @@
 package m2m
 
 import (
+	"strings"
+
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errox"
 )
 
-// IssuerFromRawIDToken retrieves the issuer from a raw ID token.
+const KubernetesTokenIssuer = "https://kubernetes"
+
+// IssuerFromRawIDToken retrieves the issuer from a raw ID token. If the token
+// is not a JWT, assume Kubernetes opaque token.
 // In case the token is malformed (i.e. jwt.ErrTokenMalformed is met), it will return an error.
 // Other errors such as an expired token will be ignored.
 // Note: This does **not** verify the token's signature or any other claim value.
 func IssuerFromRawIDToken(rawIDToken string) (string, error) {
+	if strings.HasPrefix(rawIDToken, "sha256~") {
+		// Not a JWT. Assume Kubernetes opaque token.
+		return KubernetesTokenIssuer, nil
+	}
+
 	standardClaims := &jwt.RegisteredClaims{}
 	// Explicitly ignore the signature of the ID token for now.
 	// This will be handled in a latter part, when the metadata from the provider will be used to verify the signature.

--- a/central/auth/m2m/id_token.go
+++ b/central/auth/m2m/id_token.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 )
 
-//nolint:gosec // G101
+// #nosec G101 -- This is a false positive.
 const KubernetesTokenIssuer = "https://kubernetes"
 
 // IssuerFromRawIDToken retrieves the issuer from a raw ID token. If the token

--- a/central/auth/m2m/id_token_test.go
+++ b/central/auth/m2m/id_token_test.go
@@ -3,15 +3,36 @@ package m2m
 import (
 	"testing"
 
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIssuerFromRawIDToken(t *testing.T) {
-	// Example token taken from: https://pkg.go.dev/github.com/golang-jwt/jwt/v5#example-ParseWithClaims-CustomClaimsType.
-	//#nosec G101 -- This is a static example JWT token for testing purposes.
-	rawIDToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpc3MiOiJ0ZXN0IiwiYXVkIjoic2luZ2xlIn0.QAWg1vGvnqRuCFTMcPkjZljXHh8U3L_qUjszOtQbeaA"
+	t.Run("JWT", func(t *testing.T) {
+		// Example token taken from: https://pkg.go.dev/github.com/golang-jwt/jwt/v5#example-ParseWithClaims-CustomClaimsType.
+		//#nosec G101 -- This is a static example JWT token for testing purposes.
+		rawIDToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpc3MiOiJ0ZXN0IiwiYXVkIjoic2luZ2xlIn0.QAWg1vGvnqRuCFTMcPkjZljXHh8U3L_qUjszOtQbeaA"
 
-	issuer, err := IssuerFromRawIDToken(rawIDToken)
-	assert.NoError(t, err)
-	assert.Equal(t, "test", issuer)
+		issuer, err := IssuerFromRawIDToken(rawIDToken)
+		assert.NoError(t, err)
+		assert.Equal(t, "test", issuer)
+	})
+
+	t.Run("kubernetes opaque token", func(t *testing.T) {
+		//#nosec G101 -- This is a static example Kubernetes opaque token for testing purposes.
+		rawIDToken := "sha256~98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+
+		issuer, err := IssuerFromRawIDToken(rawIDToken)
+		assert.NoError(t, err)
+		assert.Equal(t, KubernetesTokenIssuer, issuer)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		//#nosec G101 -- This is an invalid token for testing purposes.
+		rawIDToken := "notavalidtoken"
+
+		issuer, err := IssuerFromRawIDToken(rawIDToken)
+		assert.ErrorIs(t, err, errox.InvalidArgs)
+		assert.Empty(t, issuer)
+	})
 }

--- a/central/auth/m2m/kube_opaque_token.go
+++ b/central/auth/m2m/kube_opaque_token.go
@@ -1,0 +1,48 @@
+package m2m
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/authentication/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// kubeOpaqueTokenVerifier verifies tokens using the Kubernetes TokenReview API.
+type kubeOpaqueTokenVerifier struct {
+	clientset kubernetes.Interface
+}
+
+func (k *kubeOpaqueTokenVerifier) VerifyIDToken(ctx context.Context, rawIDToken string) (*IDToken, error) {
+	tr := &v1.TokenReview{
+		Spec: v1.TokenReviewSpec{
+			Token: rawIDToken,
+		},
+	}
+	trResp, err := k.clientset.AuthenticationV1().TokenReviews().
+		Create(ctx, tr, metaV1.CreateOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "performing TokenReview request")
+	}
+	if !trResp.Status.Authenticated {
+		return nil, errors.Errorf("token not authenticated: %s", trResp.Status.Error)
+	}
+
+	claims := map[string]any{
+		"sub":    trResp.Status.User.UID,
+		"name":   trResp.Status.User.Username,
+		"groups": trResp.Status.User.Groups,
+	}
+	rawClaims, _ := json.Marshal(claims)
+
+	token := &IDToken{
+		Subject: trResp.Status.User.UID,
+		Claims: func(v any) error {
+			return json.Unmarshal(rawClaims, v)
+		},
+		Audience: trResp.Status.Audiences,
+	}
+	return token, nil
+}

--- a/central/auth/m2m/kube_opaque_token_test.go
+++ b/central/auth/m2m/kube_opaque_token_test.go
@@ -1,0 +1,89 @@
+package m2m
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestKubeOpaqueTokenVerifier_VerifyIDToken_Success(t *testing.T) {
+	rawToken := "raw-token-value"
+	// Prepare fake clientset and reactor for TokenReview create.
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Fake.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		// Simulate successful TokenReview with authenticated status.
+		resp := &v1.TokenReview{
+			Status: v1.TokenReviewStatus{
+				Authenticated: true,
+				User: v1.UserInfo{
+					UID:      "uid123",
+					Username: "user123",
+					Groups:   []string{"group1", "group2"},
+				},
+				Audiences: []string{"aud1", "aud2"},
+			},
+		}
+		return true, resp, nil
+	})
+
+	verifier := kubeOpaqueTokenVerifier{clientset: fakeClient}
+	token, err := verifier.VerifyIDToken(context.Background(), rawToken)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	// Verify core fields.
+	require.Equal(t, "uid123", token.Subject)
+	require.Equal(t, []string{"aud1", "aud2"}, token.Audience)
+
+	// Verify claims unmarshalling.
+	type claimsStruct struct {
+		Sub    string   `json:"sub"`
+		Name   string   `json:"name"`
+		Groups []string `json:"groups"`
+	}
+	var claims claimsStruct
+	err = token.Claims(&claims)
+	require.NoError(t, err)
+	require.Equal(t, "uid123", claims.Sub)
+	require.Equal(t, "user123", claims.Name)
+	require.Equal(t, []string{"group1", "group2"}, claims.Groups)
+}
+
+func TestKubeOpaqueTokenVerifier_VerifyIDToken_CreateError(t *testing.T) {
+	rawToken := "raw-token-value"
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Fake.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("create failed")
+	})
+	verifier := kubeOpaqueTokenVerifier{clientset: fakeClient}
+	token, err := verifier.VerifyIDToken(context.Background(), rawToken)
+	require.Nil(t, token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "performing TokenReview request")
+	require.Contains(t, err.Error(), "create failed")
+}
+
+func TestKubeOpaqueTokenVerifier_VerifyIDToken_NotAuthenticated(t *testing.T) {
+	rawToken := "raw-token-value"
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Fake.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		// Simulate unauthenticated token review
+		resp := &v1.TokenReview{
+			Status: v1.TokenReviewStatus{
+				Authenticated: false,
+				Error:         "invalid token",
+			},
+		}
+		return true, resp, nil
+	})
+	verifier := kubeOpaqueTokenVerifier{clientset: fakeClient}
+	token, err := verifier.VerifyIDToken(context.Background(), rawToken)
+	require.Nil(t, token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token not authenticated: invalid token")
+}

--- a/central/auth/m2m/set.go
+++ b/central/auth/m2m/set.go
@@ -90,6 +90,16 @@ func (t *tokenExchangerSet) UpsertTokenExchanger(ctx context.Context, config *st
 
 // GetTokenExchanger retrieves a TokenExchanger based on the issuer.
 func (t *tokenExchangerSet) GetTokenExchanger(issuer string) (TokenExchanger, bool) {
+	// This is the issuer of the tokens, found in the secrets of type
+	// kubernetes.io/service-account-token
+	const kubernetesServiceAccountSecretIssuer = "kubernetes/serviceaccount"
+	if issuer == kubernetesServiceAccountSecretIssuer {
+		for _, tokenExchanger := range t.tokenExchangers {
+			if tokenExchanger.Config().GetType() == storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT {
+				return tokenExchanger, true
+			}
+		}
+	}
 	tokenExchanger, exists := t.tokenExchangers[issuer]
 	return tokenExchanger, exists
 }

--- a/central/auth/m2m/set.go
+++ b/central/auth/m2m/set.go
@@ -92,6 +92,7 @@ func (t *tokenExchangerSet) UpsertTokenExchanger(ctx context.Context, config *st
 func (t *tokenExchangerSet) GetTokenExchanger(issuer string) (TokenExchanger, bool) {
 	// This is the issuer of the tokens, found in the secrets of type
 	// kubernetes.io/service-account-token
+	//#nosec G101 -- This is a false positive.
 	const kubernetesServiceAccountSecretIssuer = "kubernetes/serviceaccount"
 	if issuer == kubernetesServiceAccountSecretIssuer {
 		for _, tokenExchanger := range t.tokenExchangers {

--- a/central/auth/m2m/set.go
+++ b/central/auth/m2m/set.go
@@ -95,7 +95,7 @@ func (t *tokenExchangerSet) GetTokenExchanger(issuer string) (TokenExchanger, bo
 	const kubernetesServiceAccountSecretIssuer = "kubernetes/serviceaccount"
 	if issuer == kubernetesServiceAccountSecretIssuer {
 		for _, tokenExchanger := range t.tokenExchangers {
-			if tokenExchanger.Config().GetType() == storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT {
+			if tokenExchanger.Config().GetType() == storage.AuthMachineToMachineConfig_KUBE_OPAQUE_TOKEN {
 				return tokenExchanger, true
 			}
 		}

--- a/central/auth/m2m/verifier.go
+++ b/central/auth/m2m/verifier.go
@@ -76,6 +76,7 @@ func tokenVerifierFromConfig(ctx context.Context, config *storage.AuthMachineToM
 	}
 
 	roundTripper := proxy.RoundTripper(proxy.WithTLSConfig(tlsConfig))
+	log.Debugf("config type: %q", config.GetType().String())
 	switch config.Type {
 	case storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT:
 		token, err := kubeServiceAccountTokenReader{}.readToken()

--- a/central/auth/m2m/verifier.go
+++ b/central/auth/m2m/verifier.go
@@ -76,7 +76,6 @@ func tokenVerifierFromConfig(ctx context.Context, config *storage.AuthMachineToM
 	}
 
 	roundTripper := proxy.RoundTripper(proxy.WithTLSConfig(tlsConfig))
-	log.Debugf("config type: %q", config.GetType().String())
 	switch config.Type {
 	case storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT:
 		token, err := kubeServiceAccountTokenReader{}.readToken()

--- a/generated/api/v1/auth_service.pb.go
+++ b/generated/api/v1/auth_service.pb.go
@@ -33,7 +33,7 @@ const (
 	AuthMachineToMachineConfig_GENERIC              AuthMachineToMachineConfig_Type = 0
 	AuthMachineToMachineConfig_GITHUB_ACTIONS       AuthMachineToMachineConfig_Type = 1
 	AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT AuthMachineToMachineConfig_Type = 2
-	AuthMachineToMachineConfig_KUBE_TOKEN_REVIEW    AuthMachineToMachineConfig_Type = 3
+	AuthMachineToMachineConfig_KUBE_OPAQUE_TOKEN    AuthMachineToMachineConfig_Type = 3
 )
 
 // Enum value maps for AuthMachineToMachineConfig_Type.
@@ -42,13 +42,13 @@ var (
 		0: "GENERIC",
 		1: "GITHUB_ACTIONS",
 		2: "KUBE_SERVICE_ACCOUNT",
-		3: "KUBE_TOKEN_REVIEW",
+		3: "KUBE_OPAQUE_TOKEN",
 	}
 	AuthMachineToMachineConfig_Type_value = map[string]int32{
 		"GENERIC":              0,
 		"GITHUB_ACTIONS":       1,
 		"KUBE_SERVICE_ACCOUNT": 2,
-		"KUBE_TOKEN_REVIEW":    3,
+		"KUBE_OPAQUE_TOKEN":    3,
 	}
 )
 
@@ -780,7 +780,7 @@ const file_api_v1_auth_service_proto_rawDesc = "" +
 	"\aGENERIC\x10\x00\x12\x12\n" +
 	"\x0eGITHUB_ACTIONS\x10\x01\x12\x18\n" +
 	"\x14KUBE_SERVICE_ACCOUNT\x10\x02\x12\x15\n" +
-	"\x11KUBE_TOKEN_REVIEW\x10\x03\"b\n" +
+	"\x11KUBE_OPAQUE_TOKEN\x10\x03\"b\n" +
 	"&ListAuthMachineToMachineConfigResponse\x128\n" +
 	"\aconfigs\x18\x01 \x03(\v2\x1e.v1.AuthMachineToMachineConfigR\aconfigs\"_\n" +
 	"%GetAuthMachineToMachineConfigResponse\x126\n" +

--- a/generated/api/v1/auth_service.pb.go
+++ b/generated/api/v1/auth_service.pb.go
@@ -33,6 +33,7 @@ const (
 	AuthMachineToMachineConfig_GENERIC              AuthMachineToMachineConfig_Type = 0
 	AuthMachineToMachineConfig_GITHUB_ACTIONS       AuthMachineToMachineConfig_Type = 1
 	AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT AuthMachineToMachineConfig_Type = 2
+	AuthMachineToMachineConfig_KUBE_TOKEN_REVIEW    AuthMachineToMachineConfig_Type = 3
 )
 
 // Enum value maps for AuthMachineToMachineConfig_Type.
@@ -41,11 +42,13 @@ var (
 		0: "GENERIC",
 		1: "GITHUB_ACTIONS",
 		2: "KUBE_SERVICE_ACCOUNT",
+		3: "KUBE_TOKEN_REVIEW",
 	}
 	AuthMachineToMachineConfig_Type_value = map[string]int32{
 		"GENERIC":              0,
 		"GITHUB_ACTIONS":       1,
 		"KUBE_SERVICE_ACCOUNT": 2,
+		"KUBE_TOKEN_REVIEW":    3,
 	}
 )
 
@@ -760,7 +763,7 @@ const file_api_v1_auth_service_proto_rawDesc = "" +
 	"\tuser_info\x18\x06 \x01(\v2\x11.storage.UserInfoR\buserInfo\x12:\n" +
 	"\x0fuser_attributes\x18\a \x03(\v2\x11.v1.UserAttributeR\x0euserAttributes\x12\x1b\n" +
 	"\tidp_token\x18\b \x01(\tR\bidpTokenB\x04\n" +
-	"\x02id\"\xc0\x03\n" +
+	"\x02id\"\xd7\x03\n" +
 	"\x1aAuthMachineToMachineConfig\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x127\n" +
 	"\x04type\x18\x02 \x01(\x0e2#.v1.AuthMachineToMachineConfig.TypeR\x04type\x12:\n" +
@@ -772,11 +775,12 @@ const file_api_v1_auth_service_proto_rawDesc = "" +
 	"\aMapping\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
 	"\x10value_expression\x18\x02 \x01(\tR\x0fvalueExpression\x12\x12\n" +
-	"\x04role\x18\x03 \x01(\tR\x04role\"A\n" +
+	"\x04role\x18\x03 \x01(\tR\x04role\"X\n" +
 	"\x04Type\x12\v\n" +
 	"\aGENERIC\x10\x00\x12\x12\n" +
 	"\x0eGITHUB_ACTIONS\x10\x01\x12\x18\n" +
-	"\x14KUBE_SERVICE_ACCOUNT\x10\x02\"b\n" +
+	"\x14KUBE_SERVICE_ACCOUNT\x10\x02\x12\x15\n" +
+	"\x11KUBE_TOKEN_REVIEW\x10\x03\"b\n" +
 	"&ListAuthMachineToMachineConfigResponse\x128\n" +
 	"\aconfigs\x18\x01 \x03(\v2\x1e.v1.AuthMachineToMachineConfigR\aconfigs\"_\n" +
 	"%GetAuthMachineToMachineConfigResponse\x126\n" +

--- a/generated/api/v1/auth_service.swagger.json
+++ b/generated/api/v1/auth_service.swagger.json
@@ -589,7 +589,8 @@
       "enum": [
         "GENERIC",
         "GITHUB_ACTIONS",
-        "KUBE_SERVICE_ACCOUNT"
+        "KUBE_SERVICE_ACCOUNT",
+        "KUBE_TOKEN_REVIEW"
       ],
       "default": "GENERIC",
       "description": "The type of the auth machine to machine config.\nCurrently supports GitHub actions or any other generic OIDC provider to use for verifying and\nexchanging the token."

--- a/generated/api/v1/auth_service.swagger.json
+++ b/generated/api/v1/auth_service.swagger.json
@@ -590,7 +590,7 @@
         "GENERIC",
         "GITHUB_ACTIONS",
         "KUBE_SERVICE_ACCOUNT",
-        "KUBE_TOKEN_REVIEW"
+        "KUBE_OPAQUE_TOKEN"
       ],
       "default": "GENERIC",
       "description": "The type of the auth machine to machine config.\nCurrently supports GitHub actions or any other generic OIDC provider to use for verifying and\nexchanging the token."

--- a/generated/storage/auth_machine_to_machine.pb.go
+++ b/generated/storage/auth_machine_to_machine.pb.go
@@ -27,6 +27,7 @@ const (
 	AuthMachineToMachineConfig_GENERIC              AuthMachineToMachineConfig_Type = 0
 	AuthMachineToMachineConfig_GITHUB_ACTIONS       AuthMachineToMachineConfig_Type = 1
 	AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT AuthMachineToMachineConfig_Type = 2
+	AuthMachineToMachineConfig_KUBE_OPAQUE_TOKEN    AuthMachineToMachineConfig_Type = 3
 )
 
 // Enum value maps for AuthMachineToMachineConfig_Type.
@@ -35,11 +36,13 @@ var (
 		0: "GENERIC",
 		1: "GITHUB_ACTIONS",
 		2: "KUBE_SERVICE_ACCOUNT",
+		3: "KUBE_OPAQUE_TOKEN",
 	}
 	AuthMachineToMachineConfig_Type_value = map[string]int32{
 		"GENERIC":              0,
 		"GITHUB_ACTIONS":       1,
 		"KUBE_SERVICE_ACCOUNT": 2,
+		"KUBE_OPAQUE_TOKEN":    3,
 	}
 )
 
@@ -224,7 +227,7 @@ var File_storage_auth_machine_to_machine_proto protoreflect.FileDescriptor
 
 const file_storage_auth_machine_to_machine_proto_rawDesc = "" +
 	"\n" +
-	"%storage/auth_machine_to_machine.proto\x12\astorage\x1a\x14storage/traits.proto\"\xcf\x03\n" +
+	"%storage/auth_machine_to_machine.proto\x12\astorage\x1a\x14storage/traits.proto\"\xe6\x03\n" +
 	"\x1aAuthMachineToMachineConfig\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12<\n" +
 	"\x04type\x18\x02 \x01(\x0e2(.storage.AuthMachineToMachineConfig.TypeR\x04type\x12:\n" +
@@ -235,11 +238,12 @@ const file_storage_auth_machine_to_machine_proto_rawDesc = "" +
 	"\aMapping\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
 	"\x10value_expression\x18\x02 \x01(\tR\x0fvalueExpression\x12\x12\n" +
-	"\x04role\x18\x03 \x01(\tR\x04role\"A\n" +
+	"\x04role\x18\x03 \x01(\tR\x04role\"X\n" +
 	"\x04Type\x12\v\n" +
 	"\aGENERIC\x10\x00\x12\x12\n" +
 	"\x0eGITHUB_ACTIONS\x10\x01\x12\x18\n" +
-	"\x14KUBE_SERVICE_ACCOUNT\x10\x02B.\n" +
+	"\x14KUBE_SERVICE_ACCOUNT\x10\x02\x12\x15\n" +
+	"\x11KUBE_OPAQUE_TOKEN\x10\x03B.\n" +
 	"\x19io.stackrox.proto.storageZ\x11./storage;storageb\x06proto3"
 
 var (

--- a/proto/api/v1/auth_service.proto
+++ b/proto/api/v1/auth_service.proto
@@ -49,7 +49,7 @@ message AuthMachineToMachineConfig {
     GENERIC = 0;
     GITHUB_ACTIONS = 1;
     KUBE_SERVICE_ACCOUNT = 2;
-    KUBE_TOKEN_REVIEW = 3;
+    KUBE_OPAQUE_TOKEN = 3;
   }
   Type type = 2;
 

--- a/proto/api/v1/auth_service.proto
+++ b/proto/api/v1/auth_service.proto
@@ -49,6 +49,7 @@ message AuthMachineToMachineConfig {
     GENERIC = 0;
     GITHUB_ACTIONS = 1;
     KUBE_SERVICE_ACCOUNT = 2;
+    KUBE_TOKEN_REVIEW = 3;
   }
   Type type = 2;
 

--- a/proto/storage/auth_machine_to_machine.proto
+++ b/proto/storage/auth_machine_to_machine.proto
@@ -18,6 +18,7 @@ message AuthMachineToMachineConfig {
     GENERIC = 0;
     GITHUB_ACTIONS = 1;
     KUBE_SERVICE_ACCOUNT = 2;
+    KUBE_OPAQUE_TOKEN = 3;
   }
   Type type = 2;
 

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -1134,6 +1134,10 @@
               {
                 "name": "KUBE_SERVICE_ACCOUNT",
                 "integer": 2
+              },
+              {
+                "name": "KUBE_OPAQUE_TOKEN",
+                "integer": 3
               }
             ]
           }


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR introduces a new type of M2M token exchange, which exchanges Kubernetes opaque and JWT (issued by `kubernetes/serviceaccount`, could be found in secrets of type `kubernetes.io/service-account-token`, see ROX-30862) tokens using the Kubernetes Token Review API.

Central SA is required to be granted the `auth-delegator` cluster role:

```sh
oc adm policy add-cluster-role-to-user system:auth-delegator -z central -n stackrox
```

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Example M2M configuration (to POST on `/v1/auth/m2m`):

```json
{
  "config": {
    "type": "KUBE_OPAQUE_TOKEN",
    "tokenExpirationDuration": "1h",
    "mappings": [
      {
        "key": "name",
        "valueExpression": "system:serviceaccount:stackrox:central",
        "role": "Admin"
      }
    ],
    "issuer": "https://kubernetes"
  }
}
```

Manual tests:

```console
sh$ export CENTRAL_TOKEN=$(kubectl get secret central-token -o jsonpath='{.data.token}' | base64 -d)

sh$ curl https://localhost:8000/v1/auth/status -H "Authorization: Bearer $CENTRAL_TOKEN" -ks | jq '.userInfo.roles[]|.name'
"Admin"

sh$ curl https://localhost:8000/v1/auth/status -H "Authorization: Bearer $(oc create token central)" -ks | jq '.userInfo.roles[]|.name'
"Admin"
```
