### PR TITLE
ROX-30429: Replace namespace import from services

### DIFF
--- a/ui/apps/platform/src/init/configureStore.js
+++ b/ui/apps/platform/src/init/configureStore.js
@@ -9,7 +9,7 @@ import thunk from 'redux-thunk';
 import rootSaga from 'sagas';
 import createRootReducer from 'reducers';
 import { actions as authActions } from 'reducers/auth';
-import * as AuthService from 'services/AuthService';
+import { addAuthInterceptors as authServiceAddAuthInterceptors } from 'services/AuthService';
 import registerServerErrorHandler from 'services/serverErrorHandler';
 
 const sagaMiddleware = createSagaMiddleware({
@@ -35,7 +35,7 @@ export default function configureStore(initialState = {}, history) {
 
     const store = createStore(rootReducer, initialState, composeEnhancers(...enhancers));
 
-    AuthService.addAuthInterceptors((error) =>
+    authServiceAddAuthInterceptors((error) =>
         store.dispatch(authActions.handleAuthHttpError(error))
     );
 

--- a/ui/apps/platform/src/sagas/apiTokenSagas.js
+++ b/ui/apps/platform/src/sagas/apiTokenSagas.js
@@ -1,14 +1,17 @@
 import { all, take, takeLatest, call, fork, put } from 'redux-saga/effects';
 
 import { integrationsPath } from 'routePaths';
-import * as service from 'services/APITokensService';
+import {
+    fetchAPITokens as serviceFetchAPITokens,
+    revokeAPITokens as serviceRevokeAPITokens,
+} from 'services/APITokensService';
 import { actions, types } from 'reducers/apitokens';
 import { actions as notificationActions } from 'reducers/notifications';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
 
 function* getAPITokens() {
     try {
-        const result = yield call(service.fetchAPITokens);
+        const result = yield call(serviceFetchAPITokens);
         yield put(actions.fetchAPITokens.success(result.response));
     } catch (error) {
         yield put(actions.fetchAPITokens.failure(error));
@@ -17,7 +20,7 @@ function* getAPITokens() {
 
 function* revokeAPITokens({ ids }) {
     try {
-        yield call(service.revokeAPITokens, ids);
+        yield call(serviceRevokeAPITokens, ids);
         yield fork(getAPITokens);
         yield put(
             notificationActions.addNotification(

--- a/ui/apps/platform/src/sagas/authSagas.js
+++ b/ui/apps/platform/src/sagas/authSagas.js
@@ -8,7 +8,21 @@ import { Base64 } from 'js-base64';
 import { loginPath, testLoginResultsPath, authResponsePrefix } from 'routePaths';
 import { takeEveryLocation } from 'utils/sagaEffects';
 import { parseAndDecodeFragment } from 'utils/parseAndDecodeFragment';
-import * as AuthService from 'services/AuthService';
+import {
+    deleteAuthProvider as authServiceDeleteAuthProvider,
+    exchangeAuthToken as authServiceExchangeAuthToken,
+    fetchAvailableProviderTypes as authServiceFetchAvailableProviderTypes,
+    fetchAuthProviders as authServiceFetchAuthProviders,
+    fetchLoginAuthProviders as authServiceFetchLoginAuthProviders,
+    getAccessToken as authServiceGetAccessToken,
+    getAndClearRequestedLocation as authServiceGetAndClearRequestedLocation,
+    getAuthStatus as authServiceGetAuthStatus,
+    getIsAuthProviderImmutable as authServiceGetIsAuthProviderImmutable,
+    logout as authServiceLogout,
+    saveAuthProvider as authServiceSaveAuthProvider,
+    storeAccessToken as authServiceStoreAccessToken,
+    storeRequestedLocation as authServiceStoreRequestedLocation,
+} from 'services/AuthService';
 import fetchUsersAttributes from 'services/AttributesService';
 import { fetchUserRolePermissions } from 'services/RolesService';
 import { selectors } from 'reducers';
@@ -42,7 +56,7 @@ function* getUserPermissions() {
 
 function* evaluateUserAccess() {
     const authStatus = yield select(selectors.getAuthStatus);
-    const token = yield call(AuthService.getAccessToken);
+    const token = yield call(authServiceGetAccessToken);
     const tokenExists = !!token;
 
     // No token but validated providers present? Log out the user since they
@@ -59,7 +73,7 @@ function* evaluateUserAccess() {
     if (tokenExists && authStatus !== AUTH_STATUS.LOGGED_IN) {
         // typical situation if token was stored before and then auth providers were loaded
         try {
-            const result = yield call(AuthService.getAuthStatus);
+            const result = yield call(authServiceGetAuthStatus);
             // call didn't fail, meaning that the token is fine (should we check the returned result?)
             yield put(actions.login(result));
         } catch {
@@ -75,7 +89,7 @@ function* watchNewAuthProviders() {
 
 export function* getLoginAuthProviders() {
     try {
-        const result = yield call(AuthService.fetchLoginAuthProviders);
+        const result = yield call(authServiceFetchLoginAuthProviders);
         yield put(actions.fetchLoginAuthProviders.success(result?.response || []));
     } catch (error) {
         yield put(actions.fetchLoginAuthProviders.failure(error));
@@ -84,7 +98,7 @@ export function* getLoginAuthProviders() {
 
 export function* getAuthProviders() {
     try {
-        const result = yield call(AuthService.fetchAuthProviders);
+        const result = yield call(authServiceFetchAuthProviders);
         yield put(actions.fetchAuthProviders.success(result?.response || []));
     } catch (error) {
         yield put(actions.fetchAuthProviders.failure(error));
@@ -100,7 +114,7 @@ function* watchLoginAuthProvidersFetchRequest() {
 }
 
 function* logout() {
-    yield call(AuthService.logout);
+    yield call(authServiceLogout);
 }
 
 function* watchLogout() {
@@ -111,7 +125,7 @@ function* handleLoginPageRedirect({ location }) {
     const { state } = location;
     if (state && state.from && !state.from.startsWith(loginPath)) {
         // we were redirected to login page from another page
-        yield call(AuthService.storeRequestedLocation, state.from);
+        yield call(authServiceStoreRequestedLocation, state.from);
     }
 }
 
@@ -151,7 +165,7 @@ function* handleOidcResponse(location) {
             Array.from(parsedFragment.entries()).filter(([key]) => key !== 'state')
         );
         const pseudoToken = `#${queryString.stringify({ ...otherFields })}`;
-        const result = yield call(AuthService.exchangeAuthToken, pseudoToken, 'oidc', state);
+        const result = yield call(authServiceExchangeAuthToken, pseudoToken, 'oidc', state);
         result.authorizeRoxctl = isAuthorizeRoxctlMode(state);
         return result;
     } catch (error) {
@@ -204,7 +218,7 @@ function* handleTestLoginAuthResponse(location, type, result) {
     yield put(actions.setAuthProviderTestResults(parsedResult));
 
     // set up the redirect to the results page
-    yield call(AuthService.storeRequestedLocation, testLoginResultsPath);
+    yield call(authServiceStoreRequestedLocation, testLoginResultsPath);
 }
 
 function* handleAuthorizeRoxctlLoginResponse(result) {
@@ -249,7 +263,7 @@ function* dispatchAuthResponse(type, location) {
     } else if (result?.authorizeRoxctl === true || result?.authorizeRoxctl === 'true') {
         yield call(handleAuthorizeRoxctlLoginResponse, result);
     } else if (result?.token) {
-        yield call(AuthService.storeAccessToken, result.token);
+        yield call(authServiceStoreAccessToken, result.token);
 
         // TODO-ivan: seems like react-router-redux doesn't like pushing an action synchronously while handling LOCATION_CHANGE,
         // the bug is that it doesn't produce LOCATION_CHANGE event for this next push. Waiting here should be ok for an user.
@@ -260,7 +274,7 @@ function* dispatchAuthResponse(type, location) {
 
     yield fork(getUserPermissions);
 
-    const storedLocation = yield call(AuthService.getAndClearRequestedLocation);
+    const storedLocation = yield call(authServiceGetAndClearRequestedLocation);
     yield put(push(storedLocation || '/')); // try to restore requested path
     yield call(getLoginAuthProviders);
 }
@@ -302,7 +316,7 @@ function* saveAuthProvider(action) {
             (currAuthProvider) => currAuthProvider.name === remaining.name
         ).length;
         if (isNewAuthProvider) {
-            const savedAuthProvider = yield call(AuthService.saveAuthProvider, remaining);
+            const savedAuthProvider = yield call(authServiceSaveAuthProvider, remaining);
             filteredGroups.forEach((group) =>
                 Object.assign(group.props, { authProviderId: savedAuthProvider.data.id })
             );
@@ -313,9 +327,9 @@ function* saveAuthProvider(action) {
             yield call(fetchUsersAttributes);
             yield put(actions.selectAuthProvider({ ...remaining, id: savedAuthProvider.data.id }));
         } else {
-            const isImmutable = yield call(AuthService.getIsAuthProviderImmutable, remaining);
+            const isImmutable = yield call(authServiceGetIsAuthProviderImmutable, remaining);
             if (!remaining.active && !isImmutable) {
-                yield call(AuthService.saveAuthProvider, remaining);
+                yield call(authServiceSaveAuthProvider, remaining);
             }
             yield call(getAuthProviders);
             yield call(fetchUsersAttributes);
@@ -344,7 +358,7 @@ function* saveAuthProvider(action) {
 function* deleteAuthProvider(action) {
     const { id } = action;
     try {
-        yield call(AuthService.deleteAuthProvider, id);
+        yield call(authServiceDeleteAuthProvider, id);
         yield put(actions.fetchAuthProviders.request());
     } catch (error) {
         yield put(
@@ -372,7 +386,7 @@ function* watchDeleteAuthProvider() {
 
 function* fetchAvailableProviderTypes() {
     try {
-        const result = yield call(AuthService.fetchAvailableProviderTypes);
+        const result = yield call(authServiceFetchAvailableProviderTypes);
         yield put(actions.setAvailableProviderTypes(result?.response || []));
     } catch (error) {
         yield put(

--- a/ui/apps/platform/src/sagas/authSagas.test.js
+++ b/ui/apps/platform/src/sagas/authSagas.test.js
@@ -5,7 +5,18 @@ import { dynamic, throwError } from 'redux-saga-test-plan/providers';
 
 import { selectors } from 'reducers';
 import { actions, AUTH_STATUS } from 'reducers/auth';
-import * as AuthService from 'services/AuthService';
+import {
+    AuthHttpError as AuthServiceAuthHttpError,
+    exchangeAuthToken as authServiceExchangeAuthToken,
+    fetchAvailableProviderTypes as authServiceFetchAvailableProviderTypes,
+    fetchLoginAuthProviders as authServiceFetchLoginAuthProviders,
+    getAccessToken as authServiceGetAccessToken,
+    getAndClearRequestedLocation as authServiceGetAndClearRequestedLocation,
+    getAuthStatus as authServiceGetAuthStatus,
+    logout as authServiceLogout,
+    storeAccessToken as authServiceStoreAccessToken,
+    storeRequestedLocation as authServiceStoreRequestedLocation,
+} from 'services/AuthService';
 import { fetchUserRolePermissions } from 'services/RolesService';
 import saga from './authSagas';
 import createLocationChange from './sagaTestUtils';
@@ -22,10 +33,10 @@ describe('Auth Sagas', () => {
         return expectSaga(saga)
             .provide([
                 ...createStateSelectors(),
-                [call(AuthService.fetchLoginAuthProviders), dynamic(fetchMock)],
-                [call(AuthService.logout), null],
+                [call(authServiceFetchLoginAuthProviders), dynamic(fetchMock)],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .dispatch(createLocationChange('/'))
             .dispatch(createLocationChange('/main/policies'))
@@ -40,11 +51,11 @@ describe('Auth Sagas', () => {
         expectSaga(saga)
             .provide([
                 ...createStateSelectors([{ name: 'ap1' }], AUTH_STATUS.ANONYMOUS_ACCESS),
-                [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
-                [call(AuthService.getAccessToken), null],
-                [call(AuthService.logout), null],
+                [call(authServiceFetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
+                [call(authServiceGetAccessToken), null],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .put(actions.logout())
             .dispatch(createLocationChange('/'))
@@ -54,11 +65,11 @@ describe('Auth Sagas', () => {
         expectSaga(saga)
             .provide([
                 ...createStateSelectors([{ name: 'ap1' }]),
-                [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
-                [call(AuthService.getAccessToken), 'my-token'],
-                [call(AuthService.getAuthStatus), 'ok'],
+                [call(authServiceFetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
+                [call(authServiceGetAccessToken), 'my-token'],
+                [call(authServiceGetAuthStatus), 'ok'],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .put(actions.login('ok'))
             .dispatch(createLocationChange('/'))
@@ -68,12 +79,12 @@ describe('Auth Sagas', () => {
         expectSaga(saga)
             .provide([
                 ...createStateSelectors([{ name: 'ap1' }]),
-                [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
-                [call(AuthService.getAccessToken), 'my-token'],
-                [call(AuthService.getAuthStatus), throwError(new Error('401'))],
-                [call(AuthService.logout), null],
+                [call(authServiceFetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
+                [call(authServiceGetAccessToken), 'my-token'],
+                [call(authServiceGetAuthStatus), throwError(new Error('401'))],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .put(actions.logout())
             .dispatch(createLocationChange('/'))
@@ -84,11 +95,11 @@ describe('Auth Sagas', () => {
         return expectSaga(saga)
             .provide([
                 ...createStateSelectors([{ name: 'ap1' }], AUTH_STATUS.LOGGED_IN),
-                [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
-                [call(AuthService.getAccessToken), 'my-token'],
-                [call(AuthService.logout), dynamic(logout)],
+                [call(authServiceFetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
+                [call(authServiceGetAccessToken), 'my-token'],
+                [call(authServiceLogout), dynamic(logout)],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .dispatch(createLocationChange('/'))
             .dispatch(actions.logout())
@@ -104,11 +115,11 @@ describe('Auth Sagas', () => {
         return expectSaga(saga)
             .provide([
                 ...createStateSelectors(),
-                [call(AuthService.fetchLoginAuthProviders), { response: [] }],
-                [call(AuthService.logout), null],
-                [call(AuthService.storeRequestedLocation, from), dynamic(storeLocationMock)],
+                [call(authServiceFetchLoginAuthProviders), { response: [] }],
+                [call(authServiceLogout), null],
+                [call(authServiceStoreRequestedLocation, from), dynamic(storeLocationMock)],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .dispatch(createLocationChange('/'))
             .dispatch(createLocationChange('/login', from))
@@ -127,16 +138,16 @@ describe('Auth Sagas', () => {
         return expectSaga(saga)
             .provide([
                 ...createStateSelectors(),
-                [call(AuthService.fetchLoginAuthProviders), { response: [] }],
+                [call(authServiceFetchLoginAuthProviders), { response: [] }],
                 [
-                    call(AuthService.exchangeAuthToken, `#id_token=${token}`, 'oidc', serverState),
+                    call(authServiceExchangeAuthToken, `#id_token=${token}`, 'oidc', serverState),
                     { token: exchangedToken },
                 ],
-                [call(AuthService.storeAccessToken, exchangedToken), dynamic(storeAccessTokenMock)],
-                [call(AuthService.getAndClearRequestedLocation), requestedLocation],
-                [call(AuthService.logout), null],
+                [call(authServiceStoreAccessToken, exchangedToken), dynamic(storeAccessTokenMock)],
+                [call(authServiceGetAndClearRequestedLocation), requestedLocation],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .put(push(requestedLocation))
             .dispatch(
@@ -164,16 +175,16 @@ describe('Auth Sagas', () => {
         return expectSaga(saga)
             .provide([
                 ...createStateSelectors(),
-                [call(AuthService.fetchLoginAuthProviders), { response: [] }],
+                [call(authServiceFetchLoginAuthProviders), { response: [] }],
                 [
-                    call(AuthService.exchangeAuthToken, `#id_token=${token}`, 'oidc', serverState),
+                    call(authServiceExchangeAuthToken, `#id_token=${token}`, 'oidc', serverState),
                     { token, clientState: callbackURL },
                 ],
-                [call(AuthService.storeAccessToken, token), dynamic(storeAccessTokenMock)],
-                [call(AuthService.getAndClearRequestedLocation), requestedLocation],
-                [call(AuthService.logout), null],
+                [call(authServiceStoreAccessToken, token), dynamic(storeAccessTokenMock)],
+                [call(authServiceGetAndClearRequestedLocation), requestedLocation],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .put(push(requestedLocation))
             .dispatch(
@@ -202,20 +213,20 @@ describe('Auth Sagas', () => {
         return expectSaga(saga)
             .provide([
                 ...createStateSelectors(),
-                [call(AuthService.fetchLoginAuthProviders), { response: [] }],
+                [call(authServiceFetchLoginAuthProviders), { response: [] }],
                 // TODO: mock auth action call, too
                 // [
                 //     call(actions.setAuthProviderTestResults, {}),
                 //     dynamic(setAuthProviderTestResultsMock),
                 // ],
-                [call(AuthService.getAndClearRequestedLocation), requestedLocation],
+                [call(authServiceGetAndClearRequestedLocation), requestedLocation],
                 [
-                    call(AuthService.storeRequestedLocation, requestedLocation),
+                    call(authServiceStoreRequestedLocation, requestedLocation),
                     dynamic(storeLocationMock),
                 ],
-                [call(AuthService.logout), null],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .put(push(requestedLocation))
             .dispatch(
@@ -237,29 +248,29 @@ describe('Auth Sagas', () => {
         expectSaga(saga)
             .provide([
                 ...createStateSelectors([{ name: 'ap1' }], AUTH_STATUS.LOGGED_IN),
-                [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
-                [call(AuthService.getAccessToken), 'my-token'],
-                [call(AuthService.logout), null],
+                [call(authServiceFetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
+                [call(authServiceGetAccessToken), 'my-token'],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .put(actions.logout())
             .dispatch(createLocationChange('/'))
-            .dispatch(actions.handleAuthHttpError(new AuthService.AuthHttpError('error', 401)))
+            .dispatch(actions.handleAuthHttpError(new AuthServiceAuthHttpError('error', 401)))
             .silentRun());
 
     it('should ignore 403 HTTP error', () =>
         expectSaga(saga)
             .provide([
                 ...createStateSelectors([{ name: 'ap1' }], AUTH_STATUS.LOGGED_IN),
-                [call(AuthService.fetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
-                [call(AuthService.getAccessToken), 'my-token'],
-                [call(AuthService.logout), null],
+                [call(authServiceFetchLoginAuthProviders), { response: [{ name: 'ap1' }] }],
+                [call(authServiceGetAccessToken), 'my-token'],
+                [call(authServiceLogout), null],
                 [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
+                [call(authServiceFetchAvailableProviderTypes), { response: [] }],
             ])
             .not.put(actions.logout())
             .dispatch(createLocationChange('/'))
-            .dispatch(actions.handleAuthHttpError(new AuthService.AuthHttpError('error', 403)))
+            .dispatch(actions.handleAuthHttpError(new AuthServiceAuthHttpError('error', 403)))
             .silentRun());
 });

--- a/ui/apps/platform/src/sagas/cloudSourceSagas.js
+++ b/ui/apps/platform/src/sagas/cloudSourceSagas.js
@@ -1,13 +1,16 @@
 import { all, take, call, fork, put, takeLatest } from 'redux-saga/effects';
 
 import { integrationsPath } from 'routePaths';
-import * as service from 'services/CloudSourceService';
+import {
+    deleteCloudSources as serviceDeleteCloudSources,
+    fetchCloudSources as serviceFetchCloudSources,
+} from 'services/CloudSourceService';
 import { actions, types } from 'reducers/cloudSources';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
 
 function* getCloudSources() {
     try {
-        const result = yield call(service.fetchCloudSources);
+        const result = yield call(serviceFetchCloudSources);
         yield put(actions.fetchCloudSources.success(result.response));
     } catch (error) {
         yield put(actions.fetchCloudSources.failure(error));
@@ -16,7 +19,7 @@ function* getCloudSources() {
 
 function* deleteCloudSources({ ids }) {
     try {
-        yield call(service.deleteCloudSources, ids);
+        yield call(serviceDeleteCloudSources, ids);
         yield put(actions.fetchCloudSources.request());
     } catch (error) {
         yield put(actions.deleteCloudSources.failure(error));

--- a/ui/apps/platform/src/sagas/groupSagas.js
+++ b/ui/apps/platform/src/sagas/groupSagas.js
@@ -1,5 +1,10 @@
 import { all, call, fork, put, select, takeLatest } from 'redux-saga/effects';
-import * as service from 'services/GroupsService';
+import {
+    deleteRuleGroup as serviceDeleteRuleGroup,
+    fetchGroups as serviceFetchGroups,
+    getDefaultGroup as serviceGetDefaultGroup,
+    updateOrAddGroup as serviceUpdateOrAddGroup,
+} from 'services/GroupsService';
 import { actions, types } from 'reducers/groups';
 import { actions as authActions } from 'reducers/auth';
 import { selectors } from 'reducers';
@@ -9,7 +14,7 @@ import Raven from 'raven-js';
 
 function* getRuleGroups() {
     try {
-        const result = yield call(service.fetchGroups);
+        const result = yield call(serviceFetchGroups);
         yield put(actions.fetchGroups.success(result?.response || []));
     } catch (error) {
         yield put(actions.fetchGroups.failure(error));
@@ -34,11 +39,11 @@ function* saveRuleGroup(action) {
             );
         }
         const existingGroups = yield select(selectors.getGroupsByAuthProviderId);
-        const defaultGroup = yield call(service.getDefaultGroup, {
+        const defaultGroup = yield call(serviceGetDefaultGroup, {
             authProviderId: id,
             roleName: defaultRole,
         });
-        yield call(service.updateOrAddGroup, {
+        yield call(serviceUpdateOrAddGroup, {
             requiredGroups: getGroupsWithDefault(group, id, defaultRole, defaultGroup?.response),
             previousGroups: getExistingGroupsWithDefault(existingGroups, id),
         });
@@ -64,7 +69,7 @@ function* saveRuleGroup(action) {
 function* deleteRuleGroup(action) {
     const { group } = action;
     try {
-        yield call(service.deleteRuleGroup, group);
+        yield call(serviceDeleteRuleGroup, group);
         yield call(getRuleGroups);
     } catch (error) {
         Raven.captureException(error);

--- a/ui/apps/platform/src/sagas/integrationSagas.js
+++ b/ui/apps/platform/src/sagas/integrationSagas.js
@@ -2,9 +2,12 @@ import { all, take, call, fork, put, takeLatest } from 'redux-saga/effects';
 import Raven from 'raven-js';
 
 import { integrationsPath } from 'routePaths';
-import * as service from 'services/IntegrationsService';
+import {
+    deleteIntegrations as serviceDeleteIntegrations,
+    fetchIntegration as serviceFetchIntegration,
+} from 'services/IntegrationsService';
 import * as AuthService from 'services/AuthService';
-import * as BackupIntegrationsService from 'services/BackupIntegrationsService';
+import { triggerBackup as serviceTriggerBackup } from 'services/BackupIntegrationsService';
 import { actions, types } from 'reducers/integrations';
 import { actions as notificationActions } from 'reducers/notifications';
 import { actions as apiTokenActions } from 'reducers/apitokens';
@@ -22,7 +25,7 @@ const fetchIntegrationsActionMap = {
 // with the given action type.
 function* fetchIntegrationWrapper(source, action) {
     try {
-        const result = yield call(service.fetchIntegration, source);
+        const result = yield call(serviceFetchIntegration, source);
         yield put(action.success(result.response));
     } catch (error) {
         yield put(action.failure(error));
@@ -95,7 +98,7 @@ function* deleteIntegrations({ source, sourceType, ids }) {
                 yield put(fetchIntegrationsActionMap[source]);
             }
         } else {
-            yield call(service.deleteIntegrations, source, ids);
+            yield call(serviceDeleteIntegrations, source, ids);
             yield put(fetchIntegrationsActionMap[source]);
         }
         const toastMessage = `Successfully deleted ${ids.length} integration${
@@ -111,7 +114,7 @@ function* deleteIntegrations({ source, sourceType, ids }) {
 function* triggerBackup(action) {
     const { id } = action;
     try {
-        yield call(BackupIntegrationsService.triggerBackup, id);
+        yield call(serviceTriggerBackup, id);
         yield put(notificationActions.addNotification('Backup was successful'));
         yield put(notificationActions.removeOldestNotification());
     } catch (error) {

--- a/ui/apps/platform/src/sagas/machineAccessSagas.js
+++ b/ui/apps/platform/src/sagas/machineAccessSagas.js
@@ -1,13 +1,16 @@
 import { all, take, call, fork, put, takeLatest } from 'redux-saga/effects';
 
 import { integrationsPath } from 'routePaths';
-import * as service from 'services/MachineAccessService';
+import {
+    deleteMachineAccessConfigs as serviceDeleteMachineAccessConfigs,
+    fetchMachineAccessConfigs as serviceFetchMachineAccessConfigs,
+} from 'services/MachineAccessService';
 import { actions, types } from 'reducers/machineAccessConfigs';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
 
 function* getMachineAccessConfigs() {
     try {
-        const result = yield call(service.fetchMachineAccessConfigs);
+        const result = yield call(serviceFetchMachineAccessConfigs);
         yield put(actions.fetchMachineAccessConfigs.success(result.response));
     } catch (error) {
         yield put(actions.fetchMachineAccessConfigs.failure(error));
@@ -16,7 +19,7 @@ function* getMachineAccessConfigs() {
 
 function* deleteMachineAccessConfigs({ ids }) {
     try {
-        yield call(service.deleteMachineAccessConfigs, ids);
+        yield call(serviceDeleteMachineAccessConfigs, ids);
         yield put(actions.fetchMachineAccessConfigs.request());
     } catch (error) {
         yield put(actions.deleteMachineAccessConfigs.failure(error));

--- a/ui/apps/platform/src/sagas/roleSagas.js
+++ b/ui/apps/platform/src/sagas/roleSagas.js
@@ -1,5 +1,10 @@
 import { all, call, fork, put, takeLatest, select } from 'redux-saga/effects';
-import * as service from 'services/RolesService';
+import {
+    createRole as serviceCreateRole,
+    deleteRole as serviceDeleteRole,
+    fetchRoles as serviceFetchRoles,
+    updateRole as serviceUpdateRole,
+} from 'services/RolesService';
 import { actions, types } from 'reducers/roles';
 import { selectors } from 'reducers';
 
@@ -8,7 +13,7 @@ import { actions as notificationActions } from 'reducers/notifications';
 
 function* getRoles() {
     try {
-        const result = yield call(service.fetchRoles);
+        const result = yield call(serviceFetchRoles);
         yield put(actions.fetchRoles.success(result?.response || []));
     } catch {
         // do nothing
@@ -21,10 +26,10 @@ function* saveRole(action) {
         const roles = yield select(selectors.getRoles);
         const isNewRole = !roles.filter((currRole) => currRole.name === role.name).length;
         if (isNewRole) {
-            yield call(service.createRole, role);
+            yield call(serviceCreateRole, role);
             yield put(actions.selectRole(role));
         } else {
-            yield call(service.updateRole, role);
+            yield call(serviceUpdateRole, role);
             yield put(actions.selectRole(role));
         }
         yield call(getRoles);
@@ -38,7 +43,7 @@ function* saveRole(action) {
 function* deleteRole(action) {
     const { id } = action;
     try {
-        yield call(service.deleteRole, id);
+        yield call(serviceDeleteRole, id);
         yield put(actions.fetchRoles.request());
     } catch (error) {
         yield put(notificationActions.addNotification(error.response.data.error));

--- a/ui/apps/platform/src/sagas/searchAutocompleteSagas.js
+++ b/ui/apps/platform/src/sagas/searchAutocompleteSagas.js
@@ -1,11 +1,11 @@
 import { take, call, fork, put } from 'redux-saga/effects';
 
-import * as service from 'services/SearchService';
+import { fetchAutoCompleteResults as serviceFetchAutoCompleteResults } from 'services/SearchService';
 import { actions, types } from 'reducers/searchAutocomplete';
 
 function* getAutoCompleteResults(request) {
     try {
-        const result = yield call(service.fetchAutoCompleteResults, request);
+        const result = yield call(serviceFetchAutoCompleteResults, request);
         yield put(actions.recordAutoCompleteResponse(result));
     } catch {
         yield put(actions.recordAutoCompleteResponse([]));


### PR DESCRIPTION
## Description

### Problem

1. **Saif** reminded the team that lint takes minutes.
2. **David** reminded the team that 2 rules take 90% of that

### Analysis

See #16274

### Solution

Replace `import * as` namespace with `import { … }` named import.

Batch 2 consists of various services for 13 occurrences.

Use verbose `verbObject as serviceVerbObject` naming convention, even if not always needed, because of object-ish notation which allows same name:
* reducer action method
* saga generator
* service function

Special cases:
* Because of down side risk of mistake, I used `authServiceVerbObject`
* Although integrationSagas have named imports from 2 services, I used `serviceVerbObject` for both since `triggerBackup` hints at a specific service.

### Residue

1. Investigate and delete sagas that are already obsolete (it rhymes).
    Some of the integrations-related sagas might be copy-paste but not needed.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
    See slight percent increase in `'import/no-cycle'` and decrease in `'import/namespace'` which suggests:
    * It helped to replace a few occurrences of namespace with named import.
    * Time might be proportional to number of namespace references in files, therefore `yup` package has not only most files, but by far most references.