### PR TITLE
ROX-30360: Add extension point for admin ns security tab

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/Index.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/Index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function Index() {
+    return <div>AdministrationNamespaceSecurityTab</div>;
+}

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -101,6 +101,8 @@ const config = {
                     SecurityVulnerabilitiesPage:
                         './ConsolePlugin/SecurityVulnerabilitiesPage/Index',
                     WorkloadSecurityTab: './ConsolePlugin/WorkloadSecurityTab/Index',
+                    AdministrationNamespaceSecurityTab:
+                        './ConsolePlugin/AdministrationNamespaceSecurityTab/Index',
                 },
                 dependencies: {
                     '@console/pluginAPI': '>=4.19.0',
@@ -153,6 +155,24 @@ const config = {
                         },
                     })
                 ),
+                // Administration Namespace Security Tab
+                {
+                    type: 'console.tab/horizontalNav',
+                    properties: {
+                        model: {
+                            group: '',
+                            kind: 'Namespace',
+                            version: 'v1',
+                        },
+                        page: {
+                            name: 'Security',
+                            href: 'security',
+                        },
+                        component: {
+                            $codeRef: 'AdministrationNamespaceSecurityTab.Index',
+                        },
+                    },
+                },
             ],
         }),
         new CopyWebpackPlugin({


### PR DESCRIPTION
## Description

Adds an ACS extension point on the console Administration->Namespace page.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

👀 
<img width="1545" height="744" alt="image" src="https://github.com/user-attachments/assets/95e102bb-627f-4840-9cad-b5112c9bf622" />
