### PR TITLE
ROX-30428: Replace namespace import from react-feature and react

### DIFF
--- a/ui/apps/platform/src/Components/CloseButton.jsx
+++ b/ui/apps/platform/src/Components/CloseButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Icon from 'react-feather';
+import { X } from 'react-feather';
 
 const CloseButton = ({ className, iconColor, onClose }) => (
     <div
@@ -13,7 +13,7 @@ const CloseButton = ({ className, iconColor, onClose }) => (
                 onClick={onClose}
                 aria-label="Close"
             >
-                <Icon.X className="h-7 w-7" height={null} width={null} />
+                <X className="h-7 w-7" height={null} width={null} />
             </button>
         </span>
     </div>

--- a/ui/apps/platform/src/Components/CollapsibleCard.jsx
+++ b/ui/apps/platform/src/Components/CollapsibleCard.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Collapsible from 'react-collapsible';
-import * as Icon from 'react-feather';
+import { ChevronDown, ChevronUp } from 'react-feather';
 
 class CollapsibleCard extends Component {
     static propTypes = {
@@ -29,8 +29,8 @@ class CollapsibleCard extends Component {
 
     renderTriggerElement = (cardState) => {
         const icons = {
-            opened: <Icon.ChevronUp className="h-4 w-4" />,
-            closed: <Icon.ChevronDown className="h-4 w-4" />,
+            opened: <ChevronUp className="h-4 w-4" />,
+            closed: <ChevronDown className="h-4 w-4" />,
         };
         const { title, titleClassName, headerComponents, isCollapsible } = this.props;
         const className = isCollapsible ? titleClassName : `${titleClassName} pointer-events-none`;

--- a/ui/apps/platform/src/Components/ExportButton.jsx
+++ b/ui/apps/platform/src/Components/ExportButton.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import * as Icon from 'react-feather';
+import { FileText } from 'react-feather';
 import onClickOutside from 'react-onclickoutside';
 import { toast } from 'react-toastify';
 import { Button } from '@patternfly/react-core';
@@ -190,7 +190,7 @@ class ExportButton extends Component {
                     text="Export"
                     textCondensed="Export"
                     textClass={this.props.textClass}
-                    icon={<Icon.FileText size="14" className="mx-1 lg:ml-1 lg:mr-3" />}
+                    icon={<FileText size="14" className="mx-1 lg:ml-1 lg:mr-3" />}
                     onClick={this.toggleWidget}
                 />
                 {this.renderContent()}

--- a/ui/apps/platform/src/Components/NoResultsMessage.jsx
+++ b/ui/apps/platform/src/Components/NoResultsMessage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Icon from 'react-feather';
+import { AlertTriangle, CheckCircle } from 'react-feather';
 
 const icons = {
-    info: <Icon.CheckCircle className="h-8 w-8 mr-4 text-success-500" />,
-    warn: <Icon.AlertTriangle className="h-8 w-8 mr-4 text-warning-500" />,
+    info: <CheckCircle className="h-8 w-8 mr-4 text-success-500" />,
+    warn: <AlertTriangle className="h-8 w-8 mr-4 text-warning-500" />,
 };
 
 const NoResultsMessage = (props) => (

--- a/ui/apps/platform/src/Components/PagerControls.jsx
+++ b/ui/apps/platform/src/Components/PagerControls.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as Icon from 'react-feather';
+import { ChevronLeft, ChevronRight } from 'react-feather';
 
 export const PagerButtonGroup = ({ onPagePrev, onPageNext, enableNext, enablePrev }) => (
     <div className="-mt-1 flex">
@@ -12,7 +12,7 @@ export const PagerButtonGroup = ({ onPagePrev, onPageNext, enableNext, enablePre
                 !enableNext ? 'border-r-2' : ''
             }`}
         >
-            <Icon.ChevronLeft className="mt-1 h-4" />
+            <ChevronLeft className="mt-1 h-4" />
         </button>
         <button
             type="button"
@@ -20,7 +20,7 @@ export const PagerButtonGroup = ({ onPagePrev, onPageNext, enableNext, enablePre
             disabled={!enableNext}
             className="border-base-300 border-2 hover:bg-base-200"
         >
-            <Icon.ChevronRight className="mt-1 h-4" />
+            <ChevronRight className="mt-1 h-4" />
         </button>
     </div>
 );

--- a/ui/apps/platform/src/Components/Select.jsx
+++ b/ui/apps/platform/src/Components/Select.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import * as Icon from 'react-feather';
+import { ChevronDown } from 'react-feather';
 
 class Select extends Component {
     static propTypes = {
@@ -66,7 +66,7 @@ class Select extends Component {
                 <div
                     className={`${triggerClass} absolute inset-y-0 right-0 flex items-center px-2 cursor-pointer z-10 pointer-events-none`}
                 >
-                    <Icon.ChevronDown className="h-4 w-4" />
+                    <ChevronDown className="h-4 w-4" />
                 </div>
             </div>
         );

--- a/ui/apps/platform/src/Components/TablePagination.jsx
+++ b/ui/apps/platform/src/Components/TablePagination.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import * as Icon from 'react-feather';
+import { ChevronLeft, ChevronRight } from 'react-feather';
 import debounce from 'lodash/debounce';
 import clamp from 'lodash/clamp';
 
@@ -91,7 +91,7 @@ const TablePagination = ({ dataLength, setPage, page, pageSize }) => {
                     disabled={page <= 0}
                     aria-label="Go to previous page"
                 >
-                    <Icon.ChevronLeft className="h-6 w-6" />
+                    <ChevronLeft className="h-6 w-6" />
                 </button>
                 <button
                     type="button"
@@ -100,7 +100,7 @@ const TablePagination = ({ dataLength, setPage, page, pageSize }) => {
                     disabled={page >= totalPages - 1}
                     aria-label="Go to next page"
                 >
-                    <Icon.ChevronRight className="h-6 w-6" />
+                    <ChevronRight className="h-6 w-6" />
                 </button>
             </div>
         </div>

--- a/ui/apps/platform/src/Components/ThrowingQuery.jsx
+++ b/ui/apps/platform/src/Components/ThrowingQuery.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Query } from '@apollo/client/react/components';
 import PropTypes from 'prop-types';
 import Raven from 'raven-js';
-import * as Icons from 'react-feather';
+import { XSquare } from 'react-feather';
 
 const GraphQLError = ({ error }) => (
     <div
@@ -10,7 +10,7 @@ const GraphQLError = ({ error }) => (
         data-testid="graphql-error"
     >
         <div className="flex items-center justify-center">
-            <Icons.XSquare size="48" />
+            <XSquare size="48" />
         </div>
         <div className="pl-2">
             <div className="text-2xl">An Error has occurred</div>

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.jsx
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { components } from 'react-select';
 import queryString from 'qs';
 import { connect } from 'react-redux';
-import * as Icon from 'react-feather';
+import { Filter } from 'react-feather';
 
 import { actions as searchAutoCompleteActions } from 'reducers/searchAutocomplete';
 import { Creatable } from 'Components/ReactSelect';
@@ -52,7 +52,7 @@ export const Option = ({ children, ...rest }) => {
 export const ValueContainer = ({ ...props }) => (
     <>
         <span className="text-base-500 flex h-full items-center pl-2 pr-1 pointer-events-none">
-            <Icon.Filter color="currentColor" size={18} />
+            <Filter color="currentColor" size={18} />
         </span>
         <components.ValueContainer {...props} />
     </>

--- a/ui/apps/platform/src/Components/visuals/SunburstDetailSection.jsx
+++ b/ui/apps/platform/src/Components/visuals/SunburstDetailSection.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import * as Icon from 'react-feather';
+import { Info } from 'react-feather';
 import Truncate from 'react-truncate';
 import { Link } from 'react-router-dom-v5-compat';
 
@@ -104,7 +104,7 @@ class SunburstDetailSection extends Component {
         return (
             <div className="border-t border-base-300 border-dashed flex justify-end px-2 h-7 text-sm">
                 <div className="flex items-center">
-                    <Icon.Info size="16" className="pr-1" />
+                    <Info size="16" className="pr-1" />
                     {`click to ${clicked ? 'un' : ''}lock selection`}
                 </div>
             </div>

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/Index.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/Index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { PageSection, Title } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Compliance/List/TableGroup.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/TableGroup.jsx
@@ -2,13 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Table from 'Components/Table';
 import Collapsible from 'react-collapsible';
-import * as Icon from 'react-feather';
+import { ChevronDown, ChevronUp } from 'react-feather';
 
 import { entityCountNounOrdinaryCase } from '../entitiesForCompliance';
 
 const icons = {
-    opened: <Icon.ChevronUp size="14" />,
-    closed: <Icon.ChevronDown size="14" />,
+    opened: <ChevronUp size="14" />,
+    closed: <ChevronDown size="14" />,
 };
 
 class TableGroup extends Component {

--- a/ui/apps/platform/src/Containers/Compliance/ScanButton.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/ScanButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Mutation } from '@apollo/client/react/components';
-import * as Icon from 'react-feather';
+import { RefreshCcw } from 'react-feather';
 import { Spinner } from '@patternfly/react-core';
 
 import { actions as notificationActions } from 'reducers/notifications';
@@ -64,7 +64,7 @@ class ScanButton extends React.Component {
                                 scanInProgress ? (
                                     <Spinner size="md" className="mx-1 lg:ml-1 lg:mr-3" />
                                 ) : (
-                                    <Icon.RefreshCcw
+                                    <RefreshCcw
                                         size="14"
                                         className="bg-base-100 mx-1 lg:ml-1 lg:mr-3"
                                     />

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleEdge.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleEdge.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import * as React from 'react';
+import React, { useMemo } from 'react';
+import type { FunctionComponent, PropsWithChildren } from 'react';
 import { observer } from 'mobx-react';
 import { Edge, DefaultEdge } from '@patternfly/react-topology';
 
@@ -7,13 +8,10 @@ type StyleEdgeProps = {
     element: Edge;
 };
 
-const StyleEdge: React.FunctionComponent<React.PropsWithChildren<StyleEdgeProps>> = ({
-    element,
-    ...rest
-}) => {
+const StyleEdge: FunctionComponent<PropsWithChildren<StyleEdgeProps>> = ({ element, ...rest }) => {
     const data = element.getData();
 
-    const passedData = React.useMemo(() => {
+    const passedData = useMemo(() => {
         const newData = { ...data };
         Object.keys(newData).forEach((key) => {
             if (newData[key] === undefined) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import * as React from 'react';
+import React, { useMemo } from 'react';
+import type { ComponentClass, FunctionComponent, PropsWithChildren, ReactNode } from 'react';
 import {
     Node,
     observer,
@@ -26,14 +27,12 @@ type StyleGroupProps = {
     collapsedWidth?: number;
     collapsedHeight?: number;
     onCollapseChange?: (group: Node, collapsed: boolean) => void;
-    getCollapsedShape?: (
-        node: Node
-    ) => React.FunctionComponent<React.PropsWithChildren<ShapeProps>>;
+    getCollapsedShape?: (node: Node) => FunctionComponent<PropsWithChildren<ShapeProps>>;
     collapsedShadowOffset?: number; // defaults to 10
 } & WithDragNodeProps &
     WithSelectionProps;
 
-const StyleFakeGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroupProps>> = ({
+const StyleFakeGroup: FunctionComponent<PropsWithChildren<StyleGroupProps>> = ({
     element,
     collapsedWidth = 75,
     collapsedHeight = 75,
@@ -42,7 +41,7 @@ const StyleFakeGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroup
     const data = element.getData();
     const detailsLevel = useDetailsLevel();
 
-    const getTypeIcon = (dataType?: DataTypes): React.ComponentClass<SVGIconProps> => {
+    const getTypeIcon = (dataType?: DataTypes): ComponentClass<SVGIconProps> => {
         switch (dataType) {
             case DataTypes.Alternate:
                 return AlternateIcon;
@@ -51,7 +50,7 @@ const StyleFakeGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroup
         }
     };
 
-    const renderIcon = (): React.ReactNode => {
+    const renderIcon = (): ReactNode => {
         const iconSize = Math.min(collapsedWidth, collapsedHeight) - ICON_PADDING * 2;
         const Component = getTypeIcon(data.dataType);
 
@@ -66,7 +65,7 @@ const StyleFakeGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroup
         );
     };
 
-    const passedData = React.useMemo(() => {
+    const passedData = useMemo(() => {
         const newData = { ...data };
         Object.keys(newData).forEach((key) => {
             if (newData[key] === undefined) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import React, { useMemo } from 'react';
+import type { ComponentClass, FunctionComponent, PropsWithChildren, ReactNode } from 'react';
 import {
     DefaultGroup,
     Node,
@@ -27,14 +28,12 @@ type StyleGroupProps = {
     collapsedWidth?: number;
     collapsedHeight?: number;
     onCollapseChange?: (group: Node, collapsed: boolean) => void;
-    getCollapsedShape?: (
-        node: Node
-    ) => React.FunctionComponent<React.PropsWithChildren<ShapeProps>>;
+    getCollapsedShape?: (node: Node) => FunctionComponent<PropsWithChildren<ShapeProps>>;
     collapsedShadowOffset?: number; // defaults to 10
 } & WithDragNodeProps &
     WithSelectionProps;
 
-const StyleGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroupProps>> = ({
+const StyleGroup: FunctionComponent<PropsWithChildren<StyleGroupProps>> = ({
     element,
     collapsedWidth = 75,
     collapsedHeight = 75,
@@ -43,7 +42,7 @@ const StyleGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroupProp
     const data = element.getData();
     const detailsLevel = useDetailsLevel();
 
-    const getTypeIcon = (dataType?: DataTypes): React.ComponentClass<SVGIconProps> => {
+    const getTypeIcon = (dataType?: DataTypes): ComponentClass<SVGIconProps> => {
         switch (dataType) {
             case DataTypes.Alternate:
                 return AlternateIcon;
@@ -52,7 +51,7 @@ const StyleGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroupProp
         }
     };
 
-    const renderIcon = (): React.ReactNode => {
+    const renderIcon = (): ReactNode => {
         const iconSize = Math.min(collapsedWidth, collapsedHeight) - ICON_PADDING * 2;
         const Component = getTypeIcon(data.dataType);
 
@@ -67,14 +66,14 @@ const StyleGroup: React.FunctionComponent<React.PropsWithChildren<StyleGroupProp
         );
     };
 
-    const passedData = React.useMemo(() => {
+    const passedData = useMemo(() => {
         const newData = { ...data };
         Object.keys(newData).forEach((key) => {
             if (newData[key] === undefined) {
                 delete newData[key];
             }
         });
-        // look into using `React.useMemo<CustomGroupNodeData>` instead of `as CustomGroupNodeData`
+        // look into using `useMemo<CustomGroupNodeData>` instead of `as CustomGroupNodeData`
         // https://www.freecodecamp.org/news/react-typescript-how-to-set-up-types-on-hooks/#set-types-on-usememo
         return newData as CustomGroupNodeData;
     }, [data]);

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import * as React from 'react';
+import React, { useEffect, useMemo } from 'react';
+import type {
+    ComponentClass,
+    FunctionComponent,
+    LegacyRef,
+    PropsWithChildren,
+    ReactNode,
+} from 'react';
 import {
     Decorator,
     DEFAULT_DECORATOR_RADIUS,
@@ -38,10 +45,10 @@ const CUSTOM_DECORATOR_PADDING = 2.5;
 
 type StyleNodeProps = {
     element: Node;
-    getCustomShape?: (node: Node) => React.FunctionComponent<React.PropsWithChildren<ShapeProps>>;
+    getCustomShape?: (node: Node) => FunctionComponent<PropsWithChildren<ShapeProps>>;
     getShapeDecoratorCenter?: (quadrant: TopologyQuadrant, node: Node) => { x: number; y: number };
     showLabel?: boolean; // Defaults to true
-    labelIcon?: React.ComponentClass<SVGIconProps>;
+    labelIcon?: ComponentClass<SVGIconProps>;
     showStatusDecorator?: boolean; // Defaults to false
     regrouping?: boolean;
     dragging?: boolean;
@@ -50,7 +57,7 @@ type StyleNodeProps = {
     WithDragNodeProps &
     WithSelectionProps;
 
-const getTypeIcon = (type?: NodeDataType): React.ComponentClass<SVGIconProps> => {
+const getTypeIcon = (type?: NodeDataType): ComponentClass<SVGIconProps> => {
     switch (type) {
         case 'EXTERNAL_ENTITIES':
         case 'CIDR_BLOCK':
@@ -62,7 +69,7 @@ const getTypeIcon = (type?: NodeDataType): React.ComponentClass<SVGIconProps> =>
     }
 };
 
-const renderIcon = (data: { type?: NodeDataType }, element: Node): React.ReactNode => {
+const renderIcon = (data: { type?: NodeDataType }, element: Node): ReactNode => {
     const { width, height } = element.getDimensions();
     const shape = element.getNodeShape();
     const iconSize =
@@ -95,7 +102,7 @@ function getPolicyStateIcon(policyState: NetworkPolicyState) {
 const renderDecorator = (
     element: Node,
     quadrant: TopologyQuadrant,
-    icon: React.ReactNode,
+    icon: ReactNode,
     getShapeDecoratorCenter?: (
         quadrant: TopologyQuadrant,
         node: Node,
@@ -104,7 +111,7 @@ const renderDecorator = (
         x: number;
         y: number;
     }
-): React.ReactNode => {
+): ReactNode => {
     const { x, y } = getShapeDecoratorCenter
         ? getShapeDecoratorCenter(quadrant, element)
         : getDefaultShapeDecoratorCenter(quadrant, element);
@@ -135,7 +142,7 @@ const renderDecorators = (
         x: number;
         y: number;
     }
-): React.ReactNode => {
+): ReactNode => {
     const { showPolicyState, networkPolicyState, showExternalState, isExternallyConnected } = data;
     return (
         <>
@@ -158,7 +165,7 @@ const renderDecorators = (
     );
 };
 
-const StyleNode: React.FunctionComponent<React.PropsWithChildren<StyleNodeProps>> = ({
+const StyleNode: FunctionComponent<PropsWithChildren<StyleNodeProps>> = ({
     element,
     onContextMenu,
     contextMenuOpen,
@@ -173,7 +180,7 @@ const StyleNode: React.FunctionComponent<React.PropsWithChildren<StyleNodeProps>
     const detailsLevel = useDetailsLevel();
     const [hover, hoverRef] = useHover();
 
-    const passedData = React.useMemo(() => {
+    const passedData = useMemo(() => {
         const newData = { ...data };
         Object.keys(newData).forEach((key) => {
             if (newData[key] === undefined) {
@@ -183,7 +190,7 @@ const StyleNode: React.FunctionComponent<React.PropsWithChildren<StyleNodeProps>
         return newData;
     }, [data]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (detailsLevel === ScaleDetailsLevel.low && onHideCreateConnector) {
             onHideCreateConnector();
         }
@@ -196,7 +203,7 @@ const StyleNode: React.FunctionComponent<React.PropsWithChildren<StyleNodeProps>
 
     return (
         <Layer id={hover ? TOP_LAYER : DEFAULT_LAYER}>
-            <g ref={hoverRef as React.LegacyRef<SVGGElement>}>
+            <g ref={hoverRef as LegacyRef<SVGGElement>}>
                 <DefaultNode
                     className={className}
                     element={element}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
-import * as Icon from 'react-feather';
+import { Archive, Bell, BellOff, Plus, Zap } from 'react-feather';
 import { connect } from 'react-redux';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
@@ -508,7 +508,7 @@ const VulnMgmtCves = ({
                           <RowActionButton
                               text="Add to policy"
                               onClick={addToPolicy(cve)}
-                              icon={<Icon.Plus className="my-1 h-4 w-4" />}
+                              icon={<Plus className="my-1 h-4 w-4" />}
                           />
                       )}
                       {hasWriteAccessForRiskAcceptance &&
@@ -517,7 +517,7 @@ const VulnMgmtCves = ({
                               <RowActionMenu
                                   className="h-full min-w-30"
                                   border="border-l-2 border-base-400"
-                                  icon={<Icon.BellOff className="h-4 w-4" />}
+                                  icon={<BellOff className="h-4 w-4" />}
                                   options={snoozeOptions(cve)}
                                   text="Defer and approve CVE"
                               />
@@ -529,7 +529,7 @@ const VulnMgmtCves = ({
                                   text="Reobserve CVE"
                                   border="border-l-2 border-base-400"
                                   onClick={unsuppressCves(cve)}
-                                  icon={<Icon.Bell className="my-1 h-4 w-4" />}
+                                  icon={<Bell className="my-1 h-4 w-4" />}
                               />
                           )}
                   </div>
@@ -542,7 +542,7 @@ const VulnMgmtCves = ({
         <>
             {hasWriteAccessForAddToPolicy && cveType === entityTypes.IMAGE_CVE && (
                 <PanelButton
-                    icon={<Icon.Plus className="h-4 w-4" />}
+                    icon={<Plus className="h-4 w-4" />}
                     className="btn-icon btn-tertiary"
                     onClick={addToPolicy()}
                     disabled={selectedCveIds.length === 0}
@@ -559,7 +559,7 @@ const VulnMgmtCves = ({
                         menuClassName="bg-base-100 min-w-28"
                         buttonClass="btn-icon btn-tertiary"
                         buttonText="Defer and approve"
-                        buttonIcon={<Icon.BellOff className="h-4 w-4 mr-2" />}
+                        buttonIcon={<BellOff className="h-4 w-4 mr-2" />}
                         options={snoozeOptions()}
                         disabled={selectedCveIds.length === 0}
                         tooltip="Defer and approve selected CVEs"
@@ -570,7 +570,7 @@ const VulnMgmtCves = ({
                 viewingSuppressed &&
                 shouldRenderGlobalSnoozeAction && (
                     <PanelButton
-                        icon={<Icon.Bell className="h-4 w-4" />}
+                        icon={<Bell className="h-4 w-4" />}
                         className="btn-icon btn-tertiary ml-2"
                         onClick={unsuppressCves()}
                         disabled={selectedCveIds.length === 0}
@@ -585,9 +585,9 @@ const VulnMgmtCves = ({
                 <PanelButton
                     icon={
                         viewingSuppressed ? (
-                            <Icon.Zap className="h-4 w-4" />
+                            <Zap className="h-4 w-4" />
                         ) : (
-                            <Icon.Archive className="h-4 w-4" />
+                            <Archive className="h-4 w-4" />
                         )
                     }
                     className="btn-icon btn-tertiary ml-2"


### PR DESCRIPTION
## Description

### Problem

1. **Saif** reminded the team that lint takes minutes.
2. **David** reminded the team that 2 rules take 90% of that and graciously provided the following data:

    ```sh
    $ time TIMING=1 npm run lint

    > @stackrox/platform-app@0.0.0 lint
    > eslint --quiet .

    Rule                                    | Time (ms) | Relative
    :---------------------------------------|----------:|--------:
    import/no-cycle                         | 81605.021 |    45.6%
    import/namespace                        | 78631.119 |    44.0%
    prettier/prettier                       |  8000.891 |     4.5%
    @typescript-eslint/no-unsafe-return     |  1400.253 |     0.8%
    @typescript-eslint/unbound-method       |   838.543 |     0.5%
    import/default                          |   824.172 |     0.5%
    @typescript-eslint/no-unused-vars       |   591.264 |     0.3%
    import/no-relative-packages             |   523.847 |     0.3%
    @typescript-eslint/no-floating-promises |   479.097 |     0.3%
    react/display-name                      |   377.572 |     0.2%
    TIMING=1 npm run lint  225.90s user 10.71s system 124% cpu 3:09.83 total
    ```

### Analysis

1. First slowest rule: I was reminded the hard way that `'import/no-cycle'` rule has 7 eslint-disable commemts in classic compliance, so will follow up soon.

2. Second slowest rule: `'import/namespace'` flies under the radar:

    ```js
    // https://github.com/import-js/eslint-plugin-import/blob/main/config/errors.js
    ...pluginImport.configs.errors.rules, // depends on parsers and resolver in settings
    ```

    https://github.com/import-js/eslint-plugin-import/blob/main/config/errors.js#L10

    https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md

    > Enforces names exist at the time they are dereferenced, when imported as a full namespace (i.e. `import * as foo from './foo';`

    Find in Files for `import * as` has 100 results in 98 files

    ```sh
    find src \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' \) -exec fgrep -h "import * as"  \{\} >> …/import_namespace.txt \;

    sort …/import_namespace.txt | uniq -c > …/import_namespace_sort_uniq.txt
    ```

    ```
     4 import * as AuthService from 'services/AuthService';
     1 import * as BackupIntegrationsService from 'services/BackupIntegrationsService';
    17 import * as Icon from 'react-feather';
     1 import * as Icons from 'react-feather';
     6 import * as React from 'react';
     1 import * as Yup from 'yup';
     1 import * as networkService from 'services/NetworkService';
     1 import * as service from 'services/APITokensService';
     1 import * as service from 'services/CloudSourceService';
     1 import * as service from 'services/GroupsService';
     1 import * as service from 'services/IntegrationsService';
     1 import * as service from 'services/MachineAccessService';
     1 import * as service from 'services/RolesService';
     1 import * as service from 'services/SearchService';
    62 import * as yup from 'yup';
    ```

### Solution

Replace `import * as` namespace with `import { … }` named import.

Batch 1 consists of `'react-feature'` and `react` for 24 occurrences.

Exceptions:
* Risk to prevent merge conflicts where I already replaced with PatternFly icons in #15936
* DefaultFakeGroup.tsx file so we can investigate 11 `React.createElement` calls (only file that has them),

### Residue

1. Add lint rule to report namespace import as error.
2. Investigate `createElement` calls and `LegacyRef` type.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
    See slight percent increase in `'import/no-cycle'` and decrease in `'import/namespace'` which suggests:
    * It helped to replace a few occurrences of namespace with named import.
    * Time might be proportional to number of namespace references in files, therefore `yup` package has not only most files, but by far most references.
3. `npm run start` in ui/apps/platform folder.

#### Manual testing

1. Visit classic routes, open side panel to see `X` icon.
