### PR TITLE
ROX-16290: Fix enforcement tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -1,5 +1,7 @@
 import static Services.waitForViolation
 
+import io.stackrox.proto.storage.ClusterOuterClass.AdmissionControllerConfig
+
 import io.stackrox.proto.api.v1.AlertServiceOuterClass
 import io.stackrox.proto.storage.AlertOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass
@@ -234,6 +236,21 @@ class Enforcement extends BaseSpecification {
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = 90
 
     def setupSpec() {
+        // The admission controller webhooks now enforce on creates and updates by default.
+        // For this test, to test other enforcements like scale down and kill pods, the deployment
+        // and its pods must first be created. Hence disable the admission controller enforcement to begin with.
+        // Allow the deployments and pods to first be created, and then sensor enforcement methods like
+        // scale down and kill pods - which only occur on the first time a deployment is created (not on updates)
+        // to execute for the sake of testing those paths.
+        // Another way to achieve the same goal - bypass admission controller enforcement so sensor can enforce
+        // would be to update each of the deployments in this test to have the stackrox.io/break-glass annotation
+        AdmissionControllerConfig ac = AdmissionControllerConfig.newBuilder()
+                .setEnabled(false)
+                .setEnforceOnUpdates(false)
+                .build()
+
+        assert ClusterService.updateAdmissionController(ac)
+
         POLICIES.each {
             label, create ->
             CREATED_POLICIES[label] = create()


### PR DESCRIPTION
## Description

The admission controller webhooks now enforce on creates and updates by default.

For this test, to test other enforcements like scale down and kill pods, the deployment and its pods must first be created. Hence disable the admission controller enforcement to begin with. Allow the deployments and pods to first be created, and then sensor enforcement methods like scale down and kill pods - which only occur on the first time a deployment is created (not on updates) to execute for the sake of testing those paths. Another way to achieve the same goal - bypass admission controller enforcement so sensor can enforce would be to update each of the deployments in this test to have the stackrox.io/break-glass annotation.

## User-facing documentation

- [] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI only.
