### PR TITLE
tests(disable): flaky TestExternalStatusPagination

### DIFF
--- a/central/networkbaseline/service/service_impl_sql_test.go
+++ b/central/networkbaseline/service/service_impl_sql_test.go
@@ -231,6 +231,7 @@ func (s *networkBaselineServiceSuite) TestExternalStatus() {
 }
 
 func (s *networkBaselineServiceSuite) TestExternalStatusPagination() {
+	s.T().Skip("Temporarily skipping this test (flake) : TODO(ROX-30337)")
 	s.setupTablesExternalFlows()
 
 	req := &v1.NetworkBaselineExternalStatusRequest{


### PR DESCRIPTION
## Description

TestNetworkBaselinePostgres/TestExternalStatusPagination started to be flaky and we disable it temporarily during the investigation.

The resolution will be tracked under ROX-30337

## Testing and quality

- [x] verify that the test is skipped

### How I validated my change

The change affects only unit-tests, so there is a very low risk for the product.
