### PR TITLE
ROX-30392: Fix script used for scale tests

### DIFF
--- a/scale/dev/port-forward.sh
+++ b/scale/dev/port-forward.sh
@@ -36,3 +36,8 @@ echo
 
 nohup kubectl port-forward -n "${namespace}" svc/central "${port}:443" 1>/dev/null 2>&1 &
 echo "Access central on https://localhost:${port}"
+nc -z 127.0.0.1 "$port"
+until nc -z 127.0.0.1 "$port"; do 
+        sleep 1 
+        echo "Waiting for port forward"
+done

--- a/scale/dev/run-many.sh
+++ b/scale/dev/run-many.sh
@@ -14,7 +14,6 @@ else
   kubectl -n stackrox wait --for=condition=ready pod -l app=central --timeout 5m
   killpf 8000
   "$DIR"/port-forward.sh 8000
-  sleep 5 # Allow port-forwards to initialize
 fi
 echo "Set retention settings"
 roxcurl v1/config -X PUT -d @config.json


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Currently I have to run the `scale/dev/run-many.sh` script twice. Once to deploy central and once to deploy sensor. It currently has the following

```
if ! kubectl -n stackrox get deploy/central; then
  "$DIR"/launch_central.sh
  kubectl -n stackrox wait --for=condition=ready pod -l app=central --timeout 5m
else
  kubectl -n stackrox wait --for=condition=ready pod -l app=central --timeout 5m
  killpf 8000
  "$DIR"/port-forward.sh 8000
  sleep 5 # Allow port-forwards to initialize
fi
```

If central has not been deployed, it deploys central. When it deploys central it also calls the `port-forward.sh` script. It then tries to use the port forward when deploying sensor. This often fails, because the port forward is not yet ready. When central is already up, it creates the port forward and waits 5 seconds. This increases the probability that the port forward will be ready when deploying sensor.

To fix this bug `port-forward.sh` is modified such that it waits for the port forward to be ready before exiting the script.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Ran the script and confirmed that it created sensor the first time.
