### PR TITLE
ROX-30492: Replace DOM assertion with intercept in visitNamespaceView

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -478,7 +478,12 @@ export function waitForTableLoadCompleteIndicator() {
 }
 
 export function visitNamespaceView() {
-    cy.get('a:contains("Prioritize by namespace view")').click();
+    interactAndWaitForResponses(
+        () => {
+            cy.get('a:contains("Prioritize by namespace view")').click();
+        },
+        getRouteMatcherMapForGraphQL(['getNamespaceViewNamespaces'])
+    );
 }
 
 export function viewCvesByObservationState(observationState) {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -3,7 +3,7 @@ import withAuth from '../../../helpers/basicAuth';
 import {
     visitWorkloadCveOverview,
     visitNamespaceView,
-    waitForTableLoadCompleteIndicator,
+    // waitForTableLoadCompleteIndicator,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
@@ -15,7 +15,11 @@ describe('Workload CVE Namespace View', () => {
 
         visitNamespaceView();
 
-        waitForTableLoadCompleteIndicator();
+        // ROX-30492: DOM assertion often, but not always, times out, even with retry on CI
+        // for gke but not ocp-4-19 starting about 2025-08-07
+        // David observed in video that request finishes ahead of assertion about loading spinner.
+        // Instead, wait for request in visit function.
+        // waitForTableLoadCompleteIndicator();
 
         cy.get(selectors.firstTableRow).then(($row) => {
             const namespace = $row.find('td[data-label="Namespace"]').text();


### PR DESCRIPTION
## Description

### Problem

Workload CVE Namespace View should display the correct search filter chips on the main list page when clicking the deployment link in the table

> Timed out retrying after 8000ms: Expected to find element: `table svg[role="progressbar"][aria-valuetext="Loading..."]`, but never found it.

<img width="1284" height="720" alt="ROX-30492" src="https://github.com/user-attachments/assets/3d65b235-c63a-4062-a0f8-be813d694a52" />

### Analysis

Suddenly:
* fails often, but not always, for gke-ui-e2e-tests (even with retry)
* passes for ocp-4-19-ui-e2e-tests
* passed on previous nightly

**David Vail** observed in video that request finishes ahead of assertion about loading spinner.

### Solution

1. Comment out DOM assetion in test.
2. Add wait for `getNamespaceViewNamespaces` request to `visitNamespaceView` function.

### Residue

1. Investigate responsive behavior for screen size of Cypress in CI.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] edited e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

With local deployment, I can see replacement of assertion with wait in Cypress console, but the table assertions fail because **No results found**.

Given the number of failures on CI, we will soon know if this change helps.