### PR TITLE
ROX-26177: Clusters page layout updates

### DIFF
--- a/ui/apps/platform/src/Components/CheckboxTable.jsx
+++ b/ui/apps/platform/src/Components/CheckboxTable.jsx
@@ -111,15 +111,7 @@ class CheckboxTable extends Component {
     render() {
         const { manual, ...rest } = this.props;
         const columns = this.addCheckboxColumns();
-        return (
-            <Table
-                {...rest}
-                columns={columns}
-                manual={manual}
-                setTableRef={this.setTableRef}
-                className="pf-v5-u-background-color-100"
-            />
-        );
+        return <Table {...rest} columns={columns} manual={manual} setTableRef={this.setTableRef} />;
     }
 }
 

--- a/ui/apps/platform/src/Components/CheckboxTable.jsx
+++ b/ui/apps/platform/src/Components/CheckboxTable.jsx
@@ -111,7 +111,15 @@ class CheckboxTable extends Component {
     render() {
         const { manual, ...rest } = this.props;
         const columns = this.addCheckboxColumns();
-        return <Table {...rest} columns={columns} manual={manual} setTableRef={this.setTableRef} />;
+        return (
+            <Table
+                {...rest}
+                columns={columns}
+                manual={manual}
+                setTableRef={this.setTableRef}
+                className="pf-v5-u-background-color-100"
+            />
+        );
     }
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -440,7 +440,7 @@ function ClustersTablePanel({ selectedClusterId, searchOptions }: ClustersTableP
                     </ToolbarContent>
                 </Toolbar>
                 <Text className="pf-v5-u-font-size-md">
-                    View the status of services for clusters secured by Advanced Cluster Security
+                    View the status of secured cluster services
                 </Text>
             </PageSection>
             <PageSection>
@@ -544,6 +544,7 @@ function ClustersTablePanel({ selectedClusterId, searchOptions }: ClustersTableP
                     />
                 ) : (
                     <CheckboxTable
+                        className="pf-v5-u-background-color-100"
                         ref={(table) => {
                             setTableRef(table);
                         }}

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -4,10 +4,10 @@ import {
     Alert,
     Bullseye,
     Button,
-    Divider,
     DropdownItem,
     PageSection,
     Spinner,
+    Text,
     Title,
     Toolbar,
     ToolbarContent,
@@ -439,7 +439,12 @@ function ClustersTablePanel({ selectedClusterId, searchOptions }: ClustersTableP
                         </ToolbarGroup>
                     </ToolbarContent>
                 </Toolbar>
-                <Toolbar inset={{ default: 'insetNone' }} className="pf-v5-u-pb-0">
+                <Text className="pf-v5-u-font-size-md">
+                    View the status of services for clusters secured by Advanced Cluster Security
+                </Text>
+            </PageSection>
+            <PageSection>
+                <Toolbar>
                     <ToolbarContent>
                         <ToolbarGroup
                             variant="filter-group"
@@ -510,10 +515,7 @@ function ClustersTablePanel({ selectedClusterId, searchOptions }: ClustersTableP
                         )}
                     </ToolbarContent>
                 </Toolbar>
-            </PageSection>
-            <Divider component="div" />
-            <PageSection variant="light" isFilled>
-                {errorMessage && (
+                {errorMessage && !isClustersPageMigrationEnabled && (
                     <Alert
                         variant="warning"
                         isInline

--- a/ui/apps/platform/src/Containers/Clusters/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Clusters/searchFilterConfig.ts
@@ -13,10 +13,10 @@ import type {
 } from 'Components/CompoundSearchFilter/types';
 
 export const statusSelectOptions: SelectSearchFilterOptions['options'] = [
-    { label: 'Degraded', value: 'DEGRADED' },
     { label: 'Healthy', value: 'HEALTHY' },
-    { label: 'Unavailable', value: 'UNAVAILABLE' },
+    { label: 'Degraded', value: 'DEGRADED' },
     { label: 'Unhealthy', value: 'UNHEALTHY' },
+    { label: 'Unavailable', value: 'UNAVAILABLE' },
     { label: 'Uninitialized', value: 'UNINITIALIZED' },
 ];
 


### PR DESCRIPTION
## Description

The Clusters page should align with current UX by including a subheading and margins around the table.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="2222" height="953" alt="Screenshot 2025-07-28 at 2 58 32 PM" src="https://github.com/user-attachments/assets/be4bfd2b-c74d-407e-aa3e-be9e56437264" />

