### PR TITLE
ROX-30195: get distinct serialized when by query -- WIP

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -452,20 +452,6 @@ func (p *parsedPaginationQuery) AsSQL() string {
 	return paginationSB.String()
 }
 
-// Check if any ORDER BY fields are from joined tables
-func (p *parsedPaginationQuery) hasJoinedTableOrdering(schema *walker.Schema) bool {
-	for _, entry := range p.OrderBys {
-		// Check if the field path starts with a table name other than the main table
-		if strings.Contains(entry.Field.SelectPath, ".") {
-			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
-			if tableName != schema.Table {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // hasAnyOrdering checks if there are any ORDER BY clauses present
 func (p *parsedPaginationQuery) hasAnyOrdering() bool {
 	return len(p.OrderBys) > 0
@@ -1363,13 +1349,7 @@ func (q *query) buildSubqueryWithDistinctOn() string {
 
 	// Add all ordering fields to inner SELECT
 	for _, entry := range q.Pagination.OrderBys {
-		if strings.Contains(entry.Field.SelectPath, ".") {
-			// This is a qualified field path, add it directly
-			innerSelectParts = append(innerSelectParts, entry.Field.SelectPath)
-		} else {
-			// This might be an unqualified field, qualify it with the main table
-			innerSelectParts = append(innerSelectParts, entry.Field.SelectPath)
-		}
+		innerSelectParts = append(innerSelectParts, entry.Field.SelectPath)
 	}
 
 	// Build DISTINCT ON clause

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -382,6 +382,7 @@ func (q *query) AsSQL() string {
 			querySB.WriteString(paginationSQL)
 		}
 	}
+
 	// Performing this operation on full query is safe since table names and column names
 	// can only contain alphanumeric and underscore character.
 	queryString := replaceVars(querySB.String())
@@ -1458,5 +1459,11 @@ func (q *query) buildSubqueryWithDistinctOn() string {
 		outerSB.WriteString(fmt.Sprintf(" OFFSET %d", q.Pagination.Offset))
 	}
 
-	return replaceVars(outerSB.String())
+	// Performing this operation on full query is safe since table names and column names
+	// can only contain alphanumeric and underscore character.
+	queryString := replaceVars(outerSB.String())
+	if env.PostgresQueryLogger.BooleanSetting() {
+		log.Info(queryString)
+	}
+	return queryString
 }

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -232,6 +232,19 @@ func (q *query) getPortionBeforeFromClause() string {
 		}
 		return fmt.Sprintf("select count(%s)", countOn)
 	case GET:
+		// Use DISTINCT ON for deduplication when there are joins
+		if q.DistinctAppliedOnPrimaryKeySelect() {
+			// Check if we have joined table ordering - if so, use subquery instead
+			if q.Pagination.hasJoinedTableOrdering(q.Schema) {
+				return q.getGroupBySelectClause()
+			}
+
+			var primaryKeyPaths []string
+			for _, pk := range q.Schema.PrimaryKeys() {
+				primaryKeyPaths = append(primaryKeyPaths, qualifyColumn(pk.Schema.Table, pk.ColumnName, ""))
+			}
+			return fmt.Sprintf("select distinct on (%s) %s.serialized", strings.Join(primaryKeyPaths, ", "), q.From)
+		}
 		return fmt.Sprintf("select %q.serialized", q.From)
 	case SEARCH:
 		var selectStrs []string
@@ -350,9 +363,24 @@ func (q *query) AsSQL() string {
 		}
 		querySB.WriteString(strings.Join(returnedColumnPaths, ", "))
 	}
-	if paginationSQL := q.Pagination.AsSQL(); paginationSQL != "" {
-		querySB.WriteString(" ")
-		querySB.WriteString(paginationSQL)
+	// Handle pagination (use special logic for different query types)
+	if q.QueryType == GET && q.DistinctAppliedOnPrimaryKeySelect() {
+		if q.Pagination.hasJoinedTableOrdering(q.Schema) {
+			// Use subquery approach to avoid expensive aggregation on serialized data
+			return q.buildSubqueryWithDistinctOn()
+		} else {
+			// Use DISTINCT ON with proper ordering
+			if paginationSQL := q.Pagination.AsSQLWithDistinctOn(q.Schema); paginationSQL != "" {
+				querySB.WriteString(" ")
+				querySB.WriteString(paginationSQL)
+			}
+		}
+	} else {
+		// Normal pagination
+		if paginationSQL := q.Pagination.AsSQL(); paginationSQL != "" {
+			querySB.WriteString(" ")
+			querySB.WriteString(paginationSQL)
+		}
 	}
 	// Performing this operation on full query is safe since table names and column names
 	// can only contain alphanumeric and underscore character.
@@ -410,6 +438,63 @@ func (p *parsedPaginationQuery) AsSQL() string {
 		for _, entry := range p.OrderBys {
 			orderByClauses = append(orderByClauses, fmt.Sprintf("%s %s nulls last", entry.Field.SelectPath, pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
 		}
+		paginationSB.WriteString(fmt.Sprintf("order by %s", strings.Join(orderByClauses, ", ")))
+	}
+	if p.Limit > 0 {
+		paginationSB.WriteString(fmt.Sprintf(" LIMIT %d", p.Limit))
+	}
+	if p.Offset > 0 {
+		paginationSB.WriteString(fmt.Sprintf(" OFFSET %d", p.Offset))
+	}
+	return paginationSB.String()
+}
+
+// Check if any ORDER BY fields are from joined tables
+func (p *parsedPaginationQuery) hasJoinedTableOrdering(schema *walker.Schema) bool {
+	for _, entry := range p.OrderBys {
+		// Check if the field path starts with a table name other than the main table
+		if strings.Contains(entry.Field.SelectPath, ".") {
+			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
+			if tableName != schema.Table {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AsSQLWithDistinctOn generates SQL with proper ordering for DISTINCT ON queries
+func (p *parsedPaginationQuery) AsSQLWithDistinctOn(schema *walker.Schema) string {
+	var paginationSB strings.Builder
+	if len(p.OrderBys) > 0 {
+		orderByClauses := make([]string, 0, len(p.OrderBys))
+
+		// For DISTINCT ON, we need to start with primary key ordering
+		var primaryKeyPaths []string
+		for _, pk := range schema.PrimaryKeys() {
+			primaryKeyPaths = append(primaryKeyPaths, qualifyColumn(pk.Schema.Table, pk.ColumnName, ""))
+		}
+
+		// Add primary key ordering first (required for DISTINCT ON)
+		for _, pkPath := range primaryKeyPaths {
+			orderByClauses = append(orderByClauses, fmt.Sprintf("%s asc nulls last", pkPath))
+		}
+
+		// Then add user-specified ordering
+		for _, entry := range p.OrderBys {
+			// Skip if this is already a primary key field to avoid duplication
+			isPrimaryKey := false
+			for _, pkPath := range primaryKeyPaths {
+				if entry.Field.SelectPath == pkPath {
+					isPrimaryKey = true
+					break
+				}
+			}
+			if !isPrimaryKey {
+				orderByClauses = append(orderByClauses, fmt.Sprintf("%s %s nulls last", entry.Field.SelectPath, pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
+			}
+		}
+
 		paginationSB.WriteString(fmt.Sprintf("order by %s", strings.Join(orderByClauses, ", ")))
 	}
 	if p.Limit > 0 {
@@ -1245,4 +1330,133 @@ func validateDerivedFieldDataType(queryFields map[string]searchFieldMetadata) er
 		}
 	}
 	return errList.ToError()
+}
+
+// getGroupBySelectClause generates a SELECT clause using subquery approach for joined table ordering
+func (q *query) getGroupBySelectClause() string {
+	// We'll use a subquery approach to avoid expensive aggregation on serialized data
+	// This will be handled in the full query building, not just the SELECT clause
+	return fmt.Sprintf("select %s.serialized", q.From)
+}
+
+// buildSubqueryWithDistinctOn builds a subquery approach for joined table ordering
+func (q *query) buildSubqueryWithDistinctOn() string {
+	var outerSB strings.Builder
+
+	// Outer query - select serialized and order by joined fields
+	outerSB.WriteString("select subq.serialized from (")
+
+	// Inner query - use DISTINCT ON to pick right row per ID
+	var innerSB strings.Builder
+
+	// Inner SELECT - include serialized and ordering fields
+	var innerSelectParts []string
+	innerSelectParts = append(innerSelectParts, fmt.Sprintf("%s.serialized", q.From))
+
+	// Add ordering fields from joined tables to inner SELECT
+	for _, entry := range q.Pagination.OrderBys {
+		if strings.Contains(entry.Field.SelectPath, ".") {
+			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
+			if tableName != q.Schema.Table {
+				innerSelectParts = append(innerSelectParts, entry.Field.SelectPath)
+			}
+		}
+	}
+
+	// Build DISTINCT ON clause
+	var primaryKeyPaths []string
+	for _, pk := range q.Schema.PrimaryKeys() {
+		primaryKeyPaths = append(primaryKeyPaths, qualifyColumn(pk.Schema.Table, pk.ColumnName, ""))
+	}
+
+	innerSB.WriteString(fmt.Sprintf("select distinct on (%s) %s",
+		strings.Join(primaryKeyPaths, ", "),
+		strings.Join(innerSelectParts, ", ")))
+
+	// Add FROM clause
+	innerSB.WriteString(" from ")
+	innerSB.WriteString(q.From)
+
+	// Add JOINs
+	for _, join := range q.Joins {
+		if join.joinType == Inner {
+			innerSB.WriteString(" inner join ")
+		} else {
+			innerSB.WriteString(" left join ")
+		}
+		innerSB.WriteString(join.rightTable)
+		innerSB.WriteString(" on")
+
+		for i, columnNamePair := range join.columnNamePairs {
+			if i > 0 {
+				innerSB.WriteString(" and")
+			}
+			innerSB.WriteString(fmt.Sprintf(" %s.%s = %s.%s",
+				join.leftTable, columnNamePair.ColumnNameInThisSchema,
+				join.rightTable, columnNamePair.ColumnNameInOtherSchema))
+		}
+	}
+
+	// Add WHERE clause
+	if q.Where != "" {
+		innerSB.WriteString(" where ")
+		innerSB.WriteString(q.Where)
+	}
+
+	// Inner ORDER BY - must start with DISTINCT ON fields, then joined fields
+	innerSB.WriteString(" order by ")
+	var innerOrderBy []string
+
+	// Add primary key first (required for DISTINCT ON)
+	for _, pkPath := range primaryKeyPaths {
+		innerOrderBy = append(innerOrderBy, fmt.Sprintf("%s asc", pkPath))
+	}
+
+	// Add joined table ordering fields
+	for _, entry := range q.Pagination.OrderBys {
+		if strings.Contains(entry.Field.SelectPath, ".") {
+			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
+			if tableName != q.Schema.Table {
+				innerOrderBy = append(innerOrderBy, fmt.Sprintf("%s %s nulls last",
+					entry.Field.SelectPath,
+					pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
+			}
+		}
+	}
+
+	innerSB.WriteString(strings.Join(innerOrderBy, ", "))
+
+	// Complete the subquery
+	outerSB.WriteString(innerSB.String())
+	outerSB.WriteString(") subq")
+
+	// Outer ORDER BY - order by joined fields only
+	var outerOrderBy []string
+	for _, entry := range q.Pagination.OrderBys {
+		if strings.Contains(entry.Field.SelectPath, ".") {
+			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
+			if tableName != q.Schema.Table {
+				// Reference the field from subquery
+				fieldName := strings.Split(entry.Field.SelectPath, ".")[1]
+				outerOrderBy = append(outerOrderBy, fmt.Sprintf("subq.%s %s nulls last",
+					fieldName,
+					pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
+			}
+		}
+	}
+
+	if len(outerOrderBy) > 0 {
+		outerSB.WriteString(" order by ")
+		outerSB.WriteString(strings.Join(outerOrderBy, ", "))
+	}
+
+	// Add LIMIT and OFFSET
+	if q.Pagination.Limit > 0 {
+		outerSB.WriteString(fmt.Sprintf(" LIMIT %d", q.Pagination.Limit))
+	}
+	if q.Pagination.Offset > 0 {
+		outerSB.WriteString(fmt.Sprintf(" OFFSET %d", q.Pagination.Offset))
+	}
+
+	return replaceVars(outerSB.String())
 }

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -234,8 +234,10 @@ func (q *query) getPortionBeforeFromClause() string {
 	case GET:
 		// Use DISTINCT ON for deduplication when there are joins
 		if q.DistinctAppliedOnPrimaryKeySelect() {
-			// Check if we have joined table ordering - if so, use subquery instead
-			if q.Pagination.hasJoinedTableOrdering(q.Schema) {
+			// Use subquery approach for any ORDER BY clause to ensure proper ordering
+			// DISTINCT ON requires ordering by the DISTINCT ON fields first, which would
+			// override user-specified ordering, so we need a subquery to handle this correctly
+			if q.Pagination.hasAnyOrdering() {
 				return q.getGroupBySelectClause()
 			}
 
@@ -365,8 +367,8 @@ func (q *query) AsSQL() string {
 	}
 	// Handle pagination (use special logic for different query types)
 	if q.QueryType == GET && q.DistinctAppliedOnPrimaryKeySelect() {
-		if q.Pagination.hasJoinedTableOrdering(q.Schema) {
-			// Use subquery approach to avoid expensive aggregation on serialized data
+		if q.Pagination.hasAnyOrdering() {
+			// Use subquery approach to ensure proper ordering with DISTINCT ON
 			return q.buildSubqueryWithDistinctOn()
 		} else {
 			// Use DISTINCT ON with proper ordering
@@ -462,6 +464,11 @@ func (p *parsedPaginationQuery) hasJoinedTableOrdering(schema *walker.Schema) bo
 		}
 	}
 	return false
+}
+
+// hasAnyOrdering checks if there are any ORDER BY clauses present
+func (p *parsedPaginationQuery) hasAnyOrdering() bool {
+	return len(p.OrderBys) > 0
 }
 
 // AsSQLWithDistinctOn generates SQL with proper ordering for DISTINCT ON queries
@@ -1340,27 +1347,28 @@ func (q *query) getGroupBySelectClause() string {
 	return fmt.Sprintf("select %s.serialized", q.From)
 }
 
-// buildSubqueryWithDistinctOn builds a subquery approach for joined table ordering
+// buildSubqueryWithDistinctOn builds a subquery approach for any ordering with DISTINCT ON
 func (q *query) buildSubqueryWithDistinctOn() string {
 	var outerSB strings.Builder
 
-	// Outer query - select serialized and order by joined fields
+	// Outer query - select serialized and order by all ordering fields
 	outerSB.WriteString("select subq.serialized from (")
 
 	// Inner query - use DISTINCT ON to pick right row per ID
 	var innerSB strings.Builder
 
-	// Inner SELECT - include serialized and ordering fields
+	// Inner SELECT - include serialized and all ordering fields
 	var innerSelectParts []string
 	innerSelectParts = append(innerSelectParts, fmt.Sprintf("%s.serialized", q.From))
 
-	// Add ordering fields from joined tables to inner SELECT
+	// Add all ordering fields to inner SELECT
 	for _, entry := range q.Pagination.OrderBys {
 		if strings.Contains(entry.Field.SelectPath, ".") {
-			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
-			if tableName != q.Schema.Table {
-				innerSelectParts = append(innerSelectParts, entry.Field.SelectPath)
-			}
+			// This is a qualified field path, add it directly
+			innerSelectParts = append(innerSelectParts, entry.Field.SelectPath)
+		} else {
+			// This might be an unqualified field, qualify it with the main table
+			innerSelectParts = append(innerSelectParts, entry.Field.SelectPath)
 		}
 	}
 
@@ -1404,7 +1412,7 @@ func (q *query) buildSubqueryWithDistinctOn() string {
 		innerSB.WriteString(q.Where)
 	}
 
-	// Inner ORDER BY - must start with DISTINCT ON fields, then joined fields
+	// Inner ORDER BY - must start with DISTINCT ON fields, then all ordering fields
 	innerSB.WriteString(" order by ")
 	var innerOrderBy []string
 
@@ -1413,16 +1421,11 @@ func (q *query) buildSubqueryWithDistinctOn() string {
 		innerOrderBy = append(innerOrderBy, fmt.Sprintf("%s asc", pkPath))
 	}
 
-	// Add joined table ordering fields
+	// Add all ordering fields
 	for _, entry := range q.Pagination.OrderBys {
-		if strings.Contains(entry.Field.SelectPath, ".") {
-			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
-			if tableName != q.Schema.Table {
-				innerOrderBy = append(innerOrderBy, fmt.Sprintf("%s %s nulls last",
-					entry.Field.SelectPath,
-					pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
-			}
-		}
+		innerOrderBy = append(innerOrderBy, fmt.Sprintf("%s %s nulls last",
+			entry.Field.SelectPath,
+			pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
 	}
 
 	innerSB.WriteString(strings.Join(innerOrderBy, ", "))
@@ -1431,19 +1434,21 @@ func (q *query) buildSubqueryWithDistinctOn() string {
 	outerSB.WriteString(innerSB.String())
 	outerSB.WriteString(") subq")
 
-	// Outer ORDER BY - order by joined fields only
+	// Outer ORDER BY - order by all ordering fields
 	var outerOrderBy []string
 	for _, entry := range q.Pagination.OrderBys {
+		var fieldReference string
 		if strings.Contains(entry.Field.SelectPath, ".") {
-			tableName := strings.Split(entry.Field.SelectPath, ".")[0]
-			if tableName != q.Schema.Table {
-				// Reference the field from subquery
-				fieldName := strings.Split(entry.Field.SelectPath, ".")[1]
-				outerOrderBy = append(outerOrderBy, fmt.Sprintf("subq.%s %s nulls last",
-					fieldName,
-					pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
-			}
+			// For qualified field paths, use just the field name from subquery
+			fieldName := strings.Split(entry.Field.SelectPath, ".")[1]
+			fieldReference = fmt.Sprintf("subq.%s", fieldName)
+		} else {
+			// For unqualified field paths, use the SelectPath directly from subquery
+			fieldReference = fmt.Sprintf("subq.%s", entry.Field.SelectPath)
 		}
+		outerOrderBy = append(outerOrderBy, fmt.Sprintf("%s %s nulls last",
+			fieldReference,
+			pkgUtils.IfThenElse(entry.Descending, "desc", "asc")))
 	}
 
 	if len(outerOrderBy) > 0 {

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -1265,7 +1265,7 @@ func TestGetQueries(t *testing.T) {
 				AddExactMatches(search.DeploymentID, "not a uuid").ProtoQuery(),
 			schema: deploymentBaseSchema,
 			expectedError: `uuid: incorrect UUID length 10 in string "not a uuid"
-        	            	value "not a uuid" in search query must be valid UUID`,
+							value "not a uuid" in search query must be valid UUID`,
 		},
 		{
 			desc: "child schema multiple results query - GET",
@@ -1299,11 +1299,11 @@ func TestGetQueries(t *testing.T) {
 				return query
 			}(),
 			schema: deploymentBaseSchema,
-			expectedQuery: normalizeStatement(`select subq.serialized from (select distinct on (deployments.Id) deployments.serialized, 
-				deployments_containers.Image_Name_FullName from deployments 
-				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id 
-				where deployments_containers.Image_Name_FullName = $1 
-				order by deployments.Id asc, deployments_containers.Image_Name_FullName asc nulls last) subq 
+			expectedQuery: normalizeStatement(`select subq.serialized from (select distinct on (deployments.Id) deployments.serialized,
+				deployments_containers.Image_Name_FullName from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				where deployments_containers.Image_Name_FullName = $1
+				order by deployments.Id asc, deployments_containers.Image_Name_FullName asc nulls last) subq
 				order by subq.Image_Name_FullName asc nulls last LIMIT 10`),
 			expectedData: []interface{}{"test"},
 		},
@@ -1326,13 +1326,13 @@ func TestGetQueries(t *testing.T) {
 				return query
 			}(),
 			schema: imagesSchema,
-			expectedQuery: normalizeStatement(`select subq.serialized from (select distinct on (images.Id) images.serialized, 
-				image_cves_v2.Cvss from images 
-				inner join image_cves_v2 on images.Id = image_cves_v2.ImageId 
-				where image_cves_v2.CveBaseInfo_Cve ilike $1 
-				order by images.Id asc, image_cves_v2.Cvss desc nulls last) subq 
+			expectedQuery: normalizeStatement(`select subq.serialized from (select distinct on (images.Id) images.serialized,
+				image_cves_v2.Cvss from images
+				inner join image_cves_v2 on images.Id = image_cves_v2.ImageId
+				where image_cves_v2.CveBaseInfo_Cve is not null
+				order by images.Id asc, image_cves_v2.Cvss desc nulls last) subq
 				order by subq.Cvss desc nulls last LIMIT 20`),
-			expectedData: []interface{}{"%*%"},
+			expectedData: []interface{}(nil),
 		},
 	} {
 		t.Run(c.desc, func(t *testing.T) {

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -1147,6 +1147,222 @@ func TestDeleteReturningIDsQueries(t *testing.T) {
 	}
 }
 
+func TestGetQueries(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct {
+		desc          string
+		ctx           context.Context
+		q             *v1.Query
+		schema        *walker.Schema
+		expectedQuery string
+		expectedData  []interface{}
+		expectedError string
+	}{
+		{
+			desc:          "base schema query - simple GET",
+			ctx:           sac.WithAllAccess(context.Background()),
+			q:             search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema:        deploymentBaseSchema,
+			expectedQuery: `select "deployments".serialized from deployments where deployments.Name = $1`,
+			expectedData:  []interface{}{"central"},
+		},
+		{
+			desc:          "nil query - GET",
+			ctx:           sac.WithAllAccess(context.Background()),
+			q:             nil,
+			schema:        deploymentBaseSchema,
+			expectedQuery: `select "deployments".serialized from deployments`,
+			expectedData:  []interface{}(nil),
+		},
+		{
+			desc:   "child schema query - GET with joins",
+			ctx:    sac.WithAllAccess(context.Background()),
+			q:      search.NewQueryBuilder().AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select distinct on (deployments.Id) deployments.serialized from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				where deployments_containers.Image_Name_FullName = $1`),
+			expectedData: []interface{}{"stackrox"},
+		},
+		{
+			desc: "base schema and child schema conjunction query - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.ImageName, "stackrox").
+				AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select distinct on (deployments.Id) deployments.serialized from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				where (deployments.Name = $1 and deployments_containers.Image_Name_FullName = $2)`),
+			expectedData: []interface{}{"central", "stackrox"},
+		},
+		{
+			desc: "multiple child schema query - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: search.ConjunctionQuery(
+				search.NewQueryBuilder().AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
+				search.NewQueryBuilder().AddExactMatches(search.PortProtocol, "tcp").ProtoQuery(),
+			),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select distinct on (deployments.Id) deployments.serialized from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				inner join deployments_ports on deployments.Id = deployments_ports.deployments_Id
+				where (deployments_containers.Image_Name_FullName = $1 and deployments_ports.Protocol = $2)`),
+			expectedData: []interface{}{"stackrox", "tcp"},
+		},
+		{
+			desc: "base schema and child schema disjunction query - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: search.DisjunctionQuery(
+				search.NewQueryBuilder().AddExactMatches(search.ImageName, "stackrox").ProtoQuery(),
+				search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "central").ProtoQuery(),
+			),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select distinct on (deployments.Id) deployments.serialized from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				where (deployments_containers.Image_Name_FullName = $1 or deployments.Name = $2)`),
+			expectedData: []interface{}{"stackrox", "central"},
+		},
+		{
+			desc:   "negated child schema query - GET",
+			ctx:    sac.WithAllAccess(context.Background()),
+			q:      search.NewQueryBuilder().AddStrings(search.ImageName, "!central").ProtoQuery(),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select distinct on (deployments.Id) deployments.serialized from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				where NOT (deployments_containers.Image_Name_FullName ilike $1)`),
+			expectedData: []interface{}{"central%"},
+		},
+		{
+			desc: "id query - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: search.ConjunctionQuery(
+				search.NewQueryBuilder().AddDocIDs("123").ProtoQuery(),
+				search.MatchNoneQuery(),
+			),
+			schema:        deploymentBaseSchema,
+			expectedQuery: `select "deployments".serialized from deployments where (deployments.Id = ANY($1::uuid[]) and false)`,
+			expectedData:  []interface{}{[]string{"123"}},
+		},
+		{
+			desc: "base schema and child schema conjunction query on base ID - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.ImageName, "stackrox").
+				AddExactMatches(search.DeploymentID, uuid.NewDummy().String()).ProtoQuery(),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select distinct on (deployments.Id) deployments.serialized from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				where (deployments.Id = $1 and deployments_containers.Image_Name_FullName = $2)`),
+			expectedData: []interface{}{uuid.NewDummy(), "stackrox"},
+		},
+		{
+			desc: "base schema and child schema conjunction query on base invalid ID - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.ImageName, "stackrox").
+				AddExactMatches(search.DeploymentID, "not a uuid").ProtoQuery(),
+			schema: deploymentBaseSchema,
+			expectedError: `uuid: incorrect UUID length 10 in string "not a uuid"
+        	            	value "not a uuid" in search query must be valid UUID`,
+		},
+		{
+			desc: "child schema multiple results query - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: search.NewQueryBuilder().AddLinkedFieldsHighlighted(
+				[]search.FieldLabel{search.ImageName, search.EnvironmentKey},
+				[]string{search.WildcardString, search.WildcardString}).
+				ProtoQuery(),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select distinct on (deployments.Id) deployments.serialized from deployments
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id
+				inner join deployments_containers_envs on deployments_containers.deployments_Id = deployments_containers_envs.deployments_Id
+				and deployments_containers.idx = deployments_containers_envs.deployments_containers_idx
+				where (deployments_containers.Image_Name_FullName is not null and deployments_containers_envs.Key is not null)`),
+		},
+		{
+			desc: "query with pagination that would trigger subquery approach - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: func() *v1.Query {
+				// Create a query with joined table ordering to trigger subquery logic
+				query := search.NewQueryBuilder().AddExactMatches(search.ImageName, "test").ProtoQuery()
+				query.Pagination = &v1.QueryPagination{
+					SortOptions: []*v1.QuerySortOption{
+						{
+							Field:    search.ImageName.String(),
+							Reversed: false,
+						},
+					},
+					Limit: 10,
+				}
+				return query
+			}(),
+			schema: deploymentBaseSchema,
+			expectedQuery: normalizeStatement(`select subq.serialized from (select distinct on (deployments.Id) deployments.serialized, 
+				deployments_containers.Image_Name_FullName from deployments 
+				inner join deployments_containers on deployments.Id = deployments_containers.deployments_Id 
+				where deployments_containers.Image_Name_FullName = $1 
+				order by deployments.Id asc, deployments_containers.Image_Name_FullName asc nulls last) subq 
+				order by subq.Image_Name_FullName asc nulls last LIMIT 10`),
+			expectedData: []interface{}{"test"},
+		},
+		{
+			desc: "images ordered by CVE severity using join to ImageCVEV2 - GET",
+			ctx:  sac.WithAllAccess(context.Background()),
+			q: func() *v1.Query {
+				// Create a query for images ordered by CVE severity (CVSS score)
+				// This searches for images that have CVEs and orders them by severity
+				query := search.NewQueryBuilder().AddStrings(search.CVE, "*").ProtoQuery()
+				query.Pagination = &v1.QueryPagination{
+					SortOptions: []*v1.QuerySortOption{
+						{
+							Field:    search.CVSS.String(),
+							Reversed: true, // Highest severity first
+						},
+					},
+					Limit: 20,
+				}
+				return query
+			}(),
+			schema: imagesSchema,
+			expectedQuery: normalizeStatement(`select subq.serialized from (select distinct on (images.Id) images.serialized, 
+				image_cves_v2.Cvss from images 
+				inner join image_cves_v2 on images.Id = image_cves_v2.ImageId 
+				where image_cves_v2.CveBaseInfo_Cve ilike $1 
+				order by images.Id asc, image_cves_v2.Cvss desc nulls last) subq 
+				order by subq.Cvss desc nulls last LIMIT 20`),
+			expectedData: []interface{}{"%*%"},
+		},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx := c.ctx
+			if ctx == nil {
+				ctx = sac.WithAllAccess(context.Background())
+			}
+			actual, err := standardizeQueryAndPopulatePath(ctx, c.q, c.schema, GET)
+			if c.expectedError != "" {
+				assert.Error(t, err, c.expectedError)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if c.q == nil {
+				if actual == nil {
+					// nil query should result in nil query object
+					return
+				}
+			}
+
+			assert.NotNil(t, actual)
+			assert.Equal(t, GET, actual.QueryType)
+			assert.Equal(t, c.expectedQuery, actual.AsSQL())
+			assert.Equal(t, c.expectedData, actual.Data)
+		})
+	}
+}
+
 func normalizeStatement(statement string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(statement, "\t", ""), "\n", " ")
 }

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -35,6 +35,7 @@ pkg/fixtures/image/files/*
 pkg/mitre/files/mitre.json
 pkg/mocks/github.com/aws/aws-sdk-go/service/securityhub/securityhubiface/mocks/mocks.go
 pkg/scannerv4/mappers/mappers_test.go
+pkg/search/postgres/common_test.go
 pkg/sliceutils/gen-builtins-generic.go
 proto/storage/proto.lock
 qa-tests-backend/artifacts/**/*


### PR DESCRIPTION
Back to WIP because performance was worse.  BUT we may be limited because the code to do it another way may be far worse according to explain plans.  Investigating.


### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

While eliminating searchers in favor of using the `GetByQuery` family of calls an issue was uncovered in how 'GET` queries are built when joins are included.  Get queries were ALWAYS built of the form 'select table.serialized from table join table2 on table.id = table2.id where .....`

If there were multiple rows in the join table matching the parent table id then we would get multiple versions of the same serialized object.  In these get queries we are only interested in the serialized object, so the query should only return distinct serialized objects.  Additionally the query should respect the order provided in the query.  If the sort column is on the join table we run into issues ensuring proper order.  Basically before this change using the `GetByQuery` or `WalkByQuery` family of calls would likely be incorrect with respect to paging if a join table was required.  It would additionally result in additional rows being returned that had to be filtered or processed.  This is required to eliminate the searchers and minimize 2 pass queries.  The pattern is to use `Search` to get the IDs and then `GetMany` to get the object.  2 queries are unnecessary when we can do all the same thing in a single query.

Old query with joins:
```
select images.serialized,
				image_cves_v2.Cvss from images
				inner join image_cves_v2 on images.Id = image_cves_v2.ImageId
				where image_cves_v2.CveBaseInfo_Cve is not null
				order by images.Id asc, image_cves_v2.Cvss desc nulls last LIMIT 20
```

New query with joins:
```
select subq.serialized from (select distinct on (images.Id) images.serialized,
				image_cves_v2.Cvss from images
				inner join image_cves_v2 on images.Id = image_cves_v2.ImageId
				where image_cves_v2.CveBaseInfo_Cve is not null
				order by images.Id asc, image_cves_v2.Cvss desc nulls last) subq
				order by subq.Cvss desc nulls last LIMIT 20
```

Note if no joins are required the query will simply be built as `select table.serialized from table` as it has always been.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Added tests.  This also gets tested further up the stack when the report config searcher is removed.  Removing that searcher is where I discovered this issue existed.