### PR TITLE
ROX-30279: Operator changes for new Admission Controller Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 ### Added Features
 
 - ROX-30279: The `admissionControl.enforce` field has been added to the SecuredCluster CRD as a high-level way to toggle admission controller enforcement.
-- ROX-30279: The `admissionControl.enforce` field default to true for new installations.
+- ROX-30279: The `admissionControl.enforce` field defaults to true for new installations.
   [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
 - ROX-30279: The `admissionControl.failurePolicy` field has been added to the SecuredCluster CRD for controlling admission controller's
   failure policy. It defaults to `Ignore`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Added Features
 
+- ROX-30279: The `admissionControl.enforce` field has been added to the SecuredCluster CRD as a high-level way to toggle admission controller enforcement.
+- ROX-30279: The `admissionControl.enforce` field default to true for new installations.
+  [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
+- ROX-30279: The `admissionControl.failurePolicy` field has been added to the SecuredCluster CRD for controlling admission controller's
+  failure policy. It defaults to `Ignore`.
 - ROX-27238: Central API for generating CRSs now supports custom expiration times, specified using the new fields "valid_until" or "valid_for".
   roxctl's "central crs generate" now supports specifying custom expiration times using the new parameters "--valid-until" or "--valid-for".
 - ROX-30087: Implicit exchange of OIDC tokens, accessing the API, with a role mapping according to the M2M configuration that matches the token issuer.
@@ -42,6 +47,9 @@ controller webhooks will now be configured to 1) always scan images inline 2) ei
 - ROX-30278: The `admissionControl.dynamic.timeout` configuration parameter of the secured-cluster-services Helm chart is not user-configurable anymore.
   Its value is set to `10`.
   [This is currently behind the ROX_ADMISSION_CONTROLLER_CONFIG feature flag, but the plan is to enable it for 4.9.]
+- ROX-30279: The `admissionControl.listenOn*` fields of the SecuredCluster CRD are deprecated.
+- ROX-30279: The `admissionControl.contactImageScanners` field of the SecuredCluster CRD is deprecated.
+- ROX-30279: The `admissionControl.timeoutSeconds` field of the SecuredCluster CRD is deprecated.
 - ROX-30278: The `admissionControl.dynamic.enforceOn*` configuration parameters of the secured-cluster-services Helm chart
   are deprecated and are now ignored. Please use the high-level parameter `admissionControl.enforce` instead.
   Enforce is now enabled by default.

--- a/operator/api/v1alpha1/securedcluster_types.go
+++ b/operator/api/v1alpha1/securedcluster_types.go
@@ -198,14 +198,16 @@ func (p BypassPolicy) Pointer() *BypassPolicy {
 	return &p
 }
 
-// FailurePolicy XXX.
+// FailurePolicy defines the failure policy for the admission controller webhooks, i.e. if a webhook request
+// shall fail in case the webhook does not respond in time (fail-closed) or if the request shall be allowed
+// in such a scenario (fail-open).
 // +kubebuilder:validation:Enum=Ignore;Fail
 type FailurePolicy string
 
 const (
-	// FailurePolicyFail means ...
+	// FailurePolicyFail instructs the admission controller's webhooks to fail-closed.
 	FailurePolicyFail FailurePolicy = "Fail"
-	// FailurePolicyIgnore means ....
+	// FailurePolicyIgnore instructs the admission controller's webhooks to fail-open.
 	FailurePolicyIgnore FailurePolicy = "Ignore"
 )
 

