### PR TITLE
ROX-30353: Connect OCP plugin build to main build task

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
         "test-component": "npm --prefix apps/platform run test-component",
         "posttest-e2e:coverage": "mv apps/platform/coverage/ ./test-results/artifacts/",
         "prebuild": "npm run clean",
-        "build": "npm --prefix apps/platform run build",
+        "build": "npm --prefix apps/platform run build && npm --prefix apps/platform run build:ocp-plugin",
         "postbuild": "mv apps/platform/build/ .",
         "connect": "../scripts/connect-ui.sh ${1}",
         "deploy": "../deploy/k8s/deploy.sh",


### PR DESCRIPTION
## Description

Adds the OCP plugin build task after the standalone build task when run via Makefile or top level ui package.json.

Since both builds use a single shared codebase, and will be distributed in the same folder in a single image, we will keep the builds as a single step at the top level.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

`cd ui && make build`

Verify that both sets of build files persist:
```
$ ls build/static/*.js | wc -l


$ ls build/static/ocp-plugin/*.js | wc -l

```
