### PR TITLE
ROX-30307: move ranker initialization out of band

### DIFF
--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -43,6 +43,6 @@ type DataStore interface {
 // This should be set to `false` except for some tests.
 func NewWithPostgres(storage store.Store, risks riskDS.DataStore, imageRanker *ranking.Ranker, imageComponentRanker *ranking.Ranker) DataStore {
 	ds := newDatastoreImpl(storage, search.NewV2(storage), risks, imageRanker, imageComponentRanker)
-	ds.initializeRankers()
+	go ds.initializeRankers()
 	return ds
 }

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -308,9 +308,11 @@ func (ds *datastoreImpl) initializeRankers() {
 		return nil
 	})
 	if err != nil {
-		log.Error(err)
+		log.Errorf("unable to initialize image ranking: %v", err)
 		return
 	}
+
+	log.Info("Initialized image ranking")
 }
 
 func (ds *datastoreImpl) updateListImagePriority(images ...*storage.ListImage) {

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/image/datastore/search"
 	"github.com/stackrox/rox/central/image/datastore/store"
+	"github.com/stackrox/rox/central/image/views"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/ranking"
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
@@ -19,12 +20,10 @@ import (
 	"github.com/stackrox/rox/pkg/images/enricher"
 	imageTypes "github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
-	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 )
 
 var (
@@ -312,8 +311,8 @@ func (ds *datastoreImpl) initializeRankers() {
 	query.Selects = selects
 
 	// The entire image is not needed to initialize the ranker.  We only need the image id and risk score.
-	var results []*ImageRiskView
-	results, err := pgSearch.RunSelectRequestForSchema[ImageRiskView](readCtx, globaldb.GetPostgres(), schema.ImagesSchema, query)
+	var results []*views.ImageRiskView
+	results, err := ds.storage.GetImagesRiskView(readCtx, query)
 	if err != nil {
 		log.Errorf("unable to initialize image ranking: %v", err)
 		return

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -319,23 +319,11 @@ func (ds *datastoreImpl) initializeRankers() {
 		return
 	}
 
-	log.Infof("found %d results", len(results))
-
 	for _, result := range results {
 		ds.imageRanker.Add(result.ImageID, result.ImageRiskScore)
 	}
 
-	// The bespoke store does not have a Walk nor a GetByQueryFn.  Thus, WalkByQuery must be used.
-	//err := ds.storage.WalkByQuery(readCtx, pkgSearch.EmptyQuery(), func(image *storage.Image) error {
-	//	ds.imageRanker.Add(image.GetId(), image.GetRiskScore())
-	//	return nil
-	//})
-	//if err != nil {
-	//	log.Errorf("unable to initialize image ranking: %v", err)
-	//	return
-	//}
-
-	log.Info("Initialized image ranking")
+	log.Infof("Initialized image ranking with %d images", len(results))
 }
 
 func (ds *datastoreImpl) updateListImagePriority(images ...*storage.ListImage) {

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -28,8 +28,7 @@ import (
 var (
 	log = logging.LoggerForModule()
 
-	imagesSAC    = sac.ForResource(resources.Image)
-	allAccessCtx = sac.WithAllAccess(context.Background())
+	imagesSAC = sac.ForResource(resources.Image)
 )
 
 type datastoreImpl struct {
@@ -303,6 +302,7 @@ func (ds *datastoreImpl) initializeRankers() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Image)))
 
+	// The bespoke store does not have a Walk nor a GetByQueryFn.  Thus, WalkByQuery must be used.
 	err := ds.storage.WalkByQuery(readCtx, pkgSearch.EmptyQuery(), func(image *storage.Image) error {
 		ds.imageRanker.Add(image.GetId(), image.GetRiskScore())
 		return nil

--- a/central/image/datastore/image_risk_view.go
+++ b/central/image/datastore/image_risk_view.go
@@ -1,0 +1,6 @@
+package datastore
+
+type ImageRiskView struct {
+	ImageID        string  `db:"image_sha"`
+	ImageRiskScore float32 `db:"image_risk_score"`
+}

--- a/central/image/datastore/store/mocks/store.go
+++ b/central/image/datastore/store/mocks/store.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	views "github.com/stackrox/rox/central/image/views"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	search "github.com/stackrox/rox/pkg/search"
@@ -132,6 +133,21 @@ func (m *MockStore) GetImageMetadata(ctx context.Context, id string) (*storage.I
 func (mr *MockStoreMockRecorder) GetImageMetadata(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageMetadata", reflect.TypeOf((*MockStore)(nil).GetImageMetadata), ctx, id)
+}
+
+// GetImagesRiskView mocks base method.
+func (m *MockStore) GetImagesRiskView(ctx context.Context, q *v1.Query) ([]*views.ImageRiskView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImagesRiskView", ctx, q)
+	ret0, _ := ret[0].([]*views.ImageRiskView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImagesRiskView indicates an expected call of GetImagesRiskView.
+func (mr *MockStoreMockRecorder) GetImagesRiskView(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImagesRiskView", reflect.TypeOf((*MockStore)(nil).GetImagesRiskView), ctx, q)
 }
 
 // GetManyImageMetadata mocks base method.

--- a/central/image/datastore/store/store.go
+++ b/central/image/datastore/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	"github.com/stackrox/rox/central/image/views"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/search"
@@ -29,4 +30,7 @@ type Store interface {
 	Delete(ctx context.Context, id string) error
 
 	UpdateVulnState(ctx context.Context, cve string, imageIDs []string, state storage.VulnerabilityState) error
+
+	// GetImagesRiskView retrieves an image id and risk score to initialize rankers
+	GetImagesRiskView(ctx context.Context, q *v1.Query) ([]*views.ImageRiskView, error)
 }

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -1,9 +1,7 @@
 package postgres
 
 import (
-	"cmp"
 	"context"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -600,11 +598,11 @@ func (s *storeImpl) populateImage(ctx context.Context, tx *postgres.Tx, image *s
 		// we pull the data out.  This sort is temporary to keep moving, and will be
 		// removed when the ID of the CVE is adjusted to no longer use the index of where
 		// the CVE occurs in the component list.
-		slices.SortStableFunc(cveParts, func(cvePartA, cvePartB common.CVEParts) int {
-			cveICompIndex := getCVEComponentIndex(cvePartA.CVEV2.GetId())
-			cveJCompIndex := getCVEComponentIndex(cvePartB.CVEV2.GetId())
-			return cmp.Compare(cveICompIndex, cveJCompIndex)
-		})
+		//slices.SortStableFunc(cveParts, func(cvePartA, cvePartB common.CVEParts) int {
+		//	cveICompIndex := getCVEComponentIndex(cvePartA.CVEV2.GetId())
+		//	cveJCompIndex := getCVEComponentIndex(cvePartB.CVEV2.GetId())
+		//	return cmp.Compare(cveICompIndex, cveJCompIndex)
+		//})
 
 		child := common.ComponentParts{
 			ComponentV2: component,

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -593,17 +593,6 @@ func (s *storeImpl) populateImage(ctx context.Context, tx *postgres.Tx, image *s
 			cveParts = append(cveParts, cvePart)
 		}
 
-		// TODO(remove when hashing cve):  Adding the index of where the vuln appeared in the component
-		// is not likely sustainable.  We cannot easily guarantee the order is the same when
-		// we pull the data out.  This sort is temporary to keep moving, and will be
-		// removed when the ID of the CVE is adjusted to no longer use the index of where
-		// the CVE occurs in the component list.
-		//slices.SortStableFunc(cveParts, func(cvePartA, cvePartB common.CVEParts) int {
-		//	cveICompIndex := getCVEComponentIndex(cvePartA.CVEV2.GetId())
-		//	cveJCompIndex := getCVEComponentIndex(cvePartB.CVEV2.GetId())
-		//	return cmp.Compare(cveICompIndex, cveJCompIndex)
-		//})
-
 		child := common.ComponentParts{
 			ComponentV2: component,
 			Children:    cveParts,

--- a/central/image/views/image_risk_view.go
+++ b/central/image/views/image_risk_view.go
@@ -1,4 +1,4 @@
-package datastore
+package views
 
 type ImageRiskView struct {
 	ImageID        string  `db:"image_sha"`

--- a/central/imagecomponent/datastore/datastore.go
+++ b/central/imagecomponent/datastore/datastore.go
@@ -38,7 +38,7 @@ func New(storage store.Store, searcher search.Searcher, risks riskDataStore.Data
 		imageComponentRanker: ranker,
 	}
 
-	ds.initializeRankers()
+	go ds.initializeRankers()
 	return ds
 }
 

--- a/central/imagecomponent/datastore/datastore_impl.go
+++ b/central/imagecomponent/datastore/datastore_impl.go
@@ -82,22 +82,16 @@ func (ds *datastoreImpl) initializeRankers() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Image, resources.Node)))
 
-	results, err := ds.Search(readCtx, pkgSearch.EmptyQuery())
+	err := ds.storage.Walk(readCtx, func(component *storage.ImageComponent) error {
+		ds.imageComponentRanker.Add(component.GetId(), component.GetRiskScore())
+		return nil
+	})
 	if err != nil {
-		log.Error(err)
+		log.Errorf("unable to initialize image component ranking: %v", err)
 		return
 	}
 
-	for _, id := range pkgSearch.ResultsToIDs(results) {
-		component, found, err := ds.storage.Get(readCtx, id)
-		if err != nil {
-			log.Error(err)
-			continue
-		} else if !found {
-			continue
-		}
-		ds.imageComponentRanker.Add(id, component.GetRiskScore())
-	}
+	log.Info("Initialized image component ranking")
 }
 
 func (ds *datastoreImpl) updateImageComponentPriority(ics ...*storage.ImageComponent) {

--- a/central/imagecomponent/store/mocks/store.go
+++ b/central/imagecomponent/store/mocks/store.go
@@ -119,3 +119,17 @@ func (mr *MockStoreMockRecorder) Search(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockStore)(nil).Search), ctx, q)
 }
+
+// Walk mocks base method.
+func (m *MockStore) Walk(ctx context.Context, fn func(*storage.ImageComponent) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Walk", ctx, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Walk indicates an expected call of Walk.
+func (mr *MockStoreMockRecorder) Walk(ctx, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockStore)(nil).Walk), ctx, fn)
+}

--- a/central/imagecomponent/store/store.go
+++ b/central/imagecomponent/store/store.go
@@ -17,5 +17,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (*storage.ImageComponent, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ImageComponent, []int, error)
 
+	Walk(ctx context.Context, fn func(obj *storage.ImageComponent) error) error
+
 	Exists(ctx context.Context, id string) (bool, error)
 }

--- a/central/imagecomponent/v2/datastore/datastore.go
+++ b/central/imagecomponent/v2/datastore/datastore.go
@@ -37,7 +37,7 @@ func New(storage pgStore.Store, searcher search.Searcher, risks riskDataStore.Da
 		imageComponentRanker: ranker,
 	}
 
-	ds.initializeRankers()
+	go ds.initializeRankers()
 	return ds
 }
 

--- a/central/imagecomponent/v2/datastore/datastore_impl.go
+++ b/central/imagecomponent/v2/datastore/datastore_impl.go
@@ -87,9 +87,11 @@ func (ds *datastoreImpl) initializeRankers() {
 		return nil
 	})
 	if err != nil {
-		log.Error(err)
+		log.Errorf("unable to initialize image component ranking: %v", err)
 		return
 	}
+
+	log.Info("Initialized image component ranking")
 }
 
 func (ds *datastoreImpl) updateImageComponentPriority(ics ...*storage.ImageComponentV2) {

--- a/central/imagecomponent/v2/datastore/datastore_impl.go
+++ b/central/imagecomponent/v2/datastore/datastore_impl.go
@@ -82,21 +82,13 @@ func (ds *datastoreImpl) initializeRankers() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Image, resources.Node)))
 
