### PR TITLE
ROX-30285: Use consistent-type-imports for reducers and utils

### DIFF
--- a/ui/apps/platform/src/reducers/centralCapabilities.ts
+++ b/ui/apps/platform/src/reducers/centralCapabilities.ts
@@ -1,8 +1,10 @@
-import { Reducer, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import type { Reducer } from 'redux';
 import isEqual from 'lodash/isEqual';
 
-import { PrefixedAction } from 'utils/fetchingReduxRoutines';
-import { fetchCentralCapabilities, CentralServicesCapabilities } from 'services/MetadataService';
+import { fetchCentralCapabilities } from 'services/MetadataService';
+import type { CentralServicesCapabilities } from 'services/MetadataService';
+import type { PrefixedAction } from 'utils/fetchingReduxRoutines';
 
 // Types
 

--- a/ui/apps/platform/src/reducers/feedback.ts
+++ b/ui/apps/platform/src/reducers/feedback.ts
@@ -1,4 +1,5 @@
-import { Reducer, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import type { Reducer } from 'redux';
 
 // Action types
 

--- a/ui/apps/platform/src/reducers/invite.ts
+++ b/ui/apps/platform/src/reducers/invite.ts
@@ -1,4 +1,5 @@
-import { Reducer, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import type { Reducer } from 'redux';
 
 // Action types
 

--- a/ui/apps/platform/src/reducers/metadata.ts
+++ b/ui/apps/platform/src/reducers/metadata.ts
@@ -1,8 +1,9 @@
-import { Reducer, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import type { Reducer } from 'redux';
 import isEqual from 'lodash/isEqual';
 
-import { Metadata } from 'types/metadataService.proto';
-import { PrefixedAction } from 'utils/fetchingReduxRoutines';
+import type { Metadata } from 'types/metadataService.proto';
+import type { PrefixedAction } from 'utils/fetchingReduxRoutines';
 
 // Action types
 

--- a/ui/apps/platform/src/reducers/notifications.ts
+++ b/ui/apps/platform/src/reducers/notifications.ts
@@ -1,4 +1,5 @@
-import { Reducer, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import type { Reducer } from 'redux';
 
 // Action types
 

--- a/ui/apps/platform/src/reducers/publicConfig.ts
+++ b/ui/apps/platform/src/reducers/publicConfig.ts
@@ -1,9 +1,10 @@
-import { Reducer, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import type { Reducer } from 'redux';
 import isEqual from 'lodash/isEqual';
 
 import { fetchPublicConfig } from 'services/SystemConfigService';
-import { PublicConfig } from 'types/config.proto';
-import { PrefixedAction } from 'utils/fetchingReduxRoutines';
+import type { PublicConfig } from 'types/config.proto';
+import type { PrefixedAction } from 'utils/fetchingReduxRoutines';
 import { fetchTelemetryConfigThunk } from './telemetryConfig';
 
 // Action types

--- a/ui/apps/platform/src/reducers/serverResponseStatus.ts
+++ b/ui/apps/platform/src/reducers/serverResponseStatus.ts
@@ -1,4 +1,5 @@
-import { Reducer, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import type { Reducer } from 'redux';
 
 // Action types
 

--- a/ui/apps/platform/src/utils/URLParser.ts
+++ b/ui/apps/platform/src/utils/URLParser.ts
@@ -1,5 +1,7 @@
-import { Location, matchPath } from 'react-router-dom-v5-compat';
-import qs, { ParsedQs } from 'qs';
+import { matchPath } from 'react-router-dom-v5-compat';
+import type { Location } from 'react-router-dom-v5-compat';
+import qs from 'qs';
+import type { ParsedQs } from 'qs';
 
 import useCases from 'constants/useCaseTypes';
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';

--- a/ui/apps/platform/src/utils/analyticsEventTracking.ts
+++ b/ui/apps/platform/src/utils/analyticsEventTracking.ts
@@ -1,11 +1,11 @@
-import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
-import {
+import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import { isSearchCategoryWithFilter } from 'hooks/useAnalytics';
+import type {
     AnalyticsEvent,
     NODE_CVE_FILTER_APPLIED,
     PLATFORM_CVE_FILTER_APPLIED,
     WORKLOAD_CVE_FILTER_APPLIED,
     POLICY_VIOLATIONS_FILTER_APPLIED,
-    isSearchCategoryWithFilter,
 } from 'hooks/useAnalytics';
 
 type FilterAppliedEvent =

--- a/ui/apps/platform/src/utils/chartUtils.ts
+++ b/ui/apps/platform/src/utils/chartUtils.ts
@@ -1,14 +1,10 @@
-import { NavigateFunction } from 'react-router-dom-v5-compat';
-import {
-    ChartBarProps,
-    ChartLabelProps,
-    ChartThemeColor,
-    getTheme,
-} from '@patternfly/react-charts';
+import type { NavigateFunction } from 'react-router-dom-v5-compat';
+import { ChartThemeColor, getTheme } from '@patternfly/react-charts';
+import type { ChartBarProps, ChartLabelProps } from '@patternfly/react-charts';
 import merge from 'lodash/merge';
 
 import { policySeverityColorMap } from 'constants/severityColors';
-import { ValueOf } from './type.utils';
+import type { ValueOf } from './type.utils';
 
 export const solidBlueChartColor = 'var(--pf-v5-global--palette--blue-400)';
 

--- a/ui/apps/platform/src/utils/credentialExpiry.ts
+++ b/ui/apps/platform/src/utils/credentialExpiry.ts
@@ -1,6 +1,6 @@
 import { differenceInDays, distanceInWordsStrict } from 'date-fns';
 
-import { CertExpiryComponent } from 'types/credentialExpiryService.proto';
+import type { CertExpiryComponent } from 'types/credentialExpiryService.proto';
 import { getDateTime } from './dateUtils';
 
 export function getCredentialExpiryPhrase(expirationDate: string, currentDatetime: Date) {

--- a/ui/apps/platform/src/utils/entityRelationships.ts
+++ b/ui/apps/platform/src/utils/entityRelationships.ts
@@ -3,8 +3,8 @@
 // note: the relationships are directional!
 // changing direction may change relationship type between entities!!
 
-import { RelationshipType } from 'constants/relationshipTypes';
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import type { RelationshipType } from 'constants/relationshipTypes';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 
 /*
 // For historical interest: never used.

--- a/ui/apps/platform/src/utils/featureFlagUtils.ts
+++ b/ui/apps/platform/src/utils/featureFlagUtils.ts
@@ -1,5 +1,5 @@
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
-import { FeatureFlagEnvVar } from 'types/featureFlag';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import type { FeatureFlagEnvVar } from 'types/featureFlag';
 
 // Given an array of feature flags, higher-order functions return true or false based on
 // whether all feature flags are enabled or disabled

--- a/ui/apps/platform/src/utils/fileUtils.ts
+++ b/ui/apps/platform/src/utils/fileUtils.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import type { AxiosResponse } from 'axios';
 
 const filenameSanitizerRegex = new RegExp('(:)|(/)|(\\s)', 'gi');
 

--- a/ui/apps/platform/src/utils/getTableUIState.test.ts
+++ b/ui/apps/platform/src/utils/getTableUIState.test.ts
@@ -1,4 +1,5 @@
-import { GetTableUIStateProps, getTableUIState } from './getTableUIState';
+import { getTableUIState } from './getTableUIState';
+import type { GetTableUIStateProps } from './getTableUIState';
 
 type DataType = {
     text: string;

--- a/ui/apps/platform/src/utils/getTableUIState.ts
+++ b/ui/apps/platform/src/utils/getTableUIState.ts
@@ -1,4 +1,4 @@
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 export type IdleState = {
     type: 'IDLE';

--- a/ui/apps/platform/src/utils/orchestratorComponents.ts
+++ b/ui/apps/platform/src/utils/orchestratorComponents.ts
@@ -1,4 +1,4 @@
-import { RestSearchOption } from 'services/searchOptionsToQuery';
+import type { RestSearchOption } from 'services/searchOptionsToQuery';
 
 export const orchestratorComponentsOption: RestSearchOption[] = [
     {

--- a/ui/apps/platform/src/utils/policyUtils.ts
+++ b/ui/apps/platform/src/utils/policyUtils.ts
@@ -1,4 +1,4 @@
-import { Policy } from 'types/policy.proto';
+import type { Policy } from 'types/policy.proto';
 
 // TODO - According to the usage of this function, it does nothing. The only case where a conversion
 //        will occur is when a runtime value does not match the expected TS value in the Policy object.

--- a/ui/apps/platform/src/utils/responseErrorUtils.ts
+++ b/ui/apps/platform/src/utils/responseErrorUtils.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import type { AxiosError } from 'axios';
 
 function isAxiosError(error: Error): error is AxiosError<{ message?: string }> {
     return (

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,9 +1,14 @@
 import qs from 'qs';
 
-import { ApiSortOption, GraphQLSortOption, SearchFilter, ApiSortOptionSingle } from 'types/search';
-import { RestSearchOption } from 'services/searchOptionsToQuery';
-import { Pagination } from 'services/types';
-import { ValueOf } from './type.utils';
+import type { RestSearchOption } from 'services/searchOptionsToQuery';
+import type { Pagination } from 'services/types';
+import type {
+    ApiSortOption,
+    ApiSortOptionSingle,
+    GraphQLSortOption,
+    SearchFilter,
+} from 'types/search';
+import type { ValueOf } from './type.utils';
 import { safeGeneratePath } from './urlUtils';
 
 /**

--- a/ui/apps/platform/src/utils/securityContextUtils.ts
+++ b/ui/apps/platform/src/utils/securityContextUtils.ts
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 
-import { ContainerSecurityContext } from 'types/deployment.proto';
+import type { ContainerSecurityContext } from 'types/deployment.proto';
 
 export function getFilteredSecurityContextMap(
     securityContext: ContainerSecurityContext


### PR DESCRIPTION
### Description

Batch 6 in a folder less likely to have merge conflicts with unmerged work in progress.

Next: Components folder, except for files involved in prerequisites for PatternFly 6 upgrade.

https://typescript-eslint.io/rules/consistent-type-imports/

> TypeScript allows specifying a `type` keyword on imports to indicate that the export exists only in the type system, not at runtime.

> This allows transpilers to drop imports without knowing the types of the dependencies.

### Procedure

Temporarily add `'@typescript-eslint/consistent-type-imports': 'error'` to configuration for product files, grep and sort file names.

### Residue

1. Add opt-in and opt-out configuration options after we merge opt-out configuration options for limited lint rules in #16022

### User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

### Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.