### PR TITLE
ROX-30443: Turn off 2 slowest rules for lint:fast-dev command

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -380,7 +380,6 @@ module.exports = [
             'import/first': 'error',
             'import/newline-after-import': 'error',
             'import/no-absolute-path': 'error',
-            'import/no-cycle': ['error', { maxDepth: '∞' }],
             'import/no-duplicates': 'error',
             'import/no-dynamic-require': 'error',
             // 'import/no-extraneous-dependencies' is specified in a more specific configuration
@@ -723,6 +722,7 @@ module.exports = [
             limited: pluginLimited,
         },
         rules: {
+            'import/no-cycle': ['error', { maxDepth: '∞' }], // classic compliance has 7 errors
             'limited/react-export-default': 'error',
         },
     },

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -102,6 +102,7 @@
         "test": "TZ=UTC vitest",
         "test-coverage": "TZ=UTC vitest run --coverage",
         "lint": "eslint --quiet",
+        "lint:fast-dev": "eslint --quiet --rule 'import/namespace: off' --rule 'import/no-cycle: off'",
         "lint:fix": "eslint --fix --quiet",
         "tsc": "tsc",
         "cypress-open": "./scripts/cypress.sh open --e2e --config defaultBrowser=chrome",

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
@@ -7,8 +7,6 @@ import ClusterVersion from 'Containers/Compliance/widgets/ClusterVersion';
 import Query from 'Components/CacheFirstQuery';
 import usePermissions from 'hooks/usePermissions';
 import { CLUSTER_NAME as QUERY } from 'queries/cluster';
-// TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
-/* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
 import ComplianceByStandards from 'Containers/Compliance/widgets/ComplianceByStandards';
 import Loader from 'Components/Loader';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
@@ -8,8 +8,6 @@ import ControlDetails from 'Components/ControlDetails';
 import ControlRelatedResourceList from 'Containers/Compliance/widgets/ControlRelatedResourceList';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import useCases from 'constants/useCaseTypes';
-// TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
-/* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
 import Loader from 'Components/Loader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
@@ -10,8 +10,6 @@ import Loader from 'Components/Loader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import URLService from 'utils/URLService';
-// TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
-/* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
 import EntityCompliance from 'Containers/Compliance/widgets/EntityCompliance';
 import Cluster from 'images/cluster.svg';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
@@ -7,8 +7,6 @@ import Query from 'Components/CacheFirstQuery';
 import IconWidget from 'Components/IconWidget';
 import Cluster from 'images/cluster.svg';
 import Widget from 'Components/Widget';
-// TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
-/* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
 import ResourceCount from 'Containers/Compliance/widgets/ResourceCount';
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
@@ -16,8 +16,6 @@ import Labels from 'Containers/Compliance/widgets/Labels';
 import EntityCompliance from 'Containers/Compliance/widgets/EntityCompliance';
 import Loader from 'Components/Loader';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
-// TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
-/* eslint-disable-next-line import/no-cycle */
 import ComplianceList from 'Containers/Compliance/List/List';
 import PageNotFound from 'Components/PageNotFound';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';

--- a/ui/apps/platform/src/Containers/Compliance/List/List.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/List.jsx
@@ -12,8 +12,6 @@ import searchContext from 'Containers/searchContext';
 import { searchParams } from 'constants/searchParams';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import ListTable from './Table';
-// TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
-/* eslint-disable-next-line import/no-cycle */
 import SidePanel from './SidePanel';
 import ComplianceSearchInput from '../ComplianceSearchInput';
 

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.jsx
@@ -7,8 +7,6 @@ import Query from 'Components/CacheFirstQuery';
 import CloseButton from 'Components/CloseButton';
 import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
 import { resourceTypes, standardEntityTypes } from 'constants/entityTypes';
-// TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
-/* eslint-disable import/no-cycle */
 import ControlPage from 'Containers/Compliance/Entity/Control';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import URLService from 'utils/URLService';


### PR DESCRIPTION
## Description

### Problem

1. **Saif** reminded the team that lint takes minutes.
2. **David** reminded the team that 2 rules take 90% of that and graciously provided the timing command (see below).

### Analysis

See #16274

For the 2 slowest rules:
* Visual Studio Code checks open changed files.
* One side of coin: they are needed. Other side of coin: new errors are unlikely.

### Solution

https://eslint.org/docs/latest/use/command-line-interface#--rule

> This option specifies the rules to be used.

In this case, specify 2 rules **not** to be used.

1. Edit ui/apps/platform/package.json file: add a new `"lint:fast-dev"` command off 2 slowest rules for fast lint during development and let full slow lint in CI report errors.
    * `import/no-cycle`
    * `import/namespace`
2. Edit ui/apps/platform/eslint.config.js file: move `import/namespace` rule to configuration that ignores classic compliance, and then delete eslint-disable comments.
    If the command turns off the `import/namespace` rule, then ESLint reports the unused comments as errors.

### Residue

1. Add rule that restricts namespace import to `yup` package only.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] improved lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.

    Timing for slow lint:

    ```sh
    $ time TIMING=1 npm run lint

    > @stackrox/platform-app@0.0.0 lint
    > eslint --quiet

    Rule                                    |  Time (ms) | Relative
    :---------------------------------------|-----------:|--------:
    import/namespace                        | 181637.487 |    45.1%
    import/no-cycle                         | 180808.550 |    44.9%
    prettier/prettier                       |  18105.463 |     4.5%
    @typescript-eslint/no-unsafe-return     |   2842.214 |     0.7%
    import/default                          |   1781.213 |     0.4%
    @typescript-eslint/unbound-method       |   1763.648 |     0.4%
    import/no-relative-packages             |   1232.805 |     0.3%
    @typescript-eslint/no-floating-promises |   1036.181 |     0.3%
    @typescript-eslint/no-unused-vars       |   1003.270 |     0.2%
    import/no-unresolved                    |    846.302 |     0.2%
    ```

    Timing for fast lint:

    ```sh
    $ time TIMING=1 npm run lint:fast-dev

    > @stackrox/platform-app@0.0.0 lint:fast-dev
    > eslint --quiet --rule 'import/namespace: off' --rule 'import/no-cycle: off'

    Rule                                    | Time (ms) | Relative
    :---------------------------------------|----------:|--------:
    prettier/prettier                       | 17634.148 |    35.6%
    import/default                          |  9139.559 |    18.4%
    @typescript-eslint/no-unsafe-return     |  3069.171 |     6.2%
    @typescript-eslint/unbound-method       |  1820.889 |     3.7%
    import/no-relative-packages             |  1366.644 |     2.8%
    @typescript-eslint/no-unused-vars       |  1300.585 |     2.6%
    import/no-unresolved                    |  1235.060 |     2.5%
    @typescript-eslint/no-floating-promises |  1104.934 |     2.2%
    import/no-extraneous-dependencies       |   800.552 |     1.6%
    react/display-name
    ```