### PR TITLE
ROX-30278: secured-cluster Helm: static timeout field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ options to "roxctl sensor generate".
 
 ### Removed Features
 
+- ROX-30278: The `admissionControl.dynamic.timeout` configuration parameter of the secured-cluster-services Helm chart is not user-configurable anymore.
+  Its value is set to `10`.
+  [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
 - ROX-30278: The `admissionControl.dynamic.enforceOn*` configuration parameters of the secured-cluster-services Helm chart
   are deprecated and are now ignored. Please use the high-level parameter `admissionControl.enforce` instead.
   Enforce is now enabled by default.

--- a/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
@@ -23,4 +23,10 @@
     {{- $_ := unset $._rox.admissionControl.dynamic "scanInline" -}}
 {{- end -}}
 
+{{/* timeout field. */}}
+{{- if not (kindIs "invalid" $._rox.admissionControl.dynamic.timeout) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "dynamic.timeout" $._rox._defaults.admissionControl.dynamic.timeout)) -}}
+    {{- $_ := unset $._rox.admissionControl.dynamic "timeout" -}}
+{{- end -}}
+
 {{- end -}}

--- a/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-config.tpl
@@ -1,25 +1,25 @@
 {{- define "srox.protectAdmissionControllerConfig" -}}
 {{- $ := . -}}
 
-{{- $formatMsg := "It is not supported anymore to specify 'admissionControl.%s'. This setting will be ignored. The effective value is 'true'." -}}
+{{- $formatMsg := "It is not supported anymore to specify 'admissionControl.%s'. This setting will be ignored. The effective value is '%v'." -}}
 
 {{/* listenOn* fields. */}}
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnCreates) -}}
-    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnCreates")) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnCreates" $._rox._defaults.admissionControl.listenOnCreates)) -}}
     {{- $_ := unset $._rox.admissionControl "listenOnCreates" -}}
 {{- end -}}
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnUpdates) -}}
-    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnUpdates")) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnUpdates" $._rox._defaults.admissionControl.listenOnUpdates)) -}}
     {{- $_ := unset $._rox.admissionControl "listenOnUpdates" -}}
 {{- end -}}
 {{- if not (kindIs "invalid" $._rox.admissionControl.listenOnEvents) -}}
-    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnEvents")) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "listenOnEvents" $._rox._defaults.admissionControl.listenOnEvents)) -}}
     {{- $_ := unset $._rox.admissionControl "listenOnEvents" -}}
 {{- end -}}
 
 {{/* scanInline field. */}}
 {{- if not (kindIs "invalid" $._rox.admissionControl.dynamic.scanInline) -}}
-    {{- include "srox.warn" (list $ (printf $formatMsg "dynamic.scanInline")) -}}
+    {{- include "srox.warn" (list $ (printf $formatMsg "dynamic.scanInline" $._rox._defaults.admissionControl.dynamic.scanInline)) -}}
     {{- $_ := unset $._rox.admissionControl.dynamic "scanInline" -}}
 {{- end -}}
 

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
@@ -6,6 +6,7 @@ tests:
    .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
    [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 0)
    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == true)
+   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.timeoutSeconds == 10)
 - name: "Defaults for OpenShift4"
   set:
     env.openshift: 4
@@ -13,6 +14,7 @@ tests:
    .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
    [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == true)
+   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.timeoutSeconds == 10)
 - name: "Defaults for vanilla K8s"
   set:
     env.openshift: false
@@ -20,6 +22,7 @@ tests:
    .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
    [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 1)
    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == true)
+   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.timeoutSeconds == 10)
 - name: "disabling listenOn* is ignored"
   set:
     admissionControl.listenOnCreates: false
@@ -119,3 +122,13 @@ tests:
       isInstall: true
     set:
       admissionControl.enforce: false
+- name: "When timeout field is set"
+  set:
+    admissionControl.dynamic.timeout: 11
+  tests:
+  - name: "a warning is emitted"
+    expect: |
+      .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.dynamic.timeout'. This setting will be ignored. The effective value is '10'"))
+  - name: "the user-specified value is ignored"
+    expect: |
+      .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.timeoutSeconds == 10)

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
@@ -36,14 +36,14 @@ tests:
       listenOnUpdates: false
       listenOnEvents: false
   expect: |
-    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnCreates'"))
-    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnUpdates'"))
-    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnEvents'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnCreates'. This setting will be ignored. The effective value is 'true'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnUpdates'. This setting will be ignored. The effective value is 'true'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.listenOnEvents'. This setting will be ignored. The effective value is 'true'"))
 - name: "Warning is emitted when scanInline fields set"
   set:
     admissionControl.dynamic.scanInline: false
   expect: |
-    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.dynamic.scanInline'"))
+    .notes | assertThat(contains("It is not supported anymore to specify 'admissionControl.dynamic.scanInline'. This setting will be ignored. The effective value is 'true'"))
 - name: "Enforcement defaults to enabled during installations"
   release:
     isInstall: true


### PR DESCRIPTION
## Description

Implements next snippet of the requirements:

> The option
> 
> ```
> admissionControl:
>   dynamic:
>     timeout: # natural number
> ```
> 
> will not be user-configurable anymore. If set by the user, a warning shall be emitted. It is set to 10 seconds.

## User-facing documentation

- [x] CHANGELOG.md 
- [ ] documentation changes tracked separately ([ROX-30434](https://issues.redhat.com/browse/ROX-30434)).

## Testing and quality

- [x] the change is production ready
- [x] CI results are inspected

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

```
ROX_ADMISSION_CONTROLLER_CONFIG=true roxctl helm output secured-cluster-services --remove --debug
helm template -n stackrox stackrox-secured-cluster-services ./stackrox-secured-cluster-services-chart --set clusterName=foo \
  -f ~/go/src/github.com/stackrox/stackrox/tests/roxctl/bats-tests/test-data/helm-output-secured-cluster-services/cluster-init-bundle.yaml \
  --set admissionControl.dynamic.timeout=7 \ 
  | yq eval-all 'select(.kind == "Secret" and .metadata.name == "helm-cluster-config")' - \
  | yq '.stringData["config.yaml"]'
```