-	results, err := ds.Search(readCtx, pkgSearch.EmptyQuery())
+	err := ds.storage.Walk(readCtx, func(component *storage.ImageComponentV2) error {
+		ds.imageComponentRanker.Add(component.GetId(), component.GetRiskScore())
+		return nil
+	})
 	if err != nil {
 		log.Error(err)
 		return
-	}
-
-	for _, id := range pkgSearch.ResultsToIDs(results) {
-		component, found, err := ds.storage.Get(readCtx, id)
-		if err != nil {
-			log.Error(err)
-			continue
-		} else if !found {
-			continue
-		}
-		ds.imageComponentRanker.Add(id, component.GetRiskScore())
 	}
 }
 

--- a/central/node/datastore/datastore.go
+++ b/central/node/datastore/datastore.go
@@ -42,7 +42,7 @@ type DataStore interface {
 // NewWithPostgres returns a new instance of DataStore using the input store, and searcher.
 func NewWithPostgres(storage store.Store, searcher search.Searcher, risks riskDS.DataStore, nodeRanker *ranking.Ranker, nodeComponentRanker *ranking.Ranker) DataStore {
 	ds := newDatastoreImpl(storage, searcher, risks, nodeRanker, nodeComponentRanker)
-	ds.initializeRankers()
+	go ds.initializeRankers()
 	return ds
 }
 

--- a/central/node/datastore/datastore_impl.go
+++ b/central/node/datastore/datastore_impl.go
@@ -272,9 +272,11 @@ func (ds *datastoreImpl) initializeRankers() {
 		return nil
 	})
 	if err != nil {
-		log.Error(err)
+		log.Errorf("unable to initialize node ranking: %v", err)
 		return
 	}