--- a/operator/api/v1alpha1/securedcluster_types.go
+++ b/operator/api/v1alpha1/securedcluster_types.go
@@ -117,50 +117,50 @@ type SensorComponentSpec struct {
 
 // AdmissionControlComponentSpec defines settings for the admission controller configuration.
 type AdmissionControlComponentSpec struct {
-	// Set this to 'true' to enable preventive policy enforcement for object creations.
-	//+kubebuilder:default=true
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
+	// Deprecated field. This field will be removed in a future release.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	ListenOnCreates *bool `json:"listenOnCreates,omitempty"`
 
-	// Set this to 'true' to enable preventive policy enforcement for object updates.
-	//
-	// Note: this will not have any effect unless 'Listen On Creates' is set to 'true' as well.
-	//+kubebuilder:default=true
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2
+	// Deprecated field. This field will be removed in a future release.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	ListenOnUpdates *bool `json:"listenOnUpdates,omitempty"`
 
-	// Set this to 'true' to enable monitoring and enforcement for Kubernetes events (port-forward and exec).
-	//+kubebuilder:default=true
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=3
+	// Deprecated field. This field will be removed in a future release.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	ListenOnEvents *bool `json:"listenOnEvents,omitempty"`
 
-	// Should inline scanning be performed on previously unscanned images during a deployments admission review.
-	//+kubebuilder:default=DoNotScanInline
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=4
+	// Set to false to disable policy enforcement for the admission controller. This is not recommended.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
+	// The default is: true.
+	Enforce *bool `json:"enforce,omitempty"`
+
+	// Deprecated field. This field will be removed in a future release.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	ContactImageScanners *ImageScanPolicy `json:"contactImageScanners,omitempty"`
 
-	// Maximum timeout period for admission review, upon which admission review will fail open.
-	// Use it to set request timeouts when you enable inline image scanning.
-	// The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
-	// On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding this value shall not exceed 10 seconds.
-	//+kubebuilder:default=10
-	//+kubebuilder:validation:Minimum=1
-	//+kubebuilder:validation:Maximum=25
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=5
+	// Deprecated field. This field will be removed in a future release.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty"`
 
 	// Enables teams to bypass admission control in a monitored manner in the event of an emergency.
-	//+kubebuilder:default=BreakGlassAnnotation
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=6
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2
+	// The default is: BreakGlassAnnotation.
 	Bypass *BypassPolicy `json:"bypass,omitempty"`
 
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=7
+	// If set to "Fail", the admission controller's webhooks are configured to fail-closed in case admission controller
+	// fails to respond in time. A failure policy "Ignore" configures the webhooks to fail-open.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=3
+	// The default is: Ignore.
+	FailurePolicy *FailurePolicy `json:"failurePolicy,omitempty"`
+
+	// Settings pertaining to the Admission Controller running on a Secured Cluster.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=4
 	DeploymentSpec `json:",inline"`
 
 	// The number of replicas of the admission control pod.
-	//+kubebuilder:default=3
 	//+kubebuilder:validation:Minimum=1
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Replicas",order=8
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Replicas",order=5
+	// The default is: 3.
 	Replicas *int32 `json:"replicas,omitempty"`
 }
 
@@ -197,6 +197,17 @@ const (
 func (p BypassPolicy) Pointer() *BypassPolicy {
 	return &p
 }
+
+// FailurePolicy XXX.
+// +kubebuilder:validation:Enum=Ignore;Fail
+type FailurePolicy string
+
+const (
+	// FailurePolicyFail means ...
+	FailurePolicyFail FailurePolicy = "Fail"
+	// FailurePolicyIgnore means ....
+	FailurePolicyIgnore FailurePolicy = "Ignore"
+)
 
 // PerNodeSpec declares configuration settings for components which are deployed to all nodes.
 type PerNodeSpec struct {

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -78,6 +78,11 @@ func (in *AdmissionControlComponentSpec) DeepCopyInto(out *AdmissionControlCompo
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Enforce != nil {
+		in, out := &in.Enforce, &out.Enforce
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ContactImageScanners != nil {
 		in, out := &in.ContactImageScanners, &out.ContactImageScanners
 		*out = new(ImageScanPolicy)
@@ -91,6 +96,11 @@ func (in *AdmissionControlComponentSpec) DeepCopyInto(out *AdmissionControlCompo
 	if in.Bypass != nil {
 		in, out := &in.Bypass, &out.Bypass
 		*out = new(BypassPolicy)
+		**out = **in
+	}
+	if in.FailurePolicy != nil {
+		in, out := &in.FailurePolicy, &out.FailurePolicy
+		*out = new(FailurePolicy)
 		**out = **in
 	}
 	in.DeploymentSpec.DeepCopyInto(&out.DeploymentSpec)

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -51,20 +51,33 @@ spec:
                   and for Kubernetes event monitoring.
                 properties:
                   bypass:
-                    default: BreakGlassAnnotation
-                    description: Enables teams to bypass admission control in a monitored
-                      manner in the event of an emergency.
+                    description: |-
+                      Enables teams to bypass admission control in a monitored manner in the event of an emergency.
+                      The default is: BreakGlassAnnotation.
                     enum:
                     - BreakGlassAnnotation
                     - Disabled
                     type: string
                   contactImageScanners:
-                    default: DoNotScanInline
-                    description: Should inline scanning be performed on previously
-                      unscanned images during a deployments admission review.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     enum:
                     - ScanIfMissing
                     - DoNotScanInline
+                    type: string
+                  enforce:
+                    description: |-
+                      Set to false to disable policy enforcement for the admission controller. This is not recommended.
+                      The default is: true.
+                    type: boolean
+                  failurePolicy:
+                    description: |-
+                      If set to "Fail", the admission controller's webhooks are configured to fail-closed in case admission controller
+                      fails to respond in time. A failure policy "Ignore" configures the webhooks to fail-open.
+                      The default is: Ignore.
+                    enum:
+                    - Ignore
+                    - Fail
                     type: string
                   hostAliases:
                     description: HostAliases allows configuring additional hostnames
@@ -88,21 +101,16 @@ spec:
                       type: object
                     type: array
                   listenOnCreates:
-                    default: true
-                    description: Set this to 'true' to enable preventive policy enforcement
-                      for object creations.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     type: boolean
                   listenOnEvents:
-                    default: true
-                    description: Set this to 'true' to enable monitoring and enforcement
-                      for Kubernetes events (port-forward and exec).
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     type: boolean
                   listenOnUpdates:
-                    default: true
-                    description: |-
-                      Set this to 'true' to enable preventive policy enforcement for object updates.
-
-                      Note: this will not have any effect unless 'Listen On Creates' is set to 'true' as well.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     type: boolean
                   nodeSelector:
                     additionalProperties:
@@ -111,8 +119,9 @@ spec:
                       nodes, you can configure a node selector here.
                     type: object
                   replicas:
-                    default: 3
-                    description: The number of replicas of the admission control pod.
+                    description: |-
+                      The number of replicas of the admission control pod.
+                      The default is: 3.
                     format: int32
                     minimum: 1
                     type: integer
@@ -178,15 +187,9 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 10
-                    description: |-
-                      Maximum timeout period for admission review, upon which admission review will fail open.
-                      Use it to set request timeouts when you enable inline image scanning.
-                      The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
-                      On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding this value shall not exceed 10 seconds.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     format: int32
-                    maximum: 25
-                    minimum: 1
                     type: integer
                   tolerations:
                     description: If you want this component to only run on specific

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1032,43 +1032,30 @@ spec:
         path: misc
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Set this to 'true' to enable preventive policy enforcement for
-          object creations.
-        displayName: Listen On Creates
-        path: admissionControl.listenOnCreates
-      - description: 'Set this to ''true'' to enable preventive policy enforcement
-          for object updates.
+      - description: 'Set to false to disable policy enforcement for the admission
+          controller. This is not recommended.
 
-
-          Note: this will not have any effect unless ''Listen On Creates'' is set
-          to ''true'' as well.'
-        displayName: Listen On Updates
-        path: admissionControl.listenOnUpdates
-      - description: Set this to 'true' to enable monitoring and enforcement for Kubernetes
-          events (port-forward and exec).
-        displayName: Listen On Events
-        path: admissionControl.listenOnEvents
-      - description: Should inline scanning be performed on previously unscanned images
-          during a deployments admission review.
-        displayName: Contact Image Scanners
-        path: admissionControl.contactImageScanners
-      - description: 'Maximum timeout period for admission review, upon which admission
-          review will fail open.
-
-          Use it to set request timeouts when you enable inline image scanning.
-
-          The default kubectl timeout is 30 seconds; taking padding into account,
-          this should not exceed 25 seconds.
-
-          On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding
-          this value shall not exceed 10 seconds.'
-        displayName: Timeout Seconds
-        path: admissionControl.timeoutSeconds
-      - description: Enables teams to bypass admission control in a monitored manner
+          The default is: true.'
+        displayName: Enforce
+        path: admissionControl.enforce
+      - description: 'Enables teams to bypass admission control in a monitored manner
           in the event of an emergency.
+
+          The default is: BreakGlassAnnotation.'
         displayName: Bypass
         path: admissionControl.bypass
-      - description: The number of replicas of the admission control pod.
+      - description: 'If set to "Fail", the admission controller''s webhooks are configured
+          to fail-closed in case admission controller
+
+          fails to respond in time. A failure policy "Ignore" configures the webhooks
+          to fail-open.
+
+          The default is: Ignore.'
+        displayName: Failure Policy
+        path: admissionControl.failurePolicy
+      - description: 'The number of replicas of the admission control pod.
+
+          The default is: 3.'
         displayName: Replicas
         path: admissionControl.replicas
       - description: 'Allows overriding the default resource settings for this component.
@@ -1093,6 +1080,31 @@ spec:
           in the pod's hosts file.
         displayName: Host Aliases
         path: admissionControl.hostAliases
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Contact Image Scanners
+        path: admissionControl.contactImageScanners
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Listen On Creates
+        path: admissionControl.listenOnCreates
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Listen On Events
+        path: admissionControl.listenOnEvents
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Listen On Updates
+        path: admissionControl.listenOnUpdates
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Timeout Seconds
+        path: admissionControl.timeoutSeconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: 'Whether collection of Kubernetes audit logs should be enabled
           or disabled. Currently, this is only
 

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -51,20 +51,33 @@ spec:
                   and for Kubernetes event monitoring.
                 properties:
                   bypass:
-                    default: BreakGlassAnnotation
-                    description: Enables teams to bypass admission control in a monitored
-                      manner in the event of an emergency.
+                    description: |-
+                      Enables teams to bypass admission control in a monitored manner in the event of an emergency.
+                      The default is: BreakGlassAnnotation.
                     enum:
                     - BreakGlassAnnotation
                     - Disabled
                     type: string
                   contactImageScanners:
-                    default: DoNotScanInline
-                    description: Should inline scanning be performed on previously
-                      unscanned images during a deployments admission review.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     enum:
                     - ScanIfMissing
                     - DoNotScanInline
+                    type: string
+                  enforce:
+                    description: |-
+                      Set to false to disable policy enforcement for the admission controller. This is not recommended.
+                      The default is: true.
+                    type: boolean
+                  failurePolicy:
+                    description: |-
+                      If set to "Fail", the admission controller's webhooks are configured to fail-closed in case admission controller
+                      fails to respond in time. A failure policy "Ignore" configures the webhooks to fail-open.
+                      The default is: Ignore.
+                    enum:
+                    - Ignore
+                    - Fail
                     type: string
                   hostAliases:
                     description: HostAliases allows configuring additional hostnames
@@ -88,21 +101,16 @@ spec:
                       type: object
                     type: array
                   listenOnCreates:
-                    default: true
-                    description: Set this to 'true' to enable preventive policy enforcement
-                      for object creations.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     type: boolean
                   listenOnEvents:
-                    default: true
-                    description: Set this to 'true' to enable monitoring and enforcement
-                      for Kubernetes events (port-forward and exec).
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     type: boolean
                   listenOnUpdates:
-                    default: true
-                    description: |-
-                      Set this to 'true' to enable preventive policy enforcement for object updates.
-
-                      Note: this will not have any effect unless 'Listen On Creates' is set to 'true' as well.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     type: boolean
                   nodeSelector:
                     additionalProperties:
@@ -111,8 +119,9 @@ spec:
                       nodes, you can configure a node selector here.
                     type: object
                   replicas:
-                    default: 3
-                    description: The number of replicas of the admission control pod.
+                    description: |-
+                      The number of replicas of the admission control pod.
+                      The default is: 3.
                     format: int32
                     minimum: 1
                     type: integer
@@ -178,15 +187,9 @@ spec:
                         type: object
                     type: object
                   timeoutSeconds:
-                    default: 10
-                    description: |-
-                      Maximum timeout period for admission review, upon which admission review will fail open.
-                      Use it to set request timeouts when you enable inline image scanning.
-                      The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
-                      On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding this value shall not exceed 10 seconds.
+                    description: Deprecated field. This field will be removed in a
+                      future release.
                     format: int32
-                    maximum: 25
-                    minimum: 1
                     type: integer
                   tolerations:
                     description: If you want this component to only run on specific

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -832,10 +832,11 @@ spec:
         name: ""
         version: v1
       specDescriptors:
-      - description: Set this to 'true' to enable preventive policy enforcement for
-          object creations.
-        displayName: Listen On Creates
-        path: admissionControl.listenOnCreates
+      - description: |-
+          Set to false to disable policy enforcement for the admission controller. This is not recommended.
+          The default is: true.
+        displayName: Enforce
+        path: admissionControl.enforce
       - description: |-
           Whether collection of Kubernetes audit logs should be enabled or disabled. Currently, this is only
           supported on OpenShift 4, and trying to enable it on non-OpenShift 4 clusters will result in an error.
@@ -946,11 +947,10 @@ spec:
         displayName: Scanner V4 component
         path: scannerV4.scannerComponent
       - description: |-
-          Set this to 'true' to enable preventive policy enforcement for object updates.
-
-          Note: this will not have any effect unless 'Listen On Creates' is set to 'true' as well.
-        displayName: Listen On Updates
-        path: admissionControl.listenOnUpdates
+          Enables teams to bypass admission control in a monitored manner in the event of an emergency.
+          The default is: BreakGlassAnnotation.
+        displayName: Bypass
+        path: admissionControl.bypass
       - description: |-
           The endpoint of the Red Hat Advanced Cluster Security Central instance to connect to,
           including the port number. If no port is specified and the endpoint contains an https://
@@ -1008,10 +1008,12 @@ spec:
           be configured to match this value.
         displayName: Default Replicas
         path: scannerV4.indexer.scaling.replicas
-      - description: Set this to 'true' to enable monitoring and enforcement for Kubernetes
-          events (port-forward and exec).
-        displayName: Listen On Events
-        path: admissionControl.listenOnEvents
+      - description: |-
+          If set to "Fail", the admission controller's webhooks are configured to fail-closed in case admission controller
+          fails to respond in time. A failure policy "Ignore" configures the webhooks to fail-open.
+          The default is: Ignore.
+        displayName: Failure Policy
+        path: admissionControl.failurePolicy
       - description: Custom environment variables to set on managed pods' containers.
         displayName: Environment Variables
         path: customize.envVars
@@ -1065,10 +1067,6 @@ spec:
           and for Kubernetes event monitoring.
         displayName: Admission Control Settings
         path: admissionControl
-      - description: Should inline scanning be performed on previously unscanned images
-          during a deployments admission review.
-        displayName: Contact Image Scanners
-        path: admissionControl.contactImageScanners
       - description: |-
           Optional marks the overlay as optional.
           When Optional is true, and the specified resource does not exist in the output manifests, the overlay will be skipped, and a warning will be logged.
@@ -1099,12 +1097,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:.scannerComponent:AutoSense
       - description: |-
-          Maximum timeout period for admission review, upon which admission review will fail open.
-          Use it to set request timeouts when you enable inline image scanning.
-          The default kubectl timeout is 30 seconds; taking padding into account, this should not exceed 25 seconds.
-          On OpenShift webhook timeouts cannot exceed 13 seconds, hence with padding this value shall not exceed 10 seconds.
-        displayName: Timeout Seconds
-        path: admissionControl.timeoutSeconds
+          The number of replicas of the admission control pod.
+          The default is: 3.
+        displayName: Replicas
+        path: admissionControl.replicas
       - description: List of patches to apply to resource.
         displayName: Patches
         path: overlays[0].patches
@@ -1116,10 +1112,6 @@ spec:
           in the pod's hosts file.
         displayName: Host Aliases
         path: perNode.hostAliases
-      - description: Enables teams to bypass admission control in a monitored manner
-          in the event of an emergency.
-        displayName: Bypass
-        path: admissionControl.bypass
       - description: Settings relating to the ingestion of Kubernetes audit logs.
         displayName: Kubernetes Audit Logs Ingestion Settings
         path: auditLogs
@@ -1128,9 +1120,6 @@ spec:
           images stored in a cluster-local image repository.
         displayName: Scanner Component Settings
         path: scanner
-      - description: The number of replicas of the admission control pod.
-        displayName: Replicas
-        path: admissionControl.replicas
       - description: Settings for the Scanner V4 components, which can run in addition
           to the previously existing Scanner components
         displayName: Scanner V4 Component Settings
@@ -1325,6 +1314,31 @@ spec:
           in the pod's hosts file.
         displayName: Host Aliases
         path: sensor.hostAliases
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Contact Image Scanners
+        path: admissionControl.contactImageScanners
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Listen On Creates
+        path: admissionControl.listenOnCreates
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Listen On Events
+        path: admissionControl.listenOnEvents
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Listen On Updates
+        path: admissionControl.listenOnUpdates
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated field. This field will be removed in a future release.
+        displayName: Timeout Seconds
+        path: admissionControl.timeoutSeconds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: The name of the referenced secret.
         displayName: Name
         path: imagePullSecrets[0].name

--- a/operator/hack/helm-cluster-config-assert.sh
+++ b/operator/hack/helm-cluster-config-assert.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+NAMESPACE=${NAMESPACE:-}
+if [[ -z "$NAMESPACE" ]]; then
+    echo >&2 "NAMESPACE must be set."
+    exit 1
+fi
+
+config_yaml=$(\
+    retry-kubectl.sh </dev/null -n "$NAMESPACE" get secret helm-cluster-config -o jsonpath='{.data.config\.yaml}' \
+    | base64 --decode \
+    | yq eval .clusterConfig - \
+)
+
+assertConfigValue() {
+    config_path="$1"
+    expected="$2"
+    config_value=$(echo "$config_yaml" | yq eval "$config_path" -)
+    [[ "$config_value" == "$expected" ]] || {
+        echo "Assertion failed: ${config_path} != ${expected} (actual: $config_value)"
+        return 1
+    }
+    return 0
+}
+
+if [[ $# != 2 ]]; then
+    echo >&2 "$0: <property path> <property value>"
+    exit 1
+fi
+
+assertConfigValue "$1" "$2"

--- a/operator/hack/operator.envsubst.yaml
+++ b/operator/hack/operator.envsubst.yaml
@@ -32,3 +32,6 @@ spec:
     # through correctly.
     - name: NO_PROXY
       value: "127.1.2.3/8"
+    # This feature flag is not yet enabled by default.
+    - name: ROX_ADMISSION_CONTROLLER_CONFIG
+      value: "true"

--- a/operator/internal/common/defaulting/test_helpers/helpers.go
+++ b/operator/internal/common/defaulting/test_helpers/helpers.go
@@ -59,9 +59,7 @@ func CheckStruct(t *testing.T, s any, schema chartutil.Values) {
 					CheckStruct(t, field.Elem().Interface(), table)
 				case reflect.String:
 					desc, err := schema.PathValue(fmt.Sprintf("properties.%s.description", jsonName))
-					if err != nil {
-						require.NoError(t, err)
-					}
+					require.NoError(t, err)
 					require.IsType(t, "string", desc, jsonName)
 					CheckLeafField(t, field, desc.(string))
 				default:

--- a/operator/internal/common/defaulting/test_helpers/helpers.go
+++ b/operator/internal/common/defaulting/test_helpers/helpers.go
@@ -39,9 +39,6 @@ func CheckStruct(t *testing.T, s any, schema chartutil.Values) {
 		t.Run(structField.Name, func(t *testing.T) {
 			field := structValue.Field(i)
 			jsonName, embedded := getJSONName(t, structField)
-			if jsonName == "admissionControl" {
-				require.NoError(t, nil)
-			}
 			if embedded {
 				CheckStruct(t, field.Interface(), schema)
 				return

--- a/operator/internal/common/defaulting/test_helpers/helpers.go
+++ b/operator/internal/common/defaulting/test_helpers/helpers.go
@@ -38,7 +38,14 @@ func CheckStruct(t *testing.T, s any, schema chartutil.Values) {
 
 		t.Run(structField.Name, func(t *testing.T) {
 			field := structValue.Field(i)
-			jsonName := getJSONName(t, structField)
+			jsonName, embedded := getJSONName(t, structField)
+			if jsonName == "admissionControl" {
+				require.NoError(t, nil)
+			}
+			if embedded {
+				CheckStruct(t, field.Interface(), schema)
+				return
+			}
 			switch field.Type().Kind() {
 			case reflect.Struct:
 				table, err := schema.Table("properties." + jsonName)
@@ -55,7 +62,9 @@ func CheckStruct(t *testing.T, s any, schema chartutil.Values) {
 					CheckStruct(t, field.Elem().Interface(), table)
 				case reflect.String:
 					desc, err := schema.PathValue(fmt.Sprintf("properties.%s.description", jsonName))
-					require.NoError(t, err)
+					if err != nil {
+						require.NoError(t, err)
+					}
 					require.IsType(t, "string", desc, jsonName)
 					CheckLeafField(t, field, desc.(string))
 				default:
@@ -68,10 +77,13 @@ func CheckStruct(t *testing.T, s any, schema chartutil.Values) {
 	}
 }
 
-func getJSONName(t *testing.T, structField reflect.StructField) string {
-	jsonName, _, _ := strings.Cut(structField.Tag.Get("json"), ",")
-	require.NotEmpty(t, jsonName, "field %s should have a 'json' tag", structField.Name)
-	return jsonName
+func getJSONName(t *testing.T, structField reflect.StructField) (field string, embedded bool) {
+	jsonName, rest, found := strings.Cut(structField.Tag.Get("json"), ",")
+	if found && jsonName == "" && rest == "inline" {
+		return "", true
+	}
+	require.NotEmpty(t, jsonName, "field %s should have a 'json' tag or be inline", structField.Name)
+	return jsonName, false
 }
 
 func CheckLeafField(t *testing.T, field reflect.Value, crdDescription string) {

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -191,8 +191,9 @@ func TestReconcileAdmissionControllerDefaulting(t *testing.T) {
 			assert.Equal(t, securedClusterDefaults.AdmissionControl, c.ExpectedDefaults, "SecuredCluster Defaults do not match expected Defaults")
 
 			// Verify that the expected annotations have been persisted via the provided client.
-			securedClusterFetched.Annotations = retainKeys(securedClusterFetched.Annotations, string(defaults.FeatureDefaultKeyAdmissionControllerEnforce))
-			assert.Equal(t, securedClusterFetched.Annotations, c.ExpectedAnnotations, "persisted SecuredCluster annotations do not match expected annotations")
+			for annotationKey, annotationVal := range c.ExpectedAnnotations {
+				assert.Equal(t, securedClusterFetched.Annotations[annotationKey], annotationVal, "mismatch in persisted annotation %s", annotationKey)
+			}
 
 			// Verify that the SecuredCluster Spec on the Cluster is unmodified.
 			assert.Equal(t, securedClusterFetched.Spec, c.Spec, "persisted SecuredCluster spec is modified")
@@ -336,32 +337,14 @@ func TestReconcileScannerV4FeatureDefaultsExtension(t *testing.T) {
 			assert.Equal(t, securedClusterDefaults.ScannerV4, c.ExpectedDefaults, "SecuredCluster Defaults do not match expected Defaults")
 
 			// Verify that the expected annotations have been persisted via the provided client.
-			securedClusterFetched.Annotations = retainKeys(securedClusterFetched.Annotations, defaulting.FeatureDefaultKeyScannerV4)
-			assert.Equal(t, securedClusterFetched.Annotations, c.ExpectedAnnotations, "persisted SecuredCluster annotations do not match expected annotations")
+			for annotationKey, annotationVal := range c.ExpectedAnnotations {
+				assert.Equal(t, securedClusterFetched.Annotations[annotationKey], annotationVal, "mismatch in persisted annotation %s", annotationKey)
+			}
 
 			// Verify that the SecuredCluster Spec on the Cluster is unmodified.
 			assert.Equal(t, securedClusterFetched.Spec, c.Spec, "persisted SecuredCluster spec is modified")
 		})
 	}
-}
-
-func retainKeys[T any](m map[string]T, keys ...string) map[string]T {
-	for name := range m {
-		retain := false
-		for _, key := range keys {
-			if name == key {
-				retain = true
-				break
-			}
-		}
-		if !retain {
-			delete(m, name)
-		}
-	}
-	if len(m) == 0 {
-		m = nil
-	}
-	return m
 }
 
 func securedClusterToUnstructured(t *testing.T, securedCluster *platform.SecuredCluster) *unstructured.Unstructured {

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -179,11 +179,11 @@ func TestReconcileAdmissionControllerDefaulting(t *testing.T) {
 			unstructuredSecuredCluster := securedClusterToUnstructured(t, baseSecuredCluster)
 
 			err := reconcileFeatureDefaults(ctx, client, unstructuredSecuredCluster, logr.Discard())
-			assert.Nil(t, err, "reconcileFeatureDefaults returned error")
+			assert.NoError(t, err, "reconcileFeatureDefaults returned error")
 
 			securedClusterFetched := platform.SecuredCluster{}
 			err = client.Get(ctx, ctrlClient.ObjectKey{Namespace: testutils.TestNamespace, Name: clusterName}, &securedClusterFetched)
-			assert.Nil(t, err, "retrieving SecuredCluster object from fake Kubernetes client")
+			assert.NoError(t, err, "retrieving SecuredCluster object from fake Kubernetes client")
 
 			securedClusterDefaults := extractSecuredClusterDefaults(t, unstructuredSecuredCluster)
 

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-logr/logr"
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/operator/internal/common/defaulting"
+	"github.com/stackrox/rox/operator/internal/securedcluster/values/defaults"
+
 	"github.com/stackrox/rox/operator/internal/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -26,6 +29,14 @@ type scannerV4DefaultingTestCase struct {
 	ExpectedDefaults    *platform.LocalScannerV4ComponentSpec
 }
 
+type admissionControllerDefaultingTestCase struct {
+	Annotations         map[string]string
+	Spec                platform.SecuredClusterSpec
+	Status              platform.SecuredClusterStatus
+	ExpectedAnnotations map[string]string
+	ExpectedDefaults    *platform.AdmissionControlComponentSpec
+}
+
 var (
 	nonEmptyStatus = platform.SecuredClusterStatus{
 		DeployedRelease: &platform.StackRoxRelease{
@@ -33,6 +44,161 @@ var (
 		},
 	}
 )
+
+func TestReconcileAdmissionControllerDefaulting(t *testing.T) {
+	t.Setenv("ROX_ADMISSION_CONTROLLER_CONFIG", "true")
+	cases := map[string]admissionControllerDefaultingTestCase{
+		"install: empty spec": {
+			Spec:   platform.SecuredClusterSpec{},
+			Status: platform.SecuredClusterStatus{},
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       ptr.To(true),
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "true",
+			},
+		},
+		"upgrade: annotation true is picked up": {
+			Spec:   platform.SecuredClusterSpec{},
+			Status: nonEmptyStatus,
+			Annotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "true",
+			},
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       ptr.To(true),
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "true",
+			},
+		},
+		"upgrade: annotation false is picked up": {
+			Spec:   platform.SecuredClusterSpec{},
+			Status: nonEmptyStatus,
+			Annotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "false",
+			},
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       ptr.To(false),
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "false",
+			},
+		},
+		"upgrade: enforce disabled if listenOnCreates & listenOnUpdates disabled": {
+			Spec: platform.SecuredClusterSpec{
+				AdmissionControl: &platform.AdmissionControlComponentSpec{
+					ListenOnCreates: ptr.To(false),
+					ListenOnUpdates: ptr.To(false),
+				},
+			},
+			Status: nonEmptyStatus,
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       ptr.To(false),
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "false",
+			},
+		},
+		"upgrade: enforce enabled if listenOnCreates enabled": {
+			Spec: platform.SecuredClusterSpec{
+				AdmissionControl: &platform.AdmissionControlComponentSpec{
+					ListenOnCreates: ptr.To(true),
+					ListenOnUpdates: ptr.To(false),
+				},
+			},
+			Status: nonEmptyStatus,
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       ptr.To(true),
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "true",
+			},
+		},
+		"upgrade: enforce enabled if listenOnUpdates enabled": {
+			Spec: platform.SecuredClusterSpec{
+				AdmissionControl: &platform.AdmissionControlComponentSpec{
+					ListenOnCreates: ptr.To(false),
+					ListenOnUpdates: ptr.To(true),
+				},
+			},
+			Status: nonEmptyStatus,
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       ptr.To(true),
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "true",
+			},
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			const clusterName = "test-cluster"
+			baseSecuredCluster := &platform.SecuredCluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "platform.stackrox.io/v1alpha1",
+					Kind:       "SecuredCluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        clusterName,
+					Namespace:   testutils.TestNamespace,
+					Annotations: make(map[string]string),
+				},
+				Spec:   *c.Spec.DeepCopy(),
+				Status: *c.Status.DeepCopy(),
+			}
+			for key, val := range c.Annotations {
+				baseSecuredCluster.Annotations[key] = val
+			}
+
+			ctx := context.Background()
+			sch := runtime.NewScheme()
+			require.NoError(t, platform.AddToScheme(sch))
+			require.NoError(t, scheme.AddToScheme(sch))
+			client := fake.NewClientBuilder().
+				WithScheme(sch).
+				WithObjects(baseSecuredCluster).
+				Build()
+			unstructuredSecuredCluster := securedClusterToUnstructured(t, baseSecuredCluster)
+
+			err := reconcileFeatureDefaults(ctx, client, unstructuredSecuredCluster, logr.Discard())
+			assert.Nil(t, err, "reconcileFeatureDefaults returned error")
+
+			securedClusterFetched := platform.SecuredCluster{}
+			err = client.Get(ctx, ctrlClient.ObjectKey{Namespace: testutils.TestNamespace, Name: clusterName}, &securedClusterFetched)
+			assert.Nil(t, err, "retrieving SecuredCluster object from fake Kubernetes client")
+
+			securedClusterDefaults := extractSecuredClusterDefaults(t, unstructuredSecuredCluster)
+
+			// Verify that reconcileFeatureDefaults has modified the scanner v4 defaults as expected.
+			assert.Equal(t, securedClusterDefaults.AdmissionControl, c.ExpectedDefaults, "SecuredCluster Defaults do not match expected Defaults")
+
+			// Verify that the expected annotations have been persisted via the provided client.
+			securedClusterFetched.Annotations = retainKeys(securedClusterFetched.Annotations, string(defaults.FeatureDefaultKeyAdmissionControllerEnforce))
+			assert.Equal(t, securedClusterFetched.Annotations, c.ExpectedAnnotations, "persisted SecuredCluster annotations do not match expected annotations")
+
+			// Verify that the SecuredCluster Spec on the Cluster is unmodified.
+			assert.Equal(t, securedClusterFetched.Spec, c.Spec, "persisted SecuredCluster spec is modified")
+		})
+	}
+}
 
 func TestReconcileScannerV4FeatureDefaultsExtension(t *testing.T) {
 	cases := map[string]scannerV4DefaultingTestCase{
@@ -170,12 +336,32 @@ func TestReconcileScannerV4FeatureDefaultsExtension(t *testing.T) {
 			assert.Equal(t, securedClusterDefaults.ScannerV4, c.ExpectedDefaults, "SecuredCluster Defaults do not match expected Defaults")
 
 			// Verify that the expected annotations have been persisted via the provided client.
+			securedClusterFetched.Annotations = retainKeys(securedClusterFetched.Annotations, defaulting.FeatureDefaultKeyScannerV4)
 			assert.Equal(t, securedClusterFetched.Annotations, c.ExpectedAnnotations, "persisted SecuredCluster annotations do not match expected annotations")
 
 			// Verify that the SecuredCluster Spec on the Cluster is unmodified.
 			assert.Equal(t, securedClusterFetched.Spec, c.Spec, "persisted SecuredCluster spec is modified")
 		})
 	}
+}
+
+func retainKeys[T any](m map[string]T, keys ...string) map[string]T {
+	for name := range m {
+		retain := false
+		for _, key := range keys {
+			if name == key {
+				retain = true
+				break
+			}
+		}
+		if !retain {
+			delete(m, name)
+		}
+	}
+	if len(m) == 0 {
+		m = nil
+	}
+	return m
 }
 
 func securedClusterToUnstructured(t *testing.T, securedCluster *platform.SecuredCluster) *unstructured.Unstructured {

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -61,6 +61,40 @@ func TestReconcileAdmissionControllerDefaulting(t *testing.T) {
 				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "true",
 			},
 		},
+		"install: explicit enforce false": {
+			Spec: platform.SecuredClusterSpec{
+				AdmissionControl: &platform.AdmissionControlComponentSpec{
+					Enforce: ptr.To(false),
+				},
+			},
+			Status: platform.SecuredClusterStatus{},
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       nil,
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "",
+			},
+		},
+		"install: explicit enforce true": {
+			Spec: platform.SecuredClusterSpec{
+				AdmissionControl: &platform.AdmissionControlComponentSpec{
+					Enforce: ptr.To(true),
+				},
+			},
+			Status: platform.SecuredClusterStatus{},
+			ExpectedDefaults: &platform.AdmissionControlComponentSpec{
+				Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+				FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+				Replicas:      ptr.To(int32(3)),
+				Enforce:       nil,
+			},
+			ExpectedAnnotations: map[string]string{
+				defaults.FeatureDefaultKeyAdmissionControllerEnforce: "",
+			},
+		},
 		"upgrade: annotation true is picked up": {
 			Spec:   platform.SecuredClusterSpec{},
 			Status: nonEmptyStatus,

--- a/operator/internal/securedcluster/values/defaults/admission_controller.go
+++ b/operator/internal/securedcluster/values/defaults/admission_controller.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/operator/internal/common/defaulting"
@@ -33,13 +32,7 @@ var (
 )
 
 func admissionControllerDefaultingGreenField(logger logr.Logger, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
-	var multiErr error
-
-	if err := admissionControllerDefaultingGreenFieldEnforce(logger, annotations, spec, defaults); err != nil {
-		multiErr = multierror.Append(multiErr, err)
-	}
-
-	return multiErr
+	return admissionControllerDefaultingGreenFieldEnforce(logger, annotations, spec, defaults)
 }
 
 func admissionControllerDefaultingGreenFieldEnforce(_ logr.Logger, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
@@ -101,13 +94,7 @@ func admissionControllerDefaultingBrownFieldEnforce(logger logr.Logger, annotati
 }
 
 func admissionControllerDefaultingBrownField(logger logr.Logger, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
-	var multiErr error
-
-	if err := admissionControllerDefaultingBrownFieldEnforce(logger, annotations, spec, defaults); err != nil {
-		multiErr = multierror.Append(multiErr, err)
-	}
-
-	return multiErr
+	return admissionControllerDefaultingBrownFieldEnforce(logger, annotations, spec, defaults)
 }
 
 func securedClusterAdmissionControllerDefaulting(logger logr.Logger, status *platform.SecuredClusterStatus, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {

--- a/operator/internal/securedcluster/values/defaults/admission_controller.go
+++ b/operator/internal/securedcluster/values/defaults/admission_controller.go
@@ -1,0 +1,134 @@
+package defaults
+
+import (
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	platform "github.com/stackrox/rox/operator/api/v1alpha1"
+	"github.com/stackrox/rox/operator/internal/common/defaulting"
+
+	"k8s.io/utils/ptr"
+)
+
+const (
+	FeatureDefaultKeyAdmissionControllerEnforce = "feature-defaults.platform.stackrox.io/admissionControllerEnforce"
+)
+
+var SecuredClusterAdmissionControllerDefaultingFlow = defaulting.SecuredClusterDefaultingFlow{
+	Name:           "secured-cluster-admission-controller",
+	DefaultingFunc: securedClusterAdmissionControllerDefaulting,
+}
+
+var (
+	tableBoolMarshalling = map[bool]string{
+		true:  "true",
+		false: "false",
+	}
+	tableBoolUnmarshalling = map[string]bool{
+		"true":  true,
+		"false": false,
+	}
+)
+
+func admissionControllerDefaultingGreenField(logger logr.Logger, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
+	var multiErr error
+
+	if err := admissionControllerDefaultingGreenFieldEnforce(logger, annotations, spec, defaults); err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	return multiErr
+}
+
+func admissionControllerDefaultingGreenFieldEnforce(_ logr.Logger, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
+	admissionControl := spec.AdmissionControl
+	if admissionControl == nil {
+		admissionControl = &platform.AdmissionControlComponentSpec{}
+	}
+	if admissionControl.Enforce != nil {
+		return nil
+	}
+
+	enforceBool := true
+	defaults.AdmissionControl.Enforce = ptr.To(enforceBool)
+	annotations[FeatureDefaultKeyAdmissionControllerEnforce] = tableBoolMarshalling[enforceBool]
+	return nil
+}
+
+func admissionControllerDefaultingBrownFieldEnforce(logger logr.Logger, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
+	var functionErr error
+	admissionControl := spec.AdmissionControl
+	if admissionControl == nil {
+		admissionControl = &platform.AdmissionControlComponentSpec{}
+	}
+
+	if enforceAnnotation := annotations[FeatureDefaultKeyAdmissionControllerEnforce]; enforceAnnotation != "" {
+		enforceBool, ok := tableBoolUnmarshalling[enforceAnnotation]
+		if !ok {
+			logger.Info("Failed to unmarshal CR defaulting annotation {%q: %v} as boolean", FeatureDefaultKeyAdmissionControllerEnforce, enforceAnnotation)
+			functionErr = errors.Errorf("unexpected value %q of CR annotation %s", enforceAnnotation, FeatureDefaultKeyAdmissionControllerEnforce)
+		} else {
+			defaults.AdmissionControl.Enforce = ptr.To(enforceBool)
+		}
+	}
+
+	if defaults.AdmissionControl.Enforce == nil {
+		// No previous annotation, implement defaulting flow.
+		// Note: we don't have fields "enforceOnCreates" and "enforceOnUpdated" in the CRD.
+		// These fields for the Helm chart were historically kept in sync with the "listenOnCreates" and the "listenOnUpdates" fields of the CRD.
+		listenOnCreates := false
+		listenOnUpdates := false
+
+		if listenOnCreatesPtr := admissionControl.ListenOnCreates; listenOnCreatesPtr != nil {
+			listenOnCreates = *listenOnCreatesPtr
+		}
+		if listenOnUpdatesPtr := admissionControl.ListenOnUpdates; listenOnUpdatesPtr != nil {
+			listenOnUpdates = *listenOnUpdatesPtr
+		}
+		defaults.AdmissionControl.Enforce = ptr.To(listenOnCreates || listenOnUpdates)
+	}
+
+	if defaults.AdmissionControl.Enforce != nil {
+		enforceString := tableBoolMarshalling[*defaults.AdmissionControl.Enforce]
+		if annotations[FeatureDefaultKeyAdmissionControllerEnforce] != enforceString {
+			annotations[FeatureDefaultKeyAdmissionControllerEnforce] = enforceString
+		}
+	}
+
+	return functionErr
+}
+
+func admissionControllerDefaultingBrownField(logger logr.Logger, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
+	var multiErr error
+
+	if err := admissionControllerDefaultingBrownFieldEnforce(logger, annotations, spec, defaults); err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	return multiErr
+}
+
+func securedClusterAdmissionControllerDefaulting(logger logr.Logger, status *platform.SecuredClusterStatus, annotations map[string]string, spec *platform.SecuredClusterSpec, defaults *platform.SecuredClusterSpec) error {
+	if securedClusterStatusUninitialized(status) {
+		// Green field.
+		logger.Info("Assuming new installation due to empty status.")
+		if err := admissionControllerDefaultingGreenField(logger, annotations, spec, defaults); err != nil {
+			return err
+		}
+	} else {
+		// Brown field.
+		logger.Info("Assuming upgrade due to populated status.")
+		if err := admissionControllerDefaultingBrownField(logger, annotations, spec, defaults); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// securedClusterStatusUninitialized checks if the provided Securedcluster status is uninitialized.
+func securedClusterStatusUninitialized(status *platform.SecuredClusterStatus) bool {
+	return status == nil || reflect.DeepEqual(status, &platform.SecuredClusterStatus{})
+}

--- a/operator/internal/securedcluster/values/defaults/defaults.go
+++ b/operator/internal/securedcluster/values/defaults/defaults.go
@@ -8,14 +8,19 @@ import (
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/operator/internal/common"
 	"github.com/stackrox/rox/operator/internal/common/defaulting"
+	"k8s.io/utils/ptr"
 )
 
 var staticDefaults = platform.SecuredClusterSpec{
-	ClusterName:      "",
-	ClusterLabels:    nil,
-	CentralEndpoint:  "",
-	Sensor:           nil,
-	AdmissionControl: nil,
+	ClusterName:     "",
+	ClusterLabels:   nil,
+	CentralEndpoint: "",
+	Sensor:          nil,
+	AdmissionControl: &platform.AdmissionControlComponentSpec{
+		Bypass:        ptr.To(platform.BypassBreakGlassAnnotation),
+		FailurePolicy: ptr.To(platform.FailurePolicyIgnore),
+		Replicas:      ptr.To(int32(3)),
+	},
 	PerNode: &platform.PerNodeSpec{
 		Collector:       nil,
 		Compliance:      nil,

--- a/operator/internal/securedcluster/values/defaults/defaults_test.go
+++ b/operator/internal/securedcluster/values/defaults/defaults_test.go
@@ -33,6 +33,7 @@ func TestSecuredClusterStaticDefaults(t *testing.T) {
 }
 
 func TestSecuredClusterStaticDefaultsMatchesCRD(t *testing.T) {
+	t.Setenv("ROX_ADMISSION_CONTROLLER_CONFIG", "true")
 	SecuredClusterSpecSchema := test_helpers.LoadSpecSchema(t, "securedclusters")
 
 	t.Run("Defaults", func(t *testing.T) {

--- a/operator/internal/securedcluster/values/translation/translation.go
+++ b/operator/internal/securedcluster/values/translation/translation.go
@@ -330,9 +330,7 @@ func (t Translator) getAdmissionControlValues(admissionControl *platform.Admissi
 			return dynamic.SetError(errors.Errorf("invalid spec.admissionControl.bypass setting %q", *admissionControl.Bypass))
 		}
 	}
-	if admissionControl.FailurePolicy != nil {
-		acv.SetString("failurePolicy", (*string)(admissionControl.FailurePolicy))
-	}
+	acv.SetString("failurePolicy", (*string)(admissionControl.FailurePolicy))
 	acv.AddChild("dynamic", &dynamic)
 	acv.SetStringMap("nodeSelector", admissionControl.NodeSelector)
 	acv.AddAllFrom(translation.GetTolerations(translation.TolerationsKey, admissionControl.Tolerations))

--- a/operator/internal/securedcluster/values/translation/translation.go
+++ b/operator/internal/securedcluster/values/translation/translation.go
@@ -314,27 +314,12 @@ func (t Translator) getAdmissionControlValues(admissionControl *platform.Admissi
 	acv := translation.NewValuesBuilder()
 
 	acv.AddChild(translation.ResourcesKey, translation.GetResources(admissionControl.Resources))
-	acv.SetBool("listenOnCreates", admissionControl.ListenOnCreates)
-	acv.SetBool("listenOnUpdates", admissionControl.ListenOnUpdates)
-	acv.SetBool("listenOnEvents", admissionControl.ListenOnEvents)
 	dynamic := translation.NewValuesBuilder()
 	// Unlike in the UI, both static and dynamic parts of config are driven by
-	// the single spec.admissionControl.listenOn* setting in CR. This is because
+	// the CR fields directly below spec.admissionControl. This is because
 	// redeployment is natively part of the CR lifecycle when we have an operator, so
 	// no need to distinguish between the static and dynamic part.
-	dynamic.SetBool("enforceOnCreates", admissionControl.ListenOnCreates)
-	dynamic.SetBool("enforceOnUpdates", admissionControl.ListenOnUpdates)
-	if admissionControl.ContactImageScanners != nil {
-		switch *admissionControl.ContactImageScanners {
-		case platform.ScanIfMissing:
-			dynamic.SetBoolValue("scanInline", true)
-		case platform.DoNotScanInline:
-			dynamic.SetBoolValue("scanInline", false)
-		default:
-			return dynamic.SetError(errors.Errorf("invalid spec.admissionControl.contactImageScanners setting %q", *admissionControl.ContactImageScanners))
-		}
-	}
-	dynamic.SetInt32("timeout", admissionControl.TimeoutSeconds)
+	dynamic.SetBool("enforce", admissionControl.Enforce)
 	if admissionControl.Bypass != nil {
 		switch *admissionControl.Bypass {
 		case platform.BypassBreakGlassAnnotation:
@@ -344,6 +329,9 @@ func (t Translator) getAdmissionControlValues(admissionControl *platform.Admissi
 		default:
 			return dynamic.SetError(errors.Errorf("invalid spec.admissionControl.bypass setting %q", *admissionControl.Bypass))
 		}
+	}
+	if admissionControl.FailurePolicy != nil {
+		acv.SetString("failurePolicy", (*string)(admissionControl.FailurePolicy))
 	}
 	acv.AddChild("dynamic", &dynamic)
 	acv.SetStringMap("nodeSelector", admissionControl.NodeSelector)

--- a/operator/internal/securedcluster/values/translation/translation.go
+++ b/operator/internal/securedcluster/values/translation/translation.go
@@ -319,7 +319,7 @@ func (t Translator) getAdmissionControlValues(admissionControl *platform.Admissi
 	// the CR fields directly below spec.admissionControl. This is because
 	// redeployment is natively part of the CR lifecycle when we have an operator, so
 	// no need to distinguish between the static and dynamic part.
-	dynamic.SetBool("enforce", admissionControl.Enforce)
+	acv.SetBool("enforce", admissionControl.Enforce)
 	if admissionControl.Bypass != nil {
 		switch *admissionControl.Bypass {
 		case platform.BypassBreakGlassAnnotation:

--- a/operator/internal/securedcluster/values/translation/translation_test.go
+++ b/operator/internal/securedcluster/values/translation/translation_test.go
@@ -696,8 +696,8 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"admissionControl": map[string]interface{}{
 					"dynamic": map[string]interface{}{
 						"disableBypass": false,
-						"enforce":       true,
 					},
+					"enforce":       true,
 					"failurePolicy": "Fail",
 					"nodeSelector": map[string]interface{}{
 						"admission-ctrl-node-selector1": "admission-ctrl-node-selector-val1",

--- a/operator/internal/securedcluster/values/translation/translation_test.go
+++ b/operator/internal/securedcluster/values/translation/translation_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -146,14 +146,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"clusterName":   "test-cluster",
 				"ca":            map[string]string{"cert": "ca central content"},
 				"createSecrets": false,
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
-				},
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
@@ -200,14 +192,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"clusterName":   "test-cluster",
 				"ca":            map[string]string{"cert": "ca central content"},
 				"createSecrets": false,
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
-				},
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
@@ -255,14 +239,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"clusterName":   "test-cluster",
 				"ca":            map[string]string{"cert": "ca central content"},
 				"createSecrets": false,
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
-				},
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
@@ -295,14 +271,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"clusterName":   "test-cluster",
 				"ca":            map[string]string{"cert": "ca central content"},
 				"createSecrets": false,
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
-				},
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
@@ -338,14 +306,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"clusterName":   "test-cluster",
 				"ca":            map[string]string{"cert": "ca central content"},
 				"createSecrets": false,
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
-				},
 				"scanner": map[string]interface{}{
 					"disable": true,
 				},
@@ -379,14 +339,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"clusterName":   "test-cluster",
 				"ca":            map[string]string{"cert": "ca central content"},
 				"createSecrets": false,
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
-				},
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
@@ -424,14 +376,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"clusterName":   "test-cluster",
 				"ca":            map[string]string{"cert": "ca central content"},
 				"createSecrets": false,
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
-				},
 				"scanner": map[string]interface{}{
 					"disable": false,
 				},
@@ -473,12 +417,9 @@ func (s *TranslationTestSuite) TestTranslate() {
 							},
 						},
 						AdmissionControl: &platform.AdmissionControlComponentSpec{
-							ListenOnCreates:      pointer.Bool(true),
-							ListenOnUpdates:      pointer.Bool(false),
-							ListenOnEvents:       pointer.Bool(true),
-							ContactImageScanners: platform.ScanIfMissing.Pointer(),
-							TimeoutSeconds:       pointer.Int32(4),
-							Bypass:               platform.BypassBreakGlassAnnotation.Pointer(),
+							Enforce:       ptr.To(true),
+							Bypass:        platform.BypassBreakGlassAnnotation.Pointer(),
+							FailurePolicy: ptr.To(platform.FailurePolicyFail),
 							DeploymentSpec: platform.DeploymentSpec{
 								Resources: &v1.ResourceRequirements{
 									Limits: v1.ResourceList{
@@ -655,8 +596,8 @@ func (s *TranslationTestSuite) TestTranslate() {
 							DB: &platform.ScannerV4DB{
 								Persistence: &platform.ScannerV4Persistence{
 									PersistentVolumeClaim: &platform.ScannerV4PersistentVolumeClaim{
-										ClaimName:        pointer.String("scanner-v4-db-pvc"),
-										StorageClassName: pointer.String("test-sc1"),
+										ClaimName:        ptr.To("scanner-v4-db-pvc"),
+										StorageClassName: ptr.To("test-sc1"),
 									},
 								},
 								DeploymentSpec: platform.DeploymentSpec{
@@ -754,15 +695,10 @@ func (s *TranslationTestSuite) TestTranslate() {
 				},
 				"admissionControl": map[string]interface{}{
 					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": false,
-						"scanInline":       true,
-						"disableBypass":    false,
-						"timeout":          4,
+						"disableBypass": false,
+						"enforce":       true,
 					},
-					"listenOnCreates": true,
-					"listenOnUpdates": false,
-					"listenOnEvents":  true,
+					"failurePolicy": "Fail",
 					"nodeSelector": map[string]interface{}{
 						"admission-ctrl-node-selector1": "admission-ctrl-node-selector-val1",
 						"admission-ctrl-node-selector2": "admission-ctrl-node-selector-val2",
@@ -1017,14 +953,6 @@ func (s *TranslationTestSuite) TestTranslate() {
 				"collector": map[string]interface{}{
 					"forceCollectionMethod": true,
 					"collectionMethod":      "CORE_BPF",
-				},
-				"admissionControl": map[string]interface{}{
-					"dynamic": map[string]interface{}{
-						"enforceOnCreates": true,
-						"enforceOnUpdates": true,
-					},
-					"listenOnCreates": true,
-					"listenOnUpdates": true,
 				},
 				"scanner": map[string]interface{}{
 					"disable": false,

--- a/operator/tests/common/secured-cluster-cr.yaml
+++ b/operator/tests/common/secured-cluster-cr.yaml
@@ -7,6 +7,11 @@ spec:
   imagePullSecrets:
   - name: e2e-test-pull-secret
   admissionControl:
+    listenOnCreates: false # Shall be ignored
+    listenOnUpdates: false # Shall be ignored
+    listenOnEvents: false # Shall be ignored
+    contactImageScanners: DoNotScanInline # Shall be ignored
+    timeoutSeconds: 15 # Shall be ignored
     resources:
       requests:
         memory: 100Mi

--- a/operator/tests/common/verify-dynamic-admission-controller-config.yaml
+++ b/operator/tests/common/verify-dynamic-admission-controller-config.yaml
@@ -4,24 +4,6 @@ kind: TestStep
 commands:
   - script: |
       set -eu # shell in CI does not grok -o pipefail
-
-      config_yaml=$(\
-        retry-kubectl.sh </dev/null -n $NAMESPACE get secret helm-cluster-config -o jsonpath='{.data.config\.yaml}' \
-        | base64 --decode \
-        | yq eval .clusterConfig - \
-      )
-
       ret=0
-      assertConfigValue() {
-        config_path="$1"
-        expected="$2"
-        config_value=$(echo "$config_yaml" | yq eval "$config_path" -)
-        [[ "$config_value" == "$expected" ]] || {
-          echo "Assertion failed: ${config_path} != ${expected} (actual: $config_value)"
-          ret=1
-        }
-      }
-
-      assertConfigValue ".dynamicConfig.admissionControllerConfig.scanInline" "true"
-
+      helm-cluster-config-assert.sh .dynamicConfig.admissionControllerConfig.scanInline true || ret=1
       exit $ret

--- a/operator/tests/common/verify-dynamic-admission-controller-config.yaml
+++ b/operator/tests/common/verify-dynamic-admission-controller-config.yaml
@@ -1,0 +1,27 @@
+# Default helm-cluster-config
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      set -eu # shell in CI does not grok -o pipefail
+
+      config_yaml=$(\
+        retry-kubectl.sh </dev/null -n $NAMESPACE get secret helm-cluster-config -o jsonpath='{.data.config\.yaml}' \
+        | base64 --decode \
+        | yq eval .clusterConfig - \
+      )
+
+      ret=0
+      assertConfigValue() {
+        config_path="$1"
+        expected="$2"
+        config_value=$(echo "$config_yaml" | yq eval "$config_path" -)
+        [[ "$config_value" == "$expected" ]] || {
+          echo "Assertion failed: ${config_path} != ${expected} (actual: $config_value)"
+          ret=1
+        }
+      }
+
+      assertConfigValue ".dynamicConfig.admissionControllerConfig.scanInline" "true"
+
+      exit $ret

--- a/operator/tests/securedcluster/sc-basic/011-verify-dynamic-admission-controller-config.yaml
+++ b/operator/tests/securedcluster/sc-basic/011-verify-dynamic-admission-controller-config.yaml
@@ -1,0 +1,1 @@
+../../common/verify-dynamic-admission-controller-config.yaml

--- a/operator/tests/upgrade/upgrade/010-assert-central-cr-with-pre-4-9-admission-controller-config.yaml
+++ b/operator/tests/upgrade/upgrade/010-assert-central-cr-with-pre-4-9-admission-controller-config.yaml
@@ -75,23 +75,3 @@ metadata:
   name: securedcluster-stackrox-secured-cluster-services-proxy-env
 data:
   NO_PROXY: MTI3LjEuMi4zLzg= # 127.1.2.3/8
----
-# Default ValidatingWebhookConfiguration
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: stackrox
-webhooks:
-  - name: policyeval.stackrox.io
-    rules:
-      - operations:
-          - CREATE # Due to listenOnCreates
-          - UPDATE # Due to listenOnUpdates
-    failurePolicy: Ignore
-    timeoutSeconds: 12
-  - name: k8sevents.stackrox.io
-    rules:
-      - operations:
-          - CONNECT # Due to listenOnEvents
-    failurePolicy: Ignore
-    timeoutSeconds: 12

--- a/operator/tests/upgrade/upgrade/010-assert.yaml
+++ b/operator/tests/upgrade/upgrade/010-assert.yaml
@@ -1,1 +1,0 @@
-../../common/secured-cluster-cr-assert.yaml

--- a/operator/tests/upgrade/upgrade/011-verify-pre-4-9-dynamic-admission-controller-config.yaml
+++ b/operator/tests/upgrade/upgrade/011-verify-pre-4-9-dynamic-admission-controller-config.yaml
@@ -4,24 +4,6 @@ kind: TestStep
 commands:
   - script: |
       set -eu # shell in CI does not grok -o pipefail
-
-      config_yaml=$(\
-        retry-kubectl.sh </dev/null -n $NAMESPACE get secret helm-cluster-config -o jsonpath='{.data.config\.yaml}' \
-        | base64 --decode \
-        | yq eval .clusterConfig - \
-      )
-
       ret=0
-      assertConfigValue() {
-        config_path="$1"
-        expected="$2"
-        config_value=$(echo "$config_yaml" | yq eval "$config_path" -)
-        [[ "$config_value" == "$expected" ]] || {
-          echo "Assertion failed: ${config_path} != ${expected} (actual: $config_value)"
-          ret=1
-        }
-      }
-
-      assertConfigValue ".dynamicConfig.admissionControllerConfig.scanInline" "false"
-
+      helm-cluster-config-assert.sh .dynamicConfig.admissionControllerConfig.scanInline false || ret=1
       exit $ret

--- a/operator/tests/upgrade/upgrade/011-verify-pre-4-9-dynamic-admission-controller-config.yaml
+++ b/operator/tests/upgrade/upgrade/011-verify-pre-4-9-dynamic-admission-controller-config.yaml
@@ -1,0 +1,27 @@
+# pre-4.9 Operator will not ignore the deprecated AdmissionController config fields.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      set -eu # shell in CI does not grok -o pipefail
+
+      config_yaml=$(\
+        retry-kubectl.sh </dev/null -n $NAMESPACE get secret helm-cluster-config -o jsonpath='{.data.config\.yaml}' \
+        | base64 --decode \
+        | yq eval .clusterConfig - \
+      )
+
+      ret=0
+      assertConfigValue() {
+        config_path="$1"
+        expected="$2"
+        config_value=$(echo "$config_yaml" | yq eval "$config_path" -)
+        [[ "$config_value" == "$expected" ]] || {
+          echo "Assertion failed: ${config_path} != ${expected} (actual: $config_value)"
+          ret=1
+        }
+      }
+
+      assertConfigValue ".dynamicConfig.admissionControllerConfig.scanInline" "false"
+
+      exit $ret


### PR DESCRIPTION
## Description

1. The options
```
admissionControl:
  listenOnCreates: # bool
  listenOnUpdates: # bool
  listenOnEvents:  # bool
```
are deprecated. Setting them has no effect as they are ignored (one exception, see second point). The Helm chart will treat them as enabled.

2. The field
```
admissionControl:
  enforce: # bool
```
has been added. Defaults to `true` on fresh installations. On upgrades, this setting will default to `true` if and only if at least one of the previous options `listenOnCreates`, `listenOnUpdates` is enabled.

3. The field
```
admissionControl:
  contactImageScanners: # string
```
is deprecated. It is not picked up by the translator. The Helm chart will make sure to enable inline scanning without any way to opt-out.

4. For the field
```
admissionControl:
  bypass: BreakGlassAnnotation|Disabled
```
there are no user-visible changes, but internally we have switched from static CRD defaulting to runtime defaulting.

5. The field
```
admissionControl:
  timeoutSeconds: # integer
```
is deprecated. It will not be picked up by the translator. The Helm chart uses an unchangeable reasonable default.

6. The field
```
admissionControl:
  failuryPolicy: Ignore|Fail
```
has been added. It defaults to `Ignore` if not specified.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] documentation PR is tracked separately: ROX-30434

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] added e2e tests
- [x] modified existing tests

### How I validated my change

#### Verified that Webhooks are enabled even if disabled in the CRD by setting the `listenOn*` fields to `false`.

Deploy new version and enable feature flag:
```
kubectl -n rhacs-operator-system set env deploy/rhacs-operator-controller-manager ROX_ADMISSION_CONTROLLER_CONFIG=true
```

```
$ kc -n acs-sensor get securedclusters.platform.stackrox.io stackrox-secured-cluster-services -o json | jq .spec.admissionContro
l
{
  "listenOnCreates": false,
  "listenOnEvents": false,
  "listenOnUpdates": false
}
$ kc get validatingwebhookconfigurations.admissionregistration.k8s.io stackrox -o yaml | yq '.webhooks[].name'
policyeval.stackrox.io
k8sevents.stackrox.io
```

### The new 'enforce' field is enabled by default on fresh installations

Deploy new version and enable feature flag:
```
kubectl -n rhacs-operator-system \
  set env deploy/rhacs-operator-controller-manager ROX_ADMISSION_CONTROLLER_CONFIG=true
```

```
$ kc -n acs-sensor get securedclusters.platform.stackrox.io stackrox-secured-cluster-services -o yaml | yq .spec
centralEndpoint: 35.192.158.154:443
clusterName: sensor-1529
imagePullSecrets:
  - name: stackrox
$
```
Enforcement is not specified in the CR.

```
$ kc -n acs-sensor get secret helm-cluster-config -o json | jq -r '.data["config.yaml"]' | base64 -d | yq .clusterConfig.dynamicConfig
disableAuditLogs: true
admissionControllerConfig:
  enabled: true
  timeoutSeconds: 10
  scanInline: true
  disableBypass: false
  enforceOnUpdates: true
registryOverride:
$
```
Enforcement is enabled by default.

### The new 'enforce' field can be toggled

Deploy the whole stack with the feature flag enabled and use
```
kubectl -n acs-sensor patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type=merge -p '{"spec":{"admissionControl":{"enforce":false}}}'
```
and
```
kubectl -n acs-sensor patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type=merge -p '{"spec":{"admissionControl":{"enforce":true}}}'
```
for toggling the field.

Observe with
```
kubectl -n acs-sensor get secret helm-cluster-config -o json | jq -r '.data["config.yaml"]' | base64 -d | yq .clusterConfig.dynamicConfig    
```
that the dynamic config behaves as expected, i.e.
```
admissionControllerConfig:
  enabled: false
  timeoutSeconds: 10
  scanInline: true
  disableBypass: false
  enforceOnUpdates: false
```
after setting `enforce: false` and
```
admissionControllerConfig:
  enabled: true
  timeoutSeconds: 10
  scanInline: true
  disableBypass: false
  enforceOnUpdates: true
```
after setting `enforce: true`.

### On upgrades, the `enforce` field defaults to `false` if all `listenOn*` field are `false`.

Install old operator, e.g. `4.8.2-0-g323840e2a9`.

Disable enforcement using the `listenOn*` properties:

```
$ kubectl -n acs-sensor patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type=merge -p '{"spec":{"admissionControl":{"listenOnCreates":false,"listenOnUpdates":false,"listenOnEvents":false}}}'
$
```

Upgrade operator and confirm the following:
```
❯ kc -n acs-sensor get secret helm-cluster-config -o json | jq -r '.data["config.yaml"]' | base64 -d | yq .clusterConfig.dynamicConfig
disableAuditLogs: true
admissionControllerConfig:
  enabled: false
  [...]
  enforceOnUpdates: false
  [...]
$
```

### On upgrades, the `enforce` field defaults to `true` if any `listenOn*` field is `true`.

Install old operator, e.g. `4.8.2-0-g323840e2a9`.

Set exactly one `listenOn*` property:

```
kubectl -n acs-sensor patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type=merge -p '{"spec":{"admissionControl":{"listenOnCreates":true,"listenOnUpdates":false,"listenOnEvents":false}}}'
```

Current config:
```
$ kc -n acs-sensor get secret helm-cluster-config -o json | jq -r '.data["config.yaml"]' | base64 -d | yq .clusterConfig.dynamicConfig
disableAuditLogs: true
admissionControllerConfig:
  enabled: true
[...]
  enforceOnUpdates: false
[...]
```

Upgrade operator and confirm the following:
```
$ kc -n acs-sensor get secret helm-cluster-config -o json | jq -r '.data["config.yaml"]' | base64 -d | yq .clusterConfig.dynamicConfig
disableAuditLogs: true
admissionControllerConfig:
  enabled: true
[...]
  enforceOnUpdates: true
[...]
$
```

### Field "contactImageScanners" is ignored.

Deploy new operator, central & sensor.

```
$ kubectl -n acs-sensor patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type=merge -p '{"spec":{"admissionControl":{"contactImageScanners":"DoNotScanInline"}}}'
```

Wait for reconciliation and confirm:

```
$ kubectl -n acs-sensor get secret helm-cluster-config -o json | jq -r '.data["config.yaml"]' | base64 -d | yq .clusterConfig.dynamicConfig
disableAuditLogs: true
admissionControllerConfig:
[...]
  scanInline: true
[...]
```

### Field "timeoutSeconds" is ignored.

Deploy new operator, central & sensor.

```
$ kubectl -n acs-sensor patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type=merge -p '{"spec":{"admissionControl":{"timeoutSeconds":5}}}'  
securedcluster.platform.stackrox.io/stackrox-secured-cluster-services patched
```

Wait for reconciliation and confirm:

```
$ kc -n acs-sensor get validatingwebhookconfigurations.admissionregistration.k8s.io stackrox -o yaml | rg timeoutSeconds:
  timeoutSeconds: 12
  timeoutSeconds: 12
```
```
$ kc -n acs-sensor get secret helm-cluster-config -o json | jq -r '.data["config.yaml"]' | base64 -d | yq .clusterConfig.dynamicConfig.admissionControllerConfig.timeoutSeconds
10
```

### Field "failurePolicy" is respected.

Deploy new operator, central & sensor.

```
$ kubectl -n acs-sensor patch securedclusters.platform.stackrox.io stackrox-secured-cluster-services --type=merge -p '{"spec":{"admissionControl":{"failurePolicy":"Fail"}}}' 
securedcluster.platform.stackrox.io/stackrox-secured-cluster-services patched
```

Wait for reconciliation and confirm:

```
$ kc -n acs-sensor get validatingwebhookconfigurations.admissionregistration.k8s.io stackrox -o yaml | rg -i failurePolicy:
  failurePolicy: Fail
  failurePolicy: Fail
```

