### PR TITLE
fix(CI): fix invalid github sha

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1132,7 +1132,7 @@ get_commit_sha() {
     if is_OPENSHIFT_CI; then
         echo "${PULL_PULL_SHA:-${PULL_BASE_SHA}}"
     elif is_GITHUB_ACTIONS; then
-        echo "${GITHUB_SHA}"
+        git rev-parse --verify HEAD
     else
         die "unsupported"
     fi


### PR DESCRIPTION
`${github.sha}` on PR will not return a real commit. Instead it returns artificial commit that will come from merge to the base branch. This results that our jobs in bigquery has different commit shas in PRWO and github. This PR should fix that issue.

Tested:

```sql 
SELECT name, ci_system  FROM `acs-san-stackroxci.ci_metrics.stackrox_jobs` 
WHERE commit_sha = "e00e491720755e91f72898391320588f7ca0a2a9"
```

| name                                                               | ci_system |
|--------------------------------------------------------------------|-----------|
| openshift-ci-unit-tests                                            | gha       |
| style-check                                                        | gha       |
| build-and-push-main                                                | gha       |
| build-and-push-main                                                | gha       |
| build-and-push-main                                                | gha       |
| build-and-push-operator                                            | gha       |
| build-and-push-scanner                                             | gha       |
| build-and-push-scanner                                             | gha       |
| build-and-push-scanner                                             | gha       |
| build-and-push-scanner                                             | gha       |
| check-crd-compatibility                                            | gha       |
| check-generated-files                                              | gha       |
| local-roxctl-tests                                                 | gha       |
| misc-checks                                                        | gha       |
| pre-build-cli                                                      | gha       |
| pre-build-go-binaries                                              | gha       |
| pre-build-go-binaries                                              | gha       |
| pre-build-scanner-go-binary                                        | gha       |
| pre-build-scanner-go-binary                                        | gha       |
| pre-build-ui                                                       | gha       |
| pre-build-ui                                                       | gha       |
| pre-build-docs                                                     | gha       |
| build-and-push-main                                                | gha       |
| openshift-ci-lint                                                  | gha       |
| shell-unit-tests                                                   | gha       |
| push-main-manifests                                                | gha       |
| push-main-manifests                                                | gha       |
| pull-ci-stackrox-stackrox-master-gke-scanner-v4-install-tests      | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-19-scanner-v4-install-tests | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-19-qa-e2e-tests             | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-12-scanner-v4-install-tests | prow      |
| pull-ci-stackrox-stackrox-master-gke-ui-e2e-tests                  | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-19-nongroovy-e2e-tests      | prow      |
| pull-ci-stackrox-stackrox-master-gke-upgrade-tests                 | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-12-operator-e2e-tests       | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-18-nongroovy-e2e-tests      | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-18-qa-e2e-tests             | prow      |
| pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests                  | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-18-operator-e2e-tests       | prow      |
| pull-ci-stackrox-stackrox-master-gke-operator-e2e-tests            | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests             | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-12-nongroovy-e2e-tests      | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-18-scanner-v4-install-tests | prow      |
| pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests           | prow      |
| pull-ci-stackrox-stackrox-master-ocp-4-19-operator-e2e-tests       | prow      |

See:

- https://github.com/orgs/community/discussions/26325
- https://github.com/stackrox/stackrox/pull/16052#issuecomment-3097217673