### PR TITLE
chore(ui): Rename top level plugin modules

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/AdministrationNamespaceSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/AdministrationNamespaceSecurityTab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export function Index() {
+export function AdministrationNamespaceSecurityTab() {
     return <div>AdministrationNamespaceSecurityTab</div>;
 }

--- a/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
@@ -2,15 +2,14 @@ import React from 'react';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams } from 'react-router-dom-v5-compat';
 
-export function Index() {
+export function CveDetailPage() {
+    const { cveId } = useParams();
     const [namespace] = useActiveNamespace();
-    const { imageId } = useParams();
-
     return (
         <>
-            <div>Image Detail Page</div>
+            <div>CVE Detail Page</div>
             <div>Namespace: {namespace}</div>
-            <div>Image ID: {imageId}</div>
+            <div>CVE ID: {cveId}</div>
         </>
     );
 }

--- a/ui/apps/platform/src/ConsolePlugin/ImageDetailPage/ImageDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/ImageDetailPage/ImageDetailPage.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams } from 'react-router-dom-v5-compat';
 
-export function Index() {
-    const { cveId } = useParams();
+export function ImageDetailPage() {
     const [namespace] = useActiveNamespace();
+    const { imageId } = useParams();
+
     return (
         <>
-            <div>CVE Detail Page</div>
+            <div>Image Detail Page</div>
             <div>Namespace: {namespace}</div>
-            <div>CVE ID: {cveId}</div>
+            <div>Image ID: {imageId}</div>
         </>
     );
 }

--- a/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export function Index() {
+export function ProjectSecurityTab() {
     return <div>Project Security Tab</div>;
 }

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
@@ -6,7 +6,7 @@ import usePermissions from 'hooks/usePermissions';
 import SummaryCounts from 'Containers/Dashboard/SummaryCounts';
 import ViolationsByPolicyCategory from 'Containers/Dashboard/Widgets/ViolationsByPolicyCategory';
 
-export function Index() {
+export function SecurityVulnerabilitiesPage() {
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForAlert = hasReadAccess('Alert');
     const hasReadAccessForCluster = hasReadAccess('Cluster');

--- a/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PageSection } from '@patternfly/react-core';
 
-export function Index() {
+export function WorkloadSecurityTab() {
     return <PageSection>Security</PageSection>;
 }

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -102,13 +102,13 @@ const config = {
                 exposedModules: {
                     context: './ConsolePlugin/PluginProvider',
                     AdministrationNamespaceSecurityTab:
-                        './ConsolePlugin/AdministrationNamespaceSecurityTab/Index',
-                    CveDetailPage: './ConsolePlugin/CveDetailPage/Index',
-                    ImageDetailPage: './ConsolePlugin/ImageDetailPage/Index',
-                    ProjectSecurityTab: './ConsolePlugin/ProjectSecurityTab/Index',
+                        './ConsolePlugin/AdministrationNamespaceSecurityTab/AdministrationNamespaceSecurityTab',
+                    CveDetailPage: './ConsolePlugin/CveDetailPage/CveDetailPage',
+                    ImageDetailPage: './ConsolePlugin/ImageDetailPage/ImageDetailPage',
+                    ProjectSecurityTab: './ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab',
                     SecurityVulnerabilitiesPage:
-                        './ConsolePlugin/SecurityVulnerabilitiesPage/Index',
-                    WorkloadSecurityTab: './ConsolePlugin/WorkloadSecurityTab/Index',
+                        './ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage',
+                    WorkloadSecurityTab: './ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab',
                 },
                 dependencies: {
                     '@console/pluginAPI': '>=4.19.0',
@@ -129,7 +129,9 @@ const config = {
                     properties: {
                         exact: true,
                         path: `${acsRootBaseUrl}/security/vulnerabilities`,
-                        component: { $codeRef: 'SecurityVulnerabilitiesPage.Index' },
+                        component: {
+                            $codeRef: 'SecurityVulnerabilitiesPage.SecurityVulnerabilitiesPage',
+                        },
                     },
                 },
                 {
@@ -165,7 +167,7 @@ const config = {
                                 name: 'Security',
                                 href: 'security',
                             },
-                            component: { $codeRef: 'WorkloadSecurityTab.Index' },
+                            component: { $codeRef: 'WorkloadSecurityTab.WorkloadSecurityTab' },
                         },
                     })
                 ),
@@ -183,7 +185,8 @@ const config = {
                             href: 'security',
                         },
                         component: {
-                            $codeRef: 'AdministrationNamespaceSecurityTab.Index',
+                            $codeRef:
+                                'AdministrationNamespaceSecurityTab.AdministrationNamespaceSecurityTab',
                         },
                     },
                 },
@@ -201,7 +204,7 @@ const config = {
                             href: 'security',
                         },
                         component: {
-                            $codeRef: 'ProjectSecurityTab.Index',
+                            $codeRef: 'ProjectSecurityTab.ProjectSecurityTab',
                         },
                     },
                 },
@@ -211,7 +214,7 @@ const config = {
                     properties: {
                         exact: true,
                         path: `${acsRootBaseUrl}/security/vulnerabilities/images/:imageId`,
-                        component: { $codeRef: 'ImageDetailPage.Index' },
+                        component: { $codeRef: 'ImageDetailPage.ImageDetailPage' },
                     },
                 },
                 // Image CVE Detail Page
@@ -220,7 +223,7 @@ const config = {
                     properties: {
                         exact: true,
                         path: `${acsRootBaseUrl}/security/vulnerabilities/cves/:cveId`,
-                        component: { $codeRef: 'CveDetailPage.Index' },
+                        component: { $codeRef: 'CveDetailPage.CveDetailPage' },
                     },
                 },
             ],


### PR DESCRIPTION
## Description

In the spirit of the recent discussion regarding many `CVETable.tsx` components, lets rename the already long list of `Index.tsx` files for plugin entry points to avoid similar pain.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Smoke test running plugin dev environment.
