### PR TITLE
fix(CI): save job info on failure

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -63,6 +63,12 @@ ci_exit_trap() {
         set_ci_shared_export JOB_DISPATCH_OUTCOME "${OUTCOME_FAILED}"
     fi
 
+    if [[ -f "${SHARED_DIR:-}/shared_env" ]]; then
+        # shellcheck disable=SC1091
+        cat "${SHARED_DIR:-}"/shared_env
+        source "${SHARED_DIR:-}/shared_env"
+    fi
+
     save_job_record "${JOB_NAME:-missing}" "prow" \
         outcome "${OVERALL_JOB_OUTCOME}" \
         started_at "${started_at:-0}" \

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -70,7 +70,7 @@ ci_exit_trap() {
     fi
 
     save_job_record "${JOB_NAME:-missing}" "prow" \
-        outcome "${OVERALL_JOB_OUTCOME}" \
+        outcome "${JOB_DISPATCH_OUTCOME}" \
         started_at "${started_at:-0}" \
         test_target "${test_target:-NULL}" \
         cut_product_version "${cut_product_version:-NULL}" \

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -63,6 +63,16 @@ ci_exit_trap() {
         set_ci_shared_export JOB_DISPATCH_OUTCOME "${OUTCOME_FAILED}"
     fi
 
+    save_job_record "${JOB_NAME:-missing}" "prow" \
+        outcome "${OVERALL_JOB_OUTCOME}" \
+        started_at "${started_at:-0}" \
+        test_target "${test_target:-NULL}" \
+        cut_product_version "${cut_product_version:-NULL}" \
+        cut_k8s_version "${cut_k8s_version:-NULL}" \
+        cut_os_image "${cut_os_image:-NULL}" \
+        cut_kernel_version "${cut_kernel_version:-NULL}" \
+        cut_container_runtime_version "${cut_container_runtime_version:-NULL}"
+
     post_process_test_results "${JOB_SLACK_FAILURE_ATTACHMENTS}" "${JOB_JUNIT2JIRA_SUMMARY_FILE}"
 
     while [[ -e /tmp/hold ]]; do

--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -71,6 +71,13 @@ _save_job_record() {
         return
     fi
 
+    local LOCKFILE=/tmp/job.lock
+    if [ -f $LOCKFILE ]; then
+        echo "Lock file exists, exiting"
+        exit 1
+    fi
+    touch $LOCKFILE
+
     local name="$1"
     local ci_system="$2"
     shift; shift


### PR DESCRIPTION
Looks like we need to save job record both on `end.sh` and `ci_exit_trap` as one is executed on failure and the other on success. 