### PR TITLE
fix(CI): use GKE region closer to PROW

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -134,7 +134,7 @@ create_cluster() {
     # The "services" secondary range is for ClusterIP services ("--services-ipv4-cidr").
     # See https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips#cluster_sizing.
 
-    REGION=us-central1
+    REGION=us-east4
     NUM_NODES="${NUM_NODES:-3}"
     GCP_IMAGE_TYPE="${GCP_IMAGE_TYPE:-UBUNTU_CONTAINERD}"
     POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"


### PR DESCRIPTION
This PR updates the GKE region to be geographically closer to the region where our PROW jobs are currently deployed, in order to reduce intermittent network issues. While the ideal setup would run GKE tests from `build02` (GCP-hosted), that requires changes to the PROW configuration. As a more immediate improvement, we're aligning GKE closer to the AWS-based PROW instance in `us-east-1`.

See:
- https://github.com/openshift/release/blob/a156c2b5993702463f56d17667aa23680bc13aaa/clusters/build-clusters/build02/README.md#regenerate-install-configyaml
- https://github.com/stackrox/stackrox/commit/15bc00b9fa50eda0f1606ba51a66831bc9fbf966#diff-1bfdbd7784f6a5763f7bd15c227aacf9c35b457b91e308c9ce97a931b1569715R10
