### PR TITLE
ROX-30251: Add lint rule for consistent component and props names

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -1,4 +1,6 @@
-/* globals module */
+/* globals module require */
+
+const path = require('node:path');
 
 const rules = {
     // ESLint naming convention for positive rules:
@@ -411,6 +413,79 @@ const rules = {
                             });
                         }
                     }
+                },
+            };
+        },
+    },
+    'react-props-name': {
+        // Prevent mistaken assumptions about results from Find in Files.
+        // Use eslint-disable comment if application-specific component has PatternFly props name.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Require that React component or hook have consistent props name',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                ExportDefaultDeclaration(node) {
+                    const { filename } = context;
+                    const hasTypeScriptReactExtension = path.extname(filename) === '.tsx';
+                    const hookRegExp = /^use[A-Z]/; // Uppercase prevents false match like userWhatever
+                    // specialized case: WhateverIntegrationFormProps endsWith IntegrationFormProps
+                    // current baseline: Whatever endsWith WhateverProps
+                    // possible minimal: WhateverProps endsWith Props
+                    const hasConsistentName = (name, nameOfPropsType) =>
+                        `${name}Props`.endsWith(nameOfPropsType);
+
+                    if (
+                        typeof node.declaration?.id?.name === 'string' &&
+                        hasTypeScriptReactExtension &&
+                        !hookRegExp.test(node.declaration.id.name) &&
+                        typeof node?.declaration?.params?.[0]?.typeAnnotation?.typeAnnotation
+                            ?.typeName?.name === 'string'
+                    ) {
+                        // export default function Whatever({ … }: WhateverProps) {}
+                        const { name } = node.declaration.id;
+                        const { name: nameOfPropsType } =
+                            node.declaration.params[0].typeAnnotation.typeAnnotation.typeName;
+                        if (!hasConsistentName(name, nameOfPropsType)) {
+                            context.report({
+                                node,
+                                message: `Require React component to have consistent props name: ${nameOfPropsType}`,
+                            });
+                        }
+                    } else if (
+                        typeof node.declaration?.name === 'string' &&
+                        hasTypeScriptReactExtension &&
+                        !hookRegExp.test(node.declaration.name)
+                    ) {
+                        // export default Whatever
+                        const { name } = node.declaration;
+                        const ancestors = context.sourceCode.getAncestors(node);
+                        const functionDeclaration = ancestors[0]?.body?.findLast(
+                            (child) =>
+                                child.type === 'FunctionDeclaration' &&
+                                child.id?.name === name &&
+                                typeof child?.params[0]?.typeAnnotation?.typeAnnotation?.typeName
+                                    ?.name === 'string'
+                        );
+                        if (functionDeclaration) {
+                            // function Whatever(({ … }: WhateverProps) {}
+                            const { name: nameOfPropsType } =
+                                functionDeclaration.params[0].typeAnnotation.typeAnnotation
+                                    .typeName;
+                            if (!hasConsistentName(name, nameOfPropsType)) {
+                                context.report({
+                                    node,
+                                    message: `Require React component to have consistent props name: ${nameOfPropsType}`,
+                                });
+                            }
+                        }
+                    }
+                    // Not supported because mostly in classic JavaScript files:
+                    // const Whatever = ({ … }) => {}
                 },
             };
         },

