### PR TITLE
ROX-30267: Use consistent-type-imports for types

### DIFF
--- a/ui/apps/platform/src/types/alert.proto.ts
+++ b/ui/apps/platform/src/types/alert.proto.ts
@@ -1,7 +1,7 @@
-import { ContainerImage } from './deployment.proto';
-import { L4Protocol, NetworkEntityInfoType } from './networkFlow.proto';
-import { EnforcementAction, LifecycleStage, Policy, PolicySeverity } from './policy.proto';
-import { ProcessIndicator } from './processIndicator.proto';
+import type { ContainerImage } from './deployment.proto';
+import type { L4Protocol, NetworkEntityInfoType } from './networkFlow.proto';
+import type { EnforcementAction, LifecycleStage, Policy, PolicySeverity } from './policy.proto';
+import type { ProcessIndicator } from './processIndicator.proto';
 
 // Alert is for violation page.
 

--- a/ui/apps/platform/src/types/clusterService.proto.ts
+++ b/ui/apps/platform/src/types/clusterService.proto.ts
@@ -1,4 +1,4 @@
-import { Cluster } from './cluster.proto';
+import type { Cluster } from './cluster.proto';
 
 export type DeploymentFormat = 'KUBECTL' | 'HELM' | 'HELM_VALUES';
 

