### PR TITLE
refactor: Use explicit values in image signature query builder

### DIFF
--- a/pkg/booleanpolicy/querybuilders/special_cases.go
+++ b/pkg/booleanpolicy/querybuilders/special_cases.go
@@ -203,7 +203,7 @@ func ForImageSignatureVerificationStatus() QueryBuilder {
 		return []*query.FieldQuery{{
 			Field:    search.ImageSignatureVerifiedBy.String(),
 			Values:   mapValues(group, nil),
-			Operator: operatorProtoMap[group.GetBooleanOperator()],
+			Operator: query.Or,
 			Negate:   true,
 		}}
 	}


### PR DESCRIPTION
## Description

The Image Signature query configures the returned `FieldQuery` with two settings that rely on field/criteria defaults, even if they only have an allowed value:

- `Operator`: gets its value from `group.GetBooleanOperator()`, and it must always be `or`.
- `Negate`: gets its value from `!group.Negate`, and it must always be `true`.

This PR changes that to pass the explicit desired values instead, which makes the code more explicit/readable and more defensive: even if unlikely, in the current form the image signature criterion would break if group defaults change.

See below for detailed explanations of both changes.

### Operator field

While other criteria that allow selecting multiple values (e.g. "Kubernetes resource type") enable users to define the boolean operator to apply among the values (e.g. "ClusterRoles" and/or "Secrets"), the image signature criterion only allows the `or` operator (see [validate.go](https://github.com/stackrox/stackrox/blob/22c2f18f00ba9d55324cf435d3c924a75f21017d/pkg/booleanpolicy/validate.go#L71)).

The current implementation of the image signature query builder relies on the default for all policy groups (fields/criteria), which is `or` (see [policy.proto](https://github.com/stackrox/stackrox/blob/22c2f18f00ba9d55324cf435d3c924a75f21017d/proto/storage/policy.proto#L102)). This PR changes the image signature query to use `or` explicitly: that makes the code easier to understand, because it removes the need to check what is the actual operator used by the query.

### Negate field

Image Signature is a "required" criterion, that fires when the condition is **not** met. In order to find violations, we search for the specified integration ID with a negated query, so that we get what has **not** been verified by that integration and therefore violates the criterion.

The existing value of `!group.Negate` likely comes from wanting to support the opposite behavior: give the user the possibility to create a negated signature criterion, so that it fires when the image **is** verified by the specified integration. In those cases the query would need `Negate: false`.

However, the Image Signature Verified by field is configured with negation forbidden, and therefore `group.Negate` is always `false`, see last line here:

```go
	f.registerFieldMetadata(fieldnames.ImageSignatureVerifiedBy,
		querybuilders.ForImageSignatureVerificationStatus(),
		violationmessages.ImageContextFields,
		func(*validateConfiguration) *regexp.Regexp {
			return signatureIntegrationIDValueRegex
		},
		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
		[]RuntimeFieldType{}, negationForbidden)  // <- see negationForbidden here
```

So `!group.Negate` will always be `true`. Let's use that value directly to keep developers from having to investigate this in the future.

Note that forbidding negation is a good UX choice: users most likely don't want to raise violations when their images are correctly signed, so enabling the "Not" checkbox would only increase chances for confusion and challenges.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No functional changes.

### How I validated my change

CI. For completeness, I also tried `Negate: false`: as expected, that caused unit tests to fail, and the "image signature" field fired violations when images are correctly signed by the specified key (opposite to how it should work).