### PR TITLE
ROX-30278: secured-cluster chart: Make listenOn* settings static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ since 4.7 and prior.
   - --create-admission-controller
   - --admission-controller-enabled
   - --slim-collector
+- ROX-30278: The `admissionControl.listenOn*` configuration parameters of the secured-cluster-services Helm chart are not user-configurable anymore.
+  Their values are all set to `true` (except for OpenShift 3, where `listenOnEvents` remains disabled.)
+  [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
 
 ### Deprecated Features
 - ROX-30170: The following roxctl sensor generate options have been marked as deprecated

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -57,6 +57,7 @@ sensor:
               operator: DoesNotExist
 
 admissionControl:
+[<- if .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
   listenOnCreates: true
   listenOnUpdates: true
   {{/* At this point, when defaults are applied, we can expect env.openshift to be false or a major version number (3, 4). */}}
@@ -66,6 +67,11 @@ admissionControl:
   {{/* OpenShift 3.x does not support this. */}}
   listenOnEvents: false
   {{- end }}
+[<- else >]
+  listenOnCreates: false
+  listenOnUpdates: false
+  listenOnEvents: {{ not ._rox.env.openshift }}
+[<- end >]
   dynamic:
     enforceOnCreates: false
     scanInline: false

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -57,9 +57,15 @@ sensor:
               operator: DoesNotExist
 
 admissionControl:
-  listenOnCreates: false
-  listenOnUpdates: false
-  listenOnEvents: {{ not ._rox.env.openshift }}
+  listenOnCreates: true
+  listenOnUpdates: true
+  {{/* At this point, when defaults are applied, we can expect env.openshift to be false or a major version number (3, 4). */}}
+  {{- if or (not ._rox.env.openshift) (gt ._rox.env.openshift 3) }}
+  listenOnEvents: true
+  {{- else }}
+  {{/* OpenShift 3.x does not support this. */}}
+  listenOnEvents: false
+  {{- end }}
   dynamic:
     enforceOnCreates: false
     scanInline: false

--- a/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
@@ -10,6 +10,9 @@ Secured Cluster Configuration Summary:
   Helm Release Name:                           {{ .Release.Name }}
   Central Endpoint:                            {{ ._rox.centralEndpoint }}
   OpenShift Cluster:                           {{ if eq ._rox.env.openshift 0 -}} false {{ else -}} {{ ._rox.env.openshift }} {{ end }}
+[<- if not .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
+  Admission Control Webhooks deployed:         {{ or ._rox.admissionControl.dynamic.listenOnCreates ._rox.admissionControl.dynamic.listenOnUpdates ._rox.admissionControl.dynamic.listenOnEvents}}
+[<- end >]
   Admission Control Creates/Updates enforced:  {{ or ._rox.admissionControl.dynamic.enforceOnCreates ._rox.admissionControl.dynamic.enforceOnUpdates }}
   Scanner V4:                                  {{ if ._rox._scannerV4Enabled -}} enabled {{- else -}} disabled {{- end }}
 {{- if and ._rox._scannerV4Enabled ._rox._scannerV4Volume }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/NOTES.txt.htpl
@@ -10,7 +10,6 @@ Secured Cluster Configuration Summary:
   Helm Release Name:                           {{ .Release.Name }}
   Central Endpoint:                            {{ ._rox.centralEndpoint }}
   OpenShift Cluster:                           {{ if eq ._rox.env.openshift 0 -}} false {{ else -}} {{ ._rox.env.openshift }} {{ end }}
-  Admission Control Webhooks deployed:         {{ or ._rox.admissionControl.dynamic.listenOnCreates ._rox.admissionControl.dynamic.listenOnUpdates ._rox.admissionControl.dynamic.listenOnEvents}}
   Admission Control Creates/Updates enforced:  {{ or ._rox.admissionControl.dynamic.enforceOnCreates ._rox.admissionControl.dynamic.enforceOnUpdates }}
   Scanner V4:                                  {{ if ._rox._scannerV4Enabled -}} enabled {{- else -}} disabled {{- end }}
 {{- if and ._rox._scannerV4Enabled ._rox._scannerV4Volume }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
@@ -1,7 +1,7 @@
 {{- define "srox.protectAdmissionControllerConfig" -}}
 {{- $ := . -}}
 
-{{- $formatMsg := "It is not supported anymore to specify 'admissionControl.%s'. This setting will be ignored." -}}
+{{- $formatMsg := "It is not supported anymore to specify 'admissionControl.%s'. This setting will be ignored. The effective value is 'true'." -}}
 
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnCreates) -}}
     {{- include "srox.warn" (list $ (printf $formatMsg "listenOnCreates")) -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
@@ -1,0 +1,16 @@
+{{- define "srox.protectAdmissionControllerConfig" -}}
+{{- $ := . -}}
+
+{{- $formatMsg := "It is not supported anymore to specify 'admissionControl.%s'. This setting will be ignored." -}}
+
+{{- if not (kindIs "invalid" $._rox.admissionControl.listenOnCreates) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnCreates")) -}}
+{{- end -}}
+{{- if not (kindIs "invalid" $._rox.admissionControl.listenOnUpdates) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnUpdates")) -}}
+{{- end -}}
+{{- if not (kindIs "invalid" $._rox.admissionControl.listenOnEvents) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnEvents")) -}}
+{{- end -}}
+
+{{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
@@ -5,12 +5,15 @@
 
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnCreates) -}}
     {{- include "srox.warn" (list $ (printf $formatMsg "listenOnCreates")) -}}
+    {{- $_ := unset $._rox.admissionControl "listenOnCreates" -}}
 {{- end -}}
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnUpdates) -}}
     {{- include "srox.warn" (list $ (printf $formatMsg "listenOnUpdates")) -}}
+    {{- $_ := unset $._rox.admissionControl "listenOnUpdates" -}}
 {{- end -}}
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnEvents) -}}
     {{- include "srox.warn" (list $ (printf $formatMsg "listenOnEvents")) -}}
+    {{- $_ := unset $._rox.admissionControl "listenOnEvents" -}}
 {{- end -}}
 
 {{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -129,7 +129,10 @@
 
 {{ include "srox.setInstallMethod" (list $) }}
 
-{{ include "srox.protectAdmissionControllerConfig" $ }}
+[<- if .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
+  {{ include "srox.protectAdmissionControllerConfig" $ }}
+[<- end >]
+
 {{ include "srox.applyDefaults" $ }}
 {{ include "srox.ensureCentralEndpointContainsPort" $ }}
 
@@ -201,6 +204,12 @@
 {{ if and $._rox.admissionControl.dynamic.enforceOnUpdates (not $._rox.admissionControl.listenOnUpdates) }}
   {{ include "srox.warn" (list $ "Incompatible settings: 'admissionControl.dynamic.enforceOnUpdates' is set to true, while `admissionControl.listenOnUpdates` is set to false. For the feature to be active, enable both settings by setting them to true.") }}
 {{ end }}
+
+[<- if not .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
+{{ if and (eq $._rox.env.openshift 3) $._rox.admissionControl.listenOnEvents }}
+  {{ include "srox.fail" "'admissionControl.listenOnEvents' is set to true, but the chart is being deployed in OpenShift 3.x compatibility mode, which does not work with this feature. Set 'env.openshift' to '4' in order to enable OpenShift 4.x features." }}
+{{ end }}
+[<- end >]
 
 {{ if $._rox.collector.slimMode }}
   {{ include "srox.warn" (list $ "collector.slimMode is set to true, but it has been removed in 4.7 after being deprecated since 4.5. This setting will be ignored.") }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -129,6 +129,7 @@
 
 {{ include "srox.setInstallMethod" (list $) }}
 
+{{ include "srox.protectAdmissionControllerConfig" $ }}
 {{ include "srox.applyDefaults" $ }}
 {{ include "srox.ensureCentralEndpointContainsPort" $ }}
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -202,10 +202,6 @@
   {{ include "srox.warn" (list $ "Incompatible settings: 'admissionControl.dynamic.enforceOnUpdates' is set to true, while `admissionControl.listenOnUpdates` is set to false. For the feature to be active, enable both settings by setting them to true.") }}
 {{ end }}
 
-{{ if and (eq $._rox.env.openshift 3) $._rox.admissionControl.listenOnEvents }}
-  {{ include "srox.fail" "'admissionControl.listenOnEvents' is set to true, but the chart is being deployed in OpenShift 3.x compatibility mode, which does not work with this feature. Set 'env.openshift' to '4' in order to enable OpenShift 4.x features." }}
-{{ end }}
-
 {{ if $._rox.collector.slimMode }}
   {{ include "srox.warn" (list $ "collector.slimMode is set to true, but it has been removed in 4.7 after being deprecated since 4.5. This setting will be ignored.") }}
 {{ end }}

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/feature_flags_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/feature_flags_test.go
@@ -1,0 +1,47 @@
+package flavor
+
+import (
+	"path"
+	"testing"
+
+	helmTest "github.com/stackrox/helmtest/pkg/framework"
+	"github.com/stackrox/rox/image"
+	"github.com/stackrox/rox/pkg/helm/charts"
+	helmChartTestUtils "github.com/stackrox/rox/pkg/helm/charts/testutils"
+	"github.com/stackrox/rox/pkg/images/defaults"
+	"github.com/stackrox/rox/pkg/version/testutils"
+)
+
+const testDir = "testdata/helmtest"
+
+func TestWithDifferentFeatureFlags(t *testing.T) {
+	testutils.SetVersion(t, testutils.GetExampleVersion(t))
+
+	testCases := map[string]struct {
+		featureFlags []string
+		flavor       defaults.ImageFlavor
+	}{
+		"admission-controller-config": {
+			featureFlags: []string{"ROX_ADMISSION_CONTROLLER_CONFIG"},
+			flavor:       defaults.RHACSReleaseImageFlavor(),
+		},
+	}
+
+	for testCaseName, testCaseSpec := range testCases {
+		t.Run(testCaseName, func(t *testing.T) {
+			imageFlavor := testCaseSpec.flavor
+			helmChartTestUtils.RunHelmTestSuite(t, testDir, image.SecuredClusterServicesChartPrefix, helmChartTestUtils.RunHelmTestSuiteOpts{
+				Flavor: &imageFlavor,
+				MetaValuesOverridesFunc: func(values *charts.MetaValues) {
+					if values.FeatureFlags == nil {
+						values.FeatureFlags = make(map[string]interface{})
+					}
+					for _, featureFlag := range testCaseSpec.featureFlags {
+						values.FeatureFlags[featureFlag] = true
+					}
+				},
+				HelmTestOpts: []helmTest.LoaderOpt{helmTest.WithAdditionalTestDirs(path.Join(testDir, testCaseName))},
+			})
+		})
+	}
+}

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
@@ -1,0 +1,38 @@
+tests:
+- name: "OpenShift3 defaults"
+  set:
+    env.openshift: 3
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
+   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 0)
+- name: "OpenShift4 defaults"
+  set:
+    env.openshift: 4
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
+   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
+- name: "Vanilla K8s defaults"
+  set:
+    env.openshift: false
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
+   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
+- name: "disabling listenOn* is ignored"
+  set:
+    admissionControl.listenOnCreates: false
+    admissionControl.listenOnUpdates: false
+    admissionControl.listenOnEvents: false
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0].operations | assertThat(contains(["CREATE"]))
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0].operations | assertThat(contains(["UPDATE"]))
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io") | assertThat(. != null)
+- name: "Warnings are emitted when listenOn* fields set"
+  values:
+    admissionControl:
+      listenOnCreates: false
+      listenOnUpdates: false
+      listenOnEvents: false
+  expect: |
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnCreates'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnUpdates'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnEvents'"))

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/suite.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/suite.yaml
@@ -1,0 +1,34 @@
+server:
+  visibleSchemas:
+  - kubernetes-1.20.2
+  objects:
+    # Apparently, for the `lookup` function in the Helm chart to be able to list the objects of a certain kind
+    # at least one such object needs to exist. Therefore, we create a StorageClass here solely
+    # for enabling lookups in the charts under test.
+    - apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: some-sc
+        annotations:
+          storageclass.kubernetes.io/is-default-class: false
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        namespace: stackrox
+        name: just-some-dummy-pvc
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: "314159Mi"
+values:
+  clusterName: "testcluster"
+  imagePullSecrets:
+    allowNone: true
+  createSecrets: false
+  ca:
+    cert: "DUMMY CA CERTIFICATE"
+  monitoring:
+    openshift:
+      enabled: false

--- a/pkg/helm/charts/tests/securedclusterservices/helmtest_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/helmtest_test.go
@@ -4,25 +4,9 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/image"
-	"github.com/stackrox/rox/pkg/helm/charts"
 	helmChartTestUtils "github.com/stackrox/rox/pkg/helm/charts/testutils"
 )
 
-func enableDesiredFeatureFlags(metaVals *charts.MetaValues) {
-	featureFlagsToEnable := []string{
-		"ROX_ADMISSION_CONTROLLER_CONFIG",
-	}
-	if metaVals.FeatureFlags == nil {
-		metaVals.FeatureFlags = make(map[string]interface{})
-	}
-	for _, featureFlag := range featureFlagsToEnable {
-		metaVals.FeatureFlags[featureFlag] = true
-	}
-}
-
 func TestWithHelmtest(t *testing.T) {
-	testSuiteOpts := helmChartTestUtils.RunHelmTestSuiteOpts{
-		MetaValuesOverridesFunc: enableDesiredFeatureFlags,
-	}
-	helmChartTestUtils.RunHelmTestSuite(t, "testdata/helmtest", image.SecuredClusterServicesChartPrefix, testSuiteOpts)
+	helmChartTestUtils.RunHelmTestSuite(t, "testdata/helmtest", image.SecuredClusterServicesChartPrefix, helmChartTestUtils.RunHelmTestSuiteOpts{})
 }

--- a/pkg/helm/charts/tests/securedclusterservices/helmtest_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/helmtest_test.go
@@ -4,9 +4,25 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/image"
+	"github.com/stackrox/rox/pkg/helm/charts"
 	helmChartTestUtils "github.com/stackrox/rox/pkg/helm/charts/testutils"
 )
 
+func enableDesiredFeatureFlags(metaVals *charts.MetaValues) {
+	featureFlagsToEnable := []string{
+		"ROX_ADMISSION_CONTROLLER_CONFIG",
+	}
+	if metaVals.FeatureFlags == nil {
+		metaVals.FeatureFlags = make(map[string]interface{})
+	}
+	for _, featureFlag := range featureFlagsToEnable {
+		metaVals.FeatureFlags[featureFlag] = true
+	}
+}
+
 func TestWithHelmtest(t *testing.T) {
-	helmChartTestUtils.RunHelmTestSuite(t, "testdata/helmtest", image.SecuredClusterServicesChartPrefix, helmChartTestUtils.RunHelmTestSuiteOpts{})
+	testSuiteOpts := helmChartTestUtils.RunHelmTestSuiteOpts{
+		MetaValuesOverridesFunc: enableDesiredFeatureFlags,
+	}
+	helmChartTestUtils.RunHelmTestSuite(t, "testdata/helmtest", image.SecuredClusterServicesChartPrefix, testSuiteOpts)
 }

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -48,17 +48,6 @@ tests:
     .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnCreates'"))
     .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnUpdates'"))
     .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnEvents'"))
-- name: "OpenShift3 clusters do not support admission control sideEffects"
-  server:
-    availableSchemas:
-      - openshift-3.11.0
-  set:
-    env.openshift: 3
-    admissionControl:
-      listenOnEvents: true
-      listenOnCreates: true
-      listenOnUpdates: true
-  expectError: true
 
 - name: "OpenShift4 clusters support admission control sideEffects"
   set:
@@ -180,7 +169,7 @@ tests:
           listenOnCreates: true
           listenOnEvents: false
       expect: |
-        .validatingwebhookconfigurations[].webhooks[].namespaceSelector.matchExpressions | assertThat(length == 1)
+        .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .namespaceSelector.matchExpressions | assertThat(length == 1)
     - name: "override namespace selector"
       values:
         admissionControl:
@@ -200,7 +189,7 @@ tests:
                 - kube-public
                 - istio-system
       expect: |
-        .validatingwebhookconfigurations[].webhooks[].namespaceSelector.matchExpressions | assertThat(length == 2)
+        .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .namespaceSelector.matchExpressions | assertThat(length == 2)
 
 - name: "Admission Controller Failure Policy"
   tests:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -8,46 +8,17 @@ server:
   availableSchemas:
   - openshift-4.1.0
 tests:
-- name: "OpenShift3 defaults"
+- name: "OpenShift3 clusters do not support admission control sideEffects"
   server:
     availableSchemas:
       - openshift-3.11.0
   set:
     env.openshift: 3
-  expect: |
-   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
-   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 0)
-- name: "OpenShift4 defaults"
-  set:
-    env.openshift: 4
-  expect: |
-   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
-   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
-- name: "Vanilla K8s defaults"
-  set:
-    env.openshift: false
-  expect: |
-   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
-   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
-- name: "disabling listenOn* is ignored"
-  set:
-    admissionControl.listenOnCreates: false
-    admissionControl.listenOnUpdates: false
-    admissionControl.listenOnEvents: false
-  expect: |
-   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0].operations | assertThat(contains(["CREATE"]))
-   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0].operations | assertThat(contains(["UPDATE"]))
-   .validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io") | assertThat(. != null)
-- name: "Warnings are emitted when listenOn* fields set"
-  values:
     admissionControl:
