### PR TITLE
ROX-30357: Add Security tab for Workload pages

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/Index.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/Index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { PageSection } from '@patternfly/react-core';
+
+export function Index() {
+    return <PageSection>Security</PageSection>;
+}

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -3,6 +3,8 @@ const { DefinePlugin } = require('webpack');
 const { ConsoleRemotePlugin } = require('@openshift-console/dynamic-plugin-sdk-webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
+const acsRootBaseUrl = '/acs';
+
 const isProd = process.env.NODE_ENV === 'production';
 
 const config = {
@@ -104,22 +106,32 @@ const config = {
                 },
             },
             extensions: [
+                // Security Vulnerabilities Page
                 {
                     type: 'console.page/route',
                     properties: {
                         exact: true,
-                        path: '/security-TODO',
+                        path: `${acsRootBaseUrl}/security/vulnerabilities`,
                         component: { $codeRef: 'SecurityVulnerabilitiesPage.Index' },
+                    },
+                },
+                {
+                    type: 'console.navigation/section',
+                    properties: {
+                        id: 'acs-security',
+                        name: 'Security',
+                        startsWith: `${acsRootBaseUrl}/security`,
+                        insertBefore: ['compute', 'usermanagement', 'administration'],
                     },
                 },
                 {
                     type: 'console.navigation/href',
                     properties: {
                         id: 'security-vulnerabilities',
-                        name: '%plugin__console-plugin-template~Plugin Security Vulnerabilities%',
-                        href: '/security-TODO',
+                        name: 'Vulnerabilities',
+                        section: 'acs-security',
+                        href: `${acsRootBaseUrl}/security/vulnerabilities`,
                         perspective: 'admin',
-                        section: 'home',
                     },
                 },
             ],

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -100,6 +100,7 @@ const config = {
                 exposedModules: {
                     SecurityVulnerabilitiesPage:
                         './ConsolePlugin/SecurityVulnerabilitiesPage/Index',
+                    WorkloadSecurityTab: './ConsolePlugin/WorkloadSecurityTab/Index',
                 },
                 dependencies: {
                     '@console/pluginAPI': '>=4.19.0',
@@ -134,6 +135,24 @@ const config = {
                         perspective: 'admin',
                     },
                 },
+                // Workload Detail Page Security Tab
+                ...['Deployment', 'ReplicaSet', 'StatefulSet', 'DaemonSet', 'Job', 'CronJob'].map(
+                    (kind) => ({
+                        type: 'console.tab/horizontalNav',
+                        properties: {
+                            model: {
+                                group: 'apps',
+                                kind,
+                                version: 'v1',
+                            },
+                            page: {
+                                name: 'Security',
+                                href: 'security',
+                            },
+                            component: { $codeRef: 'WorkloadSecurityTab.Index' },
+                        },
+                    })
+                ),
             ],
         }),
         new CopyWebpackPlugin({


### PR DESCRIPTION
## Description

Adds console extension point for the Security tab on OCP Workload pages.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the detail page for the different workloads and navigate to the Security tab:
<img width="1545" height="905" alt="image" src="https://github.com/user-attachments/assets/7501fee7-69ea-4bc8-8eb7-076e8c4c00a5" />

<img width="1545" height="905" alt="image" src="https://github.com/user-attachments/assets/00bee2d4-c230-40bf-b8f6-2cc184fc0053" />

