### PR TITLE
ROX-30334: Adds context for OCP plugin user permissions

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/PluginContent.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginContent.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import usePermissions from 'hooks/usePermissions';
+import LoadingSection from 'Components/PatternFly/LoadingSection';
+
+function PluginContent({ children }: { children: React.ReactNode }) {
+    const { isLoadingPermissions } = usePermissions();
+
+    if (isLoadingPermissions) {
+        return <LoadingSection />;
+    }
+
+    return <>{children}</>;
+}
+
+export default PluginContent;

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -1,10 +1,10 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, type ReactNode } from 'react';
 import { ApolloProvider } from '@apollo/client';
 
 import axios from 'services/instance';
 import configureApolloClient from '../init/configureApolloClient';
 import consoleFetchAxiosAdapter from './consoleFetchAxiosAdapter';
-import UserPermissionProvider from './UserPermissionProvider';
+import { UserPermissionProvider } from './UserPermissionProvider';
 import PluginContent from './PluginContent';
 
 // The console requires a custom fetch implementation via `consoleFetch` to correctly pass headers such
@@ -15,7 +15,7 @@ axios.defaults.adapter = (config) => consoleFetchAxiosAdapter(proxyBaseURL, conf
 
 const apolloClient = configureApolloClient();
 
-export function PluginProvider({ children }: { children: React.ReactNode }) {
+export function PluginProvider({ children }: { children: ReactNode }) {
     return (
         <ApolloProvider client={apolloClient}>
             <UserPermissionProvider>

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ApolloProvider } from '@apollo/client';
 
 import axios from 'services/instance';
 import configureApolloClient from '../init/configureApolloClient';
 import consoleFetchAxiosAdapter from './consoleFetchAxiosAdapter';
+import UserPermissionProvider from './UserPermissionProvider';
+import PluginContent from './PluginContent';
 
 // The console requires a custom fetch implementation via `consoleFetch` to correctly pass headers such
 // as X-CSRFToken to API requests. All of our current code uses `axios` to make API requests, so we need
@@ -13,6 +15,18 @@ axios.defaults.adapter = (config) => consoleFetchAxiosAdapter(proxyBaseURL, conf
 
 const apolloClient = configureApolloClient();
 
-export default function PluginProvider({ children }) {
-    return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>;
+export function PluginProvider({ children }: { children: React.ReactNode }) {
+    return (
+        <ApolloProvider client={apolloClient}>
+            <UserPermissionProvider>
+                <PluginContent>{children}</PluginContent>
+            </UserPermissionProvider>
+        </ApolloProvider>
+    );
+}
+
+// If there is any data that needs to be shared across plugin entry points that isn't covered by
+// a general purpose hook, we can add it here.
+export function usePluginContext() {
+    return useMemo(() => ({}), []);
 }

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/Index.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/Index.tsx
@@ -1,24 +1,32 @@
 import React from 'react';
 import { PageSection, Title } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
+import usePermissions from 'hooks/usePermissions';
 
 import SummaryCounts from 'Containers/Dashboard/SummaryCounts';
 import ViolationsByPolicyCategory from 'Containers/Dashboard/Widgets/ViolationsByPolicyCategory';
-import PluginProvider from '../PluginProvider';
 
 export function Index() {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForAlert = hasReadAccess('Alert');
+    const hasReadAccessForCluster = hasReadAccess('Cluster');
+    const hasReadAccessForDeployment = hasReadAccess('Deployment');
+    const hasReadAccessForImage = hasReadAccess('Image');
+    const hasReadAccessForNode = hasReadAccess('Node');
+    const hasReadAccessForSecret = hasReadAccess('Secret');
+
     return (
-        <PluginProvider>
+        <>
             <PageSection>
                 <Title headingLevel="h1">{'Hello, Plugin!'}</Title>
                 <SummaryCounts
                     hasReadAccessForResource={{
-                        Cluster: true,
-                        Node: true,
-                        Alert: true,
-                        Deployment: true,
-                        Image: true,
-                        Secret: true,
+                        Cluster: hasReadAccessForCluster,
+                        Node: hasReadAccessForNode,
+                        Alert: hasReadAccessForAlert,
+                        Deployment: hasReadAccessForDeployment,
+                        Image: hasReadAccessForImage,
+                        Secret: hasReadAccessForSecret,
                     }}
                 />
                 <ViolationsByPolicyCategory />
@@ -31,6 +39,6 @@ export function Index() {
                     {'Your plugin is working.'}
                 </p>
             </PageSection>
-        </PluginProvider>
+        </>
     );
 }

--- a/ui/apps/platform/src/ConsolePlugin/UserPermissionProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/UserPermissionProvider.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { UserPermissionContext } from 'hooks/usePermissions';
 
 import { fetchUserRolePermissions } from 'services/RolesService';
 import useRestQuery from 'hooks/useRestQuery';
 
-export default function UserPermissionProvider({ children }: { children: React.ReactNode }) {
+export function UserPermissionProvider({ children }: { children: ReactNode }) {
     const { data, isLoading } = useRestQuery(fetchUserRolePermissions);
     const userRolePermissions = data?.response || { resourceToAccess: {} };
     const isLoadingPermissions = isLoading;

--- a/ui/apps/platform/src/ConsolePlugin/UserPermissionProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/UserPermissionProvider.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { UserPermissionContext } from 'hooks/usePermissions';
+
+import { fetchUserRolePermissions } from 'services/RolesService';
+import useRestQuery from 'hooks/useRestQuery';
+
+export default function UserPermissionProvider({ children }: { children: React.ReactNode }) {
+    const { data, isLoading } = useRestQuery(fetchUserRolePermissions);
+    const userRolePermissions = data?.response || { resourceToAccess: {} };
+    const isLoadingPermissions = isLoading;
+
+    return (
+        <UserPermissionContext.Provider value={{ userRolePermissions, isLoadingPermissions }}>
+            {children}
+        </UserPermissionContext.Provider>
+    );
+}

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -98,6 +98,7 @@ const config = {
                 displayName: 'Red Hat Advanced Cluster Security for OpenShift',
                 description: 'OCP Console Plugin for Advanced Cluster Security',
                 exposedModules: {
+                    context: './ConsolePlugin/PluginProvider',
                     SecurityVulnerabilitiesPage:
                         './ConsolePlugin/SecurityVulnerabilitiesPage/Index',
                     WorkloadSecurityTab: './ConsolePlugin/WorkloadSecurityTab/Index',
@@ -111,6 +112,13 @@ const config = {
             },
             extensions: [
                 // Security Vulnerabilities Page
+                {
+                    type: 'console.context-provider',
+                    properties: {
+                        provider: { $codeRef: 'context.PluginProvider' },
+                        useValueHook: { $codeRef: 'context.usePluginContext' },
+                    },
+                },
                 {
                     type: 'console.page/route',
                     properties: {

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -111,7 +111,7 @@ const config = {
                 },
             },
             extensions: [
-                // Security Vulnerabilities Page
+                // General Context Provider to be shared across all extensions
                 {
                     type: 'console.context-provider',
                     properties: {
@@ -119,6 +119,7 @@ const config = {
                         useValueHook: { $codeRef: 'context.usePluginContext' },
                     },
                 },
+                // Security Vulnerabilities Page
                 {
                     type: 'console.page/route',
                     properties: {


### PR DESCRIPTION
## Description

Adds a context implementation for the OCP plugin in order to allow usage of the `usePermissions()` hook, and components that rely on that hook. The context implementation utilizes a [plugin SDK extension point ](https://github.com/openshift/console/blob/main/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md#consolecontext-provider)so that context data is shared across multiple plugin entry points. This should prevent duplicate requests of things like permissions during a single session. (TODO - Need to make a note to verify this when additional entry points are added.)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Load the plugin and verify that the `mypermissions` request is made and that the permissions are correctly passed to the components. If the request was not wired up correctly, none of the summary counts would render.
<img width="1541" height="1184" alt="image" src="https://github.com/user-attachments/assets/a20bfa19-f1fd-4ea8-befc-57a7b7dce5a9" />