### PR TITLE
ROX-30278: secured-cluster Helm: static scanInline field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ since 4.7 and prior.
   Their values are all set to `true` (except for OpenShift 3, where `listenOnEvents` remains disabled.)
   [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
 - ROX-30278: The `admissionControl.dynamic.scanInline` configuration parameter of the secured-cluster-services Helm chart is not user-configurable anymore.
-  Its values is set to `true`.
+  Its value is set to `true`.
   [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
 
 ### Deprecated Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ since 4.7 and prior.
 - ROX-30278: The `admissionControl.listenOn*` configuration parameters of the secured-cluster-services Helm chart are not user-configurable anymore.
   Their values are all set to `true` (except for OpenShift 3, where `listenOnEvents` remains disabled.)
   [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
+- ROX-30278: The `admissionControl.dynamic.scanInline` configuration parameter of the secured-cluster-services Helm chart is not user-configurable anymore.
+  Its values is set to `true`.
+  [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
 
 ### Deprecated Features
 - ROX-30170: The following roxctl sensor generate options have been marked as deprecated

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -73,7 +73,7 @@ admissionControl:
   listenOnEvents: {{ not ._rox.env.openshift }}
 [<- end >]
   dynamic:
-    scanInline: false
+    scanInline: true
     disableBypass: false
     timeout: 10
   replicas: 3

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -73,7 +73,11 @@ admissionControl:
   listenOnEvents: {{ not ._rox.env.openshift }}
 [<- end >]
   dynamic:
+[<- if .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
     scanInline: true
+[<- else >]
+    scanInline: false
+[<- end >]
     disableBypass: false
     timeout: 10
   replicas: 3

--- a/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
@@ -3,6 +3,7 @@
 
 {{- $formatMsg := "It is not supported anymore to specify 'admissionControl.%s'. This setting will be ignored. The effective value is 'true'." -}}
 
+{{/* listenOn* fields. */}}
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnCreates) -}}
     {{- include "srox.warn" (list $ (printf $formatMsg "listenOnCreates")) -}}
     {{- $_ := unset $._rox.admissionControl "listenOnCreates" -}}
@@ -14,6 +15,12 @@
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnEvents) -}}
     {{- include "srox.warn" (list $ (printf $formatMsg "listenOnEvents")) -}}
     {{- $_ := unset $._rox.admissionControl "listenOnEvents" -}}
+{{- end -}}
+
+{{/* scanInline field. */}}
+{{- if not (kindIs "invalid" $._rox.admissionControl.dynamic.scanInline) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "dynamic.scanInline")) -}}
+    {{- $_ := unset $._rox.admissionControl.dynamic "scanInline" -}}
 {{- end -}}
 
 {{- end -}}

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
@@ -1,22 +1,25 @@
 tests:
-- name: "OpenShift3 defaults"
+- name: "Defaults for OpenShift3"
   set:
     env.openshift: 3
   expect: |
    .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
    [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 0)
-- name: "OpenShift4 defaults"
+   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == true)
+- name: "Defaults for OpenShift4"
   set:
     env.openshift: 4
   expect: |
    .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
    [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
-- name: "Vanilla K8s defaults"
+   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == true)
+- name: "Defaults for vanilla K8s"
   set:
     env.openshift: false
   expect: |
    .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
    [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
+   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == true)
 - name: "disabling listenOn* is ignored"
   set:
     admissionControl.listenOnCreates: false
@@ -36,6 +39,11 @@ tests:
     .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnCreates'"))
     .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnUpdates'"))
     .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnEvents'"))
+- name: "Warning is emitted when scanInline fields set"
+  set:
+    admissionControl.dynamic.scanInline: false
+  expect: |
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.dynamic.scanInline'"))
 - name: "Enforcement defaults to enabled during installations"
   release:
     isInstall: true

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -179,3 +179,8 @@ tests:
           failurePolicy: "Fail"
       expect: |
         .validatingwebhookconfigurations[].webhooks[].failurePolicy | assertThat(. == "Fail")
+- name: "scanInline defaults to false"
+  set:
+    admissionControl.dynamic.scanInline: null
+  expect: |
+    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == false)


### PR DESCRIPTION
## Description

Next step, implementing this snippet:

> The setting
> 
> ```admissionControl:
>   dynamic:
>     scanInline: # bool
> ```
> 
> shall not be configurable by the user anymore. During rendering the setting admissionControl.dynamic.scanInline=true shall be effective. Furthermore, if set by the user, emit a warning message.

from the design doc.

## User-facing documentation

- [x] CHANGELOG.md
- [ ] documentation changes tracked separately ([ROX-30434](https://issues.redhat.com/browse/ROX-30434)).

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] added regression tests

### How I validated my change

* Unit tests.
* Manually, see below:

```
$ ROX_ADMISSION_CONTROLLER_CONFIG=true roxctl helm output secured-cluster-services --remove --debug
WARN:   No output directory specified, using default directory "./stackrox-secured-cluster-services-chart"
WARN:   Removed output directory ./stackrox-secured-cluster-services-chart
INFO:   Written Helm chart secured-cluster-services to directory "./stackrox-secured-cluster-services-chart"
$ helm template -n stackrox stackrox-secured-cluster-services ./stackrox-secured-cluster-services-chart --set clusterName=foo \
  -f ~/go/src/github.com/stackrox/stackrox/tests/roxctl/bats-tests/test-data/helm-output-secured-cluster-services/cluster-init-bundle.yaml \
  | yq eval-all 'select(.kind == "Secret" and .metadata.name == "helm-cluster-config")' - \
  | yq '.stringData["config.yaml"]'
```
