### PR TITLE
ROX-30362: Extend column mgmt for general conditional columns

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -234,7 +234,7 @@ describe('Workload CVE overview page tests', () => {
             }
 
             function assertCveElementsAreNotPresent() {
-                cy.get(cvesBySeverityHeader).should('not.exist');
+                cy.get(cvesBySeverityHeader).should('not.be.visible');
                 cy.get(prioritizeByNamespaceButton).should('not.exist');
                 cy.get(defaultFiltersButton).should('not.exist');
                 cy.get(selectors.severityDropdown).should('not.exist');

--- a/ui/apps/platform/src/Components/ColumnManagementButton.tsx
+++ b/ui/apps/platform/src/Components/ColumnManagementButton.tsx
@@ -2,32 +2,35 @@ import React, { useState } from 'react';
 
 import { ColumnManagementModal } from '@patternfly/react-component-groups';
 import { Button } from '@patternfly/react-core';
-
-import { ColumnConfig, ManagedColumns } from 'hooks/useManagedColumns';
 import { CogIcon } from '@patternfly/react-icons';
 
+import { ColumnConfig } from 'hooks/useManagedColumns';
+
 export type ColumnManagementButtonProps<ColumnKey extends string> = {
-    managedColumnState: ManagedColumns<ColumnKey>;
+    columnConfig: Record<ColumnKey, ColumnConfig>;
+    onApplyColumns: (columns: Record<string, boolean>) => void;
 };
 
 function ColumnManagementButton<ColumnKey extends string>({
-    managedColumnState,
+    columnConfig,
+    onApplyColumns,
 }: ColumnManagementButtonProps<ColumnKey>) {
     const [isOpen, setOpen] = useState(false);
-    const { columns, setVisibility } = managedColumnState;
-    const enabledColumnCount = Object.values<ColumnConfig>(columns).filter(
-        ({ isShown }) => isShown
+    const enabledColumnCount = Object.values<ColumnConfig>(columnConfig).filter(
+        ({ isShown, isUntoggleAble }) => isShown && !isUntoggleAble
     ).length;
 
     return (
         <>
             <ColumnManagementModal
-                appliedColumns={Object.values(columns)}
+                appliedColumns={Object.values<ColumnConfig>(columnConfig).filter(
+                    (c) => !c.isUntoggleAble
+                )}
                 applyColumns={(newColumns) => {
                     const nextState = Object.fromEntries(
                         newColumns.map(({ key, isShown }) => [key, isShown ?? false])
                     );
-                    setVisibility(nextState);
+                    onApplyColumns(nextState);
                 }}
                 isOpen={isOpen}
                 onClose={() => setOpen(false)}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -34,7 +34,7 @@ import {
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { filterManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import CvesByStatusSummaryCard, {
@@ -180,11 +180,14 @@ function DeploymentPageVulnerabilities({
     });
 
     const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const filteredColumns = filterManagedColumns(
-        defaultColumns,
-        (key) => key !== 'epssProbability' || isEpssProbabilityColumnEnabled
-    );
-    const managedColumnState = useManagedColumns(tableId, filteredColumns);
+
+    const managedColumnState = useManagedColumns(tableId, defaultColumns);
+
+    const columnConfig = overrideManagedColumns(managedColumnState.columns, {
+        epssProbability: isEpssProbabilityColumnEnabled
+            ? {}
+            : { isUntoggleAble: true, isShown: false },
+    });
 
     // Keep searchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4 also Advisory.
     const searchFilterConfigWithFeatureFlagDependency = [
@@ -304,7 +307,10 @@ function DeploymentPageVulnerabilities({
                                 </Flex>
                             </SplitItem>
                             <SplitItem>
-                                <ColumnManagementButton managedColumnState={managedColumnState} />
+                                <ColumnManagementButton
+                                    columnConfig={columnConfig}
+                                    onApplyColumns={managedColumnState.setVisibility}
+                                />
                             </SplitItem>
                             <SplitItem>
                                 <Pagination
@@ -328,7 +334,7 @@ function DeploymentPageVulnerabilities({
                                     setSearchFilter({});
                                     setPage(1);
                                 }}
-                                tableConfig={managedColumnState.columns}
+                                tableConfig={columnConfig}
                             />
                         </div>
                     </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -34,7 +34,7 @@ import {
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import CvesByStatusSummaryCard, {
@@ -179,14 +179,12 @@ function DeploymentPageVulnerabilities({
         },
     });
 
-    const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
+    const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+
     const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        epssProbability: isEpssProbabilityColumnEnabled
-            ? {}
-            : { isUntoggleAble: true, isShown: false },
+        epssProbability: hideColumnIf(!isEpssProbabilityColumnEnabled),
     });
 
     // Keep searchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4 also Advisory.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -36,7 +36,7 @@ import {
     imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import CvesByStatusSummaryCard, {
     ResourceCountByCveSeverityAndStatus,
@@ -188,17 +188,11 @@ function ImagePageVulnerabilities({
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
     const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        cveSelection: { isShown: canSelectRows },
-        nvdCvss: isNvdCvssColumnEnabled ? {} : { isUntoggleAble: true, isShown: false },
-        epssProbability: isEpssProbabilityColumnEnabled
-            ? {}
-            : { isUntoggleAble: true, isShown: false },
-        requestDetails: {
-            isShown: currentVulnerabilityState !== 'OBSERVED',
-        },
-        rowActions: {
-            isShown: createTableActions !== undefined,
-        },
+        cveSelection: hideColumnIf(!canSelectRows),
+        nvdCvss: hideColumnIf(!isNvdCvssColumnEnabled),
+        epssProbability: hideColumnIf(!isEpssProbabilityColumnEnabled),
+        requestDetails: hideColumnIf(currentVulnerabilityState === 'OBSERVED'),
+        rowActions: hideColumnIf(createTableActions === undefined),
     });
 
     // Keep searchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4 also Advisory.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -36,7 +36,7 @@ import {
     imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { filterManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import CvesByStatusSummaryCard, {
     ResourceCountByCveSeverityAndStatus,
@@ -184,24 +184,22 @@ function ImagePageVulnerabilities({
 
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    // totalAdvisories out of scope for MVP
-    /*
-    const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const filteredColumns = filterManagedColumns(
-        defaultColumns,
-        (key) =>
-            (key !== 'nvdCvss' || isNvdCvssColumnEnabled) &&
-            (key !== 'epssProbability' || isEpssProbabilityColumnEnabled) &&
-            (key !== 'totalAdvisories' || isAdvisoryColumnEnabled)
-    );
-    */
-    const filteredColumns = filterManagedColumns(
-        defaultColumns,
-        (key) =>
-            (key !== 'nvdCvss' || isNvdCvssColumnEnabled) &&
-            (key !== 'epssProbability' || isEpssProbabilityColumnEnabled)
-    );
-    const managedColumnState = useManagedColumns(tableId, filteredColumns);
+
+    const managedColumnState = useManagedColumns(tableId, defaultColumns);
+
+    const columnConfig = overrideManagedColumns(managedColumnState.columns, {
+        cveSelection: { isShown: canSelectRows },
+        nvdCvss: isNvdCvssColumnEnabled ? {} : { isUntoggleAble: true, isShown: false },
+        epssProbability: isEpssProbabilityColumnEnabled
+            ? {}
+            : { isUntoggleAble: true, isShown: false },
+        requestDetails: {
+            isShown: currentVulnerabilityState !== 'OBSERVED',
+        },
+        rowActions: {
+            isShown: createTableActions !== undefined,
+        },
+    });
 
     // Keep searchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4 also Advisory.
     const searchFilterConfigWithFeatureFlagDependency = [
@@ -316,7 +314,10 @@ function ImagePageVulnerabilities({
                                 </Flex>
                             </SplitItem>
                             <SplitItem>
-                                <ColumnManagementButton managedColumnState={managedColumnState} />
+                                <ColumnManagementButton
+                                    columnConfig={columnConfig}
+                                    onApplyColumns={managedColumnState.setVisibility}
+                                />
                             </SplitItem>
                             {canSelectRows && (
                                 <>
@@ -378,14 +379,13 @@ function ImagePageVulnerabilities({
                                 getSortParams={getSortParams}
                                 isFiltered={isFiltered}
                                 selectedCves={selectedCves}
-                                canSelectRows={canSelectRows}
                                 vulnerabilityState={currentVulnerabilityState}
                                 createTableActions={createTableActions}
                                 onClearFilters={() => {
                                     setSearchFilter({});
                                     setPage(1);
                                 }}
-                                tableConfig={managedColumnState.columns}
+                                tableConfig={columnConfig}
                             />
                         </div>
                     </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -45,7 +45,7 @@ import {
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { filterManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import { HistoryAction } from 'hooks/useURLParameter';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import { WorkloadEntityTab, VulnerabilitySeverityLabel } from '../../types';
@@ -295,19 +295,21 @@ function ImageCvePage() {
     });
 
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const affectedImagesFilteredColumns = filterManagedColumns(
-        affectedImagesDefaultColumns,
-        (key) => key !== 'nvdCvss' || isNvdCvssColumnEnabled
-    );
-    const imageTableColumnState = useManagedColumns(
+    const imageTableManagedState = useManagedColumns(
         affectedImagesTableId,
-        affectedImagesFilteredColumns
+        affectedImagesDefaultColumns
     );
 
-    const deploymentTableColumnState = useManagedColumns(
+    const imageTableColumnConfig = overrideManagedColumns(imageTableManagedState.columns, {
+        nvdCvss: isNvdCvssColumnEnabled ? {} : { isUntoggleAble: true, isShown: false },
+    });
+
+    const deploymentTableManagedState = useManagedColumns(
         affectedDeploymentsTableId,
         affectedDeploymentsDefaultColumns
     );
+
+    const deploymentTableColumnConfig = deploymentTableManagedState.columns;
 
     const imageCount = summaryRequest.data?.imageCount ?? 0;
     const deploymentCount = summaryRequest.data?.deploymentCount ?? 0;
@@ -492,12 +494,14 @@ function ImageCvePage() {
                         <SplitItem>
                             {entityTab === 'Image' && (
                                 <ColumnManagementButton
-                                    managedColumnState={imageTableColumnState}
+                                    columnConfig={imageTableColumnConfig}
+                                    onApplyColumns={imageTableManagedState.setVisibility}
                                 />
                             )}
                             {entityTab === 'Deployment' && (
                                 <ColumnManagementButton
-                                    managedColumnState={deploymentTableColumnState}
+                                    columnConfig={deploymentTableColumnConfig}
+                                    onApplyColumns={deploymentTableManagedState.setVisibility}
                                 />
                             )}
                         </SplitItem>
@@ -523,7 +527,7 @@ function ImageCvePage() {
                                 cve={cveId}
                                 vulnerabilityState={currentVulnerabilityState}
                                 onClearFilters={onClearFilters}
-                                tableConfig={imageTableColumnState.columns}
+                                tableConfig={imageTableColumnConfig}
                             />
                         )}
                         {entityTab === 'Deployment' && (
@@ -537,7 +541,7 @@ function ImageCvePage() {
                                 cve={cveId}
                                 vulnerabilityState={currentVulnerabilityState}
                                 onClearFilters={onClearFilters}
-                                tableConfig={deploymentTableColumnState.columns}
+                                tableConfig={deploymentTableColumnConfig}
                             />
                         )}
                     </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -45,7 +45,7 @@ import {
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
-import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import { HistoryAction } from 'hooks/useURLParameter';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import { WorkloadEntityTab, VulnerabilitySeverityLabel } from '../../types';
@@ -301,7 +301,7 @@ function ImageCvePage() {
     );
 
     const imageTableColumnConfig = overrideManagedColumns(imageTableManagedState.columns, {
-        nvdCvss: isNvdCvssColumnEnabled ? {} : { isUntoggleAble: true, isShown: false },
+        nvdCvss: hideColumnIf(!isNvdCvssColumnEnabled),
     });
 
     const deploymentTableManagedState = useManagedColumns(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -14,7 +14,7 @@ import { getPaginationParams } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import WorkloadCVEOverviewTable, {
     ImageCVE,
@@ -94,17 +94,11 @@ function CVEsTableContainer({
     const createTableActions = showDeferralUI ? createExceptionModalActions : undefined;
 
     const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        cveSelection: { isShown: canSelectRows },
-        topNvdCvss: isNvdCvssColumnEnabled ? {} : { isUntoggleAble: true, isShown: false },
-        epssProbability: isEpssProbabilityColumnEnabled
-            ? {}
-            : { isUntoggleAble: true, isShown: false },
-        requestDetails: {
-            isShown: vulnerabilityState !== 'OBSERVED',
-        },
-        rowActions: {
-            isShown: createTableActions !== undefined,
-        },
+        cveSelection: hideColumnIf(!canSelectRows),
+        topNvdCvss: hideColumnIf(!isNvdCvssColumnEnabled),
+        epssProbability: hideColumnIf(!isEpssProbabilityColumnEnabled),
+        requestDetails: hideColumnIf(vulnerabilityState === 'OBSERVED'),
+        rowActions: hideColumnIf(createTableActions === undefined),
     });
 
     const tableState = getTableUIState({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -8,7 +8,7 @@ import useURLPagination from 'hooks/useURLPagination';
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';
-import { useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import DeploymentsTable, {
     defaultColumns,
@@ -65,6 +65,10 @@ function DeploymentsTableContainer({
 
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
+    const columnConfig = overrideManagedColumns(managedColumnState.columns, {
+        cvesBySeverity: showCveDetailFields ? {} : { isUntoggleAble: true, isShown: false },
+    });
+
     return (
         <>
             <TableEntityToolbar
@@ -75,7 +79,10 @@ function DeploymentsTableContainer({
                 isFiltered={isFiltered}
             >
                 <ToolbarItem align={{ default: 'alignRight' }}>
-                    <ColumnManagementButton managedColumnState={managedColumnState} />
+                    <ColumnManagementButton
+                        columnConfig={columnConfig}
+                        onApplyColumns={managedColumnState.setVisibility}
+                    />
                 </ToolbarItem>
             </TableEntityToolbar>
             <Divider component="div" />
@@ -89,12 +96,11 @@ function DeploymentsTableContainer({
                     getSortParams={getSortParams}
                     isFiltered={isFiltered}
                     filteredSeverities={searchFilter.SEVERITY as VulnerabilitySeverityLabel[]}
-                    showCveDetailFields={showCveDetailFields}
                     onClearFilters={() => {
                         onFilterChange({});
                         pagination.setPage(1);
                     }}
-                    columnVisibilityState={managedColumnState.columns}
+                    columnVisibilityState={columnConfig}
                 />
             </div>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -8,7 +8,7 @@ import useURLPagination from 'hooks/useURLPagination';
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';
-import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import DeploymentsTable, {
     defaultColumns,
@@ -66,7 +66,7 @@ function DeploymentsTableContainer({
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
     const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        cvesBySeverity: showCveDetailFields ? {} : { isUntoggleAble: true, isShown: false },
+        cvesBySeverity: hideColumnIf(!showCveDetailFields),
     });
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -9,7 +9,7 @@ import usePermissions from 'hooks/usePermissions';
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';
-import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import ImageOverviewTable, {
     Image,
@@ -80,10 +80,8 @@ function ImagesTableContainer({
     const hasActionColumn = hasWriteAccessForWatchedImage || hasWriteAccessForImage;
 
     const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        cvesBySeverity: showCveDetailFields ? {} : { isUntoggleAble: true, isShown: false },
-        rowActions: {
-            isShown: hasActionColumn,
-        },
+        cvesBySeverity: hideColumnIf(!showCveDetailFields),
+        rowActions: hideColumnIf(!hasActionColumn),
     });
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -4,11 +4,12 @@ import { Divider, ToolbarItem } from '@patternfly/react-core';
 
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
+import usePermissions from 'hooks/usePermissions';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import { getPaginationParams } from 'utils/searchUtils';
 import { SearchFilter } from 'types/search';
-import { useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import ImageOverviewTable, {
     Image,
@@ -72,7 +73,18 @@ function ImagesTableContainer({
         searchFilter,
     });
 
-    const managedColumns = useManagedColumns(tableId, defaultColumns);
+    const managedColumnState = useManagedColumns(tableId, defaultColumns);
+
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForImage = hasReadWriteAccess('Image'); // SBOM Generation mutates image scan state.
+    const hasActionColumn = hasWriteAccessForWatchedImage || hasWriteAccessForImage;
+
+    const columnConfig = overrideManagedColumns(managedColumnState.columns, {
+        cvesBySeverity: showCveDetailFields ? {} : { isUntoggleAble: true, isShown: false },
+        rowActions: {
+            isShown: hasActionColumn,
+        },
+    });
 
     return (
         <>
@@ -84,7 +96,10 @@ function ImagesTableContainer({
                 isFiltered={isFiltered}
             >
                 <ToolbarItem align={{ default: 'alignRight' }}>
-                    <ColumnManagementButton managedColumnState={managedColumns} />
+                    <ColumnManagementButton
+                        columnConfig={columnConfig}
+                        onApplyColumns={managedColumnState.setVisibility}
+                    />
                 </ToolbarItem>
             </TableEntityToolbar>
             <Divider component="div" />
@@ -101,12 +116,11 @@ function ImagesTableContainer({
                     hasWriteAccessForWatchedImage={hasWriteAccessForWatchedImage}
                     onWatchImage={onWatchImage}
                     onUnwatchImage={onUnwatchImage}
-                    showCveDetailFields={showCveDetailFields}
                     onClearFilters={() => {
                         onFilterChange({});
                         pagination.setPage(1);
                     }}
-                    columnVisibilityState={managedColumns.columns}
+                    columnVisibilityState={columnConfig}
                 />
             </div>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -30,6 +30,16 @@ import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const tableId = 'WorkloadCvesAffectedDeploymentsTable';
 export const defaultColumns = {
+    rowExpansion: {
+        title: 'Row expansion',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
+    deployment: {
+        title: 'Deployment',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
     imagesBySeverity: {
         title: 'Images by severity',
         isShownByDefault: true,
@@ -115,15 +125,20 @@ function AffectedDeploymentsTable({
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
 
-    const colSpan = 7 + -hiddenColumnCount;
+    const colSpan = Object.values(defaultColumns).length - hiddenColumnCount;
     const colSpanForComponentVulnerabilitiesTable = colSpan - 1; // minus ExpandRowTh
 
     return (
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <ExpandRowTh />
-                    <Th sort={getSortParams('Deployment')}>Deployment</Th>
+                    <ExpandRowTh className={getVisibilityClass('rowExpansion')} />
+                    <Th
+                        className={getVisibilityClass('deployment')}
+                        sort={getSortParams('Deployment')}
+                    >
+                        Deployment
+                    </Th>
                     <Th className={getVisibilityClass('imagesBySeverity')}>
                         Images by severity
                         {isFiltered && <DynamicColumnIcon />}
@@ -175,13 +190,17 @@ function AffectedDeploymentsTable({
                             <Tbody key={id} isExpanded={isExpanded}>
                                 <Tr>
                                     <Td
+                                        className={getVisibilityClass('rowExpansion')}
                                         expand={{
                                             rowIndex,
                                             isExpanded,
                                             onToggle: () => expandedRowSet.toggle(id),
                                         }}
                                     />
-                                    <Td dataLabel="Deployment">
+                                    <Td
+                                        className={getVisibilityClass('deployment')}
+                                        dataLabel="Deployment"
+                                    >
                                         <Flex
                                             direction={{ default: 'column' }}
                                             spaceItems={{ default: 'spaceItemsNone' }}
@@ -242,7 +261,7 @@ function AffectedDeploymentsTable({
                                     </Td>
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>
-                                    <Td />
+                                    <Td className={getVisibilityClass('rowExpansion')} />
                                     <Td colSpan={colSpanForComponentVulnerabilitiesTable}>
                                         <ExpandableRowContent>
                                             <DeploymentComponentVulnerabilitiesTable

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import { ExpandableRowContent, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
@@ -39,6 +38,16 @@ import PendingExceptionLabelLayout from '../components/PendingExceptionLabelLayo
 
 export const tableId = 'WorkloadCvesAffectedImagesTable';
 export const defaultColumns = {
+    rowExpansion: {
+        title: 'Row expansion',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
+    image: {
+        title: 'Image',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
     cveSeverity: {
         title: 'CVE severity',
         isShownByDefault: true,
@@ -142,17 +151,17 @@ function AffectedImagesTable({
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
 
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const colSpan = 8 + (isNvdCvssColumnEnabled ? 1 : 0) + -hiddenColumnCount;
+    const colSpan = Object.values(defaultColumns).length - hiddenColumnCount;
     const colSpanForComponentVulnerabilitiesTable = colSpan - 1; // minus ExpandRowTh
 
     return (
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <ExpandRowTh />
-                    <Th sort={getSortParams('Image')}>Image</Th>
+                    <ExpandRowTh className={getVisibilityClass('rowExpansion')} />
+                    <Th className={getVisibilityClass('image')} sort={getSortParams('Image')}>
+                        Image
+                    </Th>
                     <Th
                         className={getVisibilityClass('cveSeverity')}
                         sort={getSortParams('Severity')}
@@ -164,9 +173,7 @@ function AffectedImagesTable({
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th className={getVisibilityClass('cvss')}>CVSS</Th>
-                    {isNvdCvssColumnEnabled && (
-                        <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
-                    )}
+                    <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
                     <Th
                         className={getVisibilityClass('operatingSystem')}
                         sort={getSortParams('Operating System')}
@@ -208,13 +215,14 @@ function AffectedImagesTable({
                             <Tbody key={id} isExpanded={isExpanded}>
                                 <Tr>
                                     <Td
+                                        className={getVisibilityClass('rowExpansion')}
                                         expand={{
                                             rowIndex,
                                             isExpanded,
                                             onToggle: () => expandedRowSet.toggle(id),
                                         }}
                                     />
-                                    <Td dataLabel="Image">
+                                    <Td className={getVisibilityClass('image')} dataLabel="Image">
                                         {name ? (
                                             <PendingExceptionLabelLayout
                                                 hasPendingException={hasPendingException}
@@ -251,18 +259,16 @@ function AffectedImagesTable({
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>
 
-                                    {isNvdCvssColumnEnabled && (
-                                        <Td
-                                            className={getVisibilityClass('nvdCvss')}
-                                            dataLabel="NVD CVSS"
-                                            modifier="nowrap"
-                                        >
-                                            <CvssFormatted
-                                                cvss={nvdCvss}
-                                                scoreVersion={nvdScoreVersion}
-                                            />
-                                        </Td>
-                                    )}
+                                    <Td
+                                        className={getVisibilityClass('nvdCvss')}
+                                        dataLabel="NVD CVSS"
+                                        modifier="nowrap"
+                                    >
+                                        <CvssFormatted
+                                            cvss={nvdCvss}
+                                            scoreVersion={nvdScoreVersion}
+                                        />
+                                    </Td>
                                     <Td
                                         className={getVisibilityClass('operatingSystem')}
                                         dataLabel="Operating system"
@@ -291,7 +297,7 @@ function AffectedImagesTable({
                                     </Td>
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>
-                                    <Td />
+                                    <Td className={getVisibilityClass('rowExpansion')} />
                                     <Td colSpan={colSpanForComponentVulnerabilitiesTable}>
                                         <ExpandableRowContent>
                                             <ImageComponentVulnerabilitiesTable

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -25,6 +25,11 @@ import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 export const tableId = 'WorkloadCvesDeploymentOverviewTable';
 
 export const defaultColumns = {
+    deployment: {
+        title: 'Deployment',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
     cvesBySeverity: {
         title: 'CVEs by severity',
         isShownByDefault: true,
@@ -98,7 +103,6 @@ type DeploymentOverviewTableProps = {
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
     filteredSeverities?: VulnerabilitySeverityLabel[];
-    showCveDetailFields: boolean;
     onClearFilters: () => void;
     columnVisibilityState: ManagedColumns<keyof typeof defaultColumns>['columns'];
 };
@@ -108,7 +112,6 @@ function DeploymentOverviewTable({
     getSortParams,
     isFiltered,
     filteredSeverities,
-    showCveDetailFields,
     onClearFilters,
     columnVisibilityState,
 }: DeploymentOverviewTableProps) {
@@ -116,22 +119,25 @@ function DeploymentOverviewTable({
     const vulnerabilityState = useVulnerabilityState();
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
     const hiddenColumnCount = getHiddenColumnCount(columnVisibilityState);
-    const colSpan = 5 + (showCveDetailFields ? 1 : 0) + -hiddenColumnCount;
+    const colSpan = Object.values(defaultColumns).length - hiddenColumnCount;
 
     return (
         <Table borders={false} variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th sort={getSortParams('Deployment')}>Deployment</Th>
-                    {showCveDetailFields && (
-                        <TooltipTh
-                            className={getVisibilityClass('cvesBySeverity')}
-                            tooltip="CVEs by severity across this deployment"
-                        >
-                            CVEs by severity
-                            {isFiltered && <DynamicColumnIcon />}
-                        </TooltipTh>
-                    )}
+                    <Th
+                        className={getVisibilityClass('deployment')}
+                        sort={getSortParams('Deployment')}
+                    >
+                        Deployment
+                    </Th>
+                    <TooltipTh
+                        className={getVisibilityClass('cvesBySeverity')}
+                        tooltip="CVEs by severity across this deployment"
+                    >
+                        CVEs by severity
+                        {isFiltered && <DynamicColumnIcon />}
+                    </TooltipTh>
                     <Th className={getVisibilityClass('cluster')} sort={getSortParams('Cluster')}>
                         Cluster
                     </Th>
@@ -182,7 +188,10 @@ function DeploymentOverviewTable({
                                 }}
                             >
                                 <Tr>
-                                    <Td dataLabel="Deployment">
+                                    <Td
+                                        className={getVisibilityClass('deployment')}
+                                        dataLabel="Deployment"
+                                    >
                                         <Link
                                             to={getAbsoluteUrl(
                                                 getWorkloadEntityPagePath(
@@ -195,22 +204,20 @@ function DeploymentOverviewTable({
                                             <Truncate position="middle" content={name} />
                                         </Link>
                                     </Td>
-                                    {showCveDetailFields && (
-                                        <Td
-                                            dataLabel="CVEs by severity"
-                                            className={getVisibilityClass('cvesBySeverity')}
-                                        >
-                                            <SeverityCountLabels
-                                                criticalCount={criticalCount}
-                                                importantCount={importantCount}
-                                                moderateCount={moderateCount}
-                                                lowCount={lowCount}
-                                                unknownCount={unknownCount}
-                                                entity="deployment"
-                                                filteredSeverities={filteredSeverities}
-                                            />
-                                        </Td>
-                                    )}
+                                    <Td
+                                        dataLabel="CVEs by severity"
+                                        className={getVisibilityClass('cvesBySeverity')}
+                                    >
+                                        <SeverityCountLabels
+                                            criticalCount={criticalCount}
+                                            importantCount={importantCount}
+                                            moderateCount={moderateCount}
+                                            lowCount={lowCount}
+                                            unknownCount={unknownCount}
+                                            entity="deployment"
+                                            filteredSeverities={filteredSeverities}
+                                        />
+                                    </Td>
                                     <Td
                                         dataLabel="Cluster"
                                         className={getVisibilityClass('cluster')}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom-v5-compat';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -32,6 +31,16 @@ import { FormattedDeploymentVulnerability, formatEpssProbabilityAsPercent } from
 
 export const tableId = 'WorkloadCvesDeploymentVulnerabilitiesTable';
 export const defaultColumns = {
+    rowExpansion: {
+        title: 'Row expansion',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
+    cve: {
+        title: 'CVE',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
     operatingSystem: {
         title: 'Operating system',
         isShownByDefault: true,
@@ -112,17 +121,16 @@ function DeploymentVulnerabilitiesTable({
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-
-    const colSpan = 7 + (isEpssProbabilityColumnEnabled ? 1 : 0) - hiddenColumnCount;
+    const colSpan = Object.values(defaultColumns).length - hiddenColumnCount;
 
     return (
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <ExpandRowTh />
-                    <Th sort={getSortParams('CVE')}>CVE</Th>
+                    <ExpandRowTh className={getVisibilityClass('rowExpansion')} />
+                    <Th className={getVisibilityClass('cve')} sort={getSortParams('CVE')}>
+                        CVE
+                    </Th>
                     <Th className={getVisibilityClass('operatingSystem')}>Operating system</Th>
                     <Th
                         className={getVisibilityClass('cveSeverity')}
@@ -134,15 +142,13 @@ function DeploymentVulnerabilitiesTable({
                         CVE status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    {isEpssProbabilityColumnEnabled && (
-                        <Th
-                            className={getVisibilityClass('epssProbability')}
-                            info={infoForEpssProbability}
-                            sort={getSortParams('EPSS Probability')}
-                        >
-                            EPSS probability
-                        </Th>
-                    )}
+                    <Th
+                        className={getVisibilityClass('epssProbability')}
+                        info={infoForEpssProbability}
+                        sort={getSortParams('EPSS Probability')}
+                    >
+                        EPSS probability
+                    </Th>
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}
@@ -179,13 +185,18 @@ function DeploymentVulnerabilitiesTable({
                             <Tbody key={vulnerabilityId} isExpanded={isExpanded}>
                                 <Tr>
                                     <Td
+                                        className={getVisibilityClass('rowExpansion')}
                                         expand={{
                                             rowIndex,
                                             isExpanded,
                                             onToggle: () => expandedRowSet.toggle(vulnerabilityId),
                                         }}
                                     />
-                                    <Td dataLabel="CVE" modifier="nowrap">
+                                    <Td
+                                        className={getVisibilityClass('cve')}
+                                        dataLabel="CVE"
+                                        modifier="nowrap"
+                                    >
                                         <PendingExceptionLabelLayout
                                             hasPendingException={pendingExceptionCount > 0}
                                             cve={cve}
@@ -225,15 +236,13 @@ function DeploymentVulnerabilitiesTable({
                                     >
                                         <VulnerabilityFixableIconText isFixable={isFixable} />
                                     </Td>
-                                    {isEpssProbabilityColumnEnabled && (
-                                        <Td
-                                            className={getVisibilityClass('epssProbability')}
-                                            modifier="nowrap"
-                                            dataLabel="EPSS probability"
-                                        >
-                                            {formatEpssProbabilityAsPercent(epssProbability)}
-                                        </Td>
-                                    )}
+                                    <Td
+                                        className={getVisibilityClass('epssProbability')}
+                                        modifier="nowrap"
+                                        dataLabel="EPSS probability"
+                                    >
+                                        {formatEpssProbabilityAsPercent(epssProbability)}
+                                    </Td>
                                     <Td
                                         className={getVisibilityClass('affectedComponents')}
                                         dataLabel="Affected components"
@@ -261,7 +270,7 @@ function DeploymentVulnerabilitiesTable({
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>
                                     <Td />
-                                    <Td colSpan={6}>
+                                    <Td colSpan={colSpan - 1}>
                                         <ExpandableRowContent>
                                             <>
                                                 {summary && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -34,6 +34,11 @@ import { getSeveritySortOptions } from '../../utils/sortUtils';
 export const tableId = 'WorkloadCvesImageOverviewTable';
 
 export const defaultColumns = {
+    image: {
+        title: 'Image',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
     cvesBySeverity: {
         title: 'CVEs by severity',
         isShownByDefault: true,
@@ -53,6 +58,11 @@ export const defaultColumns = {
     scanTime: {
         title: 'Scan time',
         isShownByDefault: true,
+    },
+    rowActions: {
+        title: 'Row actions',
+        isShownByDefault: true,
+        isUntoggleAble: true,
     },
 } as const;
 
@@ -144,7 +154,6 @@ export type ImageOverviewTableProps = {
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: (imageName: string) => void;
     onUnwatchImage: (imageName: string) => void;
-    showCveDetailFields: boolean;
     onClearFilters: () => void;
     columnVisibilityState: ManagedColumns<keyof typeof defaultColumns>['columns'];
 };
@@ -157,7 +166,6 @@ function ImageOverviewTable({
     hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
-    showCveDetailFields,
     onClearFilters,
     columnVisibilityState,
 }: ImageOverviewTableProps) {
@@ -166,29 +174,28 @@ function ImageOverviewTable({
     const isScannerV4Enabled = useIsScannerV4Enabled();
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
     const hiddenColumnCount = getHiddenColumnCount(columnVisibilityState);
-    const hasActionColumn = hasWriteAccessForWatchedImage || hasWriteAccessForImage;
-    const colSpan =
-        5 + (hasActionColumn ? 1 : 0) + (showCveDetailFields ? 1 : 0) + -hiddenColumnCount;
+
+    const colSpan = Object.values(defaultColumns).length - hiddenColumnCount;
     const [sbomTargetImage, setSbomTargetImage] = useState<string>();
 
     return (
         <Table borders={false} variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <Th sort={getSortParams('Image')}>Image</Th>
-                    {showCveDetailFields && (
-                        <TooltipTh
-                            className={getVisibilityClass('cvesBySeverity')}
-                            tooltip="CVEs by severity across this image"
-                            sort={getSortParams(
-                                'CVEs By Severity',
-                                getSeveritySortOptions(filteredSeverities)
-                            )}
-                        >
-                            CVEs by severity
-                            {isFiltered && <DynamicColumnIcon />}
-                        </TooltipTh>
-                    )}
+                    <Th className={getVisibilityClass('image')} sort={getSortParams('Image')}>
+                        Image
+                    </Th>
+                    <TooltipTh
+                        className={getVisibilityClass('cvesBySeverity')}
+                        tooltip="CVEs by severity across this image"
+                        sort={getSortParams(
+                            'CVEs By Severity',
+                            getSeveritySortOptions(filteredSeverities)
+                        )}
+                    >
+                        CVEs by severity
+                        {isFiltered && <DynamicColumnIcon />}
+                    </TooltipTh>
                     <Th
                         className={getVisibilityClass('operatingSystem')}
                         sort={getSortParams('Image OS')}
@@ -211,11 +218,10 @@ function ImageOverviewTable({
                     >
                         Scan time
                     </Th>
-                    {hasActionColumn && (
-                        <Th>
-                            <span className="pf-v5-screen-reader">Row actions</span>
-                        </Th>
-                    )}
+                    {/* eslint-disable-next-line generic/Th-defaultColumns */}
+                    <Th className={getVisibilityClass('rowActions')}>
+                        <span className="pf-v5-screen-reader">Row actions</span>
+                    </Th>
                 </Tr>
             </Thead>
             <TbodyUnified
@@ -288,7 +294,7 @@ function ImageOverviewTable({
                                 }}
                             >
                                 <Tr>
-                                    <Td dataLabel="Image">
+                                    <Td className={getVisibilityClass('image')} dataLabel="Image">
                                         {name ? (
                                             <ImageNameLink name={name} id={id}>
                                                 <VerifiedSignatureLabel
@@ -318,22 +324,20 @@ function ImageOverviewTable({
                                             'Image name not available'
                                         )}
                                     </Td>
-                                    {showCveDetailFields && (
-                                        <Td
-                                            className={getVisibilityClass('cvesBySeverity')}
-                                            dataLabel="CVEs by severity"
-                                        >
-                                            <SeverityCountLabels
-                                                criticalCount={criticalCount}
-                                                importantCount={importantCount}
-                                                moderateCount={moderateCount}
-                                                lowCount={lowCount}
-                                                unknownCount={unknownCount}
-                                                entity="image"
-                                                filteredSeverities={filteredSeverities}
-                                            />
-                                        </Td>
-                                    )}
+                                    <Td
+                                        className={getVisibilityClass('cvesBySeverity')}
+                                        dataLabel="CVEs by severity"
+                                    >
+                                        <SeverityCountLabels
+                                            criticalCount={criticalCount}
+                                            importantCount={importantCount}
+                                            moderateCount={moderateCount}
+                                            lowCount={lowCount}
+                                            unknownCount={unknownCount}
+                                            entity="image"
+                                            filteredSeverities={filteredSeverities}
+                                        />
+                                    </Td>
                                     <Td
                                         dataLabel="Operating system"
                                         className={getVisibilityClass('operatingSystem')}
@@ -372,14 +376,12 @@ function ImageOverviewTable({
                                     >
                                         {scanTime ? <DateDistance date={scanTime} /> : 'unknown'}
                                     </Td>
-                                    {hasActionColumn && (
-                                        <Td isActionCell>
-                                            <ActionsColumn
-                                                popperProps={ACTION_COLUMN_POPPER_PROPS}
-                                                items={rowActions}
-                                            />
-                                        </Td>
-                                    )}
+                                    <Td className={getVisibilityClass('rowActions')} isActionCell>
+                                        <ActionsColumn
+                                            popperProps={ACTION_COLUMN_POPPER_PROPS}
+                                            items={rowActions}
+                                        />
+                                    </Td>
                                 </Tr>
                             </Tbody>
                         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -13,7 +13,6 @@ import {
 } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
@@ -54,6 +53,21 @@ import { formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCvesImageVulnerabilitiesTable';
 export const defaultColumns = {
+    rowExpansion: {
+        title: 'Row expansion',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
+    cveSelection: {
+        title: 'CVE selection',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
+    cve: {
+        title: 'CVE',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
     cveSeverity: {
         title: 'CVE severity',
         isShownByDefault: true,
@@ -92,6 +106,16 @@ export const defaultColumns = {
     publishedOn: {
         title: 'Published',
         isShownByDefault: true,
+    },
+    requestDetails: {
+        title: 'Request details',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
+    rowActions: {
+        title: 'Row actions',
+        isShownByDefault: true,
+        isUntoggleAble: true,
     },
 } as const;
 
@@ -139,7 +163,6 @@ export type ImageVulnerabilitiesTableProps = {
     tableState: TableUIState<ImageVulnerability>;
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
-    canSelectRows: boolean;
     selectedCves: ReturnType<typeof useMap<string, CveSelectionsProps['cves'][number]>>;
     vulnerabilityState: VulnerabilityState;
     createTableActions?: (cve: {
@@ -156,10 +179,9 @@ function ImageVulnerabilitiesTable({
     tableState,
     getSortParams,
     isFiltered,
-    canSelectRows,
     selectedCves,
     vulnerabilityState,
-    createTableActions,
+    createTableActions = () => [],
     onClearFilters,
     tableConfig,
 }: ImageVulnerabilitiesTableProps) {
@@ -167,34 +189,21 @@ function ImageVulnerabilitiesTable({
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
     const expandedRowSet = useSet<string>();
-    const showExceptionDetailsLink = vulnerabilityState !== 'OBSERVED';
 
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    // totalAdvisories out of scope for MVP
-    /*
-    const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    */
-
-    const colSpan =
-        7 +
-        (isNvdCvssColumnEnabled ? 1 : 0) +
-        (isEpssProbabilityColumnEnabled ? 1 : 0) +
-        // totalAdvisories out of scope for MVP
-        // (isAdvisoryColumnEnabled ? 1 : 0) +
-        (canSelectRows ? 1 : 0) +
-        (createTableActions ? 1 : 0) +
-        (showExceptionDetailsLink ? 1 : 0) +
-        -hiddenColumnCount;
+    const colSpan = Object.values(defaultColumns).length - hiddenColumnCount;
 
     return (
         <Table variant="compact">
             <Thead noWrap>
                 <Tr>
-                    <ExpandRowTh />
-                    {canSelectRows && <CVESelectionTh selectedCves={selectedCves} />}
-                    <Th sort={getSortParams('CVE')}>CVE</Th>
+                    <ExpandRowTh className={getVisibilityClass('rowExpansion')} />
+                    <CVESelectionTh
+                        className={getVisibilityClass('cveSelection')}
+                        selectedCves={selectedCves}
+                    />
+                    <Th className={getVisibilityClass('cve')} sort={getSortParams('CVE')}>
+                        CVE
+                    </Th>
                     <Th
                         className={getVisibilityClass('cveSeverity')}
                         sort={getSortParams('Severity')}
@@ -208,18 +217,14 @@ function ImageVulnerabilitiesTable({
                     <Th className={getVisibilityClass('cvss')} sort={getSortParams('CVSS')}>
                         CVSS
                     </Th>
-                    {isNvdCvssColumnEnabled && (
-                        <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
-                    )}
-                    {isEpssProbabilityColumnEnabled && (
-                        <Th
-                            className={getVisibilityClass('epssProbability')}
-                            info={infoForEpssProbability}
-                            sort={getSortParams('EPSS Probability')}
-                        >
-                            EPSS probability
-                        </Th>
-                    )}
+                    <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
+                    <Th
+                        className={getVisibilityClass('epssProbability')}
+                        info={infoForEpssProbability}
+                        sort={getSortParams('EPSS Probability')}
+                    >
+                        EPSS probability
+                    </Th>
                     {/* isAdvisoryColumnEnabled && (
                         <Th className={getVisibilityClass('totalAdvisories')}>Advisories</Th>
                     ) */}
@@ -233,16 +238,16 @@ function ImageVulnerabilitiesTable({
                     <Th className={getVisibilityClass('publishedOn')} modifier="nowrap">
                         Published
                     </Th>
-                    {showExceptionDetailsLink && (
-                        <TooltipTh tooltip="View information about this exception request">
-                            Request details
-                        </TooltipTh>
-                    )}
-                    {createTableActions && (
-                        <Th>
-                            <span className="pf-v5-screen-reader">Row actions</span>
-                        </Th>
-                    )}
+                    <TooltipTh
+                        className={getVisibilityClass('requestDetails')}
+                        tooltip="View information about this exception request"
+                    >
+                        Request details
+                    </TooltipTh>
+                    {/* eslint-disable-next-line generic/Th-defaultColumns */}
+                    <Th className={getVisibilityClass('rowActions')}>
+                        <span className="pf-v5-screen-reader">Row actions</span>
+                    </Th>
                 </Tr>
             </Thead>
             <TbodyUnified
@@ -279,20 +284,24 @@ function ImageVulnerabilitiesTable({
                             <Tbody key={cve} isExpanded={isExpanded}>
                                 <Tr>
                                     <Td
+                                        className={getVisibilityClass('rowExpansion')}
                                         expand={{
                                             rowIndex,
                                             isExpanded,
                                             onToggle: () => expandedRowSet.toggle(cve),
                                         }}
                                     />
-                                    {canSelectRows && (
-                                        <CVESelectionTd
-                                            selectedCves={selectedCves}
-                                            rowIndex={rowIndex}
-                                            item={{ cve, summary, numAffectedImages: 1 }}
-                                        />
-                                    )}
-                                    <Td dataLabel="CVE" modifier="nowrap">
+                                    <CVESelectionTd
+                                        className={getVisibilityClass('cveSelection')}
+                                        selectedCves={selectedCves}
+                                        rowIndex={rowIndex}
+                                        item={{ cve, summary, numAffectedImages: 1 }}
+                                    />
+                                    <Td
+                                        className={getVisibilityClass('cve')}
+                                        dataLabel="CVE"
+                                        modifier="nowrap"
+                                    >
                                         <PendingExceptionLabelLayout
                                             hasPendingException={pendingExceptionCount > 0}
                                             cve={cve}
@@ -336,27 +345,23 @@ function ImageVulnerabilitiesTable({
                                     >
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>
-                                    {isNvdCvssColumnEnabled && (
-                                        <Td
-                                            className={getVisibilityClass('nvdCvss')}
-                                            modifier="nowrap"
-                                            dataLabel="NVD CVSS"
-                                        >
-                                            <CvssFormatted
-                                                cvss={nvdCvss ?? 0}
-                                                scoreVersion={nvdScoreVersion ?? 'UNKNOWN_VERSION'}
-                                            />
-                                        </Td>
-                                    )}
-                                    {isEpssProbabilityColumnEnabled && (
-                                        <Td
-                                            className={getVisibilityClass('epssProbability')}
-                                            modifier="nowrap"
-                                            dataLabel="EPSS probability"
-                                        >
-                                            {formatEpssProbabilityAsPercent(epssProbability)}
-                                        </Td>
-                                    )}
+                                    <Td
+                                        className={getVisibilityClass('nvdCvss')}
+                                        modifier="nowrap"
+                                        dataLabel="NVD CVSS"
+                                    >
+                                        <CvssFormatted
+                                            cvss={nvdCvss ?? 0}
+                                            scoreVersion={nvdScoreVersion ?? 'UNKNOWN_VERSION'}
+                                        />
+                                    </Td>
+                                    <Td
+                                        className={getVisibilityClass('epssProbability')}
+                                        modifier="nowrap"
+                                        dataLabel="EPSS probability"
+                                    >
+                                        {formatEpssProbabilityAsPercent(epssProbability)}
+                                    </Td>
                                     {/* isAdvisoryColumnEnabled && (
                                         <Td
                                             className={getVisibilityClass('totalAdvisories')}
@@ -390,28 +395,28 @@ function ImageVulnerabilitiesTable({
                                             'Not available'
                                         )}
                                     </Td>
-                                    {showExceptionDetailsLink && (
-                                        <ExceptionDetailsCell
-                                            cve={cve}
-                                            vulnerabilityState={vulnerabilityState}
-                                        />
-                                    )}
-                                    {createTableActions && (
-                                        <Td isActionCell>
-                                            <ActionsColumn
-                                                // menuAppendTo={() => document.body}
-                                                items={createTableActions({
-                                                    cve,
-                                                    summary,
-                                                    numAffectedImages: 1,
-                                                })}
+                                    <Td className={getVisibilityClass('requestDetails')}>
+                                        {vulnerabilityState !== 'OBSERVED' && (
+                                            <ExceptionDetailsCell
+                                                cve={cve}
+                                                vulnerabilityState={vulnerabilityState}
                                             />
-                                        </Td>
-                                    )}
+                                        )}
+                                    </Td>
+                                    <Td className={getVisibilityClass('rowActions')} isActionCell>
+                                        <ActionsColumn
+                                            // menuAppendTo={() => document.body}
+                                            items={createTableActions({
+                                                cve,
+                                                summary,
+                                                numAffectedImages: 1,
+                                            })}
+                                        />
+                                    </Td>
                                 </Tr>
                                 <Tr isExpanded={isExpanded}>
-                                    <Td />
-                                    <Td colSpan={colSpan}>
+                                    <Td className={getVisibilityClass('rowExpansion')} />
+                                    <Td colSpan={colSpan - 1}>
                                         <ExpandableRowContent>
                                             <>
                                                 {summary && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTd.tsx
@@ -7,16 +7,19 @@ export type CVESelectionTdProps<T extends { cve: string }> = {
     selectedCves: ReturnType<typeof useMap<string, T>>;
     rowIndex: number;
     item: T;
+    className?: string;
 };
 
 function CVESelectionTd<T extends { cve: string }>({
     selectedCves,
     rowIndex,
     item,
+    className,
 }: CVESelectionTdProps<T>) {
     const { cve } = item;
     return (
         <Td
+            className={className}
             select={{
                 rowIndex,
                 onSelect: () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTh.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import { pluralize } from '@patternfly/react-core';
 import { Th } from '@patternfly/react-table';
 
 import useMap from 'hooks/useMap';
 
 export type CVESelectionThProps<T extends { cve: string }> = {
     selectedCves: ReturnType<typeof useMap<string, T>>;
+    className?: string;
 };
 
-function CVESelectionTh<T extends { cve: string }>({ selectedCves }: CVESelectionThProps<T>) {
+function CVESelectionTh<T extends { cve: string }>({
+    selectedCves,
+    className,
+}: CVESelectionThProps<T>) {
     return (
         <Th
-            title={
-                selectedCves.size > 0
-                    ? `Clear ${pluralize(selectedCves.size, 'selected CVE')}`
-                    : undefined
-            }
+            className={className}
+            title={selectedCves.size > 0 ? `Clear selected CVEs` : undefined}
             select={{
                 isSelected: selectedCves.size !== 0,
                 isDisabled: selectedCves.size === 0,

--- a/ui/apps/platform/src/hooks/useManagedColumns.ts
+++ b/ui/apps/platform/src/hooks/useManagedColumns.ts
@@ -12,14 +12,22 @@ type TablePreferencesStorage = {
 export type ColumnConfig = {
     key: string;
     title: string;
+    // Whether or not the column is shown in the table
     isShown: boolean;
+    // Whether or not the column is shown by default when a configuration is first created
     isShownByDefault: boolean;
+    // Whether or not the column is untoggleable in the Column Management modal.
+    // If true, the column will not be shown in the Column Management modal.
     isUntoggleAble: boolean;
 };
 
 // The incoming type for the default column configuration
 // Note that `title` is displayed in the Column Management modal and should match the column header value
-type InitialColumnConfig = Pick<ColumnConfig, 'isShownByDefault' | 'title'>;
+type InitialColumnConfig = {
+    title: string;
+    isShownByDefault: boolean;
+    isUntoggleAble?: boolean;
+};
 
 // Basic validation of the shape of the object in local storage
 function tablePreferencesValidator(value: unknown): value is TablePreferencesStorage {
@@ -35,7 +43,7 @@ function getCurrentColumnConfig<ColumnKey extends string>(
 ): Record<ColumnKey, ColumnConfig> {
     const tableConfig = {};
     Object.entries<InitialColumnConfig>(columnConfig).forEach(
-        ([key, { title, isShownByDefault }]) => {
+        ([key, { title, isShownByDefault, isUntoggleAble }]) => {
             const isShown =
                 tablePreferences.columnManagement[tableId]?.[key]?.isShown ?? isShownByDefault;
             tableConfig[key] = {
@@ -43,7 +51,7 @@ function getCurrentColumnConfig<ColumnKey extends string>(
                 title,
                 isShownByDefault,
                 isShown,
-                isUntoggleAble: false,
+                isUntoggleAble: isUntoggleAble ?? false,
             };
         }
     );
@@ -64,6 +72,13 @@ export function filterManagedColumns<T extends Record<string, InitialColumnConfi
     const entriesFiltered = entries.filter(([key]) => predicate(key));
     const fromEntries = Object.fromEntries(entriesFiltered) as T;
     return fromEntries;
+}
+
+export function overrideManagedColumns<ColumnKey extends string>(
+    managedColumns: Record<ColumnKey, ColumnConfig>,
+    overrides: Partial<Record<ColumnKey, Partial<ColumnConfig>>>
+): Record<ColumnKey, ColumnConfig> {
+    return merge({}, managedColumns, overrides);
 }
 
 // Helper function to generate a visibility class based on the current column state

--- a/ui/apps/platform/src/hooks/useManagedColumns.ts
+++ b/ui/apps/platform/src/hooks/useManagedColumns.ts
@@ -81,6 +81,11 @@ export function overrideManagedColumns<ColumnKey extends string>(
     return merge({}, managedColumns, overrides);
 }
 
+// Helper to hide a column if a condition is met, both from the column management modal and from the table
+export function hideColumnIf(condition: boolean): Partial<ColumnConfig> {
+    return condition ? { isUntoggleAble: true, isShown: false } : {};
+}
+
 // Helper function to generate a visibility class based on the current column state
 export function generateVisibilityForColumns<T extends Record<string, ColumnConfig>>(
     columnVisibilityState: T


### PR DESCRIPTION
## Description

Expands the usage of column management to allow cleaner conditional rendering of table columns in Vuln Management.

This will help us to use these tables in the OCP dynamic plugin, which has different column requirements, without requiring us to do any of the following:
- Duplicate Table code
- Abstract our current patterns to use column descriptors instead of direct rendering (massive refactor)
- Add additional boolean flag props to handle condition columns

In addition to avoiding the previous items there are a couple of side benefits to this approach:
- Existing boolean props and permission checks can be removed or de-duplicated, and moved to the parent component
- All table columns are now explicit in the config and can simplify the ugly calculation of `colSpan` in every table
- Conditional rendering in the table is replaced with the `getVisibilityClass` helper, which is already in use and consolidates the multiple render patterns

## Review

This change has been broken down into separate commits for easier review. It is recommended to review commit-by-commit to keep focus on smaller contexts.

1. The initial change that implements the existing `isUntoggleable` argument for column management. When this is set to `true`, the column will not be displayed in the column management modal.
2. Adds the ability to pass `className` to our custom table row selection components.
3. All remaining commits - updates the logic for VM tables to use `isUntoggleable`. Instead of passing props and checking flags inside each table component, we instead delegate this responsibility to the parent. Child table components declare *all* columns in their exported column configuration, and will conditionally render those columns according to the props that they receive.

## Follow ups

1. I had to add eslint suppressions for our custom lint rule related to this pattern - it may be better to expand the rule to support the new cases if possible

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Existing thorough tests at the unit and e2e level regarding column management in VM 🙏 

Manual testing with feature flags.

Workload CVE selection column and row menu is not visible when viewing tabs other than "Observed". The inverse is true for the "Request details" column.
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/20f22ac2-a2e7-4ca5-8375-b163e8309141" />
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/741a85e4-9b32-4aca-bc23-4f80e891894c" />
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/ad022365-e365-4f98-83bb-f1a653ec8a85" />

Workload CVE Top NVD CVSS is not visible or toggleable when the feature flag is disabled:
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/0cd446c7-ef7e-4b74-960c-a6ee984ece9a" />
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/620405fd-1715-4e49-bad1-f2e706ea7d2d" />

Ditto for EPSS probability:
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/1a0aae4a-adad-40fa-9a24-dda264fecea4" />

Images list table only includes row actions when the user can "write" images for SBOM generation.
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/6a04819e-e068-466b-b548-d3a90533115e" />
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/6f7a901f-47d8-405e-be92-df999b1fa31a" />

CVEs by severity is not visible nor toggle-able when viewing the "Images without CVEs" view:
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/04a4b926-a86e-43ea-a32c-66602a9ec283" />

Deployment list table does not include CVEs by severty when viewing "Images without CVEs":
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/686488c6-6344-428c-b278-452172972d9d" />

CVE page NVD CVSS is managed by feature flag:
<img width="1543" height="838" alt="image" src="https://github.com/user-attachments/assets/aa7fccdf-5f82-4a70-8560-544af1bf2b7d" />
<img width="1543" height="943" alt="image" src="https://github.com/user-attachments/assets/37f944e4-5c48-4b68-9d85-d1b33f753db7" />

CVE page deployment columns are unchanged.

Manually test the same columns from the overview page for image and deployment detail pages.


