### PR TITLE
fix(roxctl): base on the system pool

### DIFF
--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -71,7 +71,10 @@ func tlsConfigOptsForCentral() (*clientconn.TLSConfigOptions, error) {
 }
 
 func getCertPool() (*x509.CertPool, error) {
-	roots := x509.NewCertPool()
+	roots, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get system certs pool")
+	}
 	if caFile := flags.CAFile(); caFile != "" {
 		// Read the CA from the given file.
 		if ca, err := os.ReadFile(caFile); err != nil {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

#15173 introduced a bug, where the x509 certificate pool would not include the system certificates.
This PR fixes that accidental behaviour change.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI

#### Manual Tests

1. :ok: Accessing central with a self-signed cert with `--ca` argument.
2. :ok: Accessing central via a route with system trusted certificate, without `--ca` argument.
3. :ok: Accessing central via a route with system trusted certificate, with `--ca` argument.
4. :ok: `FROM scratch` image, accessing central via port-forward with a self-signed certificate:

  ```console
  sh$ podman run ... roxctl:4.9.x-425-g3e122993e2 -e https://localhost:8000 central whoami -s central.stackrox --ca /tls/central-ca.pem
  UserID:
	  admin
  User name:
	  
  Roles:
	  - Admin
  ```

5. :red_circle: `FROM scratch`, Accessing central via a route with system trusted certificate, without `--ca` argument. `transport: authentication handshake failed: x509: certificate signed by unknown authority`
6. :ok: `FROM scratch`, Accessing central via a route with system trusted certificate, providing the mounted host's `tls-ca-bundle.pem` to `--ca`:

```console
sh$ podman run --rm -ti --name roxctl --security-opt label=disable -v /etc/pki/ca-trust/extracted/pem:/ssl:ro roxctl:4.9.x-425-g3e122993e2 -e https://mpsnowcertification.demos.rox.systems -p ... central whoami --ca /ssl/tls-ca-bundle.pem
UserID:
	admin
User name:
...
```
