### PR TITLE
ROX-30170, ROX-30100: roxctl options deprecation, fix defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-27238: Central API for generating CRSs now supports custom expiration times, specified using the new fields "valid_until" or "valid_for".
   roxctl's "central crs generate" now supports specifying custom expiration times using the new parameters "--valid-until" or "--valid-for".
 - ROX-30087: Implicit exchange of OIDC tokens, accessing the API, with a role mapping according to the M2M configuration that matches the token issuer.
+- ROX-30100: Incorrect defaults for admission controller related configuration options in "roxctl sensor generate" have been fixed. The admission controller will be deployed and configured
+for policy evaluation and enforcement as well as image scanning, out of the box - without requiring a user to specify command line
+options to "roxctl sensor generate".
 
 ### Removed Features
 
@@ -26,6 +29,15 @@ since 4.7 and prior.
   - --slim-collector
 
 ### Deprecated Features
+- ROX-30170: The following roxctl sensor generate options have been marked as deprecated
+  - `--admission-controller-enforce-on-creates`
+  - `--admission-controller-enforce-on-updates`
+  - `--admission-controller-listen-on-creates`
+  - `--admission-controller-listen-on-updates`
+  - `--admission-controller-listen-on-events`
+  - `--admission-controller-timeout`
+
+
 
 ### Technical Changes
 

--- a/roxctl/sensor/generate/k8s.go
+++ b/roxctl/sensor/generate/k8s.go
@@ -4,7 +4,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/generated/storage"
 	clusterValidation "github.com/stackrox/rox/pkg/cluster"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/util"
+)
+
+const (
+	WarningAdmissionControllerListenOnEventsSet = `The --admission-controller-listen-on-events flag has been deprecated and will be removed in future versions of roxctl. It will be ignored from version 4.9 onwards.`
 )
 
 type sensorGenerateK8sCommand struct {
@@ -33,5 +38,7 @@ func k8s(generateCmd *sensorGenerateCommand) *cobra.Command {
 	}
 
 	c.PersistentFlags().BoolVar(&k8sCommand.cluster.AdmissionControllerEvents, "admission-controller-listen-on-events", true, "Enable admission controller webhook to listen on Kubernetes events.")
+	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-listen-on-events", WarningAdmissionControllerListenOnEventsSet))
+
 	return c
 }

--- a/roxctl/sensor/generate/openshift.go
+++ b/roxctl/sensor/generate/openshift.go
@@ -7,6 +7,7 @@ import (
 	clusterValidation "github.com/stackrox/rox/pkg/cluster"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/pointers"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/util"
 )
@@ -75,8 +76,11 @@ func openshift(generateCmd *sensorGenerateCommand) *cobra.Command {
 		}),
 	}
 	c.PersistentFlags().IntVar(&openshiftCommand.openshiftVersion, "openshift-version", 0, "OpenShift major version to generate deployment files for.")
-	flags.OptBoolFlagVarPF(c.PersistentFlags(), &openshiftCommand.admissionControllerEvents, "admission-controller-listen-on-events", "", "Enable admission controller webhook to listen on Kubernetes events.", "auto")
-	flags.OptBoolFlagVarPF(c.PersistentFlags(), &openshiftCommand.disableAuditLogCollection, "disable-audit-logs", "", "Disable audit log collection for runtime detection.", "auto")
+	flags.OptBoolFlagVarPF(c.PersistentFlags(), &openshiftCommand.admissionControllerEvents, "admission-controller-listen-on-events", "", "Enable admission controller webhook to listen on Kubernetes events.", "true")
+	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-listen-on-events", WarningAdmissionControllerListenOnEventsSet))
+
+	// Audit log collection should be enabled by default, disabled = false, as with the proto
+	flags.OptBoolFlagVarPF(c.PersistentFlags(), &openshiftCommand.disableAuditLogCollection, "disable-audit-logs", "", "Disable audit log collection for runtime detection.", "false")
 
 	return c
 }


### PR DESCRIPTION
### Description

The following roxctl options related to admission controller configuration have been marked for deprecation:
  - --admission-controller-enforce-on-creates
  - --admission-controller-enforce-on-updates
  - --admission-controller-listen-on-creates
  - --admission-controller-listen-on-updates
  - --admission-controller-listen-on-events
  - --admission-controller-timeout
  
  The incorrect defaults for these options (with the exception of -admission-controller-timeout - separate JIRA and discussion ongoing for this) have been fixed to ensure:
  1. A user can generate a sensor bundle with the admission controller OOTB without specifying additional options.
  2. Validating webhooks for policy evaluation and enforcement, are configured by default for both - if a user would like to enforce policies, all they need to do is turn on enforcement on the policies of choice. Everything else is setup and ready to go.
  
Note: The feature flag has not been used because we'd like to  fix the bug introduced by incorrect defaults, and mark these options for deprecation regardless. Internal discussions with the senseco team also reveal roxctl and feature flags isn't an easy to use combo.
  
@kcarmichael08  @pedrottimark @mclasmeier  @porridge Adding you folks to keep you in the loop, you do not need to review this if you so choose.

### User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change
Manual run of roxctl sensor generate to see deprecated options do not show up in help, and print out the deprecated message on use. 

$ roxctl sensor generate k8s --name=boo-cluster -e localhost:8000 -p <redacted> --insecure-skip-tls-verify

created a bundle with the correct admission controller and validating webhooks settings.