### PR TITLE
ROX-30422: Add route for CVE detail page

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/CveDetailPage/Index.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/CveDetailPage/Index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { useParams } from 'react-router-dom-v5-compat';
+
+export function Index() {
+    const { cveId } = useParams();
+    const [namespace] = useActiveNamespace();
+    return (
+        <>
+            <div>CVE Detail Page</div>
+            <div>Namespace: {namespace}</div>
+            <div>CVE ID: {cveId}</div>
+        </>
+    );
+}

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -101,6 +101,7 @@ const config = {
                     context: './ConsolePlugin/PluginProvider',
                     AdministrationNamespaceSecurityTab:
                         './ConsolePlugin/AdministrationNamespaceSecurityTab/Index',
+                    CveDetailPage: './ConsolePlugin/CveDetailPage/Index',
                     ImageDetailPage: './ConsolePlugin/ImageDetailPage/Index',
                     ProjectSecurityTab: './ConsolePlugin/ProjectSecurityTab/Index',
                     SecurityVulnerabilitiesPage:
@@ -209,6 +210,15 @@ const config = {
                         exact: true,
                         path: `${acsRootBaseUrl}/security/vulnerabilities/images/:imageId`,
                         component: { $codeRef: 'ImageDetailPage.Index' },
+                    },
+                },
+                // Image CVE Detail Page
+                {
+                    type: 'console.page/route',
+                    properties: {
+                        exact: true,
+                        path: `${acsRootBaseUrl}/security/vulnerabilities/cves/:cveId`,
+                        component: { $codeRef: 'CveDetailPage.Index' },
                     },
                 },
             ],


### PR DESCRIPTION
## Description

Adds route and component for ImageCve single page in the console.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1545" height="744" alt="image" src="https://github.com/user-attachments/assets/e24c655b-4107-4cbd-95de-d66e8fdea70f" />