### PR TITLE
refactor(ui): Migrate NetworkGraph components from deprecated select

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -1,7 +1,6 @@
 import { visitFromLeftNavExpandable } from '../../helpers/nav';
 import { interactAndWaitForResponses } from '../../helpers/request';
 import { visit } from '../../helpers/visit';
-import selectSelectors from '../../selectors/select';
 import { networkGraphSelectors } from './networkGraph.selectors';
 
 const networkGraphClusterAlias = 'networkgraph/cluster/id';
@@ -16,9 +15,10 @@ const routeMatcherMapForClusterInNetworkGraph = {
 // select
 
 const navSelector = 'nav[aria-label="Breadcrumb"]';
-const clusterSelect = `${navSelector} .cluster-select > button`;
-const namespaceSelect = `${navSelector} .namespace-select > button`;
-const deploymentSelect = `${navSelector} .deployment-select > button`;
+const clusterSelect = `${navSelector} [aria-label="Select a cluster"]`;
+const namespaceSelect = `${navSelector} [aria-label="Select namespaces"]`;
+const deploymentSelect = `${navSelector} [aria-label="Select deployments"]`;
+const patternFlyOpenMenu = '.pf-v5-c-menu';
 
 const clusterNamespacesTarget = '/v1/sac/clusters/*/namespaces?permissions=*';
 
@@ -28,7 +28,7 @@ export function selectCluster() {
     // no longer necessary to await getting NS, because in one-cluster environments, we now pre-select the cluster
     interactAndWaitForResponses(() => {
         cy.get(clusterSelect).click();
-        cy.get(`${selectSelectors.patternFlySelect.openMenu} span:first`).click();
+        cy.get(`${patternFlyOpenMenu} .pf-v5-c-menu__item:first-child`).click();
     });
 }
 
@@ -38,9 +38,7 @@ export function selectNamespace(namespace) {
     interactAndWaitForResponses(() => {
         cy.get(namespaceSelect).click();
         // Exact match to distinguish stackrox from stackrox-operator namespaces.
-        cy.get(
-            `${selectSelectors.patternFlySelect.openMenu} .pf-v5-c-menu__list-item [data-testid="namespace-name"]`
-        )
+        cy.get(`${patternFlyOpenMenu} .pf-v5-c-menu__list-item [data-testid="namespace-name"]`)
             .contains(new RegExp(`^${namespace}$`))
             .click();
         cy.get(namespaceSelect).click();
@@ -50,9 +48,7 @@ export function selectNamespace(namespace) {
 export function selectDeployment(deployment) {
     interactAndWaitForResponses(() => {
         cy.get(deploymentSelect).click();
-        cy.get(
-            `${selectSelectors.patternFlySelect.openMenu} .pf-v5-c-menu__list-item [data-testid="deployment-name"]`
-        )
+        cy.get(`${patternFlyOpenMenu} .pf-v5-c-menu__list-item [data-testid="deployment-name"]`)
             .contains(new RegExp(`^${deployment}$`))
             .click();
         cy.get(deploymentSelect).click();

--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -6,6 +6,7 @@ import {
     SelectList,
     MenuFooter,
     SelectOptionProps,
+    MenuToggleProps,
 } from '@patternfly/react-core';
 
 export type SelectSingleProps = {
@@ -22,6 +23,9 @@ export type SelectSingleProps = {
     menuAppendTo?: () => HTMLElement;
     footer?: React.ReactNode;
     maxHeight?: string;
+    maxWidth?: string;
+    variant?: MenuToggleProps['variant'];
+    className?: string;
 };
 
 function SelectSingle({
@@ -38,6 +42,9 @@ function SelectSingle({
     menuAppendTo = undefined,
     footer,
     maxHeight = '300px',
+    maxWidth = '30ch',
+    variant = 'default',
+    className,
 }: SelectSingleProps): ReactElement {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -74,18 +81,21 @@ function SelectSingle({
             onClick={onToggle}
             isExpanded={isOpen}
             isDisabled={isDisabled}
-            icon={toggleIcon}
             aria-label={toggleAriaLabel}
             id={id}
-            variant="default"
+            variant={variant}
             className="pf-v5-u-w-100"
         >
-            {getDisplayText()}
+            <span className="pf-v5-u-display-flex pf-v5-u-align-items-center">
+                {toggleIcon && <span className="pf-v5-u-mr-sm">{toggleIcon}</span>}
+                <span>{getDisplayText()}</span>
+            </span>
         </MenuToggle>
     );
 
     return (
         <Select
+            className={className}
             aria-label={toggleAriaLabel}
             isOpen={isOpen}
             selected={value}
@@ -100,7 +110,7 @@ function SelectSingle({
             }}
             onBlur={onBlur}
         >
-            <SelectList style={{ maxHeight, overflowY: 'auto' }}>{children}</SelectList>
+            <SelectList style={{ maxHeight, maxWidth, overflowY: 'auto' }}>{children}</SelectList>
             {footer && <MenuFooter>{footer}</MenuFooter>}
         </Select>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -34,12 +34,12 @@
 
 /* Create a stacking context that is higher than the context for the react-topology component
    that is rendered below the toolbar, so that the search filter dropdown will render above the graph when open */
-[data-testid="network-graph-toolbar"] {
+[data-testid='network-graph-toolbar'] {
     z-index: 250;
 }
 
-[data-testid="network-graph-toolbar"] .pf-search-shim,
-[data-testid="network-graph-toolbar"] .react-select__menu {
+[data-testid='network-graph-toolbar'] .pf-search-shim,
+[data-testid='network-graph-toolbar'] .react-select__menu {
     z-index: 250;
 }
 
@@ -56,8 +56,8 @@ div#topology-resize-panel table td {
     opacity: 30%;
 }
 
-[data-id="External to cluster"] .pf-topology__group__label .pf-topology__node__label__background,
-[data-id="Internal to cluster"] .pf-topology__group__label .pf-topology__node__label__background {
+[data-id='External to cluster'] .pf-topology__group__label .pf-topology__node__label__background,
+[data-id='Internal to cluster'] .pf-topology__group__label .pf-topology__node__label__background {
     fill: #6853ae;
 }
 
@@ -80,6 +80,11 @@ div#topology-resize-panel table td {
     padding-top: 0;
     padding-bottom: 0;
     min-width: 220px;
+}
+
+.network-graph-menu-list {
+    max-height: 320px;
+    overflow-y: auto;
 }
 
 .pf-topology__node__label__badge {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Select, SelectOption } from '@patternfly/react-core/deprecated';
+import { SelectOption } from '@patternfly/react-core';
 
 import { ClusterScopeObject } from 'services/RolesService';
-import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import SelectSingle from 'Components/SelectSingle/SelectSingle';
 import { ClusterIcon } from '../common/NetworkGraphIcons';
 
 export type ClusterSelectorProps = {
@@ -18,15 +18,7 @@ function ClusterSelector({
     searchFilter,
     setSearchFilter,
 }: ClusterSelectorProps) {
-    const {
-        isOpen: isClusterOpen,
-        toggleSelect: toggleIsClusterOpen,
-        closeSelect: closeClusterSelect,
-    } = useSelectToggle();
-
-    const onClusterSelect = (_, value) => {
-        closeClusterSelect();
-
+    const handleSelect = (_name: string, value: string) => {
         if (value !== selectedClusterName) {
             const modifiedSearchObject = { ...searchFilter };
             modifiedSearchObject.Cluster = value;
@@ -37,31 +29,25 @@ function ClusterSelector({
     };
 
     const clusterSelectOptions: JSX.Element[] = clusters.map((cluster) => (
-        <SelectOption key={cluster.id} value={cluster.name}>
-            <span>
-                <ClusterIcon className="pf-v5-u-mr-xs" /> {cluster.name}
-            </span>
+        <SelectOption key={cluster.id} value={cluster.name} icon={<ClusterIcon />}>
+            {cluster.name}
         </SelectOption>
     ));
 
     return (
-        <Select
+        <SelectSingle
+            id="cluster-selector"
             className="cluster-select"
-            isPlain
-            placeholderText={
-                <span>
-                    <ClusterIcon className="pf-v5-u-mr-xs" />{' '}
-                    <span style={{ position: 'relative', top: '1px' }}>Cluster</span>
-                </span>
-            }
+            toggleIcon={<ClusterIcon />}
+            variant="plainText"
+            placeholderText="Cluster"
             toggleAriaLabel="Select a cluster"
-            onToggle={(_e, v) => toggleIsClusterOpen(v)}
-            onSelect={onClusterSelect}
-            isOpen={isClusterOpen}
-            selections={selectedClusterName}
+            value={selectedClusterName}
+            handleSelect={handleSelect}
+            isDisabled={clusters.length === 0}
         >
             {clusterSelectOptions}
-        </Select>
+        </SelectSingle>
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -36,7 +36,7 @@ function ClusterSelector({
 
     return (
         <SelectSingle
-            id="cluster-selector"
+            id="cluster-select"
             className="cluster-select"
             toggleIcon={<ClusterIcon />}
             variant="plainText"

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -12,10 +12,12 @@ import {
     MenuSearch,
     MenuItem,
     MenuList,
+    MenuToggle,
+    MenuToggleElement,
     SearchInput,
     MenuSearchInput,
+    Select,
 } from '@patternfly/react-core';
-import { Select } from '@patternfly/react-core/deprecated';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
@@ -96,14 +98,15 @@ function DeploymentSelector({
         setSearchFilter(modifiedSearchObject);
     };
 
+    // @TODO: DeploymentSelector and NamespaceSelector have identical menu structures.
+    // Consider refactoring to avoid code duplication.
     const deploymentSelectMenu = (
-        <Menu onSelect={onDeploymentSelect} selected={selectedDeployments} isScrollable>
+        <Menu onSelect={onDeploymentSelect} selected={selectedDeployments}>
             <MenuSearch>
                 <MenuSearchInput>
                     <SearchInput
                         value={input}
                         aria-label="Filter deployments"
-                        type="search"
                         placeholder="Filter deployments..."
                         onChange={(_event, value) => handleTextInputChange(value)}
                     />
@@ -111,7 +114,7 @@ function DeploymentSelector({
             </MenuSearch>
             <Divider className="pf-v5-u-m-0" />
             <MenuContent>
-                <MenuList>
+                <MenuList className="network-graph-menu-list">
                     {filteredDeploymentSelectMenuItems.length === 0 && (
                         <MenuItem isDisabled key="no result">
                             No deployments found
@@ -133,34 +136,47 @@ function DeploymentSelector({
         </Menu>
     );
 
+    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+            ref={toggleRef}
+            onClick={() => toggleIsDeploymentOpen(!isDeploymentOpen)}
+            isExpanded={isDeploymentOpen}
+            isDisabled={deploymentsByNamespace.length === 0}
+            aria-label="Select deployments"
+            className="deployment-select"
+            variant="plainText"
+        >
+            <Flex alignSelf={{ default: 'alignSelfCenter' }}>
+                <FlexItem
+                    spacer={{ default: 'spacerSm' }}
+                    alignSelf={{ default: 'alignSelfCenter' }}
+                >
+                    <DeploymentIcon />
+                </FlexItem>
+                <FlexItem spacer={{ default: 'spacerSm' }}>
+                    <span style={{ position: 'relative', top: '1px' }}>Deployments</span>
+                </FlexItem>
+                {selectedDeployments.length !== 0 && (
+                    <FlexItem spacer={{ default: 'spacerSm' }}>
+                        <Badge isRead>{selectedDeployments.length}</Badge>
+                    </FlexItem>
+                )}
+            </Flex>
+        </MenuToggle>
+    );
+
     return (
         <Select
             isOpen={isDeploymentOpen}
-            onToggle={(_e, v) => toggleIsDeploymentOpen(v)}
-            className="deployment-select"
-            placeholderText={
-                <Flex alignSelf={{ default: 'alignSelfCenter' }}>
-                    <FlexItem
-                        spacer={{ default: 'spacerSm' }}
-                        alignSelf={{ default: 'alignSelfCenter' }}
-                    >
-                        <DeploymentIcon />
-                    </FlexItem>
-                    <FlexItem spacer={{ default: 'spacerSm' }}>
-                        <span style={{ position: 'relative', top: '1px' }}>Deployments</span>
-                    </FlexItem>
-                    {selectedDeployments.length !== 0 && (
-                        <FlexItem spacer={{ default: 'spacerSm' }}>
-                            <Badge isRead>{selectedDeployments.length}</Badge>
-                        </FlexItem>
-                    )}
-                </Flex>
-            }
-            toggleAriaLabel="Select deployments"
-            isDisabled={deploymentsByNamespace.length === 0}
-            isPlain
-            customContent={deploymentSelectMenu}
-        />
+            onOpenChange={(nextOpen: boolean) => toggleIsDeploymentOpen(nextOpen)}
+            toggle={toggle}
+            popperProps={{
+                maxWidth: '400px',
+                direction: 'down',
+            }}
+        >
+            {deploymentSelectMenu}
+        </Select>
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
-import { Split, SplitItem } from '@patternfly/react-core';
-import { Select, SelectGroup, SelectOption } from '@patternfly/react-core/deprecated';
+import React from 'react';
+import { Split, SplitItem, SelectGroup, SelectOption } from '@patternfly/react-core';
 import { PficonNetworkRangeIcon } from '@patternfly/react-icons';
+
+import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
 
 import NoPolicyRules from 'images/network-graph/no-policy-rules.svg?react';
 import PortLabel from 'images/network-graph/tcp-icon.svg?react';
@@ -20,7 +21,7 @@ export type DisplayOption =
 
 type DisplayOptionsSelectProps = {
     selectedOptions: DisplayOption[];
-    setSelectedOptions: (options) => void;
+    setSelectedOptions: (options: DisplayOption[]) => void;
     isDisabled: boolean;
 };
 
@@ -29,32 +30,18 @@ function DisplayOptionsSelect({
     setSelectedOptions,
     isDisabled,
 }: DisplayOptionsSelectProps) {
-    const [isOpen, setIsOpen] = useState(false);
-
-    function onToggle() {
-        setIsOpen(!isOpen);
-    }
-
-    function onSelect(e, selection) {
-        if (selectedOptions.includes(selection)) {
-            setSelectedOptions(selectedOptions.filter((item) => item !== selection));
-        } else {
-            setSelectedOptions([...selectedOptions, selection]);
-        }
+    function handleChange(selections: string[]) {
+        setSelectedOptions(selections as DisplayOption[]);
     }
 
     return (
-        <Select
-            variant="checkbox"
-            isOpen={isOpen}
-            onToggle={onToggle}
-            onSelect={onSelect}
-            selections={selectedOptions}
-            placeholderText="Display options"
-            toggleAriaLabel="Select display options"
-            isDisabled={isDisabled}
-            isGrouped
+        <CheckboxSelect
             id="display-options-dropdown"
+            selections={selectedOptions}
+            onChange={handleChange}
+            ariaLabel="Select display options"
+            placeholderText="Display options"
+            isDisabled={isDisabled}
         >
             <SelectGroup label="Deployment visuals" key="deployment">
                 <SelectOption key={0} value="policyStatusBadge">
@@ -73,7 +60,7 @@ function DisplayOptionsSelect({
                 </SelectOption>
             </SelectGroup>
             <SelectGroup label="Selection indicators" key="selection-indicator">
-                <SelectOption key={2} value="selectionIndicator">
+                <SelectOption key={3} value="selectionIndicator">
                     <Split>
                         <SplitItem className="pf-v5-u-mr-xs">
                             <FilteredEntity width="24px" height="24px" />
@@ -88,7 +75,7 @@ function DisplayOptionsSelect({
                 </SelectOption>
             </SelectGroup>
             <SelectGroup label="Object type labels" key="object-type-labels">
-                <SelectOption key={2} value="objectTypeLabel">
+                <SelectOption key={4} value="objectTypeLabel">
                     <Split>
                         <SplitItem className="pf-v5-u-mr-xs">
                             <NamespaceIcon screenReaderText="namespace" />
@@ -103,7 +90,7 @@ function DisplayOptionsSelect({
                     </Split>
                 </SelectOption>
             </SelectGroup>
-        </Select>
+        </CheckboxSelect>
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Select, SelectOption } from '@patternfly/react-core/deprecated';
+import { SelectOption } from '@patternfly/react-core';
 
-import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import SelectSingle from 'Components/SelectSingle/SelectSingle';
 
 export const edgeStates = ['active', 'inactive'] as const;
 
@@ -9,27 +9,21 @@ export type EdgeState = (typeof edgeStates)[number];
 
 type EdgeStateSelectProps = {
     edgeState: EdgeState;
-    setEdgeState: (state) => void;
+    setEdgeState: (state: EdgeState) => void;
     isDisabled: boolean;
 };
 
 function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelectProps) {
-    const { isOpen, onToggle, closeSelect } = useSelectToggle();
-
-    function onSelect(_event, selection) {
-        closeSelect();
-        setEdgeState(selection);
+    function handleSelect(_name: string, value: string) {
+        setEdgeState(value as EdgeState);
     }
 
     return (
-        <Select
-            variant="single"
-            isOpen={isOpen}
-            onToggle={(_e, v) => onToggle(v)}
-            onSelect={onSelect}
-            selections={edgeState}
-            isDisabled={isDisabled}
+        <SelectSingle
             id="edge-state-select"
+            value={edgeState}
+            handleSelect={handleSelect}
+            isDisabled={isDisabled}
         >
             <SelectOption
                 value="active"
@@ -43,7 +37,7 @@ function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelec
             >
                 Inactive flows
             </SelectOption>
-        </Select>
+        </SelectSingle>
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -13,8 +13,10 @@ import {
     MenuList,
     SearchInput,
     MenuSearchInput,
+    Select,
+    MenuToggle,
+    MenuToggleElement,
 } from '@patternfly/react-core';
-import { Select } from '@patternfly/react-core/deprecated';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
@@ -125,13 +127,12 @@ function NamespaceSelector({
     };
 
     const namespaceSelectMenu = (
-        <Menu onSelect={onNamespaceSelect} selected={selectedNamespaces} isScrollable>
+        <Menu onSelect={onNamespaceSelect} selected={selectedNamespaces}>
             <MenuSearch>
                 <MenuSearchInput>
                     <SearchInput
                         value={input}
                         aria-label="Filter namespaces"
-                        type="search"
                         placeholder="Filter namespaces..."
                         onChange={(_event, value) => handleTextInputChange(value)}
                     />
@@ -139,7 +140,7 @@ function NamespaceSelector({
             </MenuSearch>
             <Divider className="pf-v5-u-m-0" />
             <MenuContent>
-                <MenuList>
+                <MenuList className="network-graph-menu-list">
                     {filteredDeploymentSelectMenuItems.length === 0 && (
                         <MenuItem isDisabled key="no result">
                             No namespaces found
@@ -161,36 +162,49 @@ function NamespaceSelector({
         </Menu>
     );
 
+    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+            ref={toggleRef}
+            onClick={() => toggleIsNamespaceOpen(!isNamespaceOpen)}
+            isExpanded={isNamespaceOpen}
+            isDisabled={namespaces.length === 0}
+            aria-label="Select namespaces"
+            className="namespace-select"
+            variant="plainText"
+        >
+            <Flex alignSelf={{ default: 'alignSelfCenter' }}>
+                <FlexItem
+                    spacer={{ default: 'spacerSm' }}
+                    alignSelf={{ default: 'alignSelfCenter' }}
+                >
+                    <NamespaceIcon />
+                </FlexItem>
+                <FlexItem spacer={{ default: 'spacerSm' }}>
+                    <span style={{ position: 'relative', top: '1px' }}>
+                        {isEmptyCluster ? 'No namespaces' : 'Namespaces'}
+                    </span>
+                </FlexItem>
+                {selectedNamespaces.length !== 0 && (
+                    <FlexItem spacer={{ default: 'spacerSm' }}>
+                        <Badge isRead>{selectedNamespaces.length}</Badge>
+                    </FlexItem>
+                )}
+            </Flex>
+        </MenuToggle>
+    );
+
     return (
         <Select
             isOpen={isNamespaceOpen}
-            onToggle={(_e, v) => toggleIsNamespaceOpen(v)}
-            className="namespace-select"
-            placeholderText={
-                <Flex alignSelf={{ default: 'alignSelfCenter' }}>
-                    <FlexItem
-                        spacer={{ default: 'spacerSm' }}
-                        alignSelf={{ default: 'alignSelfCenter' }}
-                    >
-                        <NamespaceIcon />
-                    </FlexItem>
-                    <FlexItem spacer={{ default: 'spacerSm' }}>
-                        <span style={{ position: 'relative', top: '1px' }}>
-                            {isEmptyCluster ? 'No namespaces' : 'Namespaces'}
-                        </span>
-                    </FlexItem>
-                    {selectedNamespaces.length !== 0 && (
-                        <FlexItem spacer={{ default: 'spacerSm' }}>
-                            <Badge isRead>{selectedNamespaces.length}</Badge>
-                        </FlexItem>
-                    )}
-                </Flex>
-            }
-            toggleAriaLabel="Select namespaces"
-            isDisabled={namespaces.length === 0}
-            isPlain
-            customContent={namespaceSelectMenu}
-        />
+            onOpenChange={(nextOpen: boolean) => toggleIsNamespaceOpen(nextOpen)}
+            toggle={toggle}
+            popperProps={{
+                maxWidth: '400px',
+                direction: 'down',
+            }}
+        >
+            {namespaceSelectMenu}
+        </Select>
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/TimeWindowSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/TimeWindowSelector.tsx
@@ -1,29 +1,26 @@
 import React from 'react';
-import { Select, SelectOption } from '@patternfly/react-core/deprecated';
+import { SelectOption } from '@patternfly/react-core';
 
-import { timeWindows } from 'constants/timeWindows';
-import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { TimeWindow, timeWindows } from 'constants/timeWindows';
+import SelectSingle from 'Components/SelectSingle/SelectSingle';
 
 type TimeWindowSelectorProps = {
-    setTimeWindow: (timeWindow) => void;
-    timeWindow: string;
+    setTimeWindow: (timeWindow: TimeWindow) => void;
+    timeWindow: TimeWindow;
     isDisabled: boolean;
 };
 
 function TimeWindowSelector({ setTimeWindow, timeWindow, isDisabled }: TimeWindowSelectorProps) {
-    const { closeSelect, isOpen, onToggle } = useSelectToggle();
-
-    function selectTimeWindow(_event, selection) {
-        closeSelect();
-        setTimeWindow(selection);
-    }
+    const handleSelect = (_name: string, value: string) => {
+        setTimeWindow(value as TimeWindow);
+    };
 
     return (
-        <Select
-            isOpen={isOpen}
-            onToggle={(_e, v) => onToggle(v)}
-            onSelect={selectTimeWindow}
-            selections={timeWindow}
+        <SelectSingle
+            id="time-window-selector"
+            toggleAriaLabel="Select time window"
+            value={timeWindow}
+            handleSelect={handleSelect}
             isDisabled={isDisabled}
         >
             {timeWindows.map((window) => (
@@ -31,7 +28,7 @@ function TimeWindowSelector({ setTimeWindow, timeWindow, isDisabled }: TimeWindo
                     {window}
                 </SelectOption>
             ))}
-        </Select>
+        </SelectSingle>
     );
 }
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Migrates all NetworkGraph Select components from deprecated PatternFly Select to modern PatternFly v5 Select components (minus the AdvancedFlowsFilter):

  - **ClusterSelector**: Converted to SelectSingle with icon support
  - **DeploymentSelector**: Updated to new Select with custom menu content and improved scrolling
  - **NamespaceSelector**: Migrated to new Select pattern with enhanced menu handling
  - **EdgeStateSelect**: Simple migration to SelectSingle
  - **TimeWindowSelector**: Updated to use SelectSingle component
  - **DisplayOptionsSelect**: Converted to CheckboxSelect for grouped options

**Component Enhancements:**
  - Enhanced CheckboxSelect with recursive SelectGroup support and performance optimizations
  - Added SelectSingle props for better icon handling and sizing control
  - Improved menu positioning and scrolling behavior
  - Maintained all existing functionality while removing deprecated dependencies

**Technical Changes:**
  - Removed all `@patternfly/react-core/deprecated` imports
  - Updated event handlers to match new PatternFly v5 API patterns
  - Added proper TypeScript typing for all new component props
  - Optimized selection handling with Set-based lookups for better performance

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [x] added regression tests
- [x] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

#### Before

<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 39 09 PM" src="https://github.com/user-attachments/assets/cd49b21c-6c37-431f-a5a7-a17ac5482eb8" />
<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 39 13 PM" src="https://github.com/user-attachments/assets/a12fdd25-dd6f-40d8-933d-1ad05e4dd3e5" />
<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 39 31 PM" src="https://github.com/user-attachments/assets/230ac25e-d1d3-48cb-876b-9425b22fed7b" />
<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 39 36 PM" src="https://github.com/user-attachments/assets/d92c7d9b-ae7a-4b7a-9766-d6bd26be49eb" />
<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 39 39 PM" src="https://github.com/user-attachments/assets/0ac4c463-920e-4a47-9968-8c6a8cf084ff" />
<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 39 44 PM" src="https://github.com/user-attachments/assets/72ceeecd-f9ec-44df-833e-c5713e4799e2" />

#### After

<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 40 08 PM" src="https://github.com/user-attachments/assets/7e54901a-376e-4019-a241-37f15d376171" />
<img width="3602" height="3022" alt="Screenshot 2025-08-14 at 9 53 17 AM" src="https://github.com/user-attachments/assets/2aab712e-8920-4d44-b2d0-a16abc13e57c" />
<img width="3602" height="3022" alt="Screenshot 2025-08-14 at 9 53 14 AM" src="https://github.com/user-attachments/assets/e77edb24-91d6-4a9e-a065-2bc198f7328a" />
<img width="3602" height="3022" alt="Screenshot 2025-08-14 at 10 18 48 AM" src="https://github.com/user-attachments/assets/b5cded12-1e9d-4924-8922-dd3be592170d" />
<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 40 26 PM" src="https://github.com/user-attachments/assets/45d55d7e-5af7-4819-8ecc-98f657ec20e7" />
<img width="3642" height="3022" alt="Screenshot 2025-08-13 at 5 40 29 PM" src="https://github.com/user-attachments/assets/5b0ca056-7eb6-47ef-a2c9-39f4d0163eab" />

