### PR TITLE
ROX-30337: inconsistent baseline pagination

### DIFF
--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -128,6 +130,13 @@ func (s *serviceImpl) GetNetworkBaselineStatusForExternalFlows(ctx context.Conte
 
 	totalAnomalous := len(anomalousFlows)
 	totalBaseline := len(baselineFlows)
+
+	// sort prior to pagination to ensure a consistent result
+	compareNames := func(a, b *v1.NetworkBaselinePeerStatus) int {
+		return strings.Compare(a.GetPeer().GetEntity().GetName(), b.GetPeer().GetEntity().GetName())
+	}
+	slices.SortFunc(anomalousFlows, compareNames)
+	slices.SortFunc(baselineFlows, compareNames)
 
 	pg := request.GetPagination()
 	if pg != nil {

--- a/central/networkbaseline/service/service_impl_sql_test.go
+++ b/central/networkbaseline/service/service_impl_sql_test.go
@@ -231,7 +231,6 @@ func (s *networkBaselineServiceSuite) TestExternalStatus() {
 }
 
 func (s *networkBaselineServiceSuite) TestExternalStatusPagination() {
-	s.T().Skip("Temporarily skipping this test (flake) : TODO(ROX-30337)")
 	s.setupTablesExternalFlows()
 
 	req := &v1.NetworkBaselineExternalStatusRequest{


### PR DESCRIPTION
## Description

`TestNetworkBaselinePostgres/TestExternalStatusPagination` was previously found very flaky and was disabled.

The pagination stage of this API endpoint did not sort the baseline entries and resulted in incoherent paginated results, spotted by the unit-test.

We reenable the test and introduce a sorting phase prior to the pagination.

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

