### PR TITLE
chore(CI): Ignore scanner restart because of slow db start

### DIFF
--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -13,7 +13,7 @@
     },
     {
         "comment": "scanner restart due to slow postgres db start",
-        "job": "^(ibmcloudz)",
+        "job": ".*",
         "logfile": "scanner-previous",
         "logline": "Failed to open database despite multiple retries"
     },


### PR DESCRIPTION
## Description

This PR is ignoring `scanner` (v2) pod restarts caused by timeouts on waiting for the scanner DB to be ready.

A better solution would be to increase the wait time in the scanner for the DB to be ready, but until that is fixed, we should keep this ignored, because many merge commits will have at least one test failure caused by the scanner restart.

And for nightly runs, there are often failures on ARO, EKS, or ROSA related to scanner restart.

My proposal is to disable the restart check for long scanner DB init time for two reasons:
- merge commits and nightly runs have a high probability of having at least one failed test due to scanner restart
- we are not losing coverage, because if the scanner DB is never up and ready, other tests would fail
- we can keep this "workaround" until the problem (if we can call it a problem) is fixed in another way

Related ticket: https://issues.redhat.com/browse/ROX-27096

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [ ] will let CI run