-      listenOnCreates: false
-      listenOnUpdates: false
-      listenOnEvents: false
-  expect: |
-    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnCreates'"))
-    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnUpdates'"))
-    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnEvents'"))
+      listenOnEvents: true
+      listenOnCreates: true
+      listenOnUpdates: true
+  expectError: true
 
 - name: "OpenShift4 clusters support admission control sideEffects"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -8,6 +8,37 @@ server:
   availableSchemas:
   - openshift-4.1.0
 tests:
+- name: "OpenShift3 defaults"
+  server:
+    availableSchemas:
+      - openshift-3.11.0
+  set:
+    env.openshift: 3
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
+   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 0)
+- name: "OpenShift4 defaults"
+  set:
+    env.openshift: 4
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
+   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
+- name: "Vanilla K8s defaults"
+  set:
+    env.openshift: false
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
+   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
+- name: "Warnings are emitted when listenOn* fields set"
+  values:
+    admissionControl:
+      listenOnCreates: false
+      listenOnUpdates: false
+      listenOnEvents: false
+  expect: |
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnCreates'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnUpdates'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnEvents'"))
 - name: "OpenShift3 clusters do not support admission control sideEffects"
   server:
     availableSchemas:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -29,6 +29,15 @@ tests:
   expect: |
    .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
    [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
+- name: "disabling listenOn* is ignored"
+  set:
+    admissionControl.listenOnCreates: false
+    admissionControl.listenOnUpdates: false
+    admissionControl.listenOnEvents: false
+  expect: |
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0].operations | assertThat(contains(["CREATE"]))
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0].operations | assertThat(contains(["UPDATE"]))
+   .validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io") | assertThat(. != null)
 - name: "Warnings are emitted when listenOn* fields set"
   values:
     admissionControl:


