### PR TITLE
ROX-30356: Add extensions for console Sec Vulns page

### DIFF
--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -3,6 +3,8 @@ const { DefinePlugin } = require('webpack');
 const { ConsoleRemotePlugin } = require('@openshift-console/dynamic-plugin-sdk-webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
+const acsRootBaseUrl = '/acs';
+
 const isProd = process.env.NODE_ENV === 'production';
 
 const config = {
@@ -104,22 +106,32 @@ const config = {
                 },
             },
             extensions: [
+                // Security Vulnerabilities Page
                 {
                     type: 'console.page/route',
                     properties: {
                         exact: true,
-                        path: '/security-TODO',
+                        path: `${acsRootBaseUrl}/security/vulnerabilities`,
                         component: { $codeRef: 'SecurityVulnerabilitiesPage.Index' },
+                    },
+                },
+                {
+                    type: 'console.navigation/section',
+                    properties: {
+                        id: 'acs-security',
+                        name: 'Security',
+                        startsWith: `${acsRootBaseUrl}/security`,
+                        insertBefore: ['compute', 'usermanagement', 'administration'],
                     },
                 },
                 {
                     type: 'console.navigation/href',
                     properties: {
                         id: 'security-vulnerabilities',
-                        name: '%plugin__console-plugin-template~Plugin Security Vulnerabilities%',
-                        href: '/security-TODO',
+                        name: 'Vulnerabilities',
+                        section: 'acs-security',
+                        href: `${acsRootBaseUrl}/security/vulnerabilities`,
                         perspective: 'admin',
-                        section: 'home',
                     },
                 },
             ],


### PR DESCRIPTION
## Description

Updates the extension points to correctly add the navigation items for the Security Vulnerabilities Page.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the console and see the "Security" section added to the left nav.
<img width="1545" height="905" alt="image" src="https://github.com/user-attachments/assets/77d6af7b-ef22-47d1-8a34-9e75fcf5e408" />

Expanding the Security section and selecting Vulnerabilities from the list correctly navigates to the vuln page:
<img width="1545" height="905" alt="image" src="https://github.com/user-attachments/assets/ceddf3b1-33ec-4933-aa86-92bb02bd7686" />

