### PR TITLE
ROX-30415: Use split opt when applicable

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -169,11 +169,16 @@ jobs:
 
     - name: Run updater (multi bundle)
       run: |
-        if [ "$SCANNER_BUNDLE_VERSION" = "v1" ]; then
-          scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" --split bundles
-        else
-          scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" bundles
-        fi
+        tag=$(make -s --no-print-directory tag)
+        # In pre-4.9, the exporter requires --split to generate multi-bundles.
+        case "$tag" in
+            4.[0-8].*)
+                scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" --split bundles
+                ;;
+            *)
+                scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" bundles
+                ;;
+        esac
         zip definitions/"$SCANNER_BUNDLE_VERSION"/vulnerabilities.zip bundles/*.json.zst
 
     - name: Upload definitions artifacts

--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	var exportCmd = &cobra.Command{
-		Use:   "export [--split] [--manual-url <url>] <output-dir>",
+		Use:   "export [--manual-url <url>] <output-dir>",
 		Short: "Export vulnerabilities and write bundle(s) to <output-dir>.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Description

Parse the `make tag` of the current checkout to determine when to pass `--split` to the `updater export` command. As of today, builds <= 4.8.x require `--split` that was removed in master.

## User-facing documentation

- [X] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [X] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

~Waiting for bundle to be generated based on the `pr-updat-scanner-vulns` tag, then will see...~

Unfortunately, I can't run the build-and-run workflow without publishing the data to production at the moment. Adding a step for dispatch running this and uploading the results to a dev bucket would be a good way to test this. But since we don't have that right now, I can only test the path using triggered by the `pr-update-scanner-vulns`.
