### PR TITLE
ROX-29060: Add gauge metrics for collections used in enrichment

### DIFF
--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -661,7 +661,7 @@ func computeUpdatedEndpoints(current map[containerEndpointIndicator]timestamp.Mi
 func computeUpdatedProcesses(current map[processListeningIndicator]timestamp.MicroTS, previous map[processListeningIndicator]timestamp.MicroTS, previousMutex *sync.RWMutex) []*storage.ProcessListeningOnPortFromSensor {
 	if !env.ProcessesListeningOnPort.BooleanSetting() {
 		if len(current) > 0 {
-			logging.GetRateLimitedLogger().Warn(loggingRateLimiter,
+			logging.GetRateLimitedLogger().WarnL(loggingRateLimiter,
 				"Received process while ProcessesListeningOnPort feature is disabled. This may indicate a misconfiguration.")
 		}
 		return []*storage.ProcessListeningOnPortFromSensor{}

--- a/sensor/common/networkflow/metrics/metrics.go
+++ b/sensor/common/networkflow/metrics/metrics.go
@@ -7,6 +7,8 @@ import (
 
 func init() {
 	prometheus.MustRegister(
+		EnrichmentCollectionsSize,
+
 		// Host Connections
 		NetworkConnectionInfoMessagesRcvd,
 		NumUpdated,
@@ -38,6 +40,13 @@ const (
 
 // Metrics for network flows
 var (
+	EnrichmentCollectionsSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      hostConnectionsPrefix + "collections_size_current",
+		Help:      "Current size of given collection involved in enrichment",
+	}, []string{"Name", "Type"})
+
 	// A networkConnectionInfo message arrives from collector
 
 	// NetworkConnectionInfoMessagesRcvd - 1. Collector sends NetworkConnection Info messages where each contains endpoints and connections


### PR DESCRIPTION
This PR was a part of a stack, so it misses the PR template.

## Description

The PR includes the following:
- Adds gauge metrics for the size of collections used in the enrichment, so that we can always see how long is a given slice/map
- Fixes the log-rate-limiter issue (missed that in #15076)
- Applies one tiny performance optimization when copying maps to a slice - this has been proposed by Cursor and benchmarked by me.

## Testing

- Unit tests
- Deploying on a cluster and looking at the metrics
- Using #16151 in Grafana to look at the metrics