### PR TITLE
ROX-29419: Remove test for revoking init bundle with impacted clusters

### DIFF
--- a/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
@@ -4,10 +4,8 @@ import io.stackrox.proto.api.v1.ApiTokenService
 
 import services.BaseService
 import services.ClusterInitBundleService
-import services.ClusterService
 import util.Env
 
-import org.junit.Assume
 import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Tag

--- a/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
@@ -30,33 +30,6 @@ class ClusterInitBundleTest extends BaseSpecification {
         }
     }
 
-    def "Test that revoke cluster init bundle requires impacted clusters"() {
-        BaseService.useApiToken(adminToken.token)
-
-        def cluster = ClusterService.getCluster()
-        Assume.assumeTrue(cluster.hasHelmConfig())
-
-        when:
-        "making a request for the cluster init bundle"
-        def bundles = ClusterInitBundleService.getInitBundles()
-
-        then:
-        "there is a bundle for current cluster"
-        def bundle = bundles.find { b -> b.impactedClustersList.find { c -> c.id == cluster.id } }
-        assert bundle
-
-        when:
-        "try to delete used init bundle not confirming impacted clusters"
-        def response = ClusterInitBundleService.revokeInitBundle(bundle.id)
-
-        then:
-        "no bundle is revoked"
-        assert response.initBundleRevokedIdsCount == 0
-        and:
-        "impacted cluster is listed"
-        assert response.initBundleRevocationErrorsList.first().impactedClustersList*.id.contains(cluster.id)
-    }
-
     def "Test that cluster init bundle can be revoked when it has no impacted clusters"() {
         BaseService.useApiToken(adminToken.token)
 


### PR DESCRIPTION
## Description

As discussed on https://issues.redhat.com/browse/ROX-29419, this change removes the failing test, because:

1. The same functionality is already covered elsewhere.
2. This particular test doesn't play nice with the (nowadays) automated cert rotation, which has direct impact on the need to specify "impacted clusters" during revokation.

## User-facing documentation

Nothing needed, just a test deletion.

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

Just *removed* a test for functionality, which is already covered by different tests.

### How I validated my change

Just CI.