--- a/ui/apps/platform/src/types/deployment.proto.ts
+++ b/ui/apps/platform/src/types/deployment.proto.ts
@@ -1,8 +1,8 @@
-import { ContainerRuntimeType } from './containerRuntime.proto';
-import { ImageName } from './image.proto';
-import { MatchLabelsSelector } from './labels.proto';
-import { PermissionLevel } from './rbac.proto';
-import { Toleration } from './taints.proto';
+import type { ContainerRuntimeType } from './containerRuntime.proto';
+import type { ImageName } from './image.proto';
+import type { MatchLabelsSelector } from './labels.proto';
+import type { PermissionLevel } from './rbac.proto';
+import type { Toleration } from './taints.proto';
 
 export type ListDeployment = {
     id: string;

--- a/ui/apps/platform/src/types/externalBackup.proto.ts
+++ b/ui/apps/platform/src/types/externalBackup.proto.ts
@@ -1,5 +1,5 @@
-import { BackupIntegrationType } from './integration';
-import { Schedule } from './schedule.proto';
+import type { BackupIntegrationType } from './integration';
+import type { Schedule } from './schedule.proto';
 
 export type BaseBackupIntegration = {
     id: string;

--- a/ui/apps/platform/src/types/group.proto.ts
+++ b/ui/apps/platform/src/types/group.proto.ts
@@ -1,4 +1,4 @@
-import { Traits } from './traits.proto';
+import type { Traits } from './traits.proto';
 
 export type Group = {
     // GroupProperties define the properties of a group, applying to users when their properties match.

--- a/ui/apps/platform/src/types/imageIntegration.proto.ts
+++ b/ui/apps/platform/src/types/imageIntegration.proto.ts
@@ -1,4 +1,4 @@
-import { ImageIntegrationType } from './integration';
+import type { ImageIntegrationType } from './integration';
 
 export type BaseImageIntegration = {
     id: string;

--- a/ui/apps/platform/src/types/integration.ts
+++ b/ui/apps/platform/src/types/integration.ts
@@ -1,4 +1,4 @@
-import { AuthMachineToMachineConfig } from 'services/MachineAccessService';
+import type { AuthMachineToMachineConfig } from 'services/MachineAccessService';
 
 export type IntegrationSource =
     | 'authProviders'

--- a/ui/apps/platform/src/types/networkBaseline.proto.ts
+++ b/ui/apps/platform/src/types/networkBaseline.proto.ts
@@ -1,4 +1,4 @@
-import { L4Protocol, NetworkEntity } from './networkFlow.proto';
+import type { L4Protocol, NetworkEntity } from './networkFlow.proto';
 
 export type NetworkBaselineConnectionProperties = {
     // Whether this connection is an ingress/egress, from the PoV of the deployment whose baseline this is in

--- a/ui/apps/platform/src/types/networkPolicy.proto.ts
+++ b/ui/apps/platform/src/types/networkPolicy.proto.ts
@@ -1,4 +1,4 @@
-import { LabelSelector, MatchLabelsSelector } from './labels.proto';
+import type { LabelSelector, MatchLabelsSelector } from './labels.proto';
 
 export type NetworkPolicy = {
     id: string;

--- a/ui/apps/platform/src/types/networkPolicyService.ts
+++ b/ui/apps/platform/src/types/networkPolicyService.ts
@@ -1,7 +1,7 @@
 // Some types in this file were modified for readability.
 // Check out proto/api/v1/network_policy_service.proto for the proper names
-import { NetworkBaselineConnectionProperties } from './networkBaseline.proto';
-import { NetworkEntityInfo } from './networkFlow.proto';
+import type { NetworkBaselineConnectionProperties } from './networkBaseline.proto';
+import type { NetworkEntityInfo } from './networkFlow.proto';
 
 export type ReconciledDiffFlows = {
     entity: NetworkEntityInfo;

--- a/ui/apps/platform/src/types/node.proto.ts
+++ b/ui/apps/platform/src/types/node.proto.ts
@@ -1,6 +1,6 @@
-import { ContainerRuntimeInfo } from './containerRuntime.proto';
-import { Taint } from './taints.proto';
-import { EmbeddedVulnerability } from './vulnerability.proto';
+import type { ContainerRuntimeInfo } from './containerRuntime.proto';
+import type { Taint } from './taints.proto';
+import type { EmbeddedVulnerability } from './vulnerability.proto';
 
 // Node represents information about a node in the cluster.
 export type Node = {

--- a/ui/apps/platform/src/types/notifier.proto.ts
+++ b/ui/apps/platform/src/types/notifier.proto.ts
@@ -1,6 +1,6 @@
-import { KeyValuePair } from './common.proto';
-import { PolicySeverity } from './policy.proto';
-import { Traits } from './traits.proto';
+import type { KeyValuePair } from './common.proto';
+import type { PolicySeverity } from './policy.proto';
+import type { Traits } from './traits.proto';
 
 export type NotifierIntegration =
     | AWSSecurityHubNotifierIntegration

--- a/ui/apps/platform/src/types/reportJob.ts
+++ b/ui/apps/platform/src/types/reportJob.ts
@@ -1,4 +1,4 @@
-import { SlimUser } from 'types/user.proto';
+import type { SlimUser } from 'types/user.proto';
 
 export type Snapshot = {
     reportJobId: string;

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -1,4 +1,4 @@
-import { AggregateFunc } from './table';
+import type { AggregateFunc } from './table';
 
 /*
  * Examples of search filter object properties parsed from search query string:

--- a/ui/apps/platform/src/types/table.ts
+++ b/ui/apps/platform/src/types/table.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import * as yup from 'yup';
 
 export type { ThProps } from '@patternfly/react-table';

--- a/ui/apps/platform/src/types/vulnerability.proto.ts
+++ b/ui/apps/platform/src/types/vulnerability.proto.ts
@@ -1,4 +1,4 @@
-import { CVSSV2, CVSSV3, VulnerabilitySeverity, VulnerabilityState } from './cve.proto';
+import type { CVSSV2, CVSSV3, VulnerabilitySeverity, VulnerabilityState } from './cve.proto';
 
 export type VulnerabilityType =
     | 'UNKNOWN_VULNERABILITY'


### PR DESCRIPTION
### Description

Third batch in a folder less likely to have merge conflicts with unmerged work in progress.

https://typescript-eslint.io/rules/consistent-type-imports/

> TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime.

> This allows transpilers to drop imports without knowing the types of the dependencies.

### Procedure

Temporarily add `'@typescript-eslint/consistent-type-imports': 'error'` to configuration for product files, grep and sort file names.

### Residue

1. Add opt-in and opt-out configuration options after we merge opt-out configuration options for limited lint rules in #16022

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.