### PR TITLE
chore(PR): Make top section of PR template H2 instead of H3

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-### Description
+# Description
 
 <!--
 A detailed explanation of the changes in your PR. Feel free to remove this
@@ -9,17 +9,17 @@ about contributing to this project, check "*.md" files under:
 
 change me!
 
-### User-facing documentation
+# User-facing documentation
 
 - [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
 - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed
 
-### Testing and quality
+# Testing and quality
 
 - [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
 - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)
 
-#### Automated testing
+## Automated testing
 
 <!--
 If no tests have been contributed, please explain why unless it's obvious,
@@ -32,7 +32,7 @@ e.g., the PR is a one-line comment change.
 - [ ] added compatibility tests
 - [ ] modified existing tests
 
-#### How I validated my change
+## How I validated my change
 
 <!--
 Use this space to explain **how you validated** that **your change functions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Description
+## Description
 
 <!--
 A detailed explanation of the changes in your PR. Feel free to remove this
@@ -9,17 +9,17 @@ about contributing to this project, check "*.md" files under:
 
 change me!
 
-# User-facing documentation
+## User-facing documentation
 
 - [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
 - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed
 
-# Testing and quality
+## Testing and quality
 
 - [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
 - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)
 
-## Automated testing
+### Automated testing
 
 <!--
 If no tests have been contributed, please explain why unless it's obvious,
@@ -32,7 +32,7 @@ e.g., the PR is a one-line comment change.
 - [ ] added compatibility tests
 - [ ] modified existing tests
 
-## How I validated my change
+### How I validated my change
 
 <!--
 Use this space to explain **how you validated** that **your change functions


### PR DESCRIPTION
## Description

### Current state

Before this, each section was H3-level (starting with `###`) that made it difficult to add any structure to the PR description, as one needed to use H4 and H5 section headers, which were small and not well visible.

Example: see the H5 sections used at the bottom of the description of https://github.com/stackrox/stackrox/pull/15076 - do you see how small the text "Enrichment of Endpoints" is?

### Proposed change

If there is no reason for starting with H3, let's start with ~H1 (one `#`)~ H2 (two `##`) to allow devs using H3 in the description and H4 in the testing sections.

Example: this PR.

### Notes to reviewers

I know, this change maybe controversial (intel vs. AMD, pepsi vs. cola), but felt strong urge to open this PR and check the sentiment about it.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Applied the new template to this PR. You are looking at it right now.
