### PR TITLE
ROX-30218: Use consistent-type-imports for hooks

### DIFF
--- a/ui/apps/platform/src/hooks/patternfly/useFormModal.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useFormModal.ts
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { FormikProps, FormikValues, useFormik } from 'formik';
+import { useFormik } from 'formik';
+import type { FormikProps, FormikValues } from 'formik';
 
-import { FormResponseMessage } from 'Components/PatternFly/FormMessage';
+import type { FormResponseMessage } from 'Components/PatternFly/FormMessage';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 type UseFormModalProps<T> = {

--- a/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
+++ b/ui/apps/platform/src/hooks/patternfly/useToasts.tsx
@@ -1,5 +1,6 @@
-import { AlertProps } from '@patternfly/react-core';
-import { ReactNode, useState } from 'react';
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import type { AlertProps } from '@patternfly/react-core';
 
 export type AlertVariantType = AlertProps['variant'];
 

--- a/ui/apps/platform/src/hooks/useAlert.test.ts
+++ b/ui/apps/platform/src/hooks/useAlert.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 
-import useAlert, { AlertObj } from './useAlert';
+import useAlert from './useAlert';
+import type { AlertObj } from './useAlert';
 
 describe('useAlert hook', () => {
     test('useAlert should start with null', () => {

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -3,9 +3,10 @@ import { useSelector } from 'react-redux';
 import Raven from 'raven-js';
 import mapValues from 'lodash/mapValues';
 
-import { Telemetry } from 'types/config.proto';
+import type { Telemetry } from 'types/config.proto';
 import { selectors } from 'reducers';
-import { UnionFrom, ensureExhaustive, tupleTypeGuard } from 'utils/type.utils';
+import { ensureExhaustive, tupleTypeGuard } from 'utils/type.utils';
+import type { UnionFrom } from 'utils/type.utils';
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 
 // Event Name Constants

--- a/ui/apps/platform/src/hooks/useAuthStatus.ts
+++ b/ui/apps/platform/src/hooks/useAuthStatus.ts
@@ -2,9 +2,9 @@ import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
-import { ResourceName } from 'types/roleResources';
-import { Access } from 'types/role.proto';
-import { AuthProvider } from 'services/AuthService';
+import type { ResourceName } from 'types/roleResources';
+import type { Access } from 'types/role.proto';
+import type { AuthProvider } from 'services/AuthService';
 
 type CurrentUser = {
     authProvider: AuthProvider;

--- a/ui/apps/platform/src/hooks/useCentralCapabilities.ts
+++ b/ui/apps/platform/src/hooks/useCentralCapabilities.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectors } from 'reducers';
-import { CentralCapabilitiesFlags } from 'services/MetadataService';
+import type { CentralCapabilitiesFlags } from 'services/MetadataService';
 
 type UseCentralCapabilityResult = {
     isCentralCapabilityAvailable: (centralCapabilityFlag: CentralCapabilitiesFlags) => boolean;

--- a/ui/apps/platform/src/hooks/useClipboardCopy.ts
+++ b/ui/apps/platform/src/hooks/useClipboardCopy.ts
@@ -1,4 +1,5 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
 export type UseClipboardCopyReturn = {
     wasCopied: boolean;

--- a/ui/apps/platform/src/hooks/useEffectAfterFirstRender.ts
+++ b/ui/apps/platform/src/hooks/useEffectAfterFirstRender.ts
@@ -1,4 +1,5 @@
-import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
+import type { DependencyList, EffectCallback } from 'react';
 
 // Hook that composes `useEffect` to create a variant the behaves identically after
 // the first time the component renders.

--- a/ui/apps/platform/src/hooks/useFeatureFlags.ts
+++ b/ui/apps/platform/src/hooks/useFeatureFlags.ts
@@ -2,8 +2,8 @@ import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
-import { FeatureFlagEnvVar } from 'types/featureFlag';
-import { FeatureFlag } from 'types/featureFlagService.proto';
+import type { FeatureFlagEnvVar } from 'types/featureFlag';
+import type { FeatureFlag } from 'types/featureFlagService.proto';
 
 const featureFlagsSelector = createStructuredSelector<{
     featureFlags: FeatureFlag[];

--- a/ui/apps/platform/src/hooks/useFetchClusterNamespacesForPermissions.ts
+++ b/ui/apps/platform/src/hooks/useFetchClusterNamespacesForPermissions.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { NamespaceScopeObject, getNamespacesForClusterAndPermissions } from 'services/RolesService';
-import { ResourceName } from 'types/roleResources';
+import { getNamespacesForClusterAndPermissions } from 'services/RolesService';
+import type { NamespaceScopeObject } from 'services/RolesService';
+import type { ResourceName } from 'types/roleResources';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 type NamespaceResponse = {

--- a/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
+++ b/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 
-import { getClustersForPermissions, ClusterScopeObject } from 'services/RolesService';
-import { ResourceName } from 'types/roleResources';
+import { getClustersForPermissions } from 'services/RolesService';
+import type { ClusterScopeObject } from 'services/RolesService';
+import type { ResourceName } from 'types/roleResources';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 type Result = {

--- a/ui/apps/platform/src/hooks/useFetchDeployment.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeployment.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { fetchDeployment } from 'services/DeploymentsService';
 
-import { Deployment } from 'types/deployment.proto';
+import type { Deployment } from 'types/deployment.proto';
 
 type Result = { isLoading: boolean; deployment: Deployment | null; error: string | null };
 

--- a/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
@@ -1,6 +1,7 @@
-import { gql, useQuery, ApolloError, QueryHookOptions } from '@apollo/client';
+import { gql, useQuery } from '@apollo/client';
+import type { ApolloError, QueryHookOptions } from '@apollo/client';
 
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 type DeploymentCountResponse = {

--- a/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
+++ b/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
@@ -7,7 +7,7 @@ import groupBy from 'lodash/groupBy';
 import keys from 'lodash/keys';
 
 import { listDeployments } from 'services/DeploymentsService';
-import { ListDeployment } from 'types/deployment.proto';
+import type { ListDeployment } from 'types/deployment.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 type Deployment = {

--- a/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
+++ b/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { fetchNetworkPolicies } from 'services/NetworkService';
-import { NetworkPolicy } from 'types/networkPolicy.proto';
+import type { NetworkPolicy } from 'types/networkPolicy.proto';
 
 type Result = {
     isLoading: boolean;

--- a/ui/apps/platform/src/hooks/useIsRouteEnabled.ts
+++ b/ui/apps/platform/src/hooks/useIsRouteEnabled.ts
@@ -1,4 +1,5 @@
-import { RouteKey, isRouteEnabled } from 'routePaths';
+import { isRouteEnabled } from 'routePaths';
+import type { RouteKey } from 'routePaths';
 
 import useFeatureFlags from './useFeatureFlags';
 import usePermissions from './usePermissions';

--- a/ui/apps/platform/src/hooks/useLocalStorage.ts
+++ b/ui/apps/platform/src/hooks/useLocalStorage.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { useEffect, useState } from 'react';
-import { JsonValue } from 'utils/type.utils';
+import type { JsonValue } from 'utils/type.utils';
 
 declare global {
     interface WindowEventMap {

--- a/ui/apps/platform/src/hooks/useMetadata.ts
+++ b/ui/apps/platform/src/hooks/useMetadata.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectors } from 'reducers';
-import { Metadata } from 'types/metadataService.proto';
+import type { Metadata } from 'types/metadataService.proto';
 
 function useMetadata(): Metadata {
     const metadata = useSelector(selectors.metadataSelector);

--- a/ui/apps/platform/src/hooks/usePageAction.ts
+++ b/ui/apps/platform/src/hooks/usePageAction.ts
@@ -1,4 +1,5 @@
-import useURLParameter, { QueryValue } from 'hooks/useURLParameter';
+import useURLParameter from 'hooks/useURLParameter';
+import type { QueryValue } from 'hooks/useURLParameter';
 
 type PageActionResult<T extends QueryValue> = {
     pageAction: T | undefined;

--- a/ui/apps/platform/src/hooks/usePermissions.ts
+++ b/ui/apps/platform/src/hooks/usePermissions.ts
@@ -2,8 +2,8 @@ import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
 import { selectors } from 'reducers';
-import { Access } from 'types/role.proto';
-import { ResourceName } from 'types/roleResources';
+import type { Access } from 'types/role.proto';
+import type { ResourceName } from 'types/roleResources';
 import { replacedResourceMapping } from 'constants/accessControl';
 
 export type HasNoAccess = (resourceName: ResourceName) => boolean;

--- a/ui/apps/platform/src/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/hooks/useRestQuery.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import noop from 'lodash/noop';
-import { CancellableRequest, isCancellableRequest } from 'services/cancellationUtils';
+import { isCancellableRequest } from 'services/cancellationUtils';
+import type { CancellableRequest } from 'services/cancellationUtils';
 
 export type UseRequestQueryOptions = {
     clearErrorBeforeRequest?: boolean;

--- a/ui/apps/platform/src/hooks/useTableSort.ts
+++ b/ui/apps/platform/src/hooks/useTableSort.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { ThProps } from '@patternfly/react-table';
-import { SortOption } from 'types/table';
-import { ApiSortOptionSingle } from 'types/search';
+import type { ThProps } from '@patternfly/react-table';
+import type { SortOption } from 'types/table';
+import type { ApiSortOptionSingle } from 'types/search';
 
 export type GetSortParams = (field: string) => ThProps['sort'];
 

--- a/ui/apps/platform/src/hooks/useURLPagination.ts
+++ b/ui/apps/platform/src/hooks/useURLPagination.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
-import useURLParameter, { HistoryAction } from './useURLParameter';
+import useURLParameter from './useURLParameter';
+import type { HistoryAction } from './useURLParameter';
 
 export type UseURLPaginationResult = {
     page: number;

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useRef } from 'react';
-import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
 import isEqual from 'lodash/isEqual';
 
 import { getQueryObject, getQueryString } from 'utils/queryStringUtils';

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -1,10 +1,11 @@
 import { useRef } from 'react';
 import isEqual from 'lodash/isEqual';
 
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
 
-import useURLParameter, { HistoryAction, QueryValue } from './useURLParameter';
+import useURLParameter from './useURLParameter';
+import type { HistoryAction, QueryValue } from './useURLParameter';
 
 export type SetSearchFilter = (newFilter: SearchFilter, historyAction?: HistoryAction) => void;
 

--- a/ui/apps/platform/src/hooks/useURLSort.tsx
+++ b/ui/apps/platform/src/hooks/useURLSort.tsx
@@ -3,10 +3,13 @@ import findIndex from 'lodash/findIndex';
 import intersection from 'lodash/intersection';
 import isEqual from 'lodash/isEqual';
 
-import useURLParameter, { HistoryAction, QueryValue } from 'hooks/useURLParameter';
-import { SortAggregate, SortOption, ThProps, isSortOption } from 'types/table';
-import { ApiSortOption, ApiSortOptionSingle } from 'types/search';
-import { isNonEmptyArray, NonEmptyArray } from 'utils/type.utils';
+import useURLParameter from 'hooks/useURLParameter';
+import type { HistoryAction, QueryValue } from 'hooks/useURLParameter';
+import { isSortOption } from 'types/table';
+import type { SortAggregate, SortOption, ThProps } from 'types/table';
+import type { ApiSortOption, ApiSortOptionSingle } from 'types/search';
+import { isNonEmptyArray } from 'utils/type.utils';
+import type { NonEmptyArray } from 'utils/type.utils';
 
 export type FieldOption = { field: string; aggregateBy?: SortAggregate };
 

--- a/ui/apps/platform/src/hooks/useURLStringUnion.ts
+++ b/ui/apps/platform/src/hooks/useURLStringUnion.ts
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 
-import useURLParameter, { HistoryAction } from 'hooks/useURLParameter';
-import { NonEmptyArray } from 'utils/type.utils';
+import useURLParameter from 'hooks/useURLParameter';
+import type { HistoryAction } from 'hooks/useURLParameter';
+import type { NonEmptyArray } from 'utils/type.utils';
 
 export type UseURLStringUnionReturn<Value> = [
     Value,

--- a/ui/apps/platform/src/hooks/useWidgetConfig.ts
+++ b/ui/apps/platform/src/hooks/useWidgetConfig.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import isPlainObject from 'lodash/isPlainObject';
 
-import { WidgetConfigStorage, RouteId, WidgetId, WidgetConfig } from 'types/widgetConfig';
+import type { WidgetConfigStorage, RouteId, WidgetId, WidgetConfig } from 'types/widgetConfig';
 
 export type UseWidgetConfigReturn<ConfigT extends WidgetConfig, UpdateAction> = [
     ConfigT,


### PR DESCRIPTION
### Description

First batch in a folder less likely to have merge conflicts with unmerged work in progress.

https://typescript-eslint.io/rules/consistent-type-imports/

> TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime.

> This allows transpilers to drop imports without knowing the types of the dependencies.

### Procedure

Temporarily add `'@typescript-eslint/consistent-type-imports': 'error'` to configuration for product files, grep and sort file names.

### Residue

1. Add opt-in and opt-out configuration options after we merge opt-out configuration options for limited lint rules in #16022

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.