### PR TITLE
chore(deploy): do not wait for stabilization for kind

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -589,7 +589,7 @@ function launch_central {
       "${COMMON_DIR}/monitoring.sh"
     fi
 
-    if [[ -n "$CI" ]]; then
+    if [[ -n "$CI" ]] && ! kubectl config current-context | grep -q kind; then
         # Needed for GKE and OpenShift clusters
         echo "Sleep for 2 minutes to allow for stabilization"
         sleep 120


### PR DESCRIPTION
Since we have kind clusters in CI we can save 2 minutes by skipping this check.
This code is used in jenkins-plugin and central-login e2e