### PR TITLE
ci(sensor): run test in a signle command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ go-unit-tests: build-prep test-prep
 .PHONY: sensor-integration-test
 sensor-integration-test: build-prep test-prep
 	set -o pipefail ; \
-	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 LOGLEVEL=debug GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 15m -race -cover -coverprofile test-output/coverage.out -v -p 1 ./sensor/tests/... | tee $(GO_TEST_OUTPUT_PATH)
+	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 LOGLEVEL=debug GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 15m -race -v -p 1 ./sensor/tests/... | tee $(GO_TEST_OUTPUT_PATH)
 
 sensor-pipeline-benchmark: build-prep test-prep
 	LOGLEVEL="panic" go test -bench=. -run=^# -benchtime=30s -count=5 ./sensor/tests/pipeline | tee $(CURDIR)/test-output/pipeline.results.txt


### PR DESCRIPTION
Simplify sensor integration test invocation and remove unused coverage.