### PR TITLE
fix: mount v2 virtual machine API to /v2

### DIFF
--- a/generated/api/v2/virtual_machine_service.pb.go
+++ b/generated/api/v2/virtual_machine_service.pb.go
@@ -639,10 +639,10 @@ const file_api_v2_virtual_machine_service_proto_rawDesc = "" +
 	"\x1cDeleteVirtualMachineResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess2\xdf\x03\n" +
 	"\x15VirtualMachineService\x12k\n" +
-	"\x14CreateVirtualMachine\x12\x1f.v2.CreateVirtualMachineRequest\x1a\x12.v2.VirtualMachine\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v1/virtualmachines\x12g\n" +
-	"\x11GetVirtualMachine\x12\x1c.v2.GetVirtualMachineRequest\x1a\x12.v2.VirtualMachine\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/virtualmachines/{id}\x12s\n" +
-	"\x13ListVirtualMachines\x12\x1e.v2.ListVirtualMachinesRequest\x1a\x1f.v2.ListVirtualMachinesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/virtualmachines\x12{\n" +
-	"\x14DeleteVirtualMachine\x12\x1f.v2.DeleteVirtualMachineRequest\x1a .v2.DeleteVirtualMachineResponse\" \x82\xd3\xe4\x93\x02\x1a*\x18/v1/virtualmachines/{id}B'\n" +
+	"\x14CreateVirtualMachine\x12\x1f.v2.CreateVirtualMachineRequest\x1a\x12.v2.VirtualMachine\"\x1e\x82\xd3\xe4\x93\x02\x18:\x01*\"\x13/v2/virtualmachines\x12g\n" +
+	"\x11GetVirtualMachine\x12\x1c.v2.GetVirtualMachineRequest\x1a\x12.v2.VirtualMachine\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v2/virtualmachines/{id}\x12s\n" +
+	"\x13ListVirtualMachines\x12\x1e.v2.ListVirtualMachinesRequest\x1a\x1f.v2.ListVirtualMachinesResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v2/virtualmachines\x12{\n" +
+	"\x14DeleteVirtualMachine\x12\x1f.v2.DeleteVirtualMachineRequest\x1a .v2.DeleteVirtualMachineResponse\" \x82\xd3\xe4\x93\x02\x1a*\x18/v2/virtualmachines/{id}B'\n" +
 	"\x18io.stackrox.proto.api.v2Z\v./api/v2;v2X\x01b\x06proto3"
 
 var (

--- a/generated/api/v2/virtual_machine_service.pb.gw.go
+++ b/generated/api/v2/virtual_machine_service.pb.gw.go
@@ -187,7 +187,7 @@ func RegisterVirtualMachineServiceHandlerServer(ctx context.Context, mux *runtim
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/CreateVirtualMachine", runtime.WithHTTPPathPattern("/v1/virtualmachines"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/CreateVirtualMachine", runtime.WithHTTPPathPattern("/v2/virtualmachines"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -207,7 +207,7 @@ func RegisterVirtualMachineServiceHandlerServer(ctx context.Context, mux *runtim
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/GetVirtualMachine", runtime.WithHTTPPathPattern("/v1/virtualmachines/{id}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/GetVirtualMachine", runtime.WithHTTPPathPattern("/v2/virtualmachines/{id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -227,7 +227,7 @@ func RegisterVirtualMachineServiceHandlerServer(ctx context.Context, mux *runtim
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/ListVirtualMachines", runtime.WithHTTPPathPattern("/v1/virtualmachines"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/ListVirtualMachines", runtime.WithHTTPPathPattern("/v2/virtualmachines"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -247,7 +247,7 @@ func RegisterVirtualMachineServiceHandlerServer(ctx context.Context, mux *runtim
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/DeleteVirtualMachine", runtime.WithHTTPPathPattern("/v1/virtualmachines/{id}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.VirtualMachineService/DeleteVirtualMachine", runtime.WithHTTPPathPattern("/v2/virtualmachines/{id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -305,7 +305,7 @@ func RegisterVirtualMachineServiceHandlerClient(ctx context.Context, mux *runtim
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/CreateVirtualMachine", runtime.WithHTTPPathPattern("/v1/virtualmachines"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/CreateVirtualMachine", runtime.WithHTTPPathPattern("/v2/virtualmachines"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -322,7 +322,7 @@ func RegisterVirtualMachineServiceHandlerClient(ctx context.Context, mux *runtim
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/GetVirtualMachine", runtime.WithHTTPPathPattern("/v1/virtualmachines/{id}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/GetVirtualMachine", runtime.WithHTTPPathPattern("/v2/virtualmachines/{id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -339,7 +339,7 @@ func RegisterVirtualMachineServiceHandlerClient(ctx context.Context, mux *runtim
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/ListVirtualMachines", runtime.WithHTTPPathPattern("/v1/virtualmachines"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/ListVirtualMachines", runtime.WithHTTPPathPattern("/v2/virtualmachines"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -356,7 +356,7 @@ func RegisterVirtualMachineServiceHandlerClient(ctx context.Context, mux *runtim
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/DeleteVirtualMachine", runtime.WithHTTPPathPattern("/v1/virtualmachines/{id}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.VirtualMachineService/DeleteVirtualMachine", runtime.WithHTTPPathPattern("/v2/virtualmachines/{id}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -373,10 +373,10 @@ func RegisterVirtualMachineServiceHandlerClient(ctx context.Context, mux *runtim
 }
 
 var (
-	pattern_VirtualMachineService_CreateVirtualMachine_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "virtualmachines"}, ""))
-	pattern_VirtualMachineService_GetVirtualMachine_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "virtualmachines", "id"}, ""))
-	pattern_VirtualMachineService_ListVirtualMachines_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "virtualmachines"}, ""))
-	pattern_VirtualMachineService_DeleteVirtualMachine_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "virtualmachines", "id"}, ""))
+	pattern_VirtualMachineService_CreateVirtualMachine_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v2", "virtualmachines"}, ""))
+	pattern_VirtualMachineService_GetVirtualMachine_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v2", "virtualmachines", "id"}, ""))
+	pattern_VirtualMachineService_ListVirtualMachines_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v2", "virtualmachines"}, ""))
+	pattern_VirtualMachineService_DeleteVirtualMachine_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v2", "virtualmachines", "id"}, ""))
 )
 
 var (

--- a/generated/api/v2/virtual_machine_service.swagger.json
+++ b/generated/api/v2/virtual_machine_service.swagger.json
@@ -16,7 +16,7 @@
     "application/json"
   ],
   "paths": {
-    "/v1/virtualmachines": {
+    "/v2/virtualmachines": {
       "get": {
         "operationId": "VirtualMachineService_ListVirtualMachines",
         "responses": {
@@ -68,7 +68,7 @@
         ]
       }
     },
-    "/v1/virtualmachines/{id}": {
+    "/v2/virtualmachines/{id}": {
       "get": {
         "operationId": "VirtualMachineService_GetVirtualMachine",
         "responses": {

--- a/proto/api/v2/virtual_machine_service.proto
+++ b/proto/api/v2/virtual_machine_service.proto
@@ -72,20 +72,20 @@ message DeleteVirtualMachineResponse {
 service VirtualMachineService {
   rpc CreateVirtualMachine(CreateVirtualMachineRequest) returns (VirtualMachine) {
     option (google.api.http) = {
-      post: "/v1/virtualmachines"
+      post: "/v2/virtualmachines"
       body: "*"
     };
   }
 
   rpc GetVirtualMachine(GetVirtualMachineRequest) returns (VirtualMachine) {
-    option (google.api.http) = {get: "/v1/virtualmachines/{id}"};
+    option (google.api.http) = {get: "/v2/virtualmachines/{id}"};
   }
 
   rpc ListVirtualMachines(ListVirtualMachinesRequest) returns (ListVirtualMachinesResponse) {
-    option (google.api.http) = {get: "/v1/virtualmachines"};
+    option (google.api.http) = {get: "/v2/virtualmachines"};
   }
 
   rpc DeleteVirtualMachine(DeleteVirtualMachineRequest) returns (DeleteVirtualMachineResponse) {
-    option (google.api.http) = {delete: "/v1/virtualmachines/{id}"};
+    option (google.api.http) = {delete: "/v2/virtualmachines/{id}"};
   }
 }


### PR DESCRIPTION
Needed to change some strings in the service proto definition to actually get the service mounted on v2 instead of v1.