### PR TITLE
fix: show errors from roxcurl

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -32,7 +32,7 @@ curl_cfg() { # Use built-in echo to not expose $2 in the process list.
 roxcurl() {
     local url="$1"
     shift
-    curl -sk --config <(curl_cfg user "admin:${ROX_ADMIN_PASSWORD}") -k "https://${API_ENDPOINT}${url}" "$@"
+    curl -sSk --config <(curl_cfg user "admin:${ROX_ADMIN_PASSWORD}") "https://${API_ENDPOINT}${url}" "$@"
 }
 
 is_release_version() {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Also drop duplicate `-k`.

To hopefully shed some light on cases such as:
```
INFO: Mon Jul 28 10:46:02 UTC 2025: Waiting for Central API endpoint
INFO: Mon Jul 28 10:46:02 UTC 2025: Found ingress endpoint: 34.9.192.79
INFO: Mon Jul 28 10:46:02 UTC 2025: Attempting to get 6 'ok' responses in a row from [https://34.9.192.79:443/v1/ping](https://34.9.192.79/v1/ping)
INFO: Mon Jul 28 10:46:02 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:07 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:12 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:17 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:22 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:28 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:33 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:38 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:43 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:48 UTC 2025: Curl exited with status 7 and returned ''.
INFO: Mon Jul 28 10:46:53 UTC 2025: Status is now: ok
INFO: Mon Jul 28 10:46:55 UTC 2025: Status is now: ok
INFO: Mon Jul 28 10:46:57 UTC 2025: Status is now: ok
INFO: Mon Jul 28 10:46:59 UTC 2025: Status is now: ok
INFO: Mon Jul 28 10:47:01 UTC 2025: Status is now: ok
INFO: Mon Jul 28 10:47:03 UTC 2025: Checking to see if restore overwrote previous config
****
**** 10:47:04: ERROR: test failed [Test failed: exit 7] [DB backup and restore]
****
****
**** 10:47:04: About to run post test [DB backup and restore]
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI