### PR TITLE
ROX-30278: Prefactoring: separate collecting of defaults from applying

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
@@ -1,11 +1,30 @@
 {{/*
-  srox.applyDefaults .
+  srox.collectDefaults .
 
-  Applies defaults defined in `internal/defaults`, in an order that depends on the filenames.
+  Retrieves the defaults defined in `internal/defaults`, in an order that depends on the filenames.
    */}}
-{{ define "srox.applyDefaults" }}
+{{ define "srox.collectDefaults" }}
 {{ $ := . }}
-{{/* Apply defaults */}}
+{{/*
+  We don't populate $._rox directly here, instead we store the retrieved defaults in $._rox._defaults.
+  But this undertaking is complicated by the fact that the files in internal/defaults are constructing the
+  final hierarchy of default values iteratively, in particular they are building upon what has already been stored in
+  the provided top-level context by a previous defaulting fragment.
+  (Note that they do not only access "$._rox", but also non-stackrox fields, which are added to the top-level
+  context by Helm, e.g. .Release.)
+
+  Therefore, we are creating a temporary context $tplCtx for the templating of the default files here, which is the
+  result of merging the "." context as passed to this macro and the defaults collected so far.
+
+  After having invoked the templating we need to make sure to transfer updates to $tplCtx._rox._state back to the original
+  context, otherwise invocations of "srox.warn" or "srox.note" during the templating would be lost.
+  */}}
+
+{{/* Create temporary copy of the top-level context: */}}
+{{ $tplCtx := dict }}
+{{ $_ := include "srox.mergeInto" (list $tplCtx $) }}
+{{/* This is where we will store the iteratively constructed default values hierarchy: */}}
+{{ $defaults := dict }}
 {{ range $defaultsFile, $defaultsTpl := $.Files.Glob "internal/defaults/*.yaml" }}
   {{ $tplSects := regexSplit "(^|\n)---($|\n)" (toString $defaultsTpl) -1 }}
   {{ $sectCounter := 0 }}
@@ -15,7 +34,7 @@
       to be certain that we recognized invalid templates. Hence, add a marker line at the end, and verify that it
       shows up in the output.
       */}}
-    {{ $renderedSect := tpl (list $tplSect "{{ \"\\n#MARKER\\n\" }}" | join "") $ }}
+    {{ $renderedSect := tpl (list $tplSect "{{ \"\\n#MARKER\\n\" }}" | join "") $tplCtx }}
     {{ if not (hasSuffix "\n#MARKER\n" $renderedSect) }}
       {{ include "srox.fail" (printf "Section %d in defaults file %s contains invalid templating" $sectCounter $defaultsFile) }}
     {{ end }}
@@ -28,10 +47,25 @@
       {{ include "srox.fail" (printf "Section %d in defaults file %s contains invalid YAML" $sectCounter $defaultsFile) }}
     {{ end }}
     {{ $_ := unset $sectDict "__marker" }}
-    {{ $_ = include "srox.mergeInto" (list $._rox $sectDict) }}
+    {{/* For maintaining our separate copy of default values: */}}
+    {{ $_ = include "srox.mergeInto" (list $defaults $sectDict) }}
+    {{/* For maintaining our separate copy of of the top-level context: */}}
+    {{ $_ := include "srox.mergeInto" (list $tplCtx (dict "_rox" $sectDict)) }}
     {{ $sectCounter = add $sectCounter 1 }}
   {{ end }}
 {{ end }}
+{{ $_ := set $._rox "_defaults" $defaults }}
+{{ $_ := set $._rox "_state" $tplCtx._rox._state }}
+{{ end }}
+
+{{/*
+  srox.applyDefaults .
+
+  Applies defaults defined in `internal/defaults`, in an order that depends on the filenames.
+   */}}
+{{ define "srox.applyDefaults" }}
+{{ $ := . }}
+{{ $_ := include "srox.mergeInto" (list $._rox $._rox._defaults) }}
 {{ end }}
 
 {{/*

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -129,6 +129,9 @@
 
 {{ include "srox.setInstallMethod" (list $) }}
 
+{{/* This assembles a complete dict containing all defaults from internal/defaults and stores it as $._rox._defaults. */}}
+{{ include "srox.collectDefaults" $ }}
+
 [<- if .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
   {{ include "srox.protectAdmissionControllerConfig" $ }}
 [<- end >]


### PR DESCRIPTION
## Description

### Why?

This PR will make be directly useful for the ongoing effort to upgrade certain admission controller config defaults: See https://github.com/stackrox/stackrox/blob/02a683016e9fd1f31eda40185aff61d90bf2e228/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl#L4. This is part of a templating macro, where messages are emitted to the user, explaining that a certain option is not user-configurable anymore. The message shall also mention what the new effective default of the respective field is going to be. At the moment we were able to get away with hard-coding:

```
{{- $formatMsg := "[...] The effective value is 'true'" -}}
```

But of course this is
* too unflexible (e.g., we will need a similar message for the `timeout` field).
* this also introduces a tight-coupling between this templating macro and the defaults as persisted in `internal/defaults/*.yaml`.

### Proposal

So, my proposal, implemented in this PR, is that we change the defaulting mechanism in the secured-cluster-services Helm chart so that instead of collecting and applying the defaults in one go (which would not allow us anymore to distinguish user-set field from default values) we split this up into two phases: First we collect the defaults, populating `._rox._defaults` (naming is similar to the already-existing `._rox._config_shape`). This allows us to reference actual default values in `._rox._defaults`, without any mixing with user-set fields. And then, at a later point during Helm chart initialization we can *apply* these values, which would then be reduced to a mere `mergeInto` call, merging `._rox._defaults` into `._rox`.

### Example usage

See https://github.com/stackrox/stackrox/pull/16303.

## User-facing documentation

No user-facing changes.

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

I have not added or modified any tests, instead I am getting confirmation from the fact that the whole helmtest test suite still passes unmodified.

### How I validated my change

Only automated tests.