### PR DESCRIPTION
## Description

See https://issues.redhat.com/browse/ROX-30278. This PR only contains the first set of changes for the referenced ticket.

The options

```
admissionControl:
  listenOnCreates: # bool
  listenOnUpdates: # bool
  listenOnEvents:  # bool
```

shall not be supported any longer. More precisely, since we don’t want to break backwards compatibility and in accordance with the design doc, they shall be “upgraded to true” under the hood. But to make this not entirely silent, we shall
emit a warning message, if these were changed by the user. One exception being that OpenShift 3 doesn't support the `listenOnEvents: true` setting -- in that case it will remain being disabled.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [ ] documentation changes are tracked in a dedicated ticket: ROX-30434

## Testing and quality

- [x] the change is production ready (irregardless of the `ROX_ADMISSION_CONTROLLER_CONFIG` feature flag)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

- [x] Unit tests.
- [x] Manual verification, see below.


```
$ ROX_ADMISSION_CONTROLLER_CONFIG=true roxctl helm output secured-cluster-services --remove --debug
$ helm template -n stackrox stackrox-secured-cluster-services ./stackrox-secured-cluster-services-chart --set clusterName=foo -f ~/go/src/github.com/stackrox/stackrox/tests/roxctl/bats-tests/test-data/helm-output-secured-cluster-services/cluster-init-bundle.yaml \
  --set admissionControl.listenOnCreates=false \
  --set admissionControl.listenOnEvents=false \
  --set admissionControl.listenOnUpdates=false \
  | yq eval-all 'select(.kind == "ValidatingWebhookConfiguration")' - \
  | yq .webhooks
```

And confirm that all the expected webhooks are enabled, even though they have been switched off explicitly.
```
