### PR TITLE
ROX-30140: remove t.Parallel()

### DIFF
--- a/central/administration/events/handler/handler_test.go
+++ b/central/administration/events/handler/handler_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestEventsHandler(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(handlerTestSuite))
 }
 

--- a/central/administration/events/service/service_impl_test.go
+++ b/central/administration/events/service/service_impl_test.go
@@ -38,7 +38,6 @@ func TestAuthz(t *testing.T) {
 }
 
 func TestAdministrationEventsService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(countEventsTestSuite))
 	suite.Run(t, new(getEventTestSuite))
 	suite.Run(t, new(listEventsTestSuite))
@@ -173,7 +172,6 @@ func (s *listEventsTestSuite) TestListAdministrationEvents_Error() {
 // Test query builder
 
 func TestAdministrationEventsQueryBuilder(t *testing.T) {
-	t.Parallel()
 	filter := &v1.AdministrationEventsFilter{
 		From:         protoconv.ConvertTimeToTimestamp(time.Unix(1000, 0)),
 		Until:        protoconv.ConvertTimeToTimestamp(time.Unix(10000, 0)),
@@ -195,7 +193,6 @@ func TestAdministrationEventsQueryBuilder(t *testing.T) {
 }
 
 func TestAdministrationEventsQueryBuilderNilFilter(t *testing.T) {
-	t.Parallel()
 	queryBuilder := getQueryBuilderFromFilter(nil)
 
 	rawQuery, err := queryBuilder.RawQuery()

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -342,7 +342,6 @@ func (s *alertDataStoreTestSuite) TestUpsert_PlatformComponentAndEntityTypeAssig
 }
 
 func TestAlertDataStoreWithSAC(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(alertDataStoreWithSACTestSuite))
 }
 

--- a/central/alert/service/service_test.go
+++ b/central/alert/service/service_test.go
@@ -28,7 +28,6 @@ var (
 )
 
 func TestAlertService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(getAlertTests))
 	suite.Run(t, new(listAlertsTests))
 	suite.Run(t, new(getAlertsGroupsTests))

--- a/central/apitoken/datastore/datastore_test.go
+++ b/central/apitoken/datastore/datastore_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestTokenDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(apiTokenDataStoreTestSuite))
 }
 

--- a/central/authprovider/datastore/datastore_impl_test.go
+++ b/central/authprovider/datastore/datastore_impl_test.go
@@ -19,7 +19,6 @@ import (
 
 // Separate tests for testing that things are rejected by SAC.
 func TestSACEnforceAuthProviderDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(authProviderDataStoreEnforceTestSuite))
 }
 
@@ -117,7 +116,6 @@ func (s *authProviderDataStoreEnforceTestSuite) TestEnforcesRemove() {
 
 // Test for things that should be allowed by SAC and to confirm storage is used correctly.
 func TestAuthProviderDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(authProviderDataStoreTestSuite))
 }
 

--- a/central/cloudsources/service/service_impl_test.go
+++ b/central/cloudsources/service/service_impl_test.go
@@ -14,7 +14,6 @@ func TestAuthz(t *testing.T) {
 }
 
 func TestCloudSourcesQueryBuilder(t *testing.T) {
-	t.Parallel()
 	filter := &v1.CloudSourcesFilter{
 		Names: []string{"my-integration"},
 		Types: []v1.CloudSource_Type{v1.CloudSource_TYPE_PALADIN_CLOUD, v1.CloudSource_TYPE_OCM},
@@ -29,7 +28,6 @@ func TestCloudSourcesQueryBuilder(t *testing.T) {
 }
 
 func TestCloudSourcesQueryBuilderNilFilter(t *testing.T) {
-	t.Parallel()
 	queryBuilder := getQueryBuilderFromFilter(nil)
 
 	rawQuery, err := queryBuilder.RawQuery()

--- a/central/clusterinit/backend/validation_test.go
+++ b/central/clusterinit/backend/validation_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestClusterInitValidation(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(clusterInitValidationTestSuite))
 }
 

--- a/central/compliance/checks/hipaa_164/check306e/check_test.go
+++ b/central/compliance/checks/hipaa_164/check306e/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/nist800-190/check433/check_test.go
+++ b/central/compliance/checks/nist800-190/check433/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/nist800-190/check442/check_test.go
+++ b/central/compliance/checks/nist800-190/check442/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/nist800-190/check443/check_test.go
+++ b/central/compliance/checks/nist800-190/check443/check_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 func TestNIST443_Success(t *testing.T) {
-	t.Parallel()
 
 	registry := framework.RegistrySingleton()
 	check := registry.Lookup(standardID)
@@ -67,7 +66,6 @@ func TestNIST443_Success(t *testing.T) {
 }
 
 func TestNIST443_Fail(t *testing.T) {
-	t.Parallel()
 
 	registry := framework.RegistrySingleton()
 	check := registry.Lookup(standardID)

--- a/central/compliance/checks/nist800-190/check444/check_test.go
+++ b/central/compliance/checks/nist800-190/check444/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/nist80053/check_ac_14/check_test.go
+++ b/central/compliance/checks/nist80053/check_ac_14/check_test.go
@@ -55,7 +55,6 @@ type testCase struct {
 }
 
 func TestCheckAC14(t *testing.T) {
-	t.Parallel()
 
 	acceptableRole, acceptableBinding := createRoleAndBindToSubject(true, "", systemUnauthenticatedSubject, storage.SubjectKind_GROUP, []*storage.PolicyRule{
 		{

--- a/central/compliance/checks/pcidss32/check121/check_test.go
+++ b/central/compliance/checks/pcidss32/check121/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/pcidss32/check132/check_test.go
+++ b/central/compliance/checks/pcidss32/check132/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/pcidss32/check134/check_test.go
+++ b/central/compliance/checks/pcidss32/check134/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/pcidss32/check135/check_test.go
+++ b/central/compliance/checks/pcidss32/check135/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/pcidss32/check225/check_test.go
+++ b/central/compliance/checks/pcidss32/check225/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/checks/pcidss32/check61/check_test.go
+++ b/central/compliance/checks/pcidss32/check61/check_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(suiteImpl))
 }
 

--- a/central/compliance/datastore/test/datastore_test.go
+++ b/central/compliance/datastore/test/datastore_test.go
@@ -24,7 +24,6 @@ var (
 )
 
 func TestComplianceDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(complianceDataStoreTestSuite))
 }
 
@@ -141,7 +140,6 @@ func (s *complianceDataStoreTestSuite) TestStoreFailure() {
 }
 
 func TestComplianceDataStoreWithSAC(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(complianceDataStoreWithSACTestSuite))
 }
 

--- a/central/compliance/datastore/test/sac_filter_test.go
+++ b/central/compliance/datastore/test/sac_filter_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestSacFilter(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(sacFilterTestSuite))
 }
 

--- a/central/compliance/framework/control_test.go
+++ b/central/compliance/framework/control_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestDoRunCatchesHalt(t *testing.T) {
-	t.Parallel()
 
 	var checkFn = func(ctx ComplianceContext) {
 		halt(errors.New("some error"))
@@ -23,7 +22,6 @@ func TestDoRunCatchesHalt(t *testing.T) {
 }
 
 func TestForEachNode(t *testing.T) {
-	t.Parallel()
 
 	expectedNodeIDs := set.NewStringSet(testNodes[0].Id, testNodes[1].Id)
 
@@ -39,7 +37,6 @@ func TestForEachNode(t *testing.T) {
 }
 
 func TestForEachDeployment(t *testing.T) {
-	t.Parallel()
 
 	expectedDeploymentIDs := set.NewStringSet(testDeployments[0].Id, testDeployments[1].Id)
 

--- a/central/compliance/framework/results_test.go
+++ b/central/compliance/framework/results_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestWithResults(t *testing.T) {
-	t.Parallel()
 
 	results := newResults()
 	stopSig := concurrency.NewErrorSignal()

--- a/central/compliance/framework/run_test.go
+++ b/central/compliance/framework/run_test.go
@@ -49,7 +49,6 @@ var (
 )
 
 func TestEmptyRun(t *testing.T) {
-	t.Parallel()
 
 	run, err := newComplianceRun()
 	require.NoError(t, err)

--- a/central/config/datastore/datastore_test.go
+++ b/central/config/datastore/datastore_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestConfigDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(configDataStoreTestSuite))
 }
 

--- a/central/cve/common/csv/handler_test.go
+++ b/central/cve/common/csv/handler_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestCVEScoping(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(CVEScopingTestSuite))
 }
 

--- a/central/cve/matcher/matcher_test.go
+++ b/central/cve/matcher/matcher_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestCVEMatcher(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(cveMatcherTestSuite))
 }
 

--- a/central/debug/service/service_test.go
+++ b/central/debug/service/service_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestDebugService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(debugServiceTestSuite))
 }
 

--- a/central/declarativeconfig/health/datastore/datastore_impl_test.go
+++ b/central/declarativeconfig/health/datastore/datastore_impl_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestDeclarativeConfigHealthDatastore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(declarativeConfigHealthDatastoreSuite))
 }
 

--- a/central/deployment/service/service_impl_test.go
+++ b/central/deployment/service/service_impl_test.go
@@ -28,7 +28,6 @@ func TestAuthz(t *testing.T) {
 }
 
 func TestLabelsMap(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		name           string

--- a/central/discoveredclusters/service/service_impl_test.go
+++ b/central/discoveredclusters/service/service_impl_test.go
@@ -14,7 +14,6 @@ func TestAuthz(t *testing.T) {
 }
 
 func TestDiscoveredClustersQueryBuilder(t *testing.T) {
-	t.Parallel()
 	filter := &v1.DiscoveredClustersFilter{
 		Names: []string{"my-cluster"},
 		Types: []v1.DiscoveredCluster_Metadata_Type{
@@ -34,7 +33,6 @@ func TestDiscoveredClustersQueryBuilder(t *testing.T) {
 }
 
 func TestDiscoveredClustersQueryBuilderNilFilter(t *testing.T) {
-	t.Parallel()
 	queryBuilder := getQueryBuilderFromFilter(nil)
 
 	rawQuery, err := queryBuilder.RawQuery()

--- a/central/endpoints/legacy_spec_test.go
+++ b/central/endpoints/legacy_spec_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestParseLegacySpec(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		spec     string

--- a/central/externalbackups/datastore/datastore_impl_test.go
+++ b/central/externalbackups/datastore/datastore_impl_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestExtBkpDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(extBkpDataStoreTestSuite))
 }
 

--- a/central/group/datastore/datastore_impl_test.go
+++ b/central/group/datastore/datastore_impl_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestGroupDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(groupDataStoreTestSuite))
 }
 

--- a/central/group/service/service_test.go
+++ b/central/group/service/service_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestUserService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(UserServiceTestSuite))
 }
 

--- a/central/hash/manager/deduper_test.go
+++ b/central/hash/manager/deduper_test.go
@@ -272,7 +272,6 @@ func TestDeduper(t *testing.T) {
 			},
 		},
 	}
-	t.Parallel()
 	for _, c := range cases {
 		testCase := c
 		t.Run(c.testName, func(t *testing.T) {

--- a/central/integrationhealth/datastore/datastore_impl_test.go
+++ b/central/integrationhealth/datastore/datastore_impl_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestIntegrationHealthDatastore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(integrationHealthDatastoreTestSuite))
 }
 

--- a/central/metrics/telemetry/cache_test.go
+++ b/central/metrics/telemetry/cache_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestInfoMetric(t *testing.T) {
-	t.Parallel()
 	cache := newMetricsCache()
 	require.NotNil(t, cache)
 

--- a/central/networkpolicies/datastore/datastore_impl_test.go
+++ b/central/networkpolicies/datastore/datastore_impl_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestNetPolDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(netPolDataStoreTestSuite))
 }
 

