### PR TITLE
ROX-30224: Use consistent-type-imports for services

### DIFF
--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -1,6 +1,6 @@
 import axios from './instance';
-import { Empty } from './types';
-import { Traits } from '../types/traits.proto';
+import type { Empty } from './types';
+import type { Traits } from '../types/traits.proto';
 
 const accessScopessUrl = '/v1/simpleaccessscopes';
 

--- a/ui/apps/platform/src/services/AdministrationEventsService.ts
+++ b/ui/apps/platform/src/services/AdministrationEventsService.ts
@@ -1,12 +1,12 @@
 import qs from 'qs';
 
-import { ApiSortOption, SearchFilter } from 'types/search';
-import { SortOption } from 'types/table';
+import type { ApiSortOption, SearchFilter } from 'types/search';
+import type { SortOption } from 'types/table';
 
 import { getPaginationParams } from 'utils/searchUtils';
 import axios from './instance';
 
-import { Pagination } from './types';
+import type { Pagination } from './types';
 
 const eventsCountUrl = '/v1/count/administration/events';
 const eventsUrl = '/v1/administration/events';

--- a/ui/apps/platform/src/services/AdministrationUsageService.ts
+++ b/ui/apps/platform/src/services/AdministrationUsageService.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 import axios from './instance';
-import {
+import type {
     MaxSecuredUnitsUsageResponse,
     SecuredUnitsUsage,
     TimeRange,

--- a/ui/apps/platform/src/services/AlertsService.ts
+++ b/ui/apps/platform/src/services/AlertsService.ts
@@ -1,12 +1,13 @@
 import queryString from 'qs';
 
-import { Alert, ListAlert } from 'types/alert.proto';
-import { PolicySeverity } from 'types/policy.proto';
-import { ApiSortOption, SearchFilter } from 'types/search';
+import type { Alert, ListAlert } from 'types/alert.proto';
+import type { PolicySeverity } from 'types/policy.proto';
+import type { ApiSortOption, SearchFilter } from 'types/search';
 import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import axios from './instance';
-import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
-import { Empty } from './types';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
+import type { Empty } from './types';
 
 const baseUrl = '/v1/alerts';
 const baseCountUrl = '/v1/alertscount';

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -4,15 +4,15 @@ import store from 'store';
 import axios from 'services/instance';
 import queryString from 'qs';
 
-import { Role } from 'services/RolesService';
+import type { Role } from 'services/RolesService';
 
-import { Empty } from 'services/types';
+import type { Empty } from 'services/types';
 import AccessTokenManager from './AccessTokenManager';
 import addTokenRefreshInterceptors, {
     doNotStallRequestConfig,
 } from './addTokenRefreshInterceptors';
 import { authProviderLabels } from '../../constants/accessControl';
-import { Traits } from '../../types/traits.proto';
+import type { Traits } from '../../types/traits.proto';
 import { isUserResource } from '../../Containers/AccessControl/traits';
 
 const authProvidersUrl = '/v1/authProviders';

--- a/ui/apps/platform/src/services/BackupIntegrationsService.ts
+++ b/ui/apps/platform/src/services/BackupIntegrationsService.ts
@@ -1,7 +1,7 @@
 import axios from './instance';
 
-import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
-import { Empty } from './types';
+import type { IntegrationBase, IntegrationOptions } from './IntegrationsService';
+import type { Empty } from './types';
 
 const backupIntegrationsUrl = '/v1/externalbackups';
 

--- a/ui/apps/platform/src/services/CertGenerationService.ts
+++ b/ui/apps/platform/src/services/CertGenerationService.ts
@@ -1,4 +1,4 @@
-import { CertExpiryComponent } from 'types/credentialExpiryService.proto';
+import type { CertExpiryComponent } from 'types/credentialExpiryService.proto';
 
 import { saveFile } from './DownloadService';
 

--- a/ui/apps/platform/src/services/CloudSourceService.ts
+++ b/ui/apps/platform/src/services/CloudSourceService.ts
@@ -1,5 +1,5 @@
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 export type CloudSourceType = 'TYPE_UNSPECIFIED' | 'TYPE_PALADIN_CLOUD' | 'TYPE_OCM';
 

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -1,14 +1,15 @@
 import qs from 'qs';
 
-import searchOptionsToQuery, { RestSearchOption } from 'services/searchOptionsToQuery';
+import searchOptionsToQuery from 'services/searchOptionsToQuery';
+import type { RestSearchOption } from 'services/searchOptionsToQuery';
 import { saveFile } from 'services/DownloadService';
-import {
+import type {
     ClusterDefaultsResponse,
     ClusterResponse,
     ClustersResponse,
 } from 'types/clusterService.proto';
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 const clustersUrl = '/v1/clusters';
 const clusterDefaultsUrl = '/v1/cluster-defaults';

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -1,11 +1,12 @@
 import qs from 'qs';
 
-import { ListDeployment } from 'types/deployment.proto';
-import { SearchFilter, ApiSortOption } from 'types/search';
+import type { ListDeployment } from 'types/deployment.proto';
+import type { ApiSortOption, SearchFilter } from 'types/search';
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
 import axios from './instance';
-import { Empty, FilterQuery } from './types';
+import type { Empty, FilterQuery } from './types';
 
 export const collectionsBaseUrl = '/v1/collections';
 export const collectionsCountUrl = '/v1/collectionscount';

--- a/ui/apps/platform/src/services/ComplianceCommon.ts
+++ b/ui/apps/platform/src/services/ComplianceCommon.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { SearchQueryOptions } from 'types/search';
+import type { SearchQueryOptions } from 'types/search';
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 export const complianceV2Url = '/v2/compliance';

--- a/ui/apps/platform/src/services/ComplianceProfileService.ts
+++ b/ui/apps/platform/src/services/ComplianceProfileService.ts
@@ -1,7 +1,8 @@
 import axios from 'services/instance';
 import qs from 'qs';
 
-import { ComplianceProfileSummary, complianceV2Url } from './ComplianceCommon';
+import { complianceV2Url } from './ComplianceCommon';
+import type { ComplianceProfileSummary } from './ComplianceCommon';
 
 const complianceProfilesBaseUrl = `${complianceV2Url}/profiles`;
 

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -1,12 +1,11 @@
 import axios from 'services/instance';
-import { SearchQueryOptions } from 'types/search';
+import type { SearchQueryOptions } from 'types/search';
 
-import {
-    buildNestedRawQueryParams,
+import { buildNestedRawQueryParams, complianceV2Url } from './ComplianceCommon';
+import type {
     ComplianceCheckStatus,
     ComplianceControl,
     ComplianceScanCluster,
-    complianceV2Url,
     ListComplianceProfileResults,
 } from './ComplianceCommon';
 

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -1,14 +1,13 @@
 import axios from 'services/instance';
-import { SearchFilter, SearchQueryOptions } from 'types/search';
+import type { SearchFilter, SearchQueryOptions } from 'types/search';
 import qs from 'qs';
 
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
-import {
-    buildNestedRawQueryParams,
+import { buildNestedRawQueryParams, complianceV2Url } from './ComplianceCommon';
+import type {
     ComplianceCheckResultStatusCount,
     ComplianceCheckStatusCount,
-    complianceV2Url,
     ListComplianceClusterOverallStatsResponse,
     ListComplianceProfileResults,
 } from './ComplianceCommon';

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -2,16 +2,18 @@ import Raven from 'raven-js';
 import axios from 'services/instance';
 import qs from 'qs';
 
-import { ApiSortOption, SearchFilter } from 'types/search';
-import { SlimUser } from 'types/user.proto';
+import type { ApiSortOption, SearchFilter } from 'types/search';
+import type { SlimUser } from 'types/user.proto';
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import { getQueryString } from 'utils/queryStringUtils';
-import { Snapshot } from 'types/reportJob';
-import { ComplianceProfileSummary, complianceV2Url } from './ComplianceCommon';
-import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
-import { NotifierConfiguration } from './ReportsService.types';
-import { Empty } from './types';
+import type { Snapshot } from 'types/reportJob';
+import { complianceV2Url } from './ComplianceCommon';
+import type { ComplianceProfileSummary } from './ComplianceCommon';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
+import type { NotifierConfiguration } from './ReportsService.types';
+import type { Empty } from './types';
 
 const complianceScanConfigBaseUrl = `${complianceV2Url}/scan/configurations`;
 export const complianceReportDownloadURL = '/v2/compliance/scan/configurations/reports/download';

--- a/ui/apps/platform/src/services/ComplianceService.ts
+++ b/ui/apps/platform/src/services/ComplianceService.ts
@@ -1,5 +1,5 @@
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 const standardsUrl = '/v1/compliance/standards';
 

--- a/ui/apps/platform/src/services/CredentialExpiryService.ts
+++ b/ui/apps/platform/src/services/CredentialExpiryService.ts
@@ -1,4 +1,4 @@
-import { CertExpiryComponent } from 'types/credentialExpiryService.proto';
+import type { CertExpiryComponent } from 'types/credentialExpiryService.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/DatabaseService.ts
+++ b/ui/apps/platform/src/services/DatabaseService.ts
@@ -1,4 +1,4 @@
-import { DatabaseStatus } from 'types/databaseService.proto';
+import type { DatabaseStatus } from 'types/databaseService.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/DeclarativeConfigHealthService.ts
+++ b/ui/apps/platform/src/services/DeclarativeConfigHealthService.ts
@@ -1,6 +1,6 @@
 import axios from './instance';
 
-import { DeclarativeConfigHealth } from '../types/declarativeConfigHealth.proto';
+import type { DeclarativeConfigHealth } from '../types/declarativeConfigHealth.proto';
 
 const healthUrl = '/v1/declarative-config/health';
 

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -1,18 +1,20 @@
 import queryString from 'qs';
 
-import searchOptionsToQuery, { RestSearchOption } from 'services/searchOptionsToQuery';
-import { Deployment, ListDeployment } from 'types/deployment.proto';
-import { ContainerNameAndBaselineStatus } from 'types/processBaseline.proto';
-import { Risk } from 'types/risk.proto';
-import { ApiSortOption, SearchFilter } from 'types/search';
+import searchOptionsToQuery from 'services/searchOptionsToQuery';
+import type { RestSearchOption } from 'services/searchOptionsToQuery';
+import type { Deployment, ListDeployment } from 'types/deployment.proto';
+import type { ContainerNameAndBaselineStatus } from 'types/processBaseline.proto';
+import type { Risk } from 'types/risk.proto';
+import type { ApiSortOption, SearchFilter } from 'types/search';
 import {
     ORCHESTRATOR_COMPONENTS_KEY,
     orchestratorComponentsOption,
 } from 'utils/orchestratorComponents';
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
 import axios from './instance';
-import { Pagination } from './types';
+import type { Pagination } from './types';
 
 const deploymentsUrl = '/v1/deployments';
 const deploymentsWithProcessUrl = '/v1/deploymentswithprocessinfo';

--- a/ui/apps/platform/src/services/DiscoveredClusterService.ts
+++ b/ui/apps/platform/src/services/DiscoveredClusterService.ts
@@ -1,12 +1,12 @@
 import qs from 'qs';
 
-import { SearchFilter } from 'types/search';
-import { SortOption } from 'types/table';
+import type { SearchFilter } from 'types/search';
+import type { SortOption } from 'types/table';
 
 import { getPaginationParams } from 'utils/searchUtils';
 import axios from './instance';
 
-import { Pagination } from './types';
+import type { Pagination } from './types';
 
 export type DiscoveredCluster = {
     // UUIDv5 generated deterministically from the tuple (metadata.id, metadata.type, source.id).

--- a/ui/apps/platform/src/services/FeatureFlagsService.ts
+++ b/ui/apps/platform/src/services/FeatureFlagsService.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag } from 'types/featureFlagService.proto';
+import type { FeatureFlag } from 'types/featureFlagService.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/GroupsService.ts
+++ b/ui/apps/platform/src/services/GroupsService.ts
@@ -1,6 +1,6 @@
-import { Group } from 'types/group.proto';
+import type { Group } from 'types/group.proto';
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 const url = '/v1/groups';
 const updateUrl = '/v1/groupsbatch';

--- a/ui/apps/platform/src/services/ImageIntegrationsService.ts
+++ b/ui/apps/platform/src/services/ImageIntegrationsService.ts
@@ -1,7 +1,7 @@
 import axios from './instance';
 
-import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
-import { Empty } from './types';
+import type { IntegrationBase, IntegrationOptions } from './IntegrationsService';
+import type { Empty } from './types';
 
 const imageIntegrationsUrl = '/v1/imageintegrations';
 

--- a/ui/apps/platform/src/services/IntegrationHealthService.ts
+++ b/ui/apps/platform/src/services/IntegrationHealthService.ts
@@ -1,4 +1,4 @@
-import { IntegrationHealth } from '../types/integrationHealth.proto';
+import type { IntegrationHealth } from '../types/integrationHealth.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -1,7 +1,9 @@
 import axios from './instance';
-import { Empty } from './types';
-import { AuthMachineToMachineConfig, updateMachineAccessConfig } from './MachineAccessService';
-import { UpdateCloudSourceRequest, updateCloudSource } from './CloudSourceService';
+import type { Empty } from './types';
+import { updateMachineAccessConfig } from './MachineAccessService';
+import type { AuthMachineToMachineConfig } from './MachineAccessService';
+import { updateCloudSource } from './CloudSourceService';
+import type { UpdateCloudSourceRequest } from './CloudSourceService';
 
 export type IntegrationSource =
     | 'authProviders'

--- a/ui/apps/platform/src/services/MachineAccessService.ts
+++ b/ui/apps/platform/src/services/MachineAccessService.ts
@@ -1,5 +1,5 @@
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 export type MachineConfigType = 'GENERIC' | 'GITHUB_ACTIONS' | 'KUBE_SERVICE_ACCOUNT';
 

--- a/ui/apps/platform/src/services/MetadataService.ts
+++ b/ui/apps/platform/src/services/MetadataService.ts
@@ -1,4 +1,4 @@
-import { Metadata } from 'types/metadataService.proto';
+import type { Metadata } from 'types/metadataService.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/NotifierIntegrationsService.ts
+++ b/ui/apps/platform/src/services/NotifierIntegrationsService.ts
@@ -1,8 +1,8 @@
-import { Traits } from 'types/traits.proto';
+import type { Traits } from 'types/traits.proto';
 import axios from './instance';
 
-import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
-import { Empty } from './types';
+import type { IntegrationBase, IntegrationOptions } from './IntegrationsService';
+import type { Empty } from './types';
 
 const notifierIntegrationsUrl = '/v1/notifiers';
 

--- a/ui/apps/platform/src/services/PDFExportService.ts
+++ b/ui/apps/platform/src/services/PDFExportService.ts
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify';
 import html2canvas from 'html2canvas';
 
 import { getDate, addBrandedTimestampToString } from 'utils/dateUtils';
-import { RequestAction, SuccessAction } from 'utils/fetchingReduxRoutines';
+import type { RequestAction, SuccessAction } from 'utils/fetchingReduxRoutines';
 import { getProductBranding } from 'constants/productBranding';
 
 /**

--- a/ui/apps/platform/src/services/PoliciesService.ts
+++ b/ui/apps/platform/src/services/PoliciesService.ts
@@ -1,12 +1,12 @@
 import queryString from 'qs';
 import FileSaver from 'file-saver';
 
-import { ListPolicy, Policy } from 'types/policy.proto';
+import type { ListPolicy, Policy } from 'types/policy.proto';
 import { addBrandedTimestampToString } from 'utils/dateUtils';
 import { transformPolicyCriteriaValuesToStrings } from 'utils/policyUtils';
 
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 const baseUrl = '/v1/policies';
 

--- a/ui/apps/platform/src/services/PolicyCategoriesService.ts
+++ b/ui/apps/platform/src/services/PolicyCategoriesService.ts
@@ -1,6 +1,6 @@
-import { PolicyCategory } from 'types/policy.proto';
+import type { PolicyCategory } from 'types/policy.proto';
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 const policyCategoriesUrl = '/v1/policycategories';
 

--- a/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
+++ b/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
@@ -1,7 +1,8 @@
-import { L4Protocol } from 'types/networkFlow.proto';
-import { ProcessSignal } from 'types/processIndicator.proto';
+import type { L4Protocol } from 'types/networkFlow.proto';
+import type { ProcessSignal } from 'types/processIndicator.proto';
 import axios from './instance';
-import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
 
 export const listeningEndpointsBaseUrl = '/v1/listening_endpoints';
 

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -1,17 +1,17 @@
 import queryString from 'qs';
 
-import {
+import type {
     OnDemandReportSnapshot,
     ReportConfiguration,
     ReportHistoryResponse,
     ReportSnapshot,
     RunReportResponse,
 } from 'services/ReportsService.types';
-import { ApiSortOption, SearchFilter } from 'types/search';
+import type { ApiSortOption, SearchFilter } from 'types/search';
 import { getListQueryParams, getPaginationParams } from 'utils/searchUtils';
-import { ReportNotificationMethod, ReportStatus } from 'types/reportJob';
+import type { ReportNotificationMethod, ReportStatus } from 'types/reportJob';
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 // The following functions are built around the new VM Reporting Enhancements
 export const reportDownloadURL = '/api/reports/jobs/download';

--- a/ui/apps/platform/src/services/ReportsService.types.ts
+++ b/ui/apps/platform/src/services/ReportsService.types.ts
@@ -1,5 +1,5 @@
-import { Snapshot } from 'types/reportJob';
-import { VulnerabilitySeverity } from '../types/cve.proto';
+import type { Snapshot } from 'types/reportJob';
+import type { VulnerabilitySeverity } from '../types/cve.proto';
 
 // Report configuration types
 

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -1,7 +1,7 @@
-import { Traits } from 'types/traits.proto';
 import qs from 'qs';
+import type { Traits } from 'types/traits.proto';
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 const resourcesUrl = '/v1/resources';
 

--- a/ui/apps/platform/src/services/SearchService.ts
+++ b/ui/apps/platform/src/services/SearchService.ts
@@ -1,7 +1,8 @@
 import qs from 'qs';
-import { SearchEntry } from 'types/search';
+import type { SearchEntry } from 'types/search';
 import axios from './instance';
-import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
 
 const baseUrl = '/v1/search';
 const autoCompleteURL = `${baseUrl}/autocomplete`;

--- a/ui/apps/platform/src/services/SignatureIntegrationsService.ts
+++ b/ui/apps/platform/src/services/SignatureIntegrationsService.ts
@@ -1,4 +1,4 @@
-import { SignatureIntegration } from 'types/signatureIntegration.proto';
+import type { SignatureIntegration } from 'types/signatureIntegration.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/SystemConfigService.ts
+++ b/ui/apps/platform/src/services/SystemConfigService.ts
@@ -1,4 +1,4 @@
-import { PublicConfig, SystemConfig } from '../types/config.proto';
+import type { PublicConfig, SystemConfig } from '../types/config.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
+++ b/ui/apps/platform/src/services/VulnerabilityExceptionService.ts
@@ -1,9 +1,9 @@
 import { generatePath } from 'react-router-dom';
 
-import { SlimUser } from 'types/user.proto';
-import { SearchFilter, ApiSortOption } from 'types/search';
+import type { ApiSortOption, SearchFilter } from 'types/search';
+import type { SlimUser } from 'types/user.proto';
 import { getListQueryParams } from 'utils/searchUtils';
-import { Empty } from './types';
+import type { Empty } from './types';
 import axios from './instance';
 
 const baseUrl = '/v2/vulnerability-exceptions';

--- a/ui/apps/platform/src/services/imageService.ts
+++ b/ui/apps/platform/src/services/imageService.ts
@@ -1,7 +1,7 @@
-import { ListImage, WatchedImage } from 'types/image.proto';
+import type { ListImage, WatchedImage } from 'types/image.proto';
 
 import axios from './instance';
-import { Empty } from './types';
+import type { Empty } from './types';
 
 const imagesUrl = '/v1/images';
 const watchedImagesUrl = '/v1/watchedimages';

--- a/ui/apps/platform/src/services/types.ts
+++ b/ui/apps/platform/src/services/types.ts
@@ -1,4 +1,4 @@
-import { ApiSortOption, ApiSortOptionSingle } from 'types/search';
+import type { ApiSortOption, ApiSortOptionSingle } from 'types/search';
 
 /* The type for pagination data stored and generated client side */
 export type ClientPagination = {


### PR DESCRIPTION
### Description

Second batch in a folder less likely to have merge conflicts with unmerged work in progress.

https://typescript-eslint.io/rules/consistent-type-imports/

> TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime.

> This allows transpilers to drop imports without knowing the types of the dependencies.

### Procedure

Temporarily add `'@typescript-eslint/consistent-type-imports': 'error'` to configuration for product files, grep and sort file names.

### Residue

1. Add opt-in and opt-out configuration options after we merge opt-out configuration options for limited lint rules in #16022

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.