### PR TITLE
ROX-30001,ROX-21719: disable NetworkFlowTest failing on OCP 4.20

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -919,7 +919,7 @@ class NetworkFlowTest extends BaseSpecification {
     @IgnoreIf({ !Env.IN_CI })
     @Unroll
     @Tag("BAT")
-    @IgnoreIf({ Env.ORCHESTRATOR_FLAVOR == "openshift" })
+    @IgnoreIf({ Env.ORCHESTRATOR_FLAVOR == "openshift" })  // ROX-30001 - failing on OCP 4.20 EC's
     def "Verify network policy generator apply/undo with delete modes: #deleteMode #note"() {
         given:
         "apply network policies to the system"


### PR DESCRIPTION
Disabling failing test for https://issues.redhat.com/browse/ROX-30001