+
+	log.Info("Initialized node ranking")
 }
 
 func (ds *datastoreImpl) updateNodePriority(nodes ...*storage.Node) {

--- a/central/node/datastore/datastore_impl.go
+++ b/central/node/datastore/datastore_impl.go
@@ -266,6 +266,7 @@ func (ds *datastoreImpl) initializeRankers() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Node)))
 
+	// The bespoke store does not have a Walk nor a GetByQueryFn.  Thus, WalkByQuery must be used.
 	err := ds.storage.WalkByQuery(readCtx, pkgSearch.EmptyQuery(), func(image *storage.Node) error {
 		ds.nodeRanker.Add(image.GetId(), image.GetRiskScore())
 		return nil

--- a/central/nodecomponent/datastore/datastore.go
+++ b/central/nodecomponent/datastore/datastore.go
@@ -37,7 +37,7 @@ func New(storage pgStore.Store, searcher search.Searcher, risks riskDataStore.Da
 		nodeComponentRanker: ranker,
 	}
 
-	ds.initializeRankers()
+	go ds.initializeRankers()
 	return ds
 }
 

--- a/central/nodecomponent/datastore/datastore_impl.go
+++ b/central/nodecomponent/datastore/datastore_impl.go
@@ -82,21 +82,13 @@ func (ds *datastoreImpl) initializeRankers() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Node)))
 