--- a/central/networkpolicies/generator/generator_impl_test.go
+++ b/central/networkpolicies/generator/generator_impl_test.go
@@ -45,7 +45,6 @@ type generatorTestSuite struct {
 }
 
 func TestGenerator(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(generatorTestSuite))
 }
 

--- a/central/networkpolicies/generator/ingress_test.go
+++ b/central/networkpolicies/generator/ingress_test.go
@@ -49,7 +49,6 @@ func createDeploymentNode(id, name, namespace string, selectorLabels map[string]
 }
 
 func TestGenerateIngressRule_WithInternetIngress(t *testing.T) {
-	t.Parallel()
 
 	internetNode := &node{
 		entity: networkgraph.Entity{
@@ -81,7 +80,6 @@ func TestGenerateIngressRule_WithInternetIngress(t *testing.T) {
 }
 
 func TestGenerateIngressRule_WithInternetIngress_WithPorts(t *testing.T) {
-	t.Parallel()
 
 	internetNode := &node{
 		entity: networkgraph.Entity{
@@ -147,7 +145,6 @@ func TestGenerateIngressRule_WithInternetIngress_WithPorts(t *testing.T) {
 }
 
 func TestGenerateIngressRule_WithInternetExposure(t *testing.T) {
-	t.Parallel()
 
 	deployment0 := createDeploymentNode("deployment0", "deployment0", "ns", map[string]string{"app": "foo"})
 	deployment1 := createDeploymentNode("deployment1", "deployment1", "ns", nil)
@@ -180,7 +177,6 @@ func TestGenerateIngressRule_WithInternetExposure(t *testing.T) {
 }
 
 func TestGenerateIngressRule_WithInternetExposure_WithPorts(t *testing.T) {
-	t.Parallel()
 
 	deployment0 := createDeploymentNode("deployment0", "deployment0", "ns", map[string]string{"app": "foo"})
 	deployment1 := createDeploymentNode("deployment1", "deployment1", "ns", nil)
@@ -262,7 +258,6 @@ func TestGenerateIngressRule_WithInternetExposure_WithPorts(t *testing.T) {
 }
 
 func TestGenerateIngressRule_WithoutInternet(t *testing.T) {
-	t.Parallel()
 
 	deployment0 := createDeploymentNode("deployment0", "deployment0", "ns1", map[string]string{"app": "foo"})
 	deployment1 := createDeploymentNode("deployment1", "deployment1", "ns2", map[string]string{"app": "bar"})
@@ -313,7 +308,6 @@ func TestGenerateIngressRule_WithoutInternet(t *testing.T) {
 }
 
 func TestGenerateIngressRule_WithoutInternet_WithPorts(t *testing.T) {
-	t.Parallel()
 
 	deployment0 := createDeploymentNode("deployment0", "deployment0", "ns1", map[string]string{"app": "foo"})
 	deployment1 := createDeploymentNode("deployment1", "deployment1", "ns2", map[string]string{"app": "bar"})
@@ -401,7 +395,6 @@ func TestGenerateIngressRule_WithoutInternet_WithPorts(t *testing.T) {
 }
 
 func TestGenerateIngressRule_ScopeAlienDeployment(t *testing.T) {
-	t.Parallel()
 
 	deployment0 := createDeploymentNode("deployment0", "deployment0", "ns1", map[string]string{"app": "foo"})
 	deployment1 := createDeploymentNode("deployment1", "deployment1", "ns2", map[string]string{"app": "bar"})
@@ -435,7 +428,6 @@ func TestGenerateIngressRule_ScopeAlienDeployment(t *testing.T) {
 }
 
 func TestGenerateIngressRule_ScopeAlienNSOnly(t *testing.T) {
-	t.Parallel()
 
 	deployment0 := createDeploymentNode("deployment0", "deployment0", "ns1", map[string]string{"app": "foo"})
 	deployment1 := createDeploymentNode("deployment1", "deployment1", "ns2", map[string]string{"app": "bar"})
@@ -475,7 +467,6 @@ func TestGenerateIngressRule_ScopeAlienNSOnly(t *testing.T) {
 }
 
 func TestGenerateIngressRule_FromProtectedNS(t *testing.T) {
-	t.Parallel()
 
 	tgtDeployment := createDeploymentNode("tgtDeployment", "tgtDeployment", "ns1", nil)
 

--- a/central/networkpolicies/generator/network_policy_util_test.go
+++ b/central/networkpolicies/generator/network_policy_util_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestCheckPolicyType_IngressPolicy(t *testing.T) {
-	t.Parallel()
 
 	ingressPolicy := &storage.NetworkPolicy{
 		Spec: &storage.NetworkPolicySpec{
@@ -22,7 +21,6 @@ func TestCheckPolicyType_IngressPolicy(t *testing.T) {
 }
 
 func TestCheckPolicyType_EgressPolicy(t *testing.T) {
-	t.Parallel()
 
 	egressPolicy := &storage.NetworkPolicy{
 		Spec: &storage.NetworkPolicySpec{
@@ -35,7 +33,6 @@ func TestCheckPolicyType_EgressPolicy(t *testing.T) {
 }
 
 func TestCheckPolicyType_IngressEgressPolicy(t *testing.T) {
-	t.Parallel()
 
 	ingressEgressPolicy := &storage.NetworkPolicy{
 		Spec: &storage.NetworkPolicySpec{
@@ -48,7 +45,6 @@ func TestCheckPolicyType_IngressEgressPolicy(t *testing.T) {
 }
 
 func TestGroupNetworkPolicies(t *testing.T) {
-	t.Parallel()
 
 	policy1 := &storage.NetworkPolicy{
 		Id:        "policy1",
@@ -90,7 +86,6 @@ func TestGroupNetworkPolicies(t *testing.T) {
 }
 
 func TestHasMatchingPolicy_Success(t *testing.T) {
-	t.Parallel()
 
 	policies := []*storage.NetworkPolicy{
 		{
@@ -112,7 +107,6 @@ func TestHasMatchingPolicy_Success(t *testing.T) {
 }
 
 func TestHasMatchingPolicy_WrongNamespace(t *testing.T) {
-	t.Parallel()
 
 	policies := []*storage.NetworkPolicy{
 		{
@@ -134,7 +128,6 @@ func TestHasMatchingPolicy_WrongNamespace(t *testing.T) {
 }
 
 func TestHasMatchingPolicy_WrongTypeOfLabels(t *testing.T) {
-	t.Parallel()
 
 	policies := []*storage.NetworkPolicy{
 		{

--- a/central/networkpolicies/graph/diff_test.go
+++ b/central/networkpolicies/graph/diff_test.go
@@ -81,7 +81,6 @@ func (m nodeSpecMap) toDiff(g *v1.NetworkGraph) *v1.NetworkGraphDiff {
 }
 
 func TestGraphDiffMismatchingNodes(t *testing.T) {
-	t.Parallel()
 
 	g1 := nodeSpecMap{
 		"a": {},
@@ -111,7 +110,6 @@ func TestGraphDiffMismatchingNodes(t *testing.T) {
 }
 
 func TestGraphDiffSameGraph(t *testing.T) {
-	t.Parallel()
 
 	g1 := nodeSpecMap{
 		"a": {adjacencies: adjs{"b", "c"}, policies: pols{}},
@@ -127,7 +125,6 @@ func TestGraphDiffSameGraph(t *testing.T) {
 }
 
 func TestGraphDiffOnlyAdded(t *testing.T) {
-	t.Parallel()
 
 	g1 := nodeSpecMap{
 		"a": {adjacencies: adjs{"b", "c"}, policies: pols{}},
@@ -152,7 +149,6 @@ func TestGraphDiffOnlyAdded(t *testing.T) {
 }
 
 func TestGraphDiffOnlyRemoved(t *testing.T) {
-	t.Parallel()
 
 	g1 := nodeSpecMap{
 		"a": {adjacencies: adjs{"b", "c"}, policies: pols{}},
@@ -177,7 +173,6 @@ func TestGraphDiffOnlyRemoved(t *testing.T) {
 }
 
 func TestGraphDiffAddedAndRemoved(t *testing.T) {
-	t.Parallel()
 
 	g1 := nodeSpecMap{
 		"a": {adjacencies: adjs{"b", "c"}, policies: pols{}},

--- a/central/networkpolicies/graph/graph_builder_test.go
+++ b/central/networkpolicies/graph/graph_builder_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestMatchPolicyPeer(t *testing.T) {
-	t.Parallel()
 
 	t1, err := tree.NewNetworkTreeWrapper([]*storage.NetworkEntityInfo{
 		{
@@ -458,7 +457,6 @@ func TestMatchPolicyPeer(t *testing.T) {
 }
 
 func TestIngressNetworkPolicySelectorAppliesToDeployment(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		name     string

--- a/central/networkpolicies/graph/netpol_util_test.go
+++ b/central/networkpolicies/graph/netpol_util_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestHasEgress(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		name        string
@@ -45,7 +44,6 @@ func TestHasEgress(t *testing.T) {
 }
 
 func TestHasIngress(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		name        string

--- a/central/networkpolicies/graph/port_test.go
+++ b/central/networkpolicies/graph/port_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestNormalizeInPlace(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		name     string
@@ -143,7 +142,6 @@ func TestNormalizeInPlace(t *testing.T) {
 }
 
 func TestIntersectNormalized(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		name           string

--- a/central/networkpolicies/service/service_impl_test.go
+++ b/central/networkpolicies/service/service_impl_test.go
@@ -879,7 +879,6 @@ func checkHasPolicies(policyNames ...string) gomock.Matcher {
 }
 
 func TestCheckAllNamespacesWriteAllowed(t *testing.T) {
-	t.Parallel()
 
 	namespaces := []string{"foo", "bar", "baz", "qux"}
 	clusterID := "clusterA"
@@ -946,7 +945,6 @@ func TestCheckAllNamespacesWriteAllowed(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			ctx := sac.WithGlobalAccessScopeChecker(context.Background(), c.checker)
 			err := checkAllNamespacesWriteAllowed(ctx, clusterID, namespaces...)
 			if c.expectAllowed {
@@ -959,7 +957,6 @@ func TestCheckAllNamespacesWriteAllowed(t *testing.T) {
 }
 
 func TestGetNamespacesFromModification(t *testing.T) {
-	t.Parallel()
 
 	cases := map[string]struct {
 		applyYAML string
@@ -998,7 +995,6 @@ func TestGetNamespacesFromModification(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			mod := &storage.NetworkPolicyModification{
 				ApplyYaml: c.applyYAML,

--- a/central/notifier/datastore/datastsore_test.go
+++ b/central/notifier/datastore/datastsore_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestNotifierDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(notifierDataStoreTestSuite))
 }
 

--- a/central/notifier/service/service_impl_test.go
+++ b/central/notifier/service/service_impl_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestNotifierService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(notifierServiceTestSuite))
 }
 

--- a/central/notifiers/awssh/notifier_test.go
+++ b/central/notifiers/awssh/notifier_test.go
@@ -121,7 +121,6 @@ func mockBatchImportFindingsWithFailures(failures int) func(_ context.Context, i
 }
 
 func TestNotifier(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(notifierTestSuite))
 }
 

--- a/central/notifiers/email/email_test.go
+++ b/central/notifiers/email/email_test.go
@@ -252,7 +252,6 @@ func TestContentBytes(t *testing.T) {
 }
 
 func TestApplyRfc5322LineLengthLimit(t *testing.T) {
-	t.Parallel()
 
 	cases := map[string]struct {
 		in       string
@@ -296,7 +295,6 @@ func TestApplyRfc5322LineLengthLimit(t *testing.T) {
 }
 
 func TestApplyRfc5322TextWordWrap(t *testing.T) {
-	t.Parallel()
 
 	cases := map[string]struct {
 		in       string

--- a/central/policy/handlers/handler_test.go
+++ b/central/policy/handlers/handler_test.go
@@ -33,7 +33,6 @@ var (
 )
 
 func TestPolicyHTTPTestSuite(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(PolicyHandlerTestSuite))
 }
 

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestImagesWithSignaturesQuery(t *testing.T) {
-	t.Parallel()
 
 	testCtx := sac.WithAllAccess(context.Background())
 

--- a/central/role/datastore/datastore_impl_test.go
+++ b/central/role/datastore/datastore_impl_test.go
@@ -54,7 +54,6 @@ func TestAnalystPermSetDoesNotContainAdministration(t *testing.T) {
 }
 
 func TestRoleDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(roleDataStoreTestSuite))
 }
 

--- a/central/role/mapper/store_based_mapper_impl_test.go
+++ b/central/role/mapper/store_based_mapper_impl_test.go
@@ -22,7 +22,6 @@ const (
 )
 
 func TestMapper(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(MapperTestSuite))
 }
 

--- a/central/sac/authorizer/builtin_scoped_authorizer_test.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer_test.go
@@ -47,7 +47,6 @@ var (
 )
 
 func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
-	t.Parallel()
 	clusterEdit := map[string]storage.Access{string(resources.Cluster.Resource): storage.Access_READ_WRITE_ACCESS}
 	complianceEdit := map[string]storage.Access{string(resources.Compliance.Resource): storage.Access_READ_WRITE_ACCESS}
 
@@ -134,7 +133,6 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			trace := observe.NewAuthzTrace()
 			scc := newGlobalScopeCheckerCore(clusters, namespaces, tc.roles, trace)
 			for i, scopeKey := range tc.scopeKeys {
@@ -151,7 +149,6 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 }
 
 func TestScopeCheckerWithParallelAccessAndSharedGlobalScopeChecker(t *testing.T) {
-	t.Parallel()
 	roles := []permissions.ResolvedRole{role(allResourcesView, withAccessTo1Namespace())}
 
 	subScopeChecker := newGlobalScopeCheckerCore(clusters, namespaces, roles, nil)
@@ -241,7 +238,6 @@ func TestScopeCheckerWithParallelAccessAndSharedGlobalScopeChecker(t *testing.T)
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			scc := subScopeChecker
 			for i, scopeKey := range tc.scopeKeys {
 				if i >= len(tc.results) {
@@ -257,7 +253,6 @@ func TestScopeCheckerWithParallelAccessAndSharedGlobalScopeChecker(t *testing.T)
 }
 
 func TestEffectiveAccessScope(t *testing.T) {
-	t.Parallel()
 
 	clusterEdit := map[string]storage.Access{string(resources.Cluster.Resource): storage.Access_READ_WRITE_ACCESS}
 
@@ -687,7 +682,6 @@ func TestEffectiveAccessScope(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			scc := newGlobalScopeCheckerCore(clusters, namespaces, tc.roles, nil)
 			// Checks on the global level SCC scope extraction
 			checkEffectiveAccessScope(t, scc, tc.resource, tc.resultEAS)
@@ -713,13 +707,11 @@ func checkEffectiveAccessScope(t *testing.T, scc sac.ScopeCheckerCore, resource 
 }
 
 func TestGlobalScopeCheckerCore(t *testing.T) {
-	t.Parallel()
 	scc := newGlobalScopeCheckerCore(nil, nil, nil, nil)
 	assert.Equal(t, false, scc.Allowed())
 }
 
 func TestBuiltInScopeAuthorizerPanicsWhenErrorOnComputeAccessScope(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name      string
 		roles     []permissions.ResolvedRole
@@ -741,7 +733,6 @@ func TestBuiltInScopeAuthorizerPanicsWhenErrorOnComputeAccessScope(t *testing.T)
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			scc := newGlobalScopeCheckerCore(clusters, namespaces, tc.roles, nil)
 			for i, scopeKey := range tc.scopeKeys {
 				scc = scc.SubScopeChecker(scopeKey)

--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -45,7 +45,6 @@ import (
 )
 
 func TestSearchCategoryToOptionsMultiMap(t *testing.T) {
-	t.Parallel()
 
 	for cat := range autocompleteCategories {
 		_, ok := categoryToOptionsMultimap[cat]

--- a/central/sensor/service/common/conn_replace_test.go
+++ b/central/sensor/service/common/conn_replace_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestCheckConnReplace(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		a, b      *storage.SensorDeploymentIdentification

--- a/central/sensorupgradeconfig/datastore/datastore_test.go
+++ b/central/sensorupgradeconfig/datastore/datastore_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestSensorUpgradeConfigDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(sensorUpgradeConfigDataStoreTestSuite))
 }
 

--- a/central/serviceidentities/datastore/datastore_impl_test.go
+++ b/central/serviceidentities/datastore/datastore_impl_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestServiceIdentityDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(serviceIdentityDataStoreTestSuite))
 }
 

--- a/central/signatureintegration/datastore/datastore_test.go
+++ b/central/signatureintegration/datastore/datastore_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestSignatureDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(signatureDataStoreTestSuite))
 }
 

--- a/central/user/datastore/datastore_test.go
+++ b/central/user/datastore/datastore_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestUserDataStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(userDataStoreTestSuite))
 }
 

--- a/central/user/datastore/internal/store/store_test.go
+++ b/central/user/datastore/internal/store/store_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestUserStore(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(UserStoreTestSuite))
 }
 

--- a/central/user/service/service_test.go
+++ b/central/user/service/service_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestUserService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(UserServiceTestSuite))
 }
 

--- a/central/vulnmgmt/vulnerabilityrequest/manager/querymgr/query_manager_impl_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/manager/querymgr/query_manager_impl_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestVulnReqQueryManager(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(VulnReqQueryManagerTestSuite))
 }
 

--- a/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/display_name_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr/display_name_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestRequestName(t *testing.T) {
-	t.Parallel()
 
 	layout := "2006/01/02"
 	aug29, err := time.Parse(layout, "2023/08/29")

--- a/central/vulnmgmt/vulnerabilityrequest/service/v2/service_impl_test.go
+++ b/central/vulnmgmt/vulnerabilityrequest/service/v2/service_impl_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestVulnRequestService(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(VulnRequestServiceTestSuite))
 }
 

--- a/operator/internal/central/carotation/rotation_test.go
+++ b/operator/internal/central/carotation/rotation_test.go
@@ -62,7 +62,6 @@ func Test_DetermineAction(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			now, err := time.Parse(time.RFC3339, c.now)
 			require.NoError(t, err)
 

--- a/operator/internal/central/extensions/reconcile_admin_password_test.go
+++ b/operator/internal/central/extensions/reconcile_admin_password_test.go
@@ -154,7 +154,6 @@ func TestReconcileAdminPassword(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			testSecretReconciliation(t, reconcileAdminPassword, c)
 		})
@@ -222,7 +221,6 @@ func TestUpdateStatus(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			result := c.reconcileRun.updateStatus(c.status)
 			assert.Equal(t, c.shouldReturn, result)
 			assert.Equal(t, c.status.Central.AdminPassword.Info, c.reconcileRun.infoUpdate)

--- a/operator/internal/central/extensions/reconcile_central_db_password_test.go
+++ b/operator/internal/central/extensions/reconcile_central_db_password_test.go
@@ -231,7 +231,6 @@ func TestReconcileDBPassword(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			testSecretReconciliation(t, reconcileCentralDBPassword, c)
 		})

--- a/operator/internal/central/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/central/extensions/reconcile_defaulting_test.go
@@ -137,7 +137,6 @@ func TestReconcileScannerV4FeatureDefaultsExtension(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			const centralName = "test-central"
 			central := &platform.Central{
 				TypeMeta: metav1.TypeMeta{

--- a/operator/internal/central/extensions/reconcile_scanner_db_password_test.go
+++ b/operator/internal/central/extensions/reconcile_scanner_db_password_test.go
@@ -90,7 +90,6 @@ func TestReconcileScannerDBPassword(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			testSecretReconciliation(t, reconcileScannerDBPassword, c)
 		})

--- a/operator/internal/central/extensions/reconcile_scanner_v4_db_password_test.go
+++ b/operator/internal/central/extensions/reconcile_scanner_v4_db_password_test.go
@@ -91,7 +91,6 @@ func TestReconcileScannerV4DBPassword(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			testSecretReconciliation(t, reconcileScannerV4DBPassword, c)
 		})

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -456,7 +456,6 @@ func TestCreateCentralTLS(t *testing.T) {
 			continue
 		}
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			testSecretReconciliation(t, reconcileCentralTLS, c)
 		})
@@ -721,7 +720,6 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 
 			primary, err := certgen.GenerateCA()
 			require.NoError(t, err)

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -141,7 +141,6 @@ func TestFeatureDefaultingExtensions(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			const clusterName = "test-cluster"
 			baseSecuredCluster := &platform.SecuredCluster{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/auth/authproviders/refresh_token_cookie_test.go
+++ b/pkg/auth/authproviders/refresh_token_cookie_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestRefreshTokenCookieData_EncodeDecodeRoundTrip(t *testing.T) {
-	t.Parallel()
 
 	data := refreshTokenCookieData{
 		ProviderType: "myProvider",
@@ -28,7 +27,6 @@ func TestRefreshTokenCookieData_EncodeDecodeRoundTrip(t *testing.T) {
 }
 
 func TestRefreshTokenCookieData_EncodeDecodeRoundTrip_WithType(t *testing.T) {
-	t.Parallel()
 
 	data := refreshTokenCookieData{
 		ProviderType: "myProvider",
@@ -49,7 +47,6 @@ func TestRefreshTokenCookieData_EncodeDecodeRoundTrip_WithType(t *testing.T) {
 }
 
 func TestRefreshTokenCookieData_TestEncode(t *testing.T) {
-	t.Parallel()
 
 	data := refreshTokenCookieData{
 		ProviderType: "myProvider",
@@ -75,7 +72,6 @@ func TestRefreshTokenCookieData_TestEncode(t *testing.T) {
 }
 
 func TestRefreshTokenCookieData_TestDecode(t *testing.T) {
-	t.Parallel()
 
 	encoded := "providerType=myProvider&providerId=myProviderID&refreshToken=My%20Token"
 	var decoded refreshTokenCookieData
@@ -93,7 +89,6 @@ func TestRefreshTokenCookieData_TestDecode(t *testing.T) {
 }
 
 func TestRefreshTokenCookieData_TestDecode_WithType(t *testing.T) {
-	t.Parallel()
 
 	encoded := "providerType=myProvider&refreshTokenType=access_token&providerId=myProviderID&refreshToken=My%20Token"
 	var decoded refreshTokenCookieData

--- a/pkg/auth/tokensource/tokensource_test.go
+++ b/pkg/auth/tokensource/tokensource_test.go
@@ -22,7 +22,6 @@ func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
 }
 
 func TestReuseTokenSourceWithForceRefresh(t *testing.T) {
-	t.Parallel()
 	earlyExpiry := time.Minute
 	ts := NewReuseTokenSourceWithInvalidate(&fakeTokenSource{}, earlyExpiry)
 

--- a/pkg/cloudproviders/aws/metadata_test.go
+++ b/pkg/cloudproviders/aws/metadata_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestGetClusterMetadataFromNodeLabels(t *testing.T) {
-	t.Parallel()
 
 	ctx := context.Background()
 	k8sClient := fake.NewSimpleClientset()

--- a/pkg/cloudproviders/azure/attested_vmid_test.go
+++ b/pkg/cloudproviders/azure/attested_vmid_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestAllowedCNs(t *testing.T) {
-	t.Parallel()
 
 	allowedCNs := []string{
 		"metadata.azure.com",

--- a/pkg/cloudproviders/azure/metadata_test.go
+++ b/pkg/cloudproviders/azure/metadata_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestGetMetadata_NotOnAzure(t *testing.T) {
-	t.Parallel()
 
 	_, err := GetMetadata(context.Background())
 	// We might not get metadata info, but we should not get an error.
@@ -21,7 +20,6 @@ func TestGetMetadata_NotOnAzure(t *testing.T) {
 }
 
 func TestGetClusterMetadata(t *testing.T) {
-	t.Parallel()
 
 	ctx := context.Background()
 	k8sClient := fake.NewSimpleClientset()

--- a/pkg/cloudproviders/gcp/auth/client_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/client_manager_impl_test.go
@@ -13,7 +13,6 @@ import (
 
 // TestTokenManager asserts the credentials get is called twice when we expire the token.
 func TestTokenManager(t *testing.T) {
-	t.Parallel()
 	controller := gomock.NewController(t)
 
 	mockCredManager := authMocks.NewMockCredentialsManager(controller)

--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -31,7 +31,6 @@ const (
 )
 
 func TestCredentialManager(t *testing.T) {
-	t.Parallel()
 	cases := map[string]struct {
 		setupFn  func(k8sClient *fake.Clientset) error
 		expected string
@@ -118,7 +117,6 @@ func TestCredentialManager(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
 			manager := newCredentialsManagerImpl(k8sClient, namespace, secretName, func() {})
 			manager.Start()

--- a/pkg/cloudproviders/gcp/metadata_test.go
+++ b/pkg/cloudproviders/gcp/metadata_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestNotOnGCP(t *testing.T) {
-	t.Parallel()
 
 	if !metadata.OnGCE() {
 		_, err := GetMetadata(context.Background())

--- a/pkg/compliance/checks/kubernetes/control_plane_config_test.go
+++ b/pkg/compliance/checks/kubernetes/control_plane_config_test.go
@@ -35,7 +35,6 @@ func TestControlPlaneConfigChecks(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
-			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]
 			require.NotNil(t, standard)

--- a/pkg/compliance/checks/kubernetes/etcd_test.go
+++ b/pkg/compliance/checks/kubernetes/etcd_test.go
@@ -226,7 +226,6 @@ func TestETCDChecks(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
-			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]
 			require.NotNil(t, standard)

--- a/pkg/compliance/checks/kubernetes/master_api_server_test.go
+++ b/pkg/compliance/checks/kubernetes/master_api_server_test.go
@@ -81,7 +81,6 @@ func TestMasterAPIServerChecks(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
-			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]
 			require.NotNil(t, standard)

--- a/pkg/compliance/checks/kubernetes/master_config_test.go
+++ b/pkg/compliance/checks/kubernetes/master_config_test.go
@@ -176,7 +176,6 @@ func TestMasterConfigChecks(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
-			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]
 			require.NotNil(t, standard)

--- a/pkg/compliance/checks/kubernetes/worker_node_config_test.go
+++ b/pkg/compliance/checks/kubernetes/worker_node_config_test.go
@@ -84,7 +84,6 @@ func TestWorkerNodeConfigChecks(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
-			t.Parallel()
 
 			standard := standards.NodeChecks[standards.CISKubernetes]
 			require.NotNil(t, standard)

--- a/pkg/compliance/checks/nist800-190/check421/check_test.go
+++ b/pkg/compliance/checks/nist800-190/check421/check_test.go
@@ -43,7 +43,6 @@ func TestDockerInfoBasedChecks(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(strings.ReplaceAll(c.name, ":", "-"), func(t *testing.T) {
-			t.Parallel()
 
 			checks := standards.NodeChecks[standards.NIST800190]
 			require.NotNil(t, checks)

--- a/pkg/concurrency/error_signal_test.go
+++ b/pkg/concurrency/error_signal_test.go
@@ -18,7 +18,6 @@ var (
 )
 
 func TestErrorSignal_ZeroValueIsTriggered(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	var s ErrorSignal
@@ -33,7 +32,6 @@ func TestErrorSignal_ZeroValueIsTriggered(t *testing.T) {
 }
 
 func TestNewErrorSignalIsNotDone(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewErrorSignal()
@@ -45,7 +43,6 @@ func TestNewErrorSignalIsNotDone(t *testing.T) {
 }
 
 func TestNewErrorSignalResetHasNoEffect(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewErrorSignal()
@@ -60,7 +57,6 @@ func TestNewErrorSignalResetHasNoEffect(t *testing.T) {
 }
 
 func TestErrorSignalTrigger(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewErrorSignal()
@@ -86,7 +82,6 @@ func TestErrorSignalTrigger(t *testing.T) {
 }
 
 func TestErrorSignalTriggerTwiceWithReset(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewErrorSignal()
@@ -122,7 +117,6 @@ func TestErrorSignalTriggerTwiceWithReset(t *testing.T) {
 // Tests that every error that is passed to a *successful* invocation of SignalWithError() is observed by exactly one
 // invocation of ErrorAndReset.
 func TestErrorSignal_SignalAndResetAreAtomic(t *testing.T) {
-	t.Parallel()
 
 	errSig := NewErrorSignal()
 

--- a/pkg/concurrency/flag_test.go
+++ b/pkg/concurrency/flag_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestFlag(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	f := &Flag{}

--- a/pkg/concurrency/signal_test.go
+++ b/pkg/concurrency/signal_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestNewSignalIsNotDone(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewSignal()
@@ -16,7 +15,6 @@ func TestNewSignalIsNotDone(t *testing.T) {
 }
 
 func TestNewSignalResetHasNoEffect(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewSignal()
@@ -27,7 +25,6 @@ func TestNewSignalResetHasNoEffect(t *testing.T) {
 }
 
 func TestSignalTrigger(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewSignal()
@@ -44,7 +41,6 @@ func TestSignalTrigger(t *testing.T) {
 }
 
 func TestSignalTriggerAndReset(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	s := NewSignal()
@@ -61,7 +57,6 @@ func TestSignalTriggerAndReset(t *testing.T) {
 }
 
 func TestSignalDoWithTimeout(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	var done bool

--- a/pkg/concurrency/turnstile_test.go
+++ b/pkg/concurrency/turnstile_test.go
@@ -8,7 +8,6 @@ import (
 
 // Test that a waiting go routine is released with true returned when AllowOne is called.
 func TestWaitSucceeds(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	turnstile := NewTurnstile()
@@ -33,7 +32,6 @@ func TestWaitSucceeds(t *testing.T) {
 
 // Test that a waiting go routine is released with false returned when Close is called.
 func TestWaitWhenClosed(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	turnstile := NewTurnstile()
@@ -54,7 +52,6 @@ func TestWaitWhenClosed(t *testing.T) {
 
 // Test that a waiting go routine is released with false when the cancelWhen Waitable object expires.
 func TestWaitWithCancel(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	turnstile := NewTurnstile()
@@ -80,7 +77,6 @@ func TestWaitWithCancel(t *testing.T) {
 
 // Test that closing more than once returns false.
 func TestRepeateCloseReturnsFalse(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	turnstile := NewTurnstile()

--- a/pkg/concurrency/value_stream_test.go
+++ b/pkg/concurrency/value_stream_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestValueStream_SequentialSync(t *testing.T) {
-	t.Parallel()
 
 	vs := NewValueStream(1)
 	vs.Push(2)
@@ -40,7 +39,6 @@ func TestValueStream_SequentialSync(t *testing.T) {
 }
 
 func TestValueStream_SequentialAsync(t *testing.T) {
-	t.Parallel()
 
 	vs := NewValueStream(1)
 	iter := vs.Iterator(true) // start observing
@@ -83,7 +81,6 @@ func receive(ctx context.Context, t *testing.T, start ValueStreamIter[int], num 
 }
 
 func TestValueStream_ParallelAsync(t *testing.T) {
-	t.Parallel()
 
 	vs := NewValueStream(0)
 	start := vs.Iterator(true) // start observing
@@ -123,7 +120,6 @@ func TestValueStream_ParallelAsync(t *testing.T) {
 }
 
 func TestValueStream_NonStrict(t *testing.T) {
-	t.Parallel()
 
 	vs := NewValueStream(0)
 	it := vs.Iterator(false)
@@ -160,7 +156,6 @@ func TestValueStream_NonStrict(t *testing.T) {
 }
 
 func TestValueStream_SubscribeChan(t *testing.T) {
-	t.Parallel()
 
 	vs := NewValueStream(0)
 

--- a/pkg/concurrency/wait_group_test.go
+++ b/pkg/concurrency/wait_group_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestNewWaitGroup_WithZeroIsDone(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	wg := NewWaitGroup(0)
@@ -16,7 +15,6 @@ func TestNewWaitGroup_WithZeroIsDone(t *testing.T) {
 }
 
 func TestNewWaitGroup_WithOneIsNotDone(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	wg := NewWaitGroup(1)
@@ -24,7 +22,6 @@ func TestNewWaitGroup_WithOneIsNotDone(t *testing.T) {
 }
 
 func TestWaitGroup_TriggerByAdd(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	wg := NewWaitGroup(1)
@@ -44,7 +41,6 @@ func TestWaitGroup_TriggerByAdd(t *testing.T) {
 }
 
 func TestWaitGroup_TriggerByReset(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	wg := NewWaitGroup(1)
@@ -64,7 +60,6 @@ func TestWaitGroup_TriggerByReset(t *testing.T) {
 }
 
 func TestWaitGroup_ThresholdCrossing(t *testing.T) {
-	t.Parallel()
 	a := assert.New(t)
 
 	wg := NewWaitGroup(-2)

--- a/pkg/containers/ports_test.go
+++ b/pkg/containers/ports_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestCompareExposureLevel(t *testing.T) {
-	t.Parallel()
 
 	assert.True(t, CompareExposureLevel(storage.PortConfig_INTERNAL, storage.PortConfig_EXTERNAL) < 0)
 	assert.True(t, CompareExposureLevel(storage.PortConfig_NODE, storage.PortConfig_INTERNAL) > 0)

--- a/pkg/helm/util/values_test.go
+++ b/pkg/helm/util/values_test.go
@@ -9,14 +9,12 @@ import (
 )
 
 func TestValuesForKVPair_Error_EmptyKey(t *testing.T) {
-	t.Parallel()
 
 	_, err := ValuesForKVPair("", 37)
 	assert.Error(t, err)
 }
 
 func TestValuesForKVPair_FlatKey(t *testing.T) {
-	t.Parallel()
 
 	vals, err := ValuesForKVPair("foo", 42)
 	require.NoError(t, err)
@@ -28,7 +26,6 @@ func TestValuesForKVPair_FlatKey(t *testing.T) {
 }
 
 func TestValuesForKVPair_NestedKey(t *testing.T) {
-	t.Parallel()
 
 	vals, err := ValuesForKVPair("foo.bar.baz", 1337)
 	require.NoError(t, err)

--- a/pkg/httputil/status_test.go
+++ b/pkg/httputil/status_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestIs2xxStatusCode(t *testing.T) {
-	t.Parallel()
 
 	cases := map[bool][]int{
 		true: {
@@ -42,7 +41,6 @@ func TestIs2xxStatusCode(t *testing.T) {
 }
 
 func TestIs2xxOr3xxStatusCode(t *testing.T) {
-	t.Parallel()
 
 	cases := map[bool][]int{
 		true: {

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -541,7 +541,6 @@ func TestEnricherFlow(t *testing.T) {
 }
 
 func TestCVESuppression(t *testing.T) {
-	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 

--- a/pkg/ioutils/chain_reader_test.go
+++ b/pkg/ioutils/chain_reader_test.go
@@ -51,7 +51,6 @@ func (r *testReader) Close() error {
 }
 
 func TestChainReadersFull(t *testing.T) {
-	t.Parallel()
 
 	r := ChainReadersEager(
 		strings.NewReader("foo"),
@@ -72,7 +71,6 @@ func TestChainReadersFull(t *testing.T) {
 }
 
 func TestChainReadersEager_AllAreClosed(t *testing.T) {
-	t.Parallel()
 
 	trs := []*testReader{
 		newTestReader("foo"),
@@ -98,7 +96,6 @@ func TestChainReadersEager_AllAreClosed(t *testing.T) {
 }
 
 func TestChainReadersLazy_FutureAreNotClosed(t *testing.T) {
-	t.Parallel()
 
 	trs := []*testReader{
 		newTestReader("foo"),
@@ -124,7 +121,6 @@ func TestChainReadersLazy_FutureAreNotClosed(t *testing.T) {
 }
 
 func TestChainReaders_CloseErrorPropagation(t *testing.T) {
-	t.Parallel()
 
 	trs := []*testReader{
 		newTestReader("foo"),

--- a/pkg/ioutils/chan_reader_test.go
+++ b/pkg/ioutils/chan_reader_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestChanReader_ReadSingle(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 1)
 	r := NewChanReader(context.Background(), ch)
@@ -29,7 +28,6 @@ func TestChanReader_ReadSingle(t *testing.T) {
 }
 
 func TestChanReader_ReadChunked(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 1)
 	r := NewChanReader(context.Background(), ch)
@@ -48,7 +46,6 @@ func TestChanReader_ReadChunked(t *testing.T) {
 }
 
 func TestChanReader_ReadBatched(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 2)
 	r := NewChanReader(context.Background(), ch)
@@ -68,7 +65,6 @@ func TestChanReader_ReadBatched(t *testing.T) {
 }
 
 func TestChanReader_ReadClosed(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 1)
 	r := NewChanReader(context.Background(), ch)
@@ -81,7 +77,6 @@ func TestChanReader_ReadClosed(t *testing.T) {
 }
 
 func TestChanReader_ReadError(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 1)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/ioutils/chan_writer_test.go
+++ b/pkg/ioutils/chan_writer_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestChanWriter_WriteSingle(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 1)
 	w := NewChanWriter(context.Background(), ch)
@@ -34,7 +33,6 @@ func TestChanWriter_WriteSingle(t *testing.T) {
 }
 
 func TestChanWriter_WriteMultiNoAlias(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 2)
 	w := NewChanWriter(context.Background(), ch)
@@ -64,7 +62,6 @@ func TestChanWriter_WriteMultiNoAlias(t *testing.T) {
 }
 
 func TestChanWriter_Close(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte, 1)
 	w := NewChanWriter(context.Background(), ch)
@@ -79,7 +76,6 @@ func TestChanWriter_Close(t *testing.T) {
 }
 
 func TestChanWriter_ContextError(t *testing.T) {
-	t.Parallel()
 
 	ch := make(chan []byte)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/ioutils/checksum_reader_test.go
+++ b/pkg/ioutils/checksum_reader_test.go
@@ -179,7 +179,6 @@ func (s *checksumReaderSuite) TestIncompleteRead() {
 }
 
 func TestChecksumReader(t *testing.T) {
-	t.Parallel()
 
 	algos := map[string]hash.Hash{
 		"CRC32IEEE":    crc32.NewIEEE(),
@@ -198,7 +197,6 @@ func TestChecksumReader(t *testing.T) {
 
 	for algoName, algo := range algos {
 		t.Run(algoName, func(t *testing.T) {
-			t.Parallel()
 
 			suite.Run(t, &checksumReaderSuite{
 				algo: algo,

--- a/pkg/ioutils/context_bound_reader_test.go
+++ b/pkg/ioutils/context_bound_reader_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestContextBoundReader_ReadNormal(t *testing.T) {
-	t.Parallel()
 
 	input := strings.NewReader("foobar")
 	cbr := NewContextBoundReader(context.Background(), input)
@@ -31,7 +30,6 @@ func TestContextBoundReader_ReadNormal(t *testing.T) {
 }
 
 func TestContextBoundReader_ReadWithSequentialInterrupt(t *testing.T) {
-	t.Parallel()
 
 	input := strings.NewReader("foobar")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -52,7 +50,6 @@ func TestContextBoundReader_ReadWithSequentialInterrupt(t *testing.T) {
 }
 
 func TestContextBoundReader_ReadWithParallelInterrupt(t *testing.T) {
-	t.Parallel()
 
 	cr := newChunkReader()
 

--- a/pkg/ioutils/error_reader_test.go
+++ b/pkg/ioutils/error_reader_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestErrorReader_SomeError(t *testing.T) {
-	t.Parallel()
 
 	readErr := errors.New("some error during read")
 
@@ -21,7 +20,6 @@ func TestErrorReader_SomeError(t *testing.T) {
 }
 
 func TestErrorReader_NilError(t *testing.T) {
-	t.Parallel()
 
 	var buf [1]byte
 	r := ErrorReader(nil)

--- a/pkg/ioutils/interruptible_reader_test.go
+++ b/pkg/ioutils/interruptible_reader_test.go
@@ -40,7 +40,6 @@ func (r *chunkReader) Read(buf []byte) (int, error) {
 }
 
 func TestInterruptibleReader_InterruptPreRead(t *testing.T) {
-	t.Parallel()
 
 	cr := newChunkReader()
 
@@ -62,7 +61,6 @@ func TestInterruptibleReader_InterruptPreRead(t *testing.T) {
 }
 
 func TestInterruptibleReader_InterruptDuringRead(t *testing.T) {
-	t.Parallel()
 
 	cr := newChunkReader()
 

--- a/pkg/ioutils/readutils_test.go
+++ b/pkg/ioutils/readutils_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestReadAtMost(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		input          string

--- a/pkg/ioutils/sliding_reader_test.go
+++ b/pkg/ioutils/sliding_reader_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestSlidingReader_ReadAll(t *testing.T) {
-	t.Parallel()
 
 	rwr, err := NewSlidingReader(func() io.Reader { return strings.NewReader("foobarbazqux") }, 4, func() hash.Hash { return crc32.NewIEEE() })
 	require.NoError(t, err)
@@ -26,7 +25,6 @@ func TestSlidingReader_ReadAll(t *testing.T) {
 }
 
 func TestSlidingReader_RewindInBuffer(t *testing.T) {
-	t.Parallel()
 
 	readerCreations := 0
 	rwr, err := NewSlidingReader(func() io.Reader {
@@ -54,7 +52,6 @@ func TestSlidingReader_RewindInBuffer(t *testing.T) {
 }
 
 func TestSlidingReader_RewindOutOfBuffer(t *testing.T) {
-	t.Parallel()
 
 	readerCreations := 0
 	rwr, err := NewSlidingReader(func() io.Reader {
@@ -82,7 +79,6 @@ func TestSlidingReader_RewindOutOfBuffer(t *testing.T) {
 }
 
 func TestSlidingReader_RewindOutOfBuffer_WithSeeker(t *testing.T) {
-	t.Parallel()
 
 	readerCreations := 0
 	rwr, err := NewSlidingReader(func() io.Reader {
@@ -110,7 +106,6 @@ func TestSlidingReader_RewindOutOfBuffer_WithSeeker(t *testing.T) {
 }
 
 func TestSlidingReader_FastForwardNear(t *testing.T) {
-	t.Parallel()
 
 	readerCreations := 0
 	rwr, err := NewSlidingReader(func() io.Reader {
@@ -139,7 +134,6 @@ func TestSlidingReader_FastForwardNear(t *testing.T) {
 }
 
 func TestSlidingReader_FastForwardFar(t *testing.T) {
-	t.Parallel()
 
 	readerCreations := 0
 	rwr, err := NewSlidingReader(func() io.Reader {

--- a/pkg/jsonutil/proto_test.go
+++ b/pkg/jsonutil/proto_test.go
@@ -34,7 +34,6 @@ func TestNil(t *testing.T) {
 }
 
 func TestMarshal(t *testing.T) {
-	t.Parallel()
 	output := &bytes.Buffer{}
 	err := Marshal(output, alert())
 	assert.NoError(t, err)
@@ -42,7 +41,6 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestMarshalPretty(t *testing.T) {
-	t.Parallel()
 	output := &bytes.Buffer{}
 	err := MarshalPretty(output, alert())
 	assert.NoError(t, err)
@@ -50,7 +48,6 @@ func TestMarshalPretty(t *testing.T) {
 }
 
 func TestMarshalString(t *testing.T) {
-	t.Parallel()
 	output, err := MarshalToString(alert())
 	assert.NoError(t, err)
 	assert.Equal(t, prettyJson, output)

--- a/pkg/k8scfgwatch/cfg_watcher_test.go
+++ b/pkg/k8scfgwatch/cfg_watcher_test.go
@@ -22,7 +22,6 @@ var (
 )
 
 func TestConfigMapTrigger(t *testing.T) {
-	t.Parallel()
 	cases := map[string]struct {
 		triggerFunc func(*watch.FakeWatcher, *v1.ConfigMap)
 	}{
@@ -44,7 +43,6 @@ func TestConfigMapTrigger(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
 			watcher := watch.NewFake()
 			watchReactor := NewTestWatchReactor(t, watcher)
@@ -96,7 +94,6 @@ func TestConfigMapContextCancelled(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
 			watcher := watch.NewFake()
 			watchReactor := NewTestWatchReactor(t, watcher)

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestCompileSelector_NilMatchesNothing(t *testing.T) {
-	t.Parallel()
 
 	sel, err := CompileSelector(nil)
 	require.NoError(t, err)
@@ -20,7 +19,6 @@ func TestCompileSelector_NilMatchesNothing(t *testing.T) {
 }
 
 func TestCompileSelector_EmptyMatchesEverything(t *testing.T) {
-	t.Parallel()
 
 	sel, err := CompileSelector(&storage.LabelSelector{})
 	require.NoError(t, err)
@@ -31,7 +29,6 @@ func TestCompileSelector_EmptyMatchesEverything(t *testing.T) {
 }
 
 func TestCompileSelector_Simple(t *testing.T) {
-	t.Parallel()
 	sel := &storage.LabelSelector{
 		MatchLabels: map[string]string{
 			"foo": "bar",
@@ -59,7 +56,6 @@ func TestCompileSelector_Simple(t *testing.T) {
 }
 
 func TestCompileSelector_WithRequirements(t *testing.T) {
-	t.Parallel()
 	sel := &storage.LabelSelector{
 		MatchLabels: map[string]string{
 			"foo": "bar",

--- a/pkg/mathutil/mod_test.go
+++ b/pkg/mathutil/mod_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestMod(t *testing.T) {
-	t.Parallel()
 
 	assert.Equal(t, 3, Mod(7, 4))
 	assert.Equal(t, 3, Mod(-5, 4))

--- a/pkg/metrics/tls_test.go
+++ b/pkg/metrics/tls_test.go
@@ -23,7 +23,6 @@ var (
 )
 
 func TestTLSConfigurerServerCertLoading(t *testing.T) {
-	t.Parallel()
 	cfgr := newTLSConfigurer("./testdata", fake.NewSimpleClientset(), "", "")
 	cfgrTLSConfig, err := cfgr.TLSConfig()
 	require.NoError(t, err)
@@ -37,7 +36,6 @@ func TestTLSConfigurerServerCertLoading(t *testing.T) {
 }
 
 func TestTLSConfigurerClientCALoading(t *testing.T) {
-	t.Parallel()
 	k8sClient := fake.NewSimpleClientset()
 	watcher := watch.NewFake()
 	watchReactor := k8scfgwatch.NewTestWatchReactor(t, watcher)
@@ -65,7 +63,6 @@ func TestTLSConfigurerClientCALoading(t *testing.T) {
 }
 
 func TestTLSConfigurerNoClientCAs(t *testing.T) {
-	t.Parallel()
 	k8sClient := fake.NewSimpleClientset()
 	watcher := watch.NewFake()
 	watchReactor := k8scfgwatch.NewTestWatchReactor(t, watcher)

--- a/pkg/metrics/verifier_test.go
+++ b/pkg/metrics/verifier_test.go
@@ -43,7 +43,6 @@ func TestClientCertVerifier(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			certFile, err := os.ReadFile(c.certFilePath)
 			require.NoError(t, err)
 			certs, err := helpers.ParseCertificatesPEM(certFile)

--- a/pkg/net/addr_test.go
+++ b/pkg/net/addr_test.go
@@ -66,7 +66,6 @@ func TestIPv4MappedIPv6FromBytes(t *testing.T) {
 }
 
 func TestIsPublic_True(t *testing.T) {
-	t.Parallel()
 
 	publicIPs := []string{
 		"4.4.4.4",
@@ -85,7 +84,6 @@ func TestIsPublic_True(t *testing.T) {
 }
 
 func TestIsPublic_False(t *testing.T) {
-	t.Parallel()
 
 	privateIPs := []string{
 		"10.127.127.1",
@@ -102,7 +100,6 @@ func TestIsPublic_False(t *testing.T) {
 }
 
 func TestFromCIDRString_Valid(t *testing.T) {
-	t.Parallel()
 
 	cidrs := []string{
 		"192.168.0.1/8",
@@ -119,7 +116,6 @@ func TestFromCIDRString_Valid(t *testing.T) {
 }
 
 func TestFromCIDRString_InValid(t *testing.T) {
-	t.Parallel()
 
 	cidrs := []string{
 		"192.168.0.1/64",
@@ -136,7 +132,6 @@ func TestFromCIDRString_InValid(t *testing.T) {
 }
 
 func TestFromCIDRBytes_Valid(t *testing.T) {
-	t.Parallel()
 
 	cidrs := [][]byte{
 		{192, 168, 0, 1, 8},
@@ -152,7 +147,6 @@ func TestFromCIDRBytes_Valid(t *testing.T) {
 }
 
 func TestFromCIDRBytesInvalid(t *testing.T) {
-	t.Parallel()
 
 	cidrs := [][]byte{
 		{192, 168, 0, 1, 64},

--- a/pkg/netutil/cidr_test.go
+++ b/pkg/netutil/cidr_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestIsIPNetSubnet_Equal(t *testing.T) {
-	t.Parallel()
 
 	net1 := MustParseCIDR("127.0.0.0/8")
 	net2 := MustParseCIDR("127.0.0.0/8")
@@ -16,7 +15,6 @@ func TestIsIPNetSubnet_Equal(t *testing.T) {
 }
 
 func TestIsIPNetSubnet_Disjoint(t *testing.T) {
-	t.Parallel()
 
 	net1 := MustParseCIDR("127.0.0.0/8")
 	net2 := MustParseCIDR("10.0.0.0/8")
@@ -25,7 +23,6 @@ func TestIsIPNetSubnet_Disjoint(t *testing.T) {
 }
 
 func TestIsIPNetSubnet_Contained(t *testing.T) {
-	t.Parallel()
 
 	net1 := MustParseCIDR("127.0.0.0/8")
 	net2 := MustParseCIDR("127.0.1.1/31")
@@ -34,26 +31,22 @@ func TestIsIPNetSubnet_Contained(t *testing.T) {
 }
 
 func TestOverlap_Overlap(t *testing.T) {
-	t.Parallel()
 
 	assert.True(t, Overlap(MustParseCIDR("172.16.0.0/16"), MustParseCIDR("172.16.0.0/24")))
 }
 
 func TestOverlap_NoOverlap(t *testing.T) {
-	t.Parallel()
 
 	assert.False(t, Overlap(MustParseCIDR("127.16.0.0/16"), MustParseCIDR("172.16.0.0/24")))
 }
 
 func TestAnyOverlap_Overlap(t *testing.T) {
-	t.Parallel()
 
 	nets := []*net.IPNet{MustParseCIDR("172.16.0.0/24"), MustParseCIDR("127.16.0.0/16")}
 	assert.True(t, AnyOverlap(MustParseCIDR("172.16.0.0/16"), nets))
 }
 
 func TestAnyOverlap_NoOverlap(t *testing.T) {
-	t.Parallel()
 
 	nets := []*net.IPNet{MustParseCIDR("172.16.0.0/24"), MustParseCIDR("127.16.0.0/16")}
 	assert.False(t, AnyOverlap(MustParseCIDR("126.0.0.0/8"), nets))

--- a/pkg/netutil/default_port_test.go
+++ b/pkg/netutil/default_port_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestWithDefaultPort(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		input    string
@@ -27,7 +26,6 @@ func TestWithDefaultPort(t *testing.T) {
 	for _, c := range cases {
 		// Test names must not contain colons.
 		t.Run(strings.ReplaceAll(c.input, ":", ";"), func(t *testing.T) {
-			t.Parallel()
 			assert.Equal(t, c.expected, WithDefaultPort(c.input, 1337))
 		})
 	}

--- a/pkg/netutil/endpoint_test.go
+++ b/pkg/netutil/endpoint_test.go
@@ -72,7 +72,6 @@ func TestParseEndpoint(t *testing.T) {
 }
 
 func TestParseEndpoint_Valid(t *testing.T) {
-	t.Parallel()
 
 	hosts := []string{
 		"192.168.0.1",

--- a/pkg/netutil/local_test.go
+++ b/pkg/netutil/local_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestIsLocalHost_True(t *testing.T) {
-	t.Parallel()
 
 	hosts := []string{
 		"::1",
@@ -23,7 +22,6 @@ func TestIsLocalHost_True(t *testing.T) {
 }
 
 func TestIsLocalHost_False(t *testing.T) {
-	t.Parallel()
 
 	hosts := []string{
 		"::ffff:7e00:0001",

--- a/pkg/netutil/pipeconn/pipe_listener_test.go
+++ b/pkg/netutil/pipeconn/pipe_listener_test.go
@@ -14,13 +14,11 @@ import (
 )
 
 func TestNetwork(t *testing.T) {
-	t.Parallel()
 
 	assert.Equal(t, Network, pipeAddr.Network())
 }
 
 func TestPipeListener_Connections(t *testing.T) {
-	t.Parallel()
 
 	lis, dialCtx := NewPipeListener()
 
@@ -88,7 +86,6 @@ func TestPipeListener_Connections(t *testing.T) {
 }
 
 func TestPipeListener_Close(t *testing.T) {
-	t.Parallel()
 
 	lis, dialCtx := NewPipeListener()
 

--- a/pkg/notifier/notifier_set_test.go
+++ b/pkg/notifier/notifier_set_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestNotifierSet(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(notifierSetTestSuite))
 }
 

--- a/pkg/probeupload/names_test.go
+++ b/pkg/probeupload/names_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestIsValidModuleVersion_Valid(t *testing.T) {
-	t.Parallel()
 
 	values := []string{
 		"1123dde0458e72a49880b06922e135dbcd36fb784fed530ab84ddfa8924e5c05",
@@ -29,7 +28,6 @@ func TestIsValidModuleVersion_Valid(t *testing.T) {
 }
 
 func TestIsValidModuleVersion_Invalid(t *testing.T) {
-	t.Parallel()
 
 	values := []string{
 		"",
@@ -53,7 +51,6 @@ func TestIsValidModuleVersion_Invalid(t *testing.T) {
 }
 
 func TestIsValidProbeName_Valid(t *testing.T) {
-	t.Parallel()
 
 	values := []string{
 		"collector-4.9.24-coreos.ko.gz",
@@ -70,7 +67,6 @@ func TestIsValidProbeName_Valid(t *testing.T) {
 }
 
 func TestIsValidProbeName_Invalid(t *testing.T) {
-	t.Parallel()
 
 	values := []string{
 		"",
@@ -89,7 +85,6 @@ func TestIsValidProbeName_Invalid(t *testing.T) {
 }
 
 func TestIsValidFilePath_Valid(t *testing.T) {
-	t.Parallel()
 
 	values := []string{
 		"1123dde0458e72a49880b06922e135dbcd36fb784fed530ab84ddfa8924e5c05/collector-4.9.24-coreos.ko.gz",
@@ -106,7 +101,6 @@ func TestIsValidFilePath_Valid(t *testing.T) {
 }
 
 func TestIsValidFilePath_Invalid(t *testing.T) {
-	t.Parallel()
 
 	values := []string{
 		"",

--- a/pkg/protoconv/resources/resources_test.go
+++ b/pkg/protoconv/resources/resources_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestGetVolumeSourceMap(t *testing.T) {
-	t.Parallel()
 
 	secretVol := v1.Volume{
 		Name: "secret",

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestQueue(t *testing.T) {
-	t.Parallel()
 	q := NewQueue[*string]()
 
 	// 1. Adding a new item to the queue.

--- a/pkg/registries/azure/azure_test.go
+++ b/pkg/registries/azure/azure_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestConfigConversion(t *testing.T) {
-	t.Parallel()
 
 	testCases := map[string]struct {
 		input       *storage.ImageIntegration
@@ -110,7 +109,6 @@ func TestConfigConversion(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			cfg, err := getACRConfig(tc.input)
 			if tc.shouldErr {
 				require.Error(t, err)

--- a/pkg/ringbuffer/ring_buffer_test.go
+++ b/pkg/ringbuffer/ring_buffer_test.go
@@ -15,7 +15,6 @@ func concat(slices [][]byte) string {
 }
 
 func TestRingBuffer_NewInstance(t *testing.T) {
-	t.Parallel()
 
 	rb := NewRingBuffer(37)
 	assert.Equal(t, 37, rb.Capacity())
@@ -26,7 +25,6 @@ func TestRingBuffer_NewInstance(t *testing.T) {
 }
 
 func TestRingBuffer_Read(t *testing.T) {
-	t.Parallel()
 
 	rb := NewRingBuffer(4)
 	rb.Write([]byte("foo"), nil)
@@ -54,7 +52,6 @@ func TestRingBuffer_Read(t *testing.T) {
 }
 
 func TestRingBuffer_Write(t *testing.T) {
-	t.Parallel()
 
 	rb := NewRingBuffer(4)
 	var evicted []byte

--- a/pkg/sac/effectiveaccessscope/effective_access_scope_test.go
+++ b/pkg/sac/effectiveaccessscope/effective_access_scope_test.go
@@ -797,7 +797,6 @@ func TestComputeEffectiveAccessScope(t *testing.T) {
 }
 
 func TestMergeScopeTree(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		name    string
 		a, b, c *ScopeTree
@@ -1071,7 +1070,6 @@ func TestMergeScopeTree(t *testing.T) {
 	for _, tc := range testCases {
 		a, b, c := tc.a, tc.b, tc.c
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 
 			a.Merge(b)
 

--- a/pkg/sac/tests/allow_fixed_scopes_checker_core_test.go
+++ b/pkg/sac/tests/allow_fixed_scopes_checker_core_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAllowFixedScopes(t *testing.T) {
-	t.Parallel()
 
 	resA := permissions.ResourceMetadata{
 		Resource: permissions.Resource("resA"),

--- a/pkg/search/paginated/paginated_test.go
+++ b/pkg/search/paginated/paginated_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestPagination(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(paginationTestSuite))
 }
 

--- a/pkg/search/postgres/common_pg_test.go
+++ b/pkg/search/postgres/common_pg_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestContexCancellationInWalk(t *testing.T) {
-	t.Parallel()
 
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -73,7 +73,6 @@ func BenchmarkReplaceVars(b *testing.B) {
 }
 
 func TestMultiTableQueries(t *testing.T) {
-	t.Parallel()
 
 	for _, c := range []struct {
 		desc                        string
@@ -528,7 +527,6 @@ func TestCountQueries(t *testing.T) {
 }
 
 func TestSelectQueries(t *testing.T) {
-	t.Parallel()
 
 	for _, c := range []struct {
 		desc                   string
@@ -826,7 +824,6 @@ func TestSelectQueries(t *testing.T) {
 }
 
 func TestDeleteQueries(t *testing.T) {
-	t.Parallel()
 
 	for _, c := range []struct {
 		desc          string
@@ -981,7 +978,6 @@ func TestDeleteQueries(t *testing.T) {
 }
 
 func TestDeleteReturningIDsQueries(t *testing.T) {
-	t.Parallel()
 
 	for _, c := range []struct {
 		desc          string

--- a/pkg/search/postgres/joins_test.go
+++ b/pkg/search/postgres/joins_test.go
@@ -185,7 +185,6 @@ func getTestData() map[string]testSet {
 }
 
 func TestRemoveUnnecessaryRelations(t *testing.T) {
-	t.Parallel()
 
 	testData := getTestData()
 	for testName, innerTestRecord := range testData {

--- a/pkg/search/postgres/select_query_test.go
+++ b/pkg/search/postgres/select_query_test.go
@@ -83,7 +83,6 @@ type Struct5 struct {
 }
 
 func TestSelectQuery(t *testing.T) {
-	t.Parallel()
 
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)
@@ -514,7 +513,6 @@ type DerivedStruct9 struct {
 }
 
 func TestSelectDerivedFieldQuery(t *testing.T) {
-	t.Parallel()
 
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)

--- a/pkg/search/result_test.go
+++ b/pkg/search/result_test.go
@@ -16,7 +16,6 @@ func createResults(num int) []Result {
 }
 
 func TestRemoveMissingResults_None(t *testing.T) {
-	t.Parallel()
 
 	results := createResults(8)
 	origIDs := ResultsToIDs(results)
@@ -25,7 +24,6 @@ func TestRemoveMissingResults_None(t *testing.T) {
 }
 
 func TestRemoveMissingResults_Some(t *testing.T) {
-	t.Parallel()
 
 	results := createResults(8)
 	filtered := RemoveMissingResults(results, []int{2, 3, 7})
@@ -33,7 +31,6 @@ func TestRemoveMissingResults_Some(t *testing.T) {
 }
 
 func TestRemoveMissingResults_All(t *testing.T) {
-	t.Parallel()
 
 	results := createResults(8)
 	filtered := RemoveMissingResults(results, []int{0, 1, 2, 3, 4, 5, 6, 7})

--- a/pkg/search/scoped/context_test.go
+++ b/pkg/search/scoped/context_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestContext(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(scopedContextTestSuite))
 }
 

--- a/pkg/search/sorted/searcher_test.go
+++ b/pkg/search/sorted/searcher_test.go
@@ -31,7 +31,6 @@ var fakeResults = []search.Result{
 }
 
 func TestSorted(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(sortedTestSuite))
 }
 

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -21,7 +21,6 @@ const (
 )
 
 func TestSecretInformer(t *testing.T) {
-	t.Parallel()
 	cases := map[string]struct {
 		setupFn             func(k8sClient *fake.Clientset) error
 		expectedOnAddCnt    int
@@ -110,7 +109,6 @@ func TestSecretInformer(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			k8sClient := fake.NewSimpleClientset()
 			var onAddCnt, onUpdateCnt, onDeleteCnt int
 			var mutex sync.RWMutex

--- a/pkg/stringutils/consume_test.go
+++ b/pkg/stringutils/consume_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestConsumePrefix(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		input          string
@@ -59,7 +58,6 @@ func TestConsumePrefix(t *testing.T) {
 }
 
 func TestConsumeSuffix(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		input          string

--- a/pkg/stringutils/join_test.go
+++ b/pkg/stringutils/join_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestJoinNonEmpty(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		parts    []string

--- a/pkg/stringutils/longest_common_prefix_test.go
+++ b/pkg/stringutils/longest_common_prefix_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestLongestCommonPrefix(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		a, b     string
@@ -72,7 +71,6 @@ func TestLongestCommonPrefix(t *testing.T) {
 }
 
 func TestLongestCommonPrefixUTF8(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		a, b     string

--- a/pkg/testutils/matchers_test.go
+++ b/pkg/testutils/matchers_test.go
@@ -7,14 +7,12 @@ import (
 )
 
 func TestPredMatcherWithTypeMismatch(t *testing.T) {
-	t.Parallel()
 
 	m := PredMatcher("", func(x string) bool { return true })
 	assert.False(t, m.Matches(3))
 }
 
 func TestPredMatcherWithExactTypeMatch(t *testing.T) {
-	t.Parallel()
 
 	m := PredMatcher("", func(x string) bool { return true })
 	assert.True(t, m.Matches("foo"))
@@ -25,14 +23,12 @@ type mockError struct{}
 func (e mockError) Error() string { return "" }
 
 func TestPredMatcherWithConversionTypeMatch(t *testing.T) {
-	t.Parallel()
 
 	m := PredMatcher("", func(x error) bool { return true })
 	assert.True(t, m.Matches(mockError{}))
 }
 
 func TestAssertionMatcher(t *testing.T) {
-	t.Parallel()
 
 	m := AssertionMatcher(assert.ElementsMatch, []string{"a", "b"})
 	assert.True(t, m.Matches([]string{"b", "a"}))

--- a/pkg/throttle/drop_throttle_test.go
+++ b/pkg/throttle/drop_throttle_test.go
@@ -25,7 +25,6 @@ func maybeRunAndTrack(throttler DropThrottle, wg *sync.WaitGroup, f func()) {
 }
 
 func TestThrottlesFastCalls(t *testing.T) {
-	t.Parallel()
 
 	throttler := NewDropThrottle(500 * time.Millisecond)
 
@@ -65,7 +64,6 @@ func TestThrottlesFastCalls(t *testing.T) {
 }
 
 func TestThrottlesSlowCalls(t *testing.T) {
-	t.Parallel()
 
 	throttler := NewDropThrottle(500 * time.Millisecond)
 

--- a/pkg/timeutil/date_test.go
+++ b/pkg/timeutil/date_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestDate_AddYear(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		base     Date
@@ -42,7 +41,6 @@ func TestDate_AddYear(t *testing.T) {
 }
 
 func TestDate_AddMonth(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		base      Date
@@ -86,7 +84,6 @@ func TestDate_AddMonth(t *testing.T) {
 }
 
 func TestDate_AddDay(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		base     Date

--- a/pkg/timeutil/max_test.go
+++ b/pkg/timeutil/max_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestMaxProtoValid(t *testing.T) {
-	t.Parallel()
 
 	tsProto, err := protocompat.ConvertTimeToTimestampOrError(MaxProtoValid)
 	assert.NoError(t, err)

--- a/pkg/timeutil/weekday_test.go
+++ b/pkg/timeutil/weekday_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestWeekdayOfMonthToDayOfMonth(t *testing.T) {
-	t.Parallel()
 
 	// Jan 1, 2019 is a Tuesday
 

--- a/pkg/utils/must_test.go
+++ b/pkg/utils/must_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestMust_NoErrs(t *testing.T) {
-	t.Parallel()
 
 	assert.NotPanics(t, func() {
 		Must()
@@ -16,7 +15,6 @@ func TestMust_NoErrs(t *testing.T) {
 }
 
 func TestMust_AllNilErrs(t *testing.T) {
-	t.Parallel()
 
 	assert.NotPanics(t, func() {
 		Must(nil, nil, nil)
@@ -24,7 +22,6 @@ func TestMust_AllNilErrs(t *testing.T) {
 }
 
 func TestMust_OneNonNilErr(t *testing.T) {
-	t.Parallel()
 
 	assert.Panics(t, func() {
 		Must(nil, errors.New("some error"), nil)

--- a/pkg/version/kind_test.go
+++ b/pkg/version/kind_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestGetVersionKind(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		versionStr   string

--- a/pkg/waiter/waiter_test.go
+++ b/pkg/waiter/waiter_test.go
@@ -64,7 +64,6 @@ func TestPointerWaiter(t *testing.T) {
 }
 
 func TestWaitCancel(t *testing.T) {
-	t.Parallel()
 	wm := NewManager[string]()
 	wm.Start(context.Background())
 
@@ -87,7 +86,6 @@ func TestWaitCancel(t *testing.T) {
 }
 
 func TestWaitClose(t *testing.T) {
-	t.Parallel()
 	wm := NewManager[string]()
 	wm.Start(context.Background())
 
@@ -112,7 +110,6 @@ func TestWaitClose(t *testing.T) {
 }
 
 func TestCloseManager(t *testing.T) {
-	t.Parallel()
 	wm := NewManager[string]()
 	ctx, cancel := context.WithCancel(context.Background())
 	wm.Start(ctx)
@@ -133,7 +130,6 @@ func TestCloseManager(t *testing.T) {
 }
 
 func TestCloseManagerMany(t *testing.T) {
-	t.Parallel()
 	wm := NewManager[string]()
 	ctx, cancel := context.WithCancel(context.Background())
 	wm.Start(ctx)
@@ -163,7 +159,6 @@ func TestCloseManagerMany(t *testing.T) {
 }
 
 func TestSendToClosedWaiter(t *testing.T) {
-	t.Parallel()
 	wm := NewManager[string]()
 	wm.Start(context.Background())
 
@@ -179,7 +174,6 @@ func TestSendToClosedWaiter(t *testing.T) {
 }
 
 func TestNewWaiterOnShutdownManager(t *testing.T) {
-	t.Parallel()
 	wm := NewManager[string]()
 	ctx, cancel := context.WithCancel(context.Background())
 	wm.Start(ctx)

--- a/roxctl/central/db/restore/v2_test.go
+++ b/roxctl/central/db/restore/v2_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestCentralDBRestore_Validate(t *testing.T) {
-	t.Parallel()
 	testDir := t.TempDir()
 	testFile := path.Join(testDir, "test-file")
 	_, err := os.Create(testFile)
@@ -40,7 +39,6 @@ func TestCentralDBRestore_Validate(t *testing.T) {
 	for name, c := range cases {
 		tc := c
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			err := tc.cmd.validate()
 			if tc.err != nil {
 				assert.Error(t, err)

--- a/roxctl/central/whoami/whoami_test.go
+++ b/roxctl/central/whoami/whoami_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestCentralWhoAmICommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(centralWhoAmITestSuite))
 }
 

--- a/roxctl/cluster/delete/delete_test.go
+++ b/roxctl/cluster/delete/delete_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestClusterDeleteCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(clusterDeleteTestSuite))
 }
 

--- a/roxctl/deployment/check/check_test.go
+++ b/roxctl/deployment/check/check_test.go
@@ -230,7 +230,6 @@ func (m *mockDetectionServiceServer) DetectDeployTimeFromYAML(_ context.Context,
 }
 
 func TestDeploymentCheckCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(deployCheckTestSuite))
 }
 

--- a/roxctl/helm/derivelocalvalues/command_test.go
+++ b/roxctl/helm/derivelocalvalues/command_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestHelmDeriveLocalValuesCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(helmDeriveLocalValuesTestSuite))
 }
 

--- a/roxctl/helm/output/output_test.go
+++ b/roxctl/helm/output/output_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestHelmOutputCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(helmOutputTestSuite))
 }
 

--- a/roxctl/image/check/check_test.go
+++ b/roxctl/image/check/check_test.go
@@ -192,7 +192,6 @@ func (m *mockDetectionServiceServer) DetectBuildTime(context.Context, *v1.BuildD
 }
 
 func TestImageCheckCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(imageCheckTestSuite))
 }
 

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -217,7 +217,6 @@ func (m *mockImageServiceServer) ScanImage(_ context.Context, _ *v1.ScanImageReq
 }
 
 func TestImageScanCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(imageScanTestSuite))
 }
 

--- a/roxctl/maincommand/error_writer_test.go
+++ b/roxctl/maincommand/error_writer_test.go
@@ -41,7 +41,6 @@ func TestErrorWriter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			t.Parallel()
 			io, _, out, errorOut := io.TestIO()
 			ew := errorWriter{
 				logger: logger.NewLogger(io, printer.DefaultColorPrinter()),

--- a/roxctl/netpol/connectivity/diff/diff_test.go
+++ b/roxctl/netpol/connectivity/diff/diff_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestDiffAnalyzeNetpolCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(diffAnalyzeNetpolTestSuite))
 }
 

--- a/roxctl/netpol/connectivity/map/command_test.go
+++ b/roxctl/netpol/connectivity/map/command_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestConnectivityMapCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(connectivityMapCommandSuite))
 }
 

--- a/roxctl/netpol/connectivity/map/map_test.go
+++ b/roxctl/netpol/connectivity/map/map_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestConnectivityMap(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(connectivityMapTestSuite))
 }
 

--- a/roxctl/netpol/generate/generate_test.go
+++ b/roxctl/netpol/generate/generate_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestGenerateNetpolCommand(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, new(generateNetpolTestSuite))
 }
 

--- a/scanner/enricher/csaf/csaf_test.go
+++ b/scanner/enricher/csaf/csaf_test.go
@@ -63,7 +63,6 @@ var (
 )
 
 func TestConfigure(t *testing.T) {
-	t.Parallel()
 	ctx := zlog.Test(context.Background(), t)
 
 	noopConfig := func(_ interface{}) error { return nil }

--- a/scanner/enricher/csaf/internal/zreader/zreader_test.go
+++ b/scanner/enricher/csaf/internal/zreader/zreader_test.go
@@ -27,7 +27,6 @@ var testcases = []struct {
 }
 
 func TestDetect(t *testing.T) {
-	t.Parallel()
 
 	for _, tc := range testcases {
 		t.Run(tc.Kind.String(), func(t *testing.T) {
@@ -52,7 +51,6 @@ func TestDetect(t *testing.T) {
 }
 
 func TestRead(t *testing.T) {
-	t.Parallel()
 
 	for _, tc := range testcases {
 		t.Run(tc.Kind.String(), func(t *testing.T) {

--- a/scanner/enricher/csaf/parser_test.go
+++ b/scanner/enricher/csaf/parser_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestParseEnrichment(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	url, err := url.Parse(baseURL)
 	if err != nil {

--- a/scanner/enricher/nvd/nvd_test.go
+++ b/scanner/enricher/nvd/nvd_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestConfigure(t *testing.T) {
-	t.Parallel()
 	ctx := zlog.Test(context.Background(), t)
 	tt := []configTestcase{
 		{
@@ -108,7 +107,6 @@ func (tc configTestcase) Run(ctx context.Context) func(*testing.T) {
 func noopConfig(_ interface{}) error { return nil }
 
 func TestFetch(t *testing.T) {
-	t.Parallel()
 	ctx := zlog.Test(context.Background(), t)
 	srv := mockServer(t)
 	tt := []fetchTestcase{
@@ -249,7 +247,6 @@ func mockServer(t *testing.T) *httptest.Server {
 }
 
 func TestParse(t *testing.T) {
-	t.Parallel()
 	ctx := zlog.Test(context.Background(), t)
 	srv := mockServer(t)
 	tt := []parseTestcase{
@@ -305,7 +302,6 @@ func (tc parseTestcase) Run(ctx context.Context, srv *httptest.Server) func(*tes
 }
 
 func TestEnrich(t *testing.T) {
-	t.Parallel()
 	ctx := zlog.Test(context.Background(), t)
 	g := newFakeGetter(t, "testdata/feed.json")
 	r := &claircore.VulnerabilityReport{

--- a/sensor/kubernetes/listener/resources/convert_mutating_test.go
+++ b/sensor/kubernetes/listener/resources/convert_mutating_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestConvertDifferentContainerNumbers(t *testing.T) {
-	t.Parallel()
 
 	storeProvider := InitializeStore(nil)
 	cases := []struct {

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -577,7 +577,6 @@ func TestPopulateImageMetadataWithUnqualified(t *testing.T) {
 }
 
 func TestConvert(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		name               string

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -1012,21 +1012,18 @@ func TestStoreGetPermissionLevelForDeployment(t *testing.T) {
 		name := fmt.Sprintf("%q in namespace %q should have %q permision level",
 			tc.deployment.ServiceAccount, tc.deployment.Namespace, tc.expected)
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			assert.Equal(t, tc.expected.String(), store.GetPermissionLevelForDeployment(tc.deployment).String())
 		})
 
 		name = fmt.Sprintf("%q in namespace %q should have NO permisions after removing roles but keeping bindings",
 			tc.deployment.ServiceAccount, tc.deployment.Namespace)
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			assert.Equal(t, storage.PermissionLevel_NONE.String(), storeWithNoRoles.GetPermissionLevelForDeployment(tc.deployment).String())
 		})
 
 		name = fmt.Sprintf("%q in namespace %q should have NO permisions after removing bindings but keeping roles",
 			tc.deployment.ServiceAccount, tc.deployment.Namespace)
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			assert.Equal(t, storage.PermissionLevel_NONE.String(), storeWithNoBindings.GetPermissionLevelForDeployment(tc.deployment).String())
 		})
 	}

--- a/sensor/upgrader/common/bundle_resources_test.go
+++ b/sensor/upgrader/common/bundle_resources_test.go
@@ -10,7 +10,6 @@ import (
 // TestEnsureBundleResourcesTypesAreCorrect exists to make accidental modifications of OrderedBundleResourcesTypes less
 // likely. There is of course no protection against somebody intentionally modifying both lists.
 func TestEnsureBundleResourcesTypesAreCorrect(t *testing.T) {
-	t.Parallel()
 
 	assert.ElementsMatch(t, OrderedBundleResourceTypes, []schema.GroupVersionKind{
 		{Version: "v1", Kind: "Service"},

--- a/sensor/upgrader/common/state_resources_test.go
+++ b/sensor/upgrader/common/state_resources_test.go
@@ -10,7 +10,6 @@ import (
 // TestEnsureStateResourceTypesAreCorrect exists to make accidental modifications of StateResourceTypes less likely.
 // There is of course no protection against somebody intentionally modifying both lists.
 func TestEnsureStateResourceTypesAreCorrect(t *testing.T) {
-	t.Parallel()
 
 	assert.ElementsMatch(t, StateResourceTypes, []schema.GroupVersionKind{
 		{Version: "v1", Kind: "Secret"},

--- a/sensor/upgrader/plan/normalize_object_test.go
+++ b/sensor/upgrader/plan/normalize_object_test.go
@@ -238,7 +238,6 @@ func fromYAML(t *testing.T, yamlStr string) *unstructured.Unstructured {
 }
 
 func TestNormalizeObjects_EqualAfterNormalize(t *testing.T) {
-	t.Parallel()
 
 	liveSA := fromYAML(t, liveServiceAccountYAML)
 	saFromBundle := fromYAML(t, serviceAccountFromBundleYAML)
@@ -249,7 +248,6 @@ func TestNormalizeObjects_EqualAfterNormalize(t *testing.T) {
 }
 
 func TestNormalizeObjects_NotEqualAfterNormalize(t *testing.T) {
-	t.Parallel()
 
 	liveSA := fromYAML(t, liveServiceAccountYAML)
 	modifiedSAFromBundle := fromYAML(t, modifiedServiceAccountFromBundleYAML)
@@ -260,7 +258,6 @@ func TestNormalizeObjects_NotEqualAfterNormalize(t *testing.T) {
 }
 
 func TestNormalizeAdmissionController(t *testing.T) {
-	t.Parallel()
 
 	baseKeys := []string{"clientConfig", "failurePolicy", "name", "namespaceSelector", "rules"}
 

--- a/sensor/upgrader/preflight/namespace_test.go
+++ b/sensor/upgrader/preflight/namespace_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestNamespaceExceptionMatching(t *testing.T) {
-	t.Parallel()
 	cases := map[string]struct {
 		object    *k8sobjects.ObjectRef
 		isAllowed bool

--- a/sensor/upgrader/runner/workflows_test.go
+++ b/sensor/upgrader/runner/workflows_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestWorkflowsAreValid(t *testing.T) {
-	t.Parallel()
 
 	r := &runner{}
 	workflows := sensorupgrader.Workflows()

--- a/tests/api_kernel_support_available_test.go
+++ b/tests/api_kernel_support_available_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestKernelSupportAvailableApi(t *testing.T) {
-	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestPing(t *testing.T) {
-	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/tests/ca_setup_test.go
+++ b/tests/ca_setup_test.go
@@ -28,7 +28,6 @@ func centralIsReleaseBuild(conn *grpc.ClientConn, t *testing.T) bool {
 }
 
 func TestCASetup(t *testing.T) {
-	t.Parallel()
 
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := central.NewDevelopmentServiceClient(conn)

--- a/tests/cert_test.go
+++ b/tests/cert_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestInternalCert(t *testing.T) {
-	t.Parallel()
 
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: true,
@@ -36,7 +35,6 @@ func TestInternalCert(t *testing.T) {
 }
 
 func TestCustomCert(t *testing.T) {
-	t.Parallel()
 
 	testCentralCertCAPEM := os.Getenv("ROX_TEST_CA_PEM")
 	if testCentralCertCAPEM == "" {

--- a/tests/client_ca_test.go
+++ b/tests/client_ca_test.go
@@ -219,7 +219,6 @@ func TestClientCAAuthWithMultipleVerifiedChains(t *testing.T) {
 }
 
 func TestClientCARequested(t *testing.T) {
-	t.Parallel()
 
 	clientCAFile := mustGetEnv(t, "CLIENT_CA_PATH")
 	pemBytes, err := os.ReadFile(clientCAFile)

--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -19,7 +19,6 @@ func TestFeatureFlagSettings(t *testing.T) {
 	if os.Getenv("ORCHESTRATOR_FLAVOR") == "openshift" {
 		t.Skip("Temporarily skipping this test on OCP: TODO(ROX-25171)")
 	}
-	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -30,7 +30,6 @@ func TestMetadataIsSetCorrectly(t *testing.T) {
 	if os.Getenv("ORCHESTRATOR_FLAVOR") == "openshift" {
 		t.Skip("Temporarily skipping this test on OCP: TODO(ROX-25171)")
 	}
-	t.Parallel()
 
 	if _, ok := os.LookupEnv("CI"); !ok {
 		t.Skip("Skipping metadata test because we are not on CI")

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestOptionsMapExist(t *testing.T) {
-	t.Parallel()
 
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	service := v1.NewSearchServiceClient(conn)
@@ -32,7 +31,6 @@ func TestOptionsMapExist(t *testing.T) {
 	} {
 		cat := categories
 		t.Run(fmt.Sprintf("%v", categories), func(t *testing.T) {
-			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			resp, err := service.Options(ctx, &v1.SearchOptionsRequest{Categories: cat})
 			cancel()
@@ -75,7 +73,6 @@ func TestOptionsMap(t *testing.T) {
 	}
 	for _, category := range categories {
 		t.Run(category.String(), func(t *testing.T) {
-			t.Parallel()
 			options := options.GetOptions([]v1.SearchCategory{v1.SearchCategory_DEPLOYMENTS})
 			assert.Equal(t, expectedOptions, options)
 		})

--- a/tests/versions_test.go
+++ b/tests/versions_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestVersions(t *testing.T) {
-	t.Parallel()
 
 	client := centralgrpc.HTTPClientForCentral(t)
 


### PR DESCRIPTION
This PR removes the use of `t.Parallel` to evaluate its impact on test execution time. The change aims to address misleading test output caused by parallel tests when one of them fails. In Go’s testing framework, tests marked with `t.Parallel()` are initially paused.

If a non-parallel test subsequently runs and crashes (e.g., due to a panic), the junit2jira converter seems to misinterpret the results, incorrectly marking the paused parallel tests as failed.