### PR TITLE
ROZ-29185: Limit heritage updates when only timestamps change

### DIFF
--- a/sensor/common/heritage/heritage.go
+++ b/sensor/common/heritage/heritage.go
@@ -62,6 +62,13 @@ func (a *SensorMetadata) String() string {
 		a.ContainerID, a.PodIP, a.SensorStart, a.LatestUpdate)
 }
 
+func (a *SensorMetadata) UpdateTimestamps(now time.Time) {
+	if a.SensorStart.IsZero() {
+		a.SensorStart = now
+	}
+	a.LatestUpdate = now
+}
+
 func sensorMetadataString(data []*SensorMetadata) string {
 	var str strings.Builder
 	for i, entry := range data {
@@ -82,10 +89,6 @@ type Manager struct {
 	currentSensor SensorMetadata
 
 	cmWriter configMapWriter
-	// Timestamp of the latest update to the config map. Used to rate-limit the number of updates to the cm.
-	lastCmWrite time.Time
-	// Time that defines a window where only a single write to config map should happen in case of cache hit.
-	writeCmFrequency time.Duration
 
 	maxSize int
 	minSize int
@@ -110,11 +113,9 @@ func NewHeritageManager(ns string, client corev1.ConfigMapsGetter, start time.Ti
 			k8sClient: client,
 			namespace: ns,
 		},
-		lastCmWrite:      time.Unix(0, 0),
-		writeCmFrequency: 5 * time.Minute,
-		maxSize:          env.PastSensorsMaxEntries.IntegerSetting(), // Setting value is already validated
-		minSize:          heritageMinSize,                            // Keep in sync with minimum of `env.PastSensorsMaxEntries`
-		maxAge:           heritageMaxAge,
+		maxSize: env.PastSensorsMaxEntries.IntegerSetting(), // Setting value is already validated
+		minSize: heritageMinSize,                            // Keep in sync with minimum of `env.PastSensorsMaxEntries`
+		maxAge:  heritageMaxAge,
 	}
 }
 
@@ -154,29 +155,27 @@ func (h *Manager) SetCurrentSensorData(currentIP, currentContainerID string) {
 	if h.maxSize == 0 {
 		return // feature disabled
 	}
+	now := time.Now()
+	h.currentSensor.UpdateTimestamps(now)
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := h.upsertConfigMap(ctx, time.Now()); err != nil {
+	if _, err := h.upsertConfigMap(ctx, now); err != nil {
 		log.Warnf("Failed to update heritage data in the configMap: %v", err)
 	}
 }
 
-// updateCachedTimestampNoLock updates the timestamp if container ID and IP already exist in the heritage.
-// The size of h.cache is expected to be <10 in most of the cases.
-func (h *Manager) updateCachedTimestampNoLock(now time.Time) bool {
-	for _, entry := range h.cache {
+// getCurrentSensorIndexInCache checks whether an entry with given containerID and podIP exists in cache and returns its slice index.
+func (h *Manager) getCurrentSensorIndexInCache() (found bool, index int) {
+	for idx, entry := range h.cache {
 		if entry.ContainerID == h.currentSensor.ContainerID && entry.PodIP == h.currentSensor.PodIP {
-			if entry.SensorStart.IsZero() {
-				entry.SensorStart = now
-			}
-			entry.LatestUpdate = now
-			return true
+			return true, idx
 		}
 	}
-	return false
+	return false, 0
 }
 
-func (h *Manager) upsertConfigMap(ctx context.Context, now time.Time) error {
+func (h *Manager) upsertConfigMap(ctx context.Context, now time.Time) (wrote bool, err error) {
 	h.cacheMutex.Lock()
 	defer h.cacheMutex.Unlock()
 	if !h.cacheIsPopulated.Load() {
@@ -184,33 +183,39 @@ func (h *Manager) upsertConfigMap(ctx context.Context, now time.Time) error {
 			log.Warnf("%v", err)
 		}
 	}
-	wrote, err := h.write(ctx, now)
-	if wrote {
+	if updated := h.updateCache(now); !updated {
+		return false, nil
+	}
+	err = h.write(ctx)
+	if err == nil {
 		log.Debugf("Wrote heritage data %s to ConfigMap %s/%s", sensorMetadataString(h.cache), h.namespace, cmName)
 	}
-	return err
+	return true, err
 }
 
-func (h *Manager) write(ctx context.Context, now time.Time) (wrote bool, err error) {
-	if cacheHit := h.updateCachedTimestampNoLock(now); !cacheHit {
-		h.currentSensor.LatestUpdate = now
-		h.cache = append(h.cache, &h.currentSensor)
-	} else {
-		// On cache-hit, we would update the `LatestUpdate` field, which should not happen too often to save on IO load.
-		timeSinceLastWrite := now.Sub(h.lastCmWrite)
-		if timeSinceLastWrite < h.writeCmFrequency {
-			return false, nil
-		}
+// updateCache adds the currentSensor data to cache, prunes old data (according to settings) and returns true.
+// If the cache already contains data of currentSensor and there are no updates to its containerID or podIP,
+// then the configMap is not written and false is returned.
+func (h *Manager) updateCache(now time.Time) bool {
+	cacheHit, idx := h.getCurrentSensorIndexInCache()
+	if cacheHit {
+		h.cache[idx].UpdateTimestamps(now)
+		// Limit requests to k8s API and do not update configMap if only the timestamps have changed.
+		return false
 	}
 
+	// Current sensor is not found in cache or there is an update to containerID or podIP.
+	h.cache = append(h.cache, &h.currentSensor)
 	h.cache = pruneOldHeritageData(h.cache, now, h.maxAge, h.minSize, h.maxSize)
+	return true
+}
 
-	err = h.cmWriter.Write(ctx, h.cache...)
-	if err == nil {
-		h.lastCmWrite = now
-		return true, nil
+// write writes the cache contents into configMap.
+func (h *Manager) write(ctx context.Context) error {
+	if err := h.cmWriter.Write(ctx, h.cache...); err != nil {
+		return errors.Wrap(err, "writing configmap")
 	}
-	return false, errors.Wrap(err, "writing configmap")
+	return nil
 }
 
 // pruneOldHeritageData reduces the number of elements in the []*PastSensor slice by removing

--- a/sensor/common/heritage/heritage_test.go
+++ b/sensor/common/heritage/heritage_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_cleanupHeritageData(t *testing.T) {
@@ -355,98 +356,104 @@ func Test_cleanupHeritageData(t *testing.T) {
 	}
 }
 
-type dummyWriter struct{}
+type dummyWriter struct {
+	cmState []*SensorMetadata
+}
 
-func (d *dummyWriter) Write(_ context.Context, _ ...*SensorMetadata) error {
+func (d *dummyWriter) Write(_ context.Context, input ...*SensorMetadata) error {
+	d.cmState = input
 	return nil
 }
 
 func (d *dummyWriter) Read(_ context.Context) ([]*SensorMetadata, error) {
-	return []*SensorMetadata{}, nil
+	return d.cmState, nil
 }
 
-func Test_writeRateLimiter(t *testing.T) {
-	data := []*SensorMetadata{
-		{
-			ContainerID:  "a",
-			PodIP:        "1.1.1.1",
-			SensorStart:  time.Unix(0, 0),
-			LatestUpdate: time.Unix(10, 0),
-		},
-		{
-			ContainerID:  "b",
-			PodIP:        "1.1.1.2",
-			SensorStart:  time.Unix(100, 0),
-			LatestUpdate: time.Unix(110, 0),
-		},
+func newSensorMetadata(cID, podIP string, update ...time.Time) *SensorMetadata {
+	sm := &SensorMetadata{
+		ContainerID: cID,
+		PodIP:       podIP,
 	}
+	if len(update) > 0 {
+		sm.LatestUpdate = update[0]
+	}
+	return sm
+}
+
+func Test_upsertConfigMap(t *testing.T) {
+	now := time.Now()
+	a1 := newSensorMetadata("a", "1.1.1.1")
+	a2 := newSensorMetadata("a", "1.1.1.2")
+	b1 := newSensorMetadata("b", "1.1.1.1")
+	b99 := newSensorMetadata("b", "1.1.1.99")
+
 	tests := map[string]struct {
-		lastWrite     time.Time
-		frequency     time.Duration
-		now           time.Time
-		cacheHit      bool
-		writeExpected bool
+		initialConfigMap       []*SensorMetadata
+		currentSensor          *SensorMetadata
+		wantWrite              bool
+		expectedConfigMapState []*SensorMetadata
 	}{
-		"Write after 15s should not trigger 10s rate limit": {
-			lastWrite:     time.Unix(0, 0),
-			frequency:     10 * time.Second,
-			now:           time.Unix(15, 0),
-			cacheHit:      true,
-			writeExpected: true,
+		"Missing podID should result in write to cm": {
+			initialConfigMap:       []*SensorMetadata{},
+			currentSensor:          a1,
+			wantWrite:              true,
+			expectedConfigMapState: []*SensorMetadata{a1},
 		},
-		"Write after 5s should trigger 10s rate limit": {
-			lastWrite:     time.Unix(0, 0),
-			frequency:     10 * time.Second,
-			now:           time.Unix(5, 0),
-			cacheHit:      true,
-			writeExpected: false,
+		"Updates only to podID should be treated as new data entry": {
+			initialConfigMap:       []*SensorMetadata{a1},
+			currentSensor:          a2,
+			wantWrite:              true,
+			expectedConfigMapState: []*SensorMetadata{a1, a2},
 		},
-		"Write after 5s should not trigger 10s rate limit on cache-miss": {
-			lastWrite:     time.Unix(0, 0),
-			frequency:     10 * time.Second,
-			now:           time.Unix(5, 0),
-			cacheHit:      false,
-			writeExpected: true,
+		"Updates only to containerID should be treated as new data entry": {
+			initialConfigMap:       []*SensorMetadata{a1},
+			currentSensor:          b1,
+			wantWrite:              true,
+			expectedConfigMapState: []*SensorMetadata{a1, b1},
 		},
-		"Negative time difference on cache hit should not write": {
-			lastWrite:     time.Unix(10, 0),
-			frequency:     10 * time.Second,
-			now:           time.Unix(5, 0),
-			cacheHit:      true,
-			writeExpected: false,
+		"updates on timestamps should result in no writes to cm": {
+			initialConfigMap:       []*SensorMetadata{a1},
+			currentSensor:          newSensorMetadata("a", "1.1.1.1", time.Unix(9999, 00)),
+			wantWrite:              false,
+			expectedConfigMapState: []*SensorMetadata{a1},
+		},
+		"Updates to timestamps on further positions in cache should yield no writes to cm": {
+			initialConfigMap:       []*SensorMetadata{b99, a1},
+			currentSensor:          newSensorMetadata("a", "1.1.1.1", time.Unix(9999, 00)),
+			wantWrite:              false,
+			expectedConfigMapState: []*SensorMetadata{b99, a1},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			hm := newManager(&dummyWriter{}, data, tt.lastWrite, tt.frequency)
-			if tt.cacheHit {
-				hm.currentSensor.PodIP = "1.1.1.1"
-				hm.currentSensor.ContainerID = "a"
-			} else {
-				hm.currentSensor.PodIP = "1.1.1.199"
-				hm.currentSensor.ContainerID = "z"
-			}
-			gotWrite, gotErr := hm.write(context.Background(), tt.now)
+			w := &dummyWriter{cmState: tt.initialConfigMap}
+			hm := newManager(w, tt.currentSensor)
+			gotWrite, gotErr := hm.upsertConfigMap(context.Background(), now)
+			assert.Equal(t, tt.wantWrite, gotWrite)
 			assert.NoError(t, gotErr)
-			assert.Equal(t, tt.writeExpected, gotWrite)
+
+			// Assert on the configMap contents
+			gotState, _ := w.Read(t.Context())
+			require.Len(t, gotState, len(tt.expectedConfigMapState))
+			for i, entry := range gotState {
+				assert.Equal(t, tt.expectedConfigMapState[i].PodIP, entry.PodIP)
+				assert.Equal(t, tt.expectedConfigMapState[i].ContainerID, entry.ContainerID)
+			}
 		})
 	}
 }
 
-func newManager(writer configMapWriter, cache []*SensorMetadata, lastWrite time.Time, freq time.Duration) *Manager {
-	return &Manager{
+func newManager(writer configMapWriter, currentSensor *SensorMetadata) *Manager {
+	m := &Manager{
 		cacheIsPopulated: atomic.Bool{},
-		cache:            cache,
+		cache:            make([]*SensorMetadata, 0),
 		namespace:        "test",
-		currentSensor: SensorMetadata{
-			SensorVersion: "1.0.0-test",
-			SensorStart:   time.Unix(0, 0),
-		},
+		currentSensor:    *currentSensor,
 		cmWriter:         writer,
-		lastCmWrite:      lastWrite,
-		writeCmFrequency: freq,
 		maxSize:          10,
 		minSize:          2,
 		maxAge:           heritageMaxAge,
 	}
+	m.cacheIsPopulated.Store(false)
+	return m
 }


### PR DESCRIPTION
## Description

Because of frequent updates to sensor deployment that do not change containerID or podIP, the heritage feature was triggering many updates to the configmap where only the timestamps were updated. That caused high load on the k8s API for writing configMaps in some specific scenarios.

In this PR, we update the configMap if and only if there are changes to containerID or podIP. A mere change to any of the timestamps do not trigger a write operation to the configmap.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- There are unit tests that cover exactly this change
