### PR TITLE
ROX-30268: Use consistent-type-imports for constants and messages

### DIFF
--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -1,5 +1,5 @@
 /* constants specific to Roles */
-import { ResourceName } from '../types/roleResources';
+import type { ResourceName } from '../types/roleResources';
 
 export const NO_ACCESS = 'NO_ACCESS';
 export const READ_ACCESS = 'READ_ACCESS';

--- a/ui/apps/platform/src/constants/enforcementActions.ts
+++ b/ui/apps/platform/src/constants/enforcementActions.ts
@@ -1,4 +1,4 @@
-import { EnforcementAction } from 'types/policy.proto';
+import type { EnforcementAction } from 'types/policy.proto';
 
 export const ENFORCEMENT_ACTIONS: Record<EnforcementAction, string> = Object.freeze({
     UNSET_ENFORCEMENT: 'UNSET_ENFORCEMENT',

--- a/ui/apps/platform/src/constants/entityTypes.ts
+++ b/ui/apps/platform/src/constants/entityTypes.ts
@@ -1,4 +1,4 @@
-import { SearchCategory } from 'services/SearchService';
+import type { SearchCategory } from 'services/SearchService';
 
 export type ResourceType =
     | 'NAMESPACE'

--- a/ui/apps/platform/src/constants/networkFlow.ts
+++ b/ui/apps/platform/src/constants/networkFlow.ts
@@ -1,4 +1,4 @@
-import { L4Protocol } from 'types/networkFlow.proto';
+import type { L4Protocol } from 'types/networkFlow.proto';
 
 export const l4ProtocolLabels: Record<L4Protocol, string> = {
     L4_PROTOCOL_UNKNOWN: 'Unknown',

--- a/ui/apps/platform/src/constants/reportConstants.ts
+++ b/ui/apps/platform/src/constants/reportConstants.ts
@@ -1,4 +1,4 @@
-import { Fixability } from 'services/ReportsService.types';
+import type { Fixability } from 'services/ReportsService.types';
 
 export type FixabilityLabelKey = Exclude<Fixability, 'BOTH'>;
 type FixabilityLabels = Record<FixabilityLabelKey, string>;

--- a/ui/apps/platform/src/constants/severityColors.ts
+++ b/ui/apps/platform/src/constants/severityColors.ts
@@ -1,5 +1,5 @@
-import { VulnerabilitySeverity } from 'types/cve.proto';
-import { PolicySeverity } from 'types/policy.proto';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
+import type { PolicySeverity } from 'types/policy.proto';
 
 export const noViolationsClassName = 'pf-v5-u-color-200';
 export const noViolationsColor = 'var(--pf-v5-global--Color--200)';

--- a/ui/apps/platform/src/constants/vulnerabilities.ts
+++ b/ui/apps/platform/src/constants/vulnerabilities.ts
@@ -1,4 +1,4 @@
-import { VulnerabilitySeverity } from 'types/cve.proto';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
 
 export const severityRankings: Record<VulnerabilitySeverity, number> = {
     UNKNOWN_VULNERABILITY_SEVERITY: 0,

--- a/ui/apps/platform/src/messages/common.ts
+++ b/ui/apps/platform/src/messages/common.ts
@@ -1,5 +1,5 @@
-import { AccessControlEntityType, RbacConfigType } from 'constants/entityTypes';
-import {
+import type { AccessControlEntityType, RbacConfigType } from 'constants/entityTypes';
+import type {
     EnforcementAction,
     LifecycleStage,
     PolicyEventSource,


### PR DESCRIPTION
### Description

Batch 4 in a folder less likely to have merge conflicts with unmerged work in progress.

https://typescript-eslint.io/rules/consistent-type-imports/

> TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime.

> This allows transpilers to drop imports without knowing the types of the dependencies.

### Procedure

Temporarily add `'@typescript-eslint/consistent-type-imports': 'error'` to configuration for product files, grep and sort file names.

### Residue

1. Add opt-in and opt-out configuration options after we merge opt-out configuration options for limited lint rules in #16022

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.