### PR TITLE
chore(ui): Add webpack alias fn and .ico loading

### DIFF
--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const { DefinePlugin } = require('webpack');
 const { ConsoleRemotePlugin } = require('@openshift-console/dynamic-plugin-sdk-webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -6,6 +7,25 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const acsRootBaseUrl = '/acs';
 
 const isProd = process.env.NODE_ENV === 'production';
+
+/*
+ * Alias all top level directories and files under `/src/` so that we can import them in our code
+ * via `import * from 'Components/SomeComponent`;`. This mirrors the Vite configuration approach.
+ */
+function getSrcAliases() {
+    const aliases = {};
+
+    fs.readdirSync(path.resolve(__dirname, 'src'), { withFileTypes: true }).forEach(({ name }) => {
+        if (name.startsWith('.')) {
+            // avoid hidden directories, like `.DS_Store`
+            return;
+        }
+        const alias = name.includes('.') ? name.split('.').slice(0, -1).join('.') : name;
+        aliases[alias] = path.resolve(__dirname, 'src', name);
+    });
+
+    return aliases;
+}
 
 const config = {
     mode: isProd ? 'production' : 'development',
@@ -19,25 +39,7 @@ const config = {
     },
     resolve: {
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
-        alias: {
-            Containers: path.resolve(__dirname, 'src/Containers'),
-            Components: path.resolve(__dirname, 'src/Components'),
-            services: path.resolve(__dirname, 'src/services'),
-            utils: path.resolve(__dirname, 'src/utils'),
-            hooks: path.resolve(__dirname, 'src/hooks'),
-            types: path.resolve(__dirname, 'src/types'),
-            constants: path.resolve(__dirname, 'src/constants'),
-            queries: path.resolve(__dirname, 'src/queries'),
-            reducers: path.resolve(__dirname, 'src/reducers'),
-            sagas: path.resolve(__dirname, 'src/sagas'),
-            messages: path.resolve(__dirname, 'src/messages'),
-            mockData: path.resolve(__dirname, 'src/mockData'),
-            sorters: path.resolve(__dirname, 'src/sorters'),
-            'test-utils': path.resolve(__dirname, 'src/test-utils'),
-            images: path.resolve(__dirname, 'src/images'),
-            css: path.resolve(__dirname, 'src/css'),
-            routePaths: path.resolve(__dirname, 'src/routePaths.ts'),
-        },
+        alias: getSrcAliases(),
     },
     module: {
         rules: [
@@ -59,7 +61,7 @@ const config = {
                 use: ['style-loader', 'css-loader'],
             },
             {
-                test: /\.(png|jpg|jpeg|gif|svg|woff2?|ttf|eot|otf)(\?.*$|$)/,
+                test: /\.(png|jpg|jpeg|gif|svg|woff2?|ttf|eot|otf|ico)(\?.*$|$)/,
                 type: 'asset/resource',
                 generator: {
                     filename: isProd ? 'assets/[contenthash][ext]' : 'assets/[name][ext]',


### PR DESCRIPTION
## Description

Adds the ability to bundle .ico files and switch to an alias creation function equivalent to the one used in our Vite config.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

`npm run build:ocp-plugin` and verify build completes successfully.


