### PR TITLE
fix(qa): Fix @Retry annotation default values

### DIFF
--- a/qa-tests-backend/src/test/groovy/RetryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RetryTest.groovy
@@ -19,10 +19,10 @@ class RetryTest extends Specification {
         fail("called", 1)
     }
 
-    private int i = 0
+    private static int i = 0
 
-    @Retry(attempts = 3, delay = 0)
-    def fail(def text, int x) {
+    @Retry(delay = 0)
+    static def fail(def text, int x) {
         assert text
         assert x == 1
         assert i++ > 2, "I was $text $i times"


### PR DESCRIPTION
This PR fixes problem with `@Retry` that does not read default values and uses 0 instead. 

The following code was decompiled from group service and present the change 

```diff
    public static Object createGroup(GroupOuterClass.Group group) {
        final Reference group = new Reference(group);

        final class _createGroup_closure2 extends Closure implements GeneratedClosure {
            public _createGroup_closure2(Object _outerInstance, Object _thisObject) {
                super(_outerInstance, _thisObject);
            }

            public Object doCall(Object it) {
                return ScriptBytecodeAdapter.invokeMethodOnCurrentN(_createGroup_closure2.class, this, "createGroup_with_retry", new Object[]{((Class)group.get()).cast<invokedynamic>(group.get())});
            }

            @Generated
            public GroupOuterClass.Group getGroup() {
                return ((Class)group.get()).cast<invokedynamic>(group.get());
            }

            @Generated
            public Object call(Object args) {
                return this.doCall(args);
            }

            @Generated
            public Object call() {
                return this.doCall((Object)null);
            }

            @Generated
            public Object doCall() {
                return this.doCall((Object)null);
            }
        }

+        return ScriptBytecodeAdapter.invokeStaticMethodN(GroupService.class, Helpers.class, "evaluateWithRetry", new Object[]{3, 1, "services.GroupService.createGroup", new _createGroup_closure2(GroupService.class, GroupService.class)});
-        return ScriptBytecodeAdapter.invokeStaticMethodN(GroupService.class, Helpers.class, "evaluateWithRetry", new Object[]{0, 0, "services.GroupService.createGroup", new _createGroup_closure2(GroupService.class, GroupService.class)});
    }

```