### PR TITLE
ROX-30413: Optimize deployment ranking

### DIFF
--- a/central/deployment/datastore/datastore.go
+++ b/central/deployment/datastore/datastore.go
@@ -60,7 +60,7 @@ func newDataStore(
 	platformMatcher platformmatcher.PlatformMatcher) (DataStore, error) {
 	ds := newDatastoreImpl(storage, images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker, platformMatcher)
 
-	ds.initializeRanker()
+	go ds.initializeRanker()
 	return ds, nil
 }
 

--- a/central/deployment/datastore/datastore_impl.go
+++ b/central/deployment/datastore/datastore_impl.go
@@ -87,13 +87,8 @@ func (ds *datastoreImpl) initializeRanker() {
 
 	clusterScores := make(map[string]float32)
 	nsScores := make(map[string]float32)
-
-	query := pkgSearch.NewQueryBuilder().AddSelectFields(pkgSearch.NewQuerySelect(pkgSearch.DeploymentID),
-		pkgSearch.NewQuerySelect(pkgSearch.NamespaceID),
-		pkgSearch.NewQuerySelect(pkgSearch.ClusterID),
-		pkgSearch.NewQuerySelect(pkgSearch.RiskScore)).ProtoQuery()
-
-	err := ds.deploymentStore.WalkByQuery(readCtx, query, func(deployment *storage.Deployment) error {
+	// The store search function does not use select fields, only views do. Hence empty query is used in the walk below
+	err := ds.deploymentStore.WalkByQuery(readCtx, pkgSearch.EmptyQuery(), func(deployment *storage.Deployment) error {
 		riskScore := deployment.GetRiskScore()
 		ds.deploymentRanker.Add(deployment.GetId(), riskScore)
 

--- a/central/deployment/datastore/datastore_impl.go
+++ b/central/deployment/datastore/datastore_impl.go
@@ -85,25 +85,17 @@ func (ds *datastoreImpl) initializeRanker() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Deployment)))
 
-	results, err := ds.Search(readCtx, pkgSearch.EmptyQuery())
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
 	clusterScores := make(map[string]float32)
 	nsScores := make(map[string]float32)
-	for _, id := range pkgSearch.ResultsToIDs(results) {
-		deployment, found, err := ds.deploymentStore.Get(readCtx, id)
-		if err != nil {
-			log.Error(err)
-			continue
-		} else if !found {
-			continue
-		}
 
+	query := pkgSearch.NewQueryBuilder().AddSelectFields(pkgSearch.NewQuerySelect(pkgSearch.DeploymentID),
+		pkgSearch.NewQuerySelect(pkgSearch.NamespaceID),
+		pkgSearch.NewQuerySelect(pkgSearch.ClusterID),
+		pkgSearch.NewQuerySelect(pkgSearch.RiskScore)).ProtoQuery()
+
+	err := ds.deploymentStore.WalkByQuery(readCtx, query, func(deployment *storage.Deployment) error {
 		riskScore := deployment.GetRiskScore()
-		ds.deploymentRanker.Add(id, deployment.GetRiskScore())
+		ds.deploymentRanker.Add(deployment.GetId(), riskScore)
 
 		// TODO: ROX-6235: account for nodes in cluster risk
 		// aggregate deployment risk scores to get cluster risk score
@@ -111,6 +103,12 @@ func (ds *datastoreImpl) initializeRanker() {
 
 		// aggregate deployment risk scores to obtain namespace risk score
 		nsScores[deployment.GetNamespaceId()] += riskScore
+
+		return nil
+	})
+	if err != nil {
+		log.Errorf("unable to initialize deployment ranking: %v", err)
+		return
 	}
 
 	if ds.nsRanker != nil {

--- a/central/deployment/datastore/datastore_impl_test.go
+++ b/central/deployment/datastore/datastore_impl_test.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
 	storeMocks "github.com/stackrox/rox/central/deployment/datastore/internal/store/mocks"
 	matcherMocks "github.com/stackrox/rox/central/platform/matcher/mocks"
 	"github.com/stackrox/rox/central/ranking"
 	riskMocks "github.com/stackrox/rox/central/risk/datastore/mocks"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sac"
-	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -84,14 +83,7 @@ func (suite *DeploymentDataStoreTestSuite) TestInitializeRanker() {
 			Id: "5",
 		},
 	}
-
-	suite.storage.EXPECT().Search(gomock.Any(), search.EmptyQuery()).Return([]search.Result{{ID: "1"}, {ID: "2"}, {ID: "3"}, {ID: "4"}, {ID: "5"}}, nil)
-	suite.storage.EXPECT().Get(gomock.Any(), deployments[0].Id).Return(deployments[0], true, nil)
-	suite.storage.EXPECT().Get(gomock.Any(), deployments[1].Id).Return(deployments[1], true, nil)
-	suite.storage.EXPECT().Get(gomock.Any(), deployments[2].Id).Return(deployments[2], true, nil)
-	suite.storage.EXPECT().Get(gomock.Any(), deployments[3].Id).Return(nil, false, nil)
-	suite.storage.EXPECT().Get(gomock.Any(), deployments[4].Id).Return(nil, false, errors.New("fake error"))
-
+	suite.storage.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(walkMockFunc(deployments))
 	ds.initializeRanker()
 
 	suite.Equal(int64(1), clusterRanker.GetRankForID("c1"))
@@ -103,6 +95,17 @@ func (suite *DeploymentDataStoreTestSuite) TestInitializeRanker() {
 	suite.Equal(int64(1), deploymentRanker.GetRankForID("2"))
 	suite.Equal(int64(2), deploymentRanker.GetRankForID("1"))
 	suite.Equal(int64(3), deploymentRanker.GetRankForID("3"))
+}
+
+func walkMockFunc(deployments []*storage.Deployment) func(_ context.Context, _ *v1.Query, fn func(group *storage.Deployment) error) error {
+	return func(_ context.Context, _ *v1.Query, fn func(deployment *storage.Deployment) error) error {
+		for _, g := range deployments {
+			if err := fn(g); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 }
 
 func (suite *DeploymentDataStoreTestSuite) TestMergeCronJobs() {

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -303,12 +303,8 @@ func (ds *datastoreImpl) initializeRankers() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Image)))
 
-	selects := []*v1.QuerySelect{
-		pkgSearch.NewQuerySelect(pkgSearch.ImageSHA).Proto(),
-		pkgSearch.NewQuerySelect(pkgSearch.ImageRiskScore).Proto(),
-	}
-	query := pkgSearch.EmptyQuery()
-	query.Selects = selects
+	query := pkgSearch.NewQueryBuilder().AddSelectFields(pkgSearch.NewQuerySelect(pkgSearch.ImageSHA),
+		pkgSearch.NewQuerySelect(pkgSearch.ImageRiskScore)).ProtoQuery()
 
 	// The entire image is not needed to initialize the ranker.  We only need the image id and risk score.
 	var results []*views.ImageRiskView


### PR DESCRIPTION
## Description

Deployment rankers should not be initialized in the critical path of central startup which brings up the deployment service.
Also, given deployment store is a high cardinality store, using Walk with query instead of the dual Search and GetByID for each deployment is optimized data access pattern. This change should improve startup times and central memory needed.

Also in the image datastore, modified the query construction to use the query builder pattern for better readability.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change
 Deployed PR image, and click around on UI, deployment listing, risk scores, dashboard etc. all worked fine.