--- a/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
@@ -15,11 +15,11 @@ import {
 
 import { EmbeddedSecret } from 'types/deployment.proto';
 
-type ContainerSecretInfoProps = {
+type ContainerSecretsInfoProps = {
     secrets: EmbeddedSecret[];
 };
 
-function ContainerSecretsInfo({ secrets }: ContainerSecretInfoProps) {
+function ContainerSecretsInfo({ secrets }: ContainerSecretsInfoProps) {
     const initialToggleValues = Array.from({ length: secrets.length }, () => true);
     const [secretToggles, setSecretToggles] = useState(initialToggleValues);
 

--- a/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
@@ -15,11 +15,11 @@ import {
 
 import { ContainerVolume } from 'types/deployment.proto';
 
-type ContainerVolumeInfoProps = {
+type ContainerVolumesInfoProps = {
     volumes: ContainerVolume[];
 };
 
-function ContainerVolumesInfo({ volumes }: ContainerVolumeInfoProps) {
+function ContainerVolumesInfo({ volumes }: ContainerVolumesInfoProps) {
     const initialToggleValues = Array.from({ length: volumes.length }, () => true);
     const [volumeToggles, setVolumeToggles] = useState(initialToggleValues);
 

--- a/ui/apps/platform/src/Components/DescriptionListCompact/DescriptionListCompact.tsx
+++ b/ui/apps/platform/src/Components/DescriptionListCompact/DescriptionListCompact.tsx
@@ -15,4 +15,6 @@ function DescriptionListCompact({ children, ...rest }: DescriptionListProps): Re
     );
 }
 
+// Component props have inconsistent name because DescriptionListProps is from PatternFly.
+// eslint-disable-next-line generic/react-props-name
 export default DescriptionListCompact;

--- a/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierModal.tsx
+++ b/ui/apps/platform/src/Components/EmailNotifier/EmailNotifierModal.tsx
@@ -13,7 +13,7 @@ import useFormModal from 'hooks/patternfly/useFormModal';
 import { createIntegration } from 'services/IntegrationsService';
 import EmailNotifierForm from './EmailNotifierForm';
 
-export type EmailNotifierFormModalProps = {
+export type EmailNotifierModalProps = {
     isOpen: boolean;
     updateNotifierList: (string) => void;
     onToggleEmailNotifierModal: () => void;
@@ -23,7 +23,7 @@ function EmailNotifierModal({
     isOpen,
     updateNotifierList,
     onToggleEmailNotifierModal,
-}: EmailNotifierFormModalProps): ReactElement {
+}: EmailNotifierModalProps): ReactElement {
     const formInitialValues = { ...defaultValues };
 
     const { formik, message, onHandleSubmit, onHandleCancel } =

--- a/ui/apps/platform/src/Components/PatternFly/LinkShim/LinkShim.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/LinkShim/LinkShim.tsx
@@ -28,4 +28,6 @@ function LinkShim({
     );
 }
 
+// Component props have inconsistent name because AnchorHTMLAttributes is from react.
+// eslint-disable-next-line generic/react-props-name
 export default LinkShim;

--- a/ui/apps/platform/src/Components/TableCellValue/TableCellValue.tsx
+++ b/ui/apps/platform/src/Components/TableCellValue/TableCellValue.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import resolvePath from 'object-resolve-path';
 
-type TableCellProps<T> = {
+type TableCellValueProps<T> = {
     row: T;
     column: {
         Header: string;
@@ -9,7 +9,7 @@ type TableCellProps<T> = {
     };
 };
 
-function TableCellValue<T>({ row, column }: TableCellProps<T>): React.ReactElement {
+function TableCellValue<T>({ row, column }: TableCellValueProps<T>): React.ReactElement {
     let value: string;
     if (typeof column.accessor === 'function') {
         value = column.accessor(row).toString();

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeStateIcon.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeStateIcon.tsx
@@ -107,7 +107,7 @@ const unknownState = (
     </Tooltip>
 );
 
-export type EffectiveAccessScopeStateProps = {
+export type EffectiveAccessScopeStateIconProps = {
     state: EffectiveAccessScopeState;
     isCluster: boolean;
 };
@@ -115,7 +115,7 @@ export type EffectiveAccessScopeStateProps = {
 function EffectiveAccessScopeStateIcon({
     state,
     isCluster,
-}: EffectiveAccessScopeStateProps): ReactElement {
+}: EffectiveAccessScopeStateIconProps): ReactElement {
     switch (state) {
         case 'EXCLUDED':
             return isCluster ? notAllowedCluster : notAllowedNamespace;

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
@@ -3,11 +3,11 @@ import { Card, CardBody, CardProps, CardTitle, Progress } from '@patternfly/reac
 
 import { ComplianceRunStatusResponse } from './useComplianceRunStatuses';
 
-export type ComplianceDashboardCurrentProps = {
+export type ComplianceScanProgressProps = {
     runs: ComplianceRunStatusResponse['complianceRunStatuses']['runs'];
 } & CardProps;
 
-function ComplianceScanProgress({ runs, ...props }: ComplianceDashboardCurrentProps) {
+function ComplianceScanProgress({ runs, ...props }: ComplianceScanProgressProps) {
     const unfinishedRunCount = runs.filter((run) => run.state !== 'FINISHED').length;
     const finishedRunCount = runs.length - unfinishedRunCount;
 

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
@@ -1,12 +1,12 @@
 import React, { ReactElement } from 'react';
 import { Alert, Modal } from '@patternfly/react-core';
 
-export type ManageStandardsErrorProp = {
+export type ManageStandardsErrorProps = {
     onClose: () => void;
     errorMessage: string;
 };
 
-function ManageStandardsError({ onClose, errorMessage }: ManageStandardsErrorProp): ReactElement {
+function ManageStandardsError({ onClose, errorMessage }: ManageStandardsErrorProps): ReactElement {
     return (
         <Modal title="Manage standards" variant="small" isOpen onClose={onClose} showClose>
             <Alert title="Unable to fetch standards" component="p" variant="warning" isInline>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRiskTable.tsx
@@ -47,7 +47,7 @@ function countImportant(
         : imageVulnerabilityCounter.important.total;
 }
 
-export type ImagesAtMostRiskProps = {
+export type ImagesAtMostRiskTableProps = {
     imageData: ImageData;
     cveStatusOption: CveStatusOption;
 };
@@ -56,7 +56,10 @@ function linkToImage(id: string) {
     return `${vulnManagementPath}/image/${id}#image-findings`;
 }
 
-function ImagesAtMostRiskTable({ imageData: { images }, cveStatusOption }: ImagesAtMostRiskProps) {
+function ImagesAtMostRiskTable({
+    imageData: { images },
+    cveStatusOption,
+}: ImagesAtMostRiskTableProps) {
     return (
         <Table variant="compact" borders={false}>
             <Thead>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MicrosoftSentinelIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MicrosoftSentinelIntegrationForm.tsx
@@ -57,7 +57,7 @@ export type MicrosoftSentinel = {
     type: 'microsoftSentinel';
 } & NotifierIntegrationBase;
 
-export type MicrosoftSentinelFormValues = {
+export type MicrosoftSentinelIntegrationFormValues = {
     notifier: MicrosoftSentinel;
     updatePassword: boolean;
 };
@@ -83,7 +83,7 @@ export const validationSchema = yup.object().shape({
     updatePassword: yup.bool(),
 });
 
-export const defaultValues: MicrosoftSentinelFormValues = {
+export const defaultValues: MicrosoftSentinelIntegrationFormValues = {
     notifier: {
         id: '',
         name: '',
@@ -116,7 +116,7 @@ export const defaultValues: MicrosoftSentinelFormValues = {
     updatePassword: true,
 };
 
-function MicrosoftSentinelForm({
+function MicrosoftSentinelIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<MicrosoftSentinel>): ReactElement {
@@ -145,7 +145,7 @@ function MicrosoftSentinelForm({
         onTest,
         onCancel,
         message,
-    } = useIntegrationForm<MicrosoftSentinelFormValues>({
+    } = useIntegrationForm<MicrosoftSentinelIntegrationFormValues>({
         initialValues: formInitialValues,
         validationSchema,
     });
@@ -613,4 +613,4 @@ function MicrosoftSentinelForm({
     );
 }
 
-export default MicrosoftSentinelForm;
+export default MicrosoftSentinelIntegrationForm;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
@@ -29,7 +29,7 @@ import EmailIntegrationForm from './Forms/EmailIntegrationForm';
 import GenericWebhookIntegrationForm from './Forms/GenericWebhookIntegrationForm';
 import GoogleCloudSccIntegrationForm from './Forms/GoogleCloudSccIntegrationForm';
 import JiraIntegrationForm from './Forms/JiraIntegrationForm';
-import MicrosoftSentinelForm from './Forms/MicrosoftSentinelForm';
+import MicrosoftSentinelIntegrationForm from './Forms/MicrosoftSentinelIntegrationForm';
 import PagerDutyIntegrationForm from './Forms/PagerDutyIntegrationForm';
 import SlackIntegrationForm from './Forms/SlackIntegrationForm';
 import SplunkIntegrationForm from './Forms/SplunkIntegrationForm';
@@ -102,7 +102,7 @@ const ComponentFormMap = {
         email: EmailIntegrationForm,
         generic: GenericWebhookIntegrationForm,
         jira: JiraIntegrationForm,
-        microsoftSentinel: MicrosoftSentinelForm,
+        microsoftSentinel: MicrosoftSentinelIntegrationForm,
         pagerduty: PagerDutyIntegrationForm,
         slack: SlackIntegrationForm,
         splunk: SplunkIntegrationForm,

--- a/ui/apps/platform/src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx
@@ -11,7 +11,7 @@ import {
     nameOfComponent,
 } from 'utils/credentialExpiry';
 
-type CredentialExpiryProps = {
+type CredentialExpiryBannerProps = {
     component: CertExpiryComponent;
     showCertGenerateAction: boolean;
 };
@@ -19,7 +19,7 @@ type CredentialExpiryProps = {
 function CredentialExpiryBanner({
     component,
     showCertGenerateAction,
-}: CredentialExpiryProps): ReactElement | null {
+}: CredentialExpiryBannerProps): ReactElement | null {
     const [expirationDate, setExpirationDate] = useState('');
     useEffect(() => {
         fetchCertExpiryForComponent(component)

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
@@ -40,7 +40,7 @@ type GetMitreAttackVectorsVars = {
     id: string;
 };
 
-type MitreAttackVectorsViewProps = {
+type MitreAttackVectorsViewContainerProps = {
     policyId?: string;
     policyFormMitreAttackVectors?: {
         tactic: string;
@@ -51,7 +51,7 @@ type MitreAttackVectorsViewProps = {
 function MitreAttackVectorsViewContainer({
     policyId,
     policyFormMitreAttackVectors,
-}: MitreAttackVectorsViewProps): ReactElement {
+}: MitreAttackVectorsViewContainerProps): ReactElement {
     const {
         loading: isLoading,
         data,

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -10,13 +10,13 @@ import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
 
 import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
-type NetworkPoliciesYAMLProp = {
+type NetworkPoliciesYAMLProps = {
     yaml: string;
     style?: CSSProperties;
     additionalControls?: ReactNode;
 };
 
-function NetworkPoliciesYAML({ yaml, style, additionalControls }: NetworkPoliciesYAMLProp) {
+function NetworkPoliciesYAML({ yaml, style, additionalControls }: NetworkPoliciesYAMLProps) {
     const { analyticsTrack } = useAnalytics();
     const { searchFilter } = useSearchFilter();
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
@@ -16,7 +16,7 @@ import DuplicatePolicyForm from './DuplicatePolicyForm';
 
 const RESOLUTION = { resolution: '', newName: '' };
 
-type ImportPolicyJSONErrorProps = {
+type ImportPolicyJSONModalErrorProps = {
     handleCancelModal: () => void;
     startImportPolicies: () => void;
     policies: Policy[];
@@ -34,7 +34,7 @@ function ImportPolicyJSONModalError({
     duplicateResolution,
     setDuplicateResolution,
     errorMessages,
-}: ImportPolicyJSONErrorProps): ReactElement {
+}: ImportPolicyJSONModalErrorProps): ReactElement {
     function updateResolution(key, value) {
         setDuplicateResolution({ ...duplicateResolution, [key]: value });
     }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -14,11 +14,11 @@ import './PolicyCriteriaForm.css';
 
 const MAX_POLICY_SECTIONS = 16;
 
-type PolicyBehaviorFormProps = {
+type PolicyCriteriaFormProps = {
     hasActiveViolations: boolean;
 };
 
-function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
+function PolicyCriteriaForm({ hasActiveViolations }: PolicyCriteriaFormProps) {
     const { values, setFieldValue } = useFormikContext<ClientPolicy>();
     const { criteriaLocked } = values;
     const { isFeatureFlagEnabled } = useFeatureFlags();

--- a/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
@@ -17,7 +17,7 @@ import { FormikProvider, useFormik } from 'formik';
 import { PolicyCategory } from 'types/policy.proto';
 import { postPolicyCategory } from 'services/PolicyCategoriesService';
 
-type CreatePolicyCategoryModalType = {
+type CreatePolicyCategoryModalProps = {
     isOpen: boolean;
     onClose: () => void;
     addToast: (toast) => void;
@@ -35,7 +35,7 @@ function CreatePolicyCategoryModal({
     onClose,
     addToast,
     refreshPolicyCategories,
-}: CreatePolicyCategoryModalType) {
+}: CreatePolicyCategoryModalProps) {
     const formik = useFormik({
         initialValues: emptyPolicyCategory as PolicyCategory,
         onSubmit: (values, { setSubmitting, resetForm }) => {

--- a/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
@@ -20,7 +20,7 @@ import { deletePolicyCategory } from 'services/PolicyCategoriesService';
 import { PolicyCategory, ListPolicy } from 'types/policy.proto';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
-type DeletePolicyCategoryModalType = {
+type DeletePolicyCategoryModalProps = {
     isOpen: boolean;
     onClose: () => void;
     addToast: (toast) => void;
@@ -36,7 +36,7 @@ function DeletePolicyCategoryModal({
     refreshPolicyCategories,
     selectedCategory,
     setSelectedCategory,
-}: DeletePolicyCategoryModalType) {
+}: DeletePolicyCategoryModalProps) {
     const [affectedPolicies, setAffectedPolicies] = useState<ListPolicy[]>([]);
 
     function handleDelete() {

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
@@ -17,7 +17,7 @@ import {
 import { PolicyCategory } from 'types/policy.proto';
 import { renamePolicyCategory } from 'services/PolicyCategoriesService';
 
-type PolicyCategoriesSidePanelProps = {
+type PolicyCategorySidePanelProps = {
     selectedCategory: PolicyCategory;
     setSelectedCategory: (selectedCategory?: PolicyCategory) => void;
     addToast: (toast) => void;
@@ -31,7 +31,7 @@ function PolicyCategorySidePanel({
     addToast,
     refreshPolicyCategories,
     openDeleteModal,
-}: PolicyCategoriesSidePanelProps) {
+}: PolicyCategorySidePanelProps) {
     const formik = useFormik({
         initialValues: selectedCategory,
         onSubmit: (values, { setSubmitting }) => {

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -16,7 +16,7 @@ import {
     TheadClustersHealth,
 } from './ClustersHealthTable';
 
-export type ClusterStatusTableProps = {
+export type ClusterStatusCardProps = {
     clusters: Cluster[];
     isFetchingInitialRequest: boolean;
     errorMessageFetching: string;
@@ -26,7 +26,7 @@ function ClusterStatusCard({
     clusters,
     isFetchingInitialRequest,
     errorMessageFetching,
-}: ClusterStatusTableProps): ReactElement {
+}: ClusterStatusCardProps): ReactElement {
     const countsOverall =
         !isFetchingInitialRequest && !errorMessageFetching
             ? getClusterStatusCounts(clusters)

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
@@ -14,4 +14,6 @@ function ScanDataMessage({ header = '', body = '' }: ScanMessage): ReactElement 
     ) : null;
 }
 
+// Component props have inconsistent name because ScanMessage is application-specific data structure.
+// eslint-disable-next-line generic/react-props-name
 export default ScanDataMessage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -58,7 +58,7 @@ import ScheduleDetails from '../components/ScheduleDetails';
 import { defaultEmailBody, getDefaultEmailSubject } from '../forms/emailTemplateFormUtils';
 import JobDetails from './JobDetails';
 
-export type RunHistoryProps = {
+export type ReportJobsProps = {
     reportId: string;
 };
 
@@ -69,7 +69,7 @@ const sortOptions = {
 
 const headingLevel = 'h2';
 
-function ReportJobs({ reportId }: RunHistoryProps) {
+function ReportJobs({ reportId }: ReportJobsProps) {
     const { currentUser } = useAuthStatus();
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { sortOption, getSortParams } = useURLSort(sortOptions);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -16,12 +16,12 @@ import {
 import { ReportFormValues } from './useReportFormValues';
 import EmailTemplatePreview from '../components/EmailTemplatePreview';
 
-export type DeliveryDestinationsFormParams = {
+export type DeliveryDestinationsFormProps = {
     title: string;
     formik: FormikProps<ReportFormValues>;
 };
 
-function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormParams): ReactElement {
+function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormProps): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -35,12 +35,12 @@ import { CollectionSlim } from 'services/CollectionsService';
 import { NotifierConfiguration } from 'services/ReportsService.types';
 import CollectionSelection from './CollectionSelection';
 
-export type ReportParametersFormParams = {
+export type ReportParametersFormProps = {
     title: string;
     formik: FormikProps<ReportFormValues>;
 };
 
-function ReportParametersForm({ title, formik }: ReportParametersFormParams): ReactElement {
+function ReportParametersForm({ title, formik }: ReportParametersFormProps): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isIncludeAdvisoryEnabled =
         isFeatureFlagEnabled('ROX_SCANNER_V4') &&

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportReviewForm.tsx
@@ -11,14 +11,14 @@ import ReportParametersDetails from '../components/ReportParametersDetails';
 import ScheduleDetails from '../components/ScheduleDetails';
 import { defaultEmailBody, getDefaultEmailSubject } from './emailTemplateFormUtils';
 
-export type ReportReviewFormParams = {
+export type ReportReviewFormProps = {
     title: string;
     formValues: ReportFormValues;
 };
 
 const headingLevel = 'h3';
 
-function ReportReviewForm({ title, formValues }: ReportReviewFormParams): ReactElement {
+function ReportReviewForm({ title, formValues }: ReportReviewFormProps): ReactElement {
     return (
         <>
             <PageSection variant="light" padding={{ default: 'noPadding' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -111,11 +111,11 @@ function getWorkloadCveContextFromView(
     };
 }
 
-export type WorkloadCvePageProps = {
+export type WorkloadCvesPageProps = {
     view: string;
 };
 
-function WorkloadCvesPage({ view }: WorkloadCvePageProps) {
+function WorkloadCvesPage({ view }: WorkloadCvesPageProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');

--- a/ui/apps/platform/src/test-utils/ComponentProviders.tsx
+++ b/ui/apps/platform/src/test-utils/ComponentProviders.tsx
@@ -6,7 +6,8 @@ import { ApolloProvider } from '@apollo/client';
 
 import configureApolloClient from 'init/configureApolloClient';
 
-export type ComponentTestProviderProps = {
+// TODO: rebase and revert this name change when we merge 16022
+export type ComponentTestProvidersProps = {
     children: React.ReactNode;
     reduxStore?: Store;
 };
@@ -17,7 +18,7 @@ const defaultStore = createStore(() => ({}), {});
 export default function ComponentTestProviders({
     children,
     reduxStore = defaultStore,
-}: ComponentTestProviderProps) {
+}: ComponentTestProvidersProps) {
     return (
         <Provider store={reduxStore}>
             <BrowserRouter>


### PR DESCRIPTION
### Description

Ready to review for name changes, but **Usability** heading below describes potential refactoring of lint rule to report error at more intuitive location.

### Problem

Find in Files results can mislead if component name is inconsistent with its props type name.

### Analysis

Use `'.tsx'` file name extension and **not** hook name as cue for React component.

Why omit hooks? It seems as if there is not a majority pattern for hook props type name.

Playground **ESTree** tab provides optional chaining paths for two scenarios below.

https://typescript-eslint.io/play/#ts=5.8.2&showAST=es&fileType=.tsx

```tsx
export default function Whatever({ … }: WhateverProps) {}
```

```tsx
function Whatever(({ … }: WhateverProps) {}

export default Whatever;
```

A few components have props types either from a package or from a data structure:
* `DescriptionListCompact` has `DescriptionListProps` from PatternFly
* `LinkShim` has `AnchorHTMLAttributes` from react
* `ScanDataMessage` has `ScanMessage` from application-specific data structure

One component has name (and file name) that is inconsistent with pattern in its folder:
* `MicrosoftSentinelForm` instead of `MicrosoftSentinelIntegrationForm` which is consistent with `IntegrationFormProps` because of `endsWith` criterion

### Solution

1. Edit eslint-plugins/pluginGeneric.js file to add `react-props-name` rule.
2. Rename one inconsistent file name and its component name.
3. Edit other files:
    * Rename props type.
    * Add `eslint-disable-next-lint` comment if props type is external to component.

### Usability

Error message is at `export default Whatever` statement instead of `InconsistentProps` type in function parameter.

While this contribution waits for rebase and resolve merge conflicts, I will attempt to refactor the other way around, because props type name needs to change more often than component name.

### Residue

1. Investigate replacement of `DescriptionListCompact` with `DescriptionList` element and `variant="compact"` prop.

    ```js
    // TODO Replace occurrences with DescriptionList if variant="compact" becomes available.
    ```

    https://www.patternfly.org/components/description-list#compact-horizontal

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.