-	results, err := ds.Search(readCtx, pkgSearch.EmptyQuery())
+	err := ds.storage.Walk(readCtx, func(component *storage.NodeComponent) error {
+		ds.nodeComponentRanker.Add(component.GetId(), component.GetRiskScore())
+		return nil
+	})
 	if err != nil {
 		log.Error(err)
 		return
-	}
-
-	for _, id := range pkgSearch.ResultsToIDs(results) {
-		component, found, err := ds.storage.Get(readCtx, id)
-		if err != nil {
-			log.Error(err)
-			continue
-		} else if !found {
-			continue
-		}
-		ds.nodeComponentRanker.Add(id, component.GetRiskScore())
 	}
 }
 

--- a/central/nodecomponent/datastore/datastore_impl.go
+++ b/central/nodecomponent/datastore/datastore_impl.go
@@ -87,9 +87,11 @@ func (ds *datastoreImpl) initializeRankers() {
 		return nil
 	})
 	if err != nil {
-		log.Error(err)
+		log.Errorf("unable to initialize node component ranking: %v", err)
 		return
 	}
+
+	log.Info("Initialized node component ranking")
 }
 
 func (ds *datastoreImpl) updateNodeComponentPriority(ics ...*storage.NodeComponent) {


### PR DESCRIPTION
### Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

initializing rankers at startup can lead to unnecessarily elongated startup times.  Move that to processing in a separate go func.

Additionally the rankers are initialized by a search to pull in ALL the records into a slice and then a second call to get the details.  This can be accomplished with the use of `Walk` or `GetByQueryFn` in a single pass to the database in a way that is much more friendly to memory.

The scope here creeped a little upon testing.  When testing it was obvious that the image rankers were the issue.  The Walk of the image would get the image serialized object and then go get the components one by one and then go get the CVEs one by one.  All we really need is the image ID and the Risk Score such that we can seed the Rankers.  So I'm using our view construct to simply get the id and Risk Score to populate the ranker.  This pulls much less data and makes many viewer queries.  This took startup from several minutes to seconds and while I didn't check, I'm certain consumed far less memory on start up.

### User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

### Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

#### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

#### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Long running 4.7 cluster.  Then upgraded to 4.8 and then to this image taking a look at startup times and memory usages.