### PR TITLE
ROX-30375: Added changes to parse query string for ondemand reports

### DIFF
--- a/central/reports/common/query_builder_view_based.go
+++ b/central/reports/common/query_builder_view_based.go
@@ -3,12 +3,9 @@ package common
 import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/sac"
-	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
-	"github.com/stackrox/rox/pkg/search"
 )
 
-// ReportQuery encapsulates the cve specific fields query, and the resource scope
+// ReportQueryViewBased encapsulates the cve specific fields query, and the resource scope
 // queries to be used in a report generation run
 type ReportQueryViewBased struct {
 	CveFieldsQuery         string
@@ -19,7 +16,7 @@ type queryBuilderViewBased struct {
 	vulnFilters *storage.ViewBasedVulnerabilityReportFilters
 }
 
-// NewVulnReportQueryBuilder builds a query builder to build scope and cve filtering queries for vuln reporting
+// NewVulnReportQueryBuilderViewBased builds a query builder to build scope and cve filtering queries for vuln reporting
 func NewVulnReportQueryBuilderViewBased(vulnFilters *storage.ViewBasedVulnerabilityReportFilters) *queryBuilderViewBased {
 	return &queryBuilderViewBased{
 		vulnFilters: vulnFilters,
@@ -29,7 +26,7 @@ func NewVulnReportQueryBuilderViewBased(vulnFilters *storage.ViewBasedVulnerabil
 // BuildQueryViewBased builds scope and cve filtering queries for view-based vuln reporting
 func (q *queryBuilderViewBased) BuildQueryViewBased(clusters []*storage.Cluster,
 	namespaces []*storage.NamespaceMetadata) (*ReportQueryViewBased, error) {
-	deploymentsScopedQuery, err := q.buildAccessScopeQueryViewBased(clusters, namespaces)
+	deploymentsScopedQuery, err := BuildAccessScopeQueryViewBased(q.vulnFilters.GetAccessScopeRules(), clusters, namespaces)
 	if err != nil {
 		return nil, err
 	}
@@ -45,32 +42,4 @@ func (q *queryBuilderViewBased) BuildQueryViewBased(clusters []*storage.Cluster,
 func (q *queryBuilderViewBased) buildCVEAttributesQueryViewBased() string {
 	vulnReportFilters := q.vulnFilters
 	return vulnReportFilters.GetQuery()
-}
-
-func (q *queryBuilderViewBased) buildAccessScopeQueryViewBased(clusters []*storage.Cluster,
-	namespaces []*storage.NamespaceMetadata) (*v1.Query, error) {
-	accessScopeRules := q.vulnFilters.GetAccessScopeRules()
-	if accessScopeRules == nil {
-		return search.EmptyQuery(), nil
-	}
-	var scopeTree *effectiveaccessscope.ScopeTree
-	for _, rules := range accessScopeRules {
-		sct, err := effectiveaccessscope.ComputeEffectiveAccessScope(rules, clusters, namespaces, v1.ComputeEffectiveAccessScopeRequest_MINIMAL)
-		if err != nil {
-			return nil, err
-		}
-		if scopeTree == nil {
-			scopeTree = sct
-		} else {
-			scopeTree.Merge(sct)
-		}
-	}
-	scopeQuery, err := sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
-	if err != nil {
-		return nil, err
-	}
-	if scopeQuery == nil {
-		return search.EmptyQuery(), nil
-	}
-	return scopeQuery, nil
 }

--- a/central/reports/common/query_builder_view_based.go
+++ b/central/reports/common/query_builder_view_based.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"time"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+// ReportQuery encapsulates the cve specific fields query, and the resource scope
+// queries to be used in a report generation run
+type ReportQueryViewBased struct {
+	CveFieldsQuery         string
+	DeploymentsScopedQuery *v1.Query
+}
+
+type queryBuilderViewBased struct {
+	vulnFilters   *storage.ViewBasedVulnerabilityReportFilters
+	dataStartTime time.Time
+}
+
+// NewVulnReportQueryBuilder builds a query builder to build scope and cve filtering queries for vuln reporting
+func NewVulnReportQueryBuilderViewBased(vulnFilters *storage.ViewBasedVulnerabilityReportFilters, dataStartTime time.Time) *queryBuilderViewBased {
+	return &queryBuilderViewBased{
+		vulnFilters:   vulnFilters,
+		dataStartTime: dataStartTime,
+	}
+}
+
+// BuildQuery builds scope and cve filtering queries for vuln reporting
+func (q *queryBuilderViewBased) BuildQueryViewBased(clusters []*storage.Cluster,
+	namespaces []*storage.NamespaceMetadata) (*ReportQueryViewBased, error) {
+	scopeQuery, err := q.buildAccessScopeQueryViewBased(clusters, namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	cveQuery := q.buildCVEAttributesQueryViewBased()
+	if err != nil {
+		return nil, err
+	}
+	return &ReportQueryViewBased{
+		CveFieldsQuery:         cveQuery,
+		DeploymentsScopedQuery: scopeQuery,
+	}, nil
+}
+
+func (q *queryBuilderViewBased) buildCVEAttributesQueryViewBased() string {
+	vulnReportFilters := q.vulnFilters
+	return vulnReportFilters.GetQuery()
+}
+
+func (q *queryBuilderViewBased) buildAccessScopeQueryViewBased(clusters []*storage.Cluster,
+	namespaces []*storage.NamespaceMetadata) (*v1.Query, error) {
+	accessScopeRules := q.vulnFilters.GetAccessScopeRules()
+	var scopeTree *effectiveaccessscope.ScopeTree
+	for _, rules := range accessScopeRules {
+		sct, err := effectiveaccessscope.ComputeEffectiveAccessScope(rules, clusters, namespaces, v1.ComputeEffectiveAccessScopeRequest_MINIMAL)
+		if err != nil {
+			return nil, err
+		}
+		if scopeTree == nil {
+			scopeTree = sct
+		} else {
+			scopeTree.Merge(sct)
+		}
+	}
+	scopeQuery, err := sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	if scopeQuery == nil {
+		return search.EmptyQuery(), nil
+	}
+	return scopeQuery, nil
+}
+
+func filterVulnsByFirstOccurrenceTimeViewBased(vulnReportFilters *storage.VulnerabilityReportFilters) bool {
+	return vulnReportFilters.GetSinceLastSentScheduledReport() || vulnReportFilters.GetSinceStartDate() != nil
+}

--- a/central/reports/common/query_builder_view_based.go
+++ b/central/reports/common/query_builder_view_based.go
@@ -57,12 +57,12 @@ func (q *queryBuilderViewBased) buildCVEAttributesQueryViewBased() string {
 func (q *queryBuilderViewBased) buildAccessScopeQueryViewBased(clusters []*storage.Cluster,
 	namespaces []*storage.NamespaceMetadata) (*v1.Query, error) {
 	accessScopeRules := q.vulnFilters.GetAccessScopeRules()
-	if len(accessScopeRules) == 0 {
-		// For view-based reports, if no access scope rules are specified,
-		// we allow access to all clusters and namespaces
+	if accessScopeRules == nil {
+		// Old(v1) report configurations would have nil access scope rules.
+		// For backward compatibility, nil access scope would mean access to all clusters and namespaces.
+		// To deny access to all clusters and namespaces, the accessScopeRules should be empty.
 		return search.EmptyQuery(), nil
 	}
-
 	var scopeTree *effectiveaccessscope.ScopeTree
 	for _, rules := range accessScopeRules {
 		sct, err := effectiveaccessscope.ComputeEffectiveAccessScope(rules, clusters, namespaces, v1.ComputeEffectiveAccessScopeRequest_MINIMAL)

--- a/central/reports/common/query_builder_view_based.go
+++ b/central/reports/common/query_builder_view_based.go
@@ -6,8 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 )
 
-// ReportQueryViewBased encapsulates the cve specific fields query, and the resource scope
-// queries to be used in a report generation run
+// ReportQueryViewBased returns deployed images query and watched images query
 type ReportQueryViewBased struct {
 	DeployedImagesQuery *v1.Query
 	WatchedImagesQuery  *v1.Query
@@ -32,7 +31,7 @@ func (q *queryBuilderViewBased) BuildQueryViewBased(clusters []*storage.Cluster,
 		return nil, err
 	}
 
-	cveQuery := q.buildCVEAttributesQueryViewBased()
+	cveQuery := q.getViewBasedReportQueryString()
 	cveFilterQuery, err := search.ParseQuery(cveQuery, search.MatchAllIfEmpty())
 	if err != nil {
 		return nil, err
@@ -49,7 +48,7 @@ func (q *queryBuilderViewBased) BuildQueryViewBased(clusters []*storage.Cluster,
 	}, nil
 }
 
-func (q *queryBuilderViewBased) buildCVEAttributesQueryViewBased() string {
+func (q *queryBuilderViewBased) getViewBasedReportQueryString() string {
 	vulnReportFilters := q.vulnFilters
 	return vulnReportFilters.GetQuery()
 }

--- a/central/reports/common/utils.go
+++ b/central/reports/common/utils.go
@@ -5,6 +5,8 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 	"github.com/stackrox/rox/pkg/search"
 )
 
@@ -59,4 +61,32 @@ func WithoutV1ReportConfigs(query *v1.Query) *v1.Query {
 	return search.ConjunctionQuery(
 		query,
 		search.NewQueryBuilder().AddExactMatches(search.EmbeddedCollectionID, "").ProtoQuery())
+}
+
+// BuildAccessScopeQueryViewBased builds v1 query for given access scope rules
+func BuildAccessScopeQueryViewBased(accessScopeRules []*storage.SimpleAccessScope_Rules, clusters []*storage.Cluster,
+	namespaces []*storage.NamespaceMetadata) (*v1.Query, error) {
+	if accessScopeRules == nil {
+		return search.EmptyQuery(), nil
+	}
+	var scopeTree *effectiveaccessscope.ScopeTree
+	for _, rules := range accessScopeRules {
+		sct, err := effectiveaccessscope.ComputeEffectiveAccessScope(rules, clusters, namespaces, v1.ComputeEffectiveAccessScopeRequest_MINIMAL)
+		if err != nil {
+			return nil, err
+		}
+		if scopeTree == nil {
+			scopeTree = sct
+		} else {
+			scopeTree.Merge(sct)
+		}
+	}
+	scopeQuery, err := sac.BuildClusterNamespaceLevelSACQueryFilter(scopeTree)
+	if err != nil {
+		return nil, err
+	}
+	if scopeQuery == nil {
+		return search.EmptyQuery(), nil
+	}
+	return scopeQuery, nil
 }

--- a/central/reports/common/utils.go
+++ b/central/reports/common/utils.go
@@ -64,7 +64,7 @@ func WithoutV1ReportConfigs(query *v1.Query) *v1.Query {
 }
 
 // BuildAccessScopeQueryViewBased builds v1 query for given access scope rules
-func BuildAccessScopeQueryViewBased(accessScopeRules []*storage.SimpleAccessScope_Rules, clusters []*storage.Cluster,
+func BuildAccessScopeQuery(accessScopeRules []*storage.SimpleAccessScope_Rules, clusters []*storage.Cluster,
 	namespaces []*storage.NamespaceMetadata) (*v1.Query, error) {
 	if accessScopeRules == nil {
 		return search.EmptyQuery(), nil

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -286,8 +286,8 @@ func (rg *reportGeneratorImpl) getReportDataSQF(snap *storage.ReportSnapshot, co
 	}, nil
 }
 
-func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapshot, dataStartTime time.Time) (*ReportData, error) {
-	rQuery, err := rg.buildReportQueryViewBased(snap, dataStartTime)
+func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapshot) (*ReportData, error) {
+	rQuery, err := rg.buildReportQueryViewBased(snap)
 	if err != nil {
 		return nil, err
 	}
@@ -346,9 +346,8 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapsh
 
 }
 
-func (rg *reportGeneratorImpl) buildReportQueryViewBased(snap *storage.ReportSnapshot, dataStartTime time.Time) (*common.ReportQueryViewBased, error) {
-	qb := common.NewVulnReportQueryBuilderViewBased(snap.GetViewBasedVulnReportFilters(),
-		dataStartTime)
+func (rg *reportGeneratorImpl) buildReportQueryViewBased(snap *storage.ReportSnapshot) (*common.ReportQueryViewBased, error) {
+	qb := common.NewVulnReportQueryBuilderViewBased(snap.GetViewBasedVulnReportFilters())
 	allClusters, err := rg.clusterDatastore.GetClusters(reportGenCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching clusters to build report query")

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -346,13 +346,30 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapsh
 
 }
 
-func (rg *reportGeneratorImpl) buildReportQueryViewBased(snap *storage.ReportSnapshot) (*common.ReportQueryViewBased, error) {
-	qb := common.NewVulnReportQueryBuilderViewBased(snap.GetViewBasedVulnReportFilters())
+func (rg *reportGeneratorImpl) getNamespaces() ([]*storage.NamespaceMetadata, error) {
+
+	allNamespaces, err := rg.namespaceDatastore.GetAllNamespaces(reportGenCtx)
+	if err != nil {
+		return nil, errors.Wrap(err, "error fetching namespaces to build report query")
+	}
+	return allNamespaces, nil
+}
+
+func (rg *reportGeneratorImpl) getClusters() ([]*storage.Cluster, error) {
 	allClusters, err := rg.clusterDatastore.GetClusters(reportGenCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching clusters to build report query")
 	}
-	allNamespaces, err := rg.namespaceDatastore.GetAllNamespaces(reportGenCtx)
+	return allClusters, nil
+}
+
+func (rg *reportGeneratorImpl) buildReportQueryViewBased(snap *storage.ReportSnapshot) (*common.ReportQueryViewBased, error) {
+	qb := common.NewVulnReportQueryBuilderViewBased(snap.GetViewBasedVulnReportFilters())
+	allClusters, err := rg.getClusters()
+	if err != nil {
+		return nil, errors.Wrap(err, "error fetching clusters to build report query")
+	}
+	allNamespaces, err := rg.getNamespaces()
 	if err != nil {
 		return nil, errors.Wrap(err, "error fetching namespaces to build report query")
 	}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -218,6 +218,23 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			},
 		},
 		{
+			name:  "View-based report filtering by NVD CVSS score",
+			query: "NVD CVSS:>=8",
+			expected: &viewBasedReportData{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+				},
+			},
+		},
+		{
 			name:  "View-based report filtering by vulnerability state",
 			query: "Vulnerability State:OBSERVED",
 			expected: &viewBasedReportData{

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -306,13 +306,11 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			query: "Cluster:c1",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
@@ -321,9 +319,9 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			query: "Namespace:c1_ns1",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp", "CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp", "CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp"},
+				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp"},
 			},
 		},
 		{
@@ -333,7 +331,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 				deploymentNames: []string{"c1_ns1_dep0"},
 				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
 				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp", "CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp", "CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp"},
+				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp"},
 			},
 		},
 		// Test cases for fixability-related search fields
@@ -342,15 +340,13 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			query: "Fixable:false",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
 				cveNames: []string{
 					"CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-					"CVE-nonFixable_low-w0_img_comp",
-					"CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
@@ -360,13 +356,11 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			query: "Cluster:c1+Severity:CRITICAL_VULNERABILITY_SEVERITY+Fixable:true",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
@@ -472,24 +466,6 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
 					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
 					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
-				},
-			},
-		},
-		// Test cases for negation queries
-		{
-			name:  "View-based report with negation query for severity",
-			query: "!Severity:LOW_VULNERABILITY_SEVERITY",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-				cveNames: []string{
-					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -330,7 +330,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
 				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp"},
 				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp"},
 			},
 		},
@@ -340,13 +340,15 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			query: "Fixable:false",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-nonFixable_low-w0_img_comp",
+					"CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
@@ -364,62 +366,28 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 				},
 			},
 		},
-		//Test cases for timestamp-based search fields
-		{
-			name:  "View-based report filtering by first image occurrence timestamp range",
-			query: "First Image Occurrence Timestamp:>01/01/2020",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-				cveNames: []string{
-					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
-				},
-			},
-		},
+		////Test cases for timestamp-based search fields
+		//{
+		//	name:  "View-based report filtering by first image occurrence timestamp range",
+		//	query: "First Image Occurrence Timestamp:>01/01/2020",
+		//	expected: &viewBasedReportData{
+		//		deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+		//		imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+		//		componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+		//		cveNames: []string{
+		//			"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+		//			"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
+		//			"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
+		//			"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+		//			"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+		//			"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
+		//		},
+		//	},
+		//},
 		// Test cases for advanced search fields - EPSS and Advisory fields
 		{
 			name:  "View-based report filtering by EPSS Probability",
 			query: "EPSS Probability:>=0.0",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-				cveNames: []string{
-					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
-				},
-			},
-		},
-		{
-			name:  "View-based report filtering by Advisory Name",
-			query: "Advisory Name:RHSA-2025-CVE-fixable",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-				cveNames: []string{
-					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
-				},
-			},
-		},
-		{
-			name:  "View-based report filtering by Advisory Link",
-			query: "Advisory Link:test-rhsa-link",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
 				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -158,12 +158,14 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
 				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
@@ -172,13 +174,17 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			query: "",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+					"CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
@@ -210,23 +216,23 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 				},
 			},
 		},
-		{
-			name:  "View-based report filtering by NVD CVSS score",
-			query: "NVD CVSS:>=8.0",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-				cveNames: []string{
-					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp",
-				},
-			},
-		},
+		//{
+		//	name:  "View-based report filtering by NVD CVSS score",
+		//	query: "NVD CVSS:>=8",
+		//	expected: &viewBasedReportData{
+		//		deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+		//		imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+		//		componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+		//		cveNames: []string{
+		//			"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+		//			"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+		//			"CVE-fixable_critical-c2_ns1_dep0_img_comp",
+		//			"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+		//			"CVE-fixable_critical-w0_img_comp",
+		//			"CVE-fixable_critical-w1_img_comp",
+		//		},
+		//	},
+		//},
 		{
 			name:  "View-based report filtering by vulnerability state",
 			query: "Vulnerability State:OBSERVED",
@@ -303,7 +309,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		// Test cases for deployment-related search fields
 		{
 			name:  "View-based report filtering by cluster name",
-			query: "Cluster:c1",
+			query: "Cluster:r/c1",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
 				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img"},
@@ -316,20 +322,20 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		},
 		{
 			name:  "View-based report filtering by namespace",
-			query: "Namespace:c1_ns1",
+			query: "Namespace:r/ns1",
 			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp"},
-				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp"},
+				deploymentNames: []string{"c1_ns1_dep0", "c2_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c2_ns1_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c2_ns1_dep0_img_comp"},
+				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp", "CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp"},
 			},
 		},
 		{
 			name:  "View-based report filtering by deployment name",
-			query: "Deployment:c1_ns1_dep0",
+			query: "Deployment:r/c1_ns1_dep0",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
+				imageNames:      []string{"c1_ns1_dep0_img"},
 				componentNames:  []string{"c1_ns1_dep0_img_comp"},
 				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp"},
 			},

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -724,7 +724,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedAccessScope() {
 		expected   *viewBasedReportData
 	}{
 		{
-			name: "View-based report with deployed images,CVE severity filter,access scope ns1,c1",
+			name: "View-based report with access scope rules",
 			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
 				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
 			},

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -232,7 +232,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		//			"CVE-fixable_critical-w1_img_comp",
 		//		},
 		//	},
-		//},
+		// },
 		{
 			name:  "View-based report filtering by vulnerability state",
 			query: "Vulnerability State:OBSERVED",
@@ -389,7 +389,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		//			"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 		//		},
 		//	},
-		//},
+		// },
 		// Test cases for advanced search fields - EPSS and Advisory fields
 		{
 			name:  "View-based report filtering by EPSS Probability",

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -1,0 +1,363 @@
+//go:build sql_integration
+
+package reportgenerator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	blobDS "github.com/stackrox/rox/central/blob/datastore"
+	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	"github.com/stackrox/rox/central/graphql/resolvers"
+	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
+	namespaceDSMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	collectionPostgres "github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres"
+	deploymentsView "github.com/stackrox/rox/central/views/deployments"
+	imagesView "github.com/stackrox/rox/central/views/images"
+	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	postgresSchema "github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestViewBasedReporting(t *testing.T) {
+	suite.Run(t, new(ViewBasedReportingTestSuite))
+}
+
+type ViewBasedReportingTestSuite struct {
+	suite.Suite
+	mockCtrl *gomock.Controller
+
+	ctx                     context.Context
+	testDB                  *pgtest.TestPostgres
+	reportGenerator         *reportGeneratorImpl
+	resolver                *resolvers.Resolver
+	schema                  *graphql.Schema
+	watchedImageDatastore   watchedImageDS.DataStore
+	collectionQueryResolver collectionDS.QueryResolver
+	clusterDatastore        *clusterDSMocks.MockDataStore
+	namespaceDatastore      *namespaceDSMocks.MockDataStore
+	blobStore               blobDS.Datastore
+}
+
+type viewBasedReportData struct {
+	deploymentNames []string
+	imageNames      []string
+	componentNames  []string
+	cveNames        []string
+	cvss            []float64
+}
+
+func (s *ViewBasedReportingTestSuite) SetupSuite() {
+	s.ctx = loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
+	s.mockCtrl = gomock.NewController(s.T())
+	s.testDB = resolvers.SetupTestPostgresConn(s.T())
+
+	// Create data stores based on feature flag
+	if features.FlattenCVEData.Enabled() {
+		imageDataStore := resolvers.CreateTestImageV2Datastore(s.T(), s.testDB, s.mockCtrl)
+		s.resolver, s.schema = resolvers.SetupTestResolver(s.T(),
+			imagesView.NewImageView(s.testDB.DB),
+			imageDataStore,
+			resolvers.CreateTestImageComponentV2Datastore(s.T(), s.testDB, s.mockCtrl),
+			resolvers.CreateTestImageCVEV2Datastore(s.T(), s.testDB),
+			resolvers.CreateTestDeploymentDatastore(s.T(), s.testDB, s.mockCtrl, imageDataStore),
+			deploymentsView.NewDeploymentView(s.testDB.DB),
+		)
+	} else {
+		imageDataStore := resolvers.CreateTestImageDatastore(s.T(), s.testDB, s.mockCtrl)
+		imageCVEDatastore := resolvers.CreateTestImageCVEDatastore(s.T(), s.testDB)
+		s.resolver, s.schema = resolvers.SetupTestResolver(s.T(),
+			imageDataStore,
+			imagesView.NewImageView(s.testDB.DB),
+			resolvers.CreateTestImageComponentDatastore(s.T(), s.testDB, s.mockCtrl),
+			imageCVEDatastore,
+			resolvers.CreateTestImageComponentCVEEdgeDatastore(s.T(), s.testDB),
+			resolvers.CreateTestImageCVEEdgeDatastore(s.T(), s.testDB),
+			resolvers.CreateTestDeploymentDatastore(s.T(), s.testDB, s.mockCtrl, imageDataStore),
+			deploymentsView.NewDeploymentView(s.testDB.DB),
+		)
+	}
+
+	var err error
+	collectionStore := collectionPostgres.CreateTableAndNewStore(s.ctx, s.testDB.DB, s.testDB.GetGormDB(s.T()))
+	_, s.collectionQueryResolver, err = collectionDS.New(collectionStore)
+	s.NoError(err)
+
+	s.watchedImageDatastore = watchedImageDS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	s.clusterDatastore = clusterDSMocks.NewMockDataStore(s.mockCtrl)
+	s.namespaceDatastore = namespaceDSMocks.NewMockDataStore(s.mockCtrl)
+	s.blobStore = blobDS.NewTestDatastore(s.T(), s.testDB.DB)
+
+	s.reportGenerator = newReportGeneratorImpl(s.testDB, nil, s.resolver.DeploymentDataStore,
+		s.watchedImageDatastore, s.collectionQueryResolver, nil, s.blobStore, s.clusterDatastore,
+		s.namespaceDatastore, s.resolver.ImageCVEDataStore, s.resolver.ImageCVEV2DataStore, s.schema)
+}
+
+func (s *ViewBasedReportingTestSuite) TearDownSuite() {
+	s.mockCtrl.Finish()
+}
+
+func (s *ViewBasedReportingTestSuite) TearDownTest() {
+	s.truncateTable(postgresSchema.DeploymentsTableName)
+	s.truncateTable(postgresSchema.ImagesTableName)
+	s.truncateTable(postgresSchema.ImageComponentV2TableName)
+	s.truncateTable(postgresSchema.ImageCvesV2TableName)
+
+	s.truncateTable(postgresSchema.CollectionsTableName)
+}
+
+func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
+	clusters := []*storage.Cluster{
+		{Id: uuid.NewV4().String(), Name: "c1"},
+		{Id: uuid.NewV4().String(), Name: "c2"},
+	}
+
+	namespaces := testNamespaces(clusters, 2)
+
+	deployments, images := testDeploymentsWithImages(namespaces, 1)
+	s.upsertManyImages(images)
+	s.upsertManyDeployments(deployments)
+
+	watchedImages := testWatchedImages(2)
+	s.upsertManyImages(watchedImages)
+	s.upsertManyWatchedImages(watchedImages)
+
+	s.clusterDatastore.EXPECT().GetClusters(gomock.Any()).
+		Return(clusters, nil).AnyTimes()
+
+	s.namespaceDatastore.EXPECT().GetAllNamespaces(gomock.Any()).
+		Return(namespaces, nil).AnyTimes()
+
+	testCases := []struct {
+		name       string
+		imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType
+		query      string
+		expected   *viewBasedReportData
+	}{
+		{
+			name: "View-based report with deployed images and CVE severity filter",
+			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
+				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
+			},
+			query: "SEVERITY:CRITICAL_VULNERABILITY_SEVERITY",
+			expected: &viewBasedReportData{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+				},
+			},
+		},
+		{
+			name: "View-based report with watched images and fixable filter",
+			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
+				storage.ViewBasedVulnerabilityReportFilters_WATCHED,
+			},
+			query: "Fixable:true",
+			expected: &viewBasedReportData{
+				deploymentNames: []string{},
+				imageNames:      []string{"w0_img", "w1_img"},
+				componentNames:  []string{"w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+				},
+			},
+		},
+		{
+			name: "View-based report with both deployed and watched images",
+			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
+				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
+				storage.ViewBasedVulnerabilityReportFilters_WATCHED,
+			},
+			query: "CVE Severity:CRITICAL,IMPORTANT",
+			expected: &viewBasedReportData{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames: []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp",
+					"w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+				},
+			},
+		},
+		{
+			name: "View-based report with complex query combining multiple fields",
+			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
+				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
+			},
+			query: "CVE Severity:CRITICAL+Fixable:true",
+			expected: &viewBasedReportData{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+				},
+			},
+		},
+		{
+			name: "View-based report with empty query (should return all vulnerabilities)",
+			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
+				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
+			},
+			query: "",
+			expected: &viewBasedReportData{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			reportSnap := testViewBasedReportSnapshot(tc.imageTypes, tc.query)
+			// Test get data using view-based approach
+			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap, time.Time{})
+			s.NoError(err)
+			collected := s.collectViewBasedReportData(reportData.CVEResponses)
+			s.ElementsMatch(tc.expected.deploymentNames, collected.deploymentNames)
+			s.ElementsMatch(tc.expected.imageNames, collected.imageNames)
+			s.ElementsMatch(tc.expected.componentNames, collected.componentNames)
+			s.ElementsMatch(tc.expected.cveNames, collected.cveNames)
+			s.Equal(len(tc.expected.cveNames), reportData.NumDeployedImageResults+reportData.NumWatchedImageResults)
+			s.Equal(len(tc.expected.cveNames), len(collected.cvss))
+		})
+	}
+}
+
+func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedWithInvalidQuery() {
+	clusters := []*storage.Cluster{
+		{Id: uuid.NewV4().String(), Name: "c1"},
+	}
+
+	namespaces := testNamespaces(clusters, 1)
+	deployments, images := testDeploymentsWithImages(namespaces, 1)
+	s.upsertManyImages(images)
+	s.upsertManyDeployments(deployments)
+
+	s.clusterDatastore.EXPECT().GetClusters(gomock.Any()).
+		Return(clusters, nil).AnyTimes()
+	s.namespaceDatastore.EXPECT().GetAllNamespaces(gomock.Any()).
+		Return(namespaces, nil).AnyTimes()
+
+	testCases := []struct {
+		name       string
+		imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType
+		query      string
+		expectErr  bool
+	}{
+		{
+			name: "Invalid field in query",
+			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
+				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
+			},
+			query:     "InvalidField:value",
+			expectErr: false, // Invalid fields are typically ignored by the query parser
+		},
+		{
+			name: "Malformed query syntax",
+			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
+				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
+			},
+			query:     "CVE Severity:",
+			expectErr: false, // Empty values are typically handled gracefully
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			reportSnap := testViewBasedReportSnapshot(tc.imageTypes, tc.query)
+			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap, time.Time{})
+			if tc.expectErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+				s.NotNil(reportData)
+			}
+		})
+	}
+}
+
+// Helper functions
+func (s *ViewBasedReportingTestSuite) truncateTable(name string) {
+	sql := fmt.Sprintf("TRUNCATE %s CASCADE", name)
+	_, err := s.testDB.Exec(s.ctx, sql)
+	s.NoError(err)
+}
+
+func (s *ViewBasedReportingTestSuite) upsertManyImages(images []*storage.Image) {
+	for _, img := range images {
+		err := s.resolver.ImageDataStore.UpsertImage(s.ctx, img)
+		s.NoError(err)
+	}
+}
+
+func (s *ViewBasedReportingTestSuite) upsertManyWatchedImages(images []*storage.Image) {
+	for _, img := range images {
+		err := s.watchedImageDatastore.UpsertWatchedImage(s.ctx, img.Name.FullName)
+		s.NoError(err)
+	}
+}
+
+func (s *ViewBasedReportingTestSuite) upsertManyDeployments(deployments []*storage.Deployment) {
+	for _, dep := range deployments {
+		err := s.resolver.DeploymentDataStore.UpsertDeployment(s.ctx, dep)
+		s.NoError(err)
+	}
+}
+
+func (s *ViewBasedReportingTestSuite) collectViewBasedReportData(cveResponses []*ImageCVEQueryResponse) *viewBasedReportData {
+	deploymentNames := set.NewStringSet()
+	imageNames := set.NewStringSet()
+	componentNames := set.NewStringSet()
+	cveNames := make([]string, 0)
+	cvss := make([]float64, 0)
+
+	for _, res := range cveResponses {
+		if res.GetDeployment() != "" {
+			deploymentNames.Add(res.GetDeployment())
+		}
+		imageNames.Add(res.GetImage())
+		componentNames.Add(res.GetComponent())
+		cveNames = append(cveNames, res.GetCVE())
+		cvss = append(cvss, res.GetCVSS())
+	}
+	return &viewBasedReportData{
+		deploymentNames: deploymentNames.AsSlice(),
+		imageNames:      imageNames.AsSlice(),
+		componentNames:  componentNames.AsSlice(),
+		cveNames:        cveNames,
+		cvss:            cvss,
+	}
+}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -409,7 +409,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 				},
 			},
 		},
-		//Test cases for timestamp-based search fields
+		// Test cases for timestamp-based search fields
 		{
 			name:  "View-based report filtering by first image occurrence timestamp range",
 			query: "First Image Occurrence Timestamp:<01/01/2020",

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -217,23 +217,6 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 				},
 			},
 		},
-		//{
-		//	name:  "View-based report filtering by NVD CVSS score",
-		//	query: "NVD CVSS:>=8",
-		//	expected: &viewBasedReportData{
-		//		deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-		//		imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-		//		componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-		//		cveNames: []string{
-		//			"CVE-fixable_critical-c1_ns1_dep0_img_comp",
-		//			"CVE-fixable_critical-c1_ns2_dep0_img_comp",
-		//			"CVE-fixable_critical-c2_ns1_dep0_img_comp",
-		//			"CVE-fixable_critical-c2_ns2_dep0_img_comp",
-		//			"CVE-fixable_critical-w0_img_comp",
-		//			"CVE-fixable_critical-w1_img_comp",
-		//		},
-		//	},
-		// },
 		{
 			name:  "View-based report filtering by vulnerability state",
 			query: "Vulnerability State:OBSERVED",
@@ -373,24 +356,6 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 				},
 			},
 		},
-		////Test cases for timestamp-based search fields
-		//{
-		//	name:  "View-based report filtering by first image occurrence timestamp range",
-		//	query: "First Image Occurrence Timestamp:>01/01/2020",
-		//	expected: &viewBasedReportData{
-		//		deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-		//		imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-		//		componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
-		//		cveNames: []string{
-		//			"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
-		//			"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
-		//			"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
-		//			"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-		//			"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
-		//			"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
-		//		},
-		//	},
-		// },
 		// Test cases for advanced search fields - EPSS and Advisory fields
 		{
 			name:  "View-based report filtering by EPSS Probability",
@@ -430,6 +395,24 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		{
 			name:  "View-based report filtering by component version",
 			query: "Component Version:1.0",
+			expected: &viewBasedReportData{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
+				},
+			},
+		},
+		//Test cases for timestamp-based search fields
+		{
+			name:  "View-based report filtering by first image occurrence timestamp range",
+			query: "First Image Occurrence Timestamp:<01/01/2020",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
 				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -53,8 +53,11 @@ type viewBasedReportData struct {
 
 func (s *ViewBasedReportingTestSuite) SetupSuite() {
 	s.ctx = loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
-	s.mockCtrl = gomock.NewController(s.T())
 	s.testDB = resolvers.SetupTestPostgresConn(s.T())
+}
+
+func (s *ViewBasedReportingTestSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
 
 	// Create data stores based on feature flag
 	imageDataStore := resolvers.CreateTestImageV2Datastore(s.T(), s.testDB, s.mockCtrl)
@@ -77,11 +80,9 @@ func (s *ViewBasedReportingTestSuite) SetupSuite() {
 		s.namespaceDatastore, s.resolver.ImageCVEDataStore, s.resolver.ImageCVEV2DataStore, nil)
 }
 
-func (s *ViewBasedReportingTestSuite) TearDownSuite() {
-	s.mockCtrl.Finish()
-}
-
 func (s *ViewBasedReportingTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+
 	s.truncateTable(postgresSchema.DeploymentsTableName)
 	s.truncateTable(postgresSchema.ImagesTableName)
 	s.truncateTable(postgresSchema.ImageComponentV2TableName)

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -113,51 +113,29 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		Return(namespaces, nil).AnyTimes()
 
 	testCases := []struct {
-		name       string
-		imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType
-		query      string
-		expected   *viewBasedReportData
+		name     string
+		query    string
+		expected *viewBasedReportData
 	}{
 		{
-			name: "View-based report with deployed images and CVE severity filter",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report with CVE severity filter",
 			query: "SEVERITY:CRITICAL_VULNERABILITY_SEVERITY",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
-				},
-			},
-		},
-		{
-			name: "View-based report with watched images and fixable filter",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_WATCHED,
-			},
-			query: "Fixable:true",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{},
-				imageNames:      []string{"w0_img", "w1_img"},
-				componentNames:  []string{"w0_img_comp", "w1_img_comp"},
-				cveNames: []string{
 					"CVE-fixable_critical-w0_img_comp",
 					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report with both deployed and watched images",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-				storage.ViewBasedVulnerabilityReportFilters_WATCHED,
-			},
+			name:  "View-based report with critical important severity filter",
 			query: "SEVERITY:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
@@ -175,14 +153,11 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			},
 		},
 		{
-			name: "View-based report with complex query combining multiple fields",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report with complex query combining multiple fields",
 			query: "CVE Severity:CRITICAL_VULNERABILITY_SEVERITY+Fixable:true",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
 				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
@@ -193,10 +168,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			},
 		},
 		{
-			name: "View-based report with empty query (should return all vulnerabilities)",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report with empty query (should return all vulnerabilities)",
 			query: "",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
@@ -212,10 +184,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		},
 		// Test cases for CVE-specific search fields
 		{
-			name: "View-based report filtering by CVE ID",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by CVE ID",
 			query: "CVE:CVE-fixable_critical-c1_ns1_dep0_img_comp",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
@@ -225,65 +194,59 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			},
 		},
 		{
-			name: "View-based report filtering by CVSS score range",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by CVSS score range",
 			query: "CVSS:>=7.0",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report filtering by NVD CVSS score",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by NVD CVSS score",
 			query: "NVD CVSS:>=8.0",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report filtering by vulnerability state",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by vulnerability state",
 			query: "Vulnerability State:OBSERVED",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		// Test cases for component-related search fields
 		{
-			name: "View-based report filtering by component name",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by component name",
 			query: "Component:c1_ns1_dep0_img_comp",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
@@ -294,10 +257,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 		},
 		// Test cases for image-related search fields
 		{
-			name: "View-based report filtering by image name",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by image name",
 			query: "Image:c1_ns1_dep0_img",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
@@ -307,315 +267,227 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			},
 		},
 		{
-			name: "View-based report filtering by image registry",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by image registry",
 			query: "Image Registry:docker.io",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report filtering by image tag",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by image tag",
 			query: "Image Tag:latest",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		// Test cases for deployment-related search fields
 		{
-			name: "View-based report filtering by cluster name",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by cluster name",
 			query: "Cluster:c1",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report filtering by namespace",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
-			query: "Namespace:r/c1_ns1",
+			name:  "View-based report filtering by namespace",
+			query: "Namespace:c1_ns1",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp"},
-				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp", "CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp", "CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp"},
 			},
 		},
 		{
-			name: "View-based report filtering by deployment name",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by deployment name",
 			query: "Deployment:c1_ns1_dep0",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp"},
-				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames:        []string{"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp", "CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp", "CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp"},
 			},
 		},
 		// Test cases for fixability-related search fields
 		{
-			name: "View-based report filtering by non-fixable vulnerabilities",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by non-fixable vulnerabilities",
 			query: "Fixable:false",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-nonFixable_low-w0_img_comp",
+					"CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		// Test cases for combinations of multiple search fields
 		{
-			name: "View-based report with multiple field combination",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report with multiple field combination",
 			query: "Cluster:c1+Severity:CRITICAL_VULNERABILITY_SEVERITY+Fixable:true",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
-				},
-			},
-		},
-		{
-			name: "View-based report with OR conditions",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
-			query: "Deployment:c1_ns1_dep0,c2_ns1_dep0",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c2_ns1_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c2_ns1_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c2_ns1_dep0_img_comp"},
-				cveNames: []string{
-					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
 		//Test cases for timestamp-based search fields
 		{
-			name: "View-based report filtering by first image occurrence timestamp range",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by first image occurrence timestamp range",
 			query: "First Image Occurrence Timestamp:>01/01/2020",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-				},
-			},
-		},
-		// Test cases for impact score
-		{
-			name: "View-based report filtering by impact score range",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
-			query: "Impact Score:>=5.0",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
-				cveNames: []string{
-					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
-					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		// Test cases for advanced search fields - EPSS and Advisory fields
 		{
-			name: "View-based report filtering by EPSS Probability",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by EPSS Probability",
 			query: "EPSS Probability:>=0.0",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report filtering by Advisory Name",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by Advisory Name",
 			query: "Advisory Name:RHSA-2025-CVE-fixable",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report filtering by Advisory Link",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by Advisory Link",
 			query: "Advisory Link:test-rhsa-link",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		{
-			name: "View-based report filtering by Fixed By version",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by Fixed By version",
 			query: "Fixed By:1.1",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
 		// Test cases for component version field
 		{
-			name: "View-based report filtering by component version",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report filtering by component version",
 			query: "Component Version:1.0",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},
 		// Test cases for negation queries
 		{
-			name: "View-based report with negation query for severity",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report with negation query for severity",
 			query: "!Severity:LOW_VULNERABILITY_SEVERITY",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp",
-				},
-			},
-		},
-		{
-			name: "View-based report with negation query for fixable",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
-			query: "!Fixable:true",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
-				cveNames: []string{
-					"CVE-nonFixable_low-c1_ns1_dep0_img_comp",
-					"CVE-nonFixable_low-c1_ns2_dep0_img_comp",
-					"CVE-nonFixable_low-c2_ns1_dep0_img_comp",
-					"CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-				},
-			},
-		},
-		// Test case for watched images with multiple search fields
-		{
-			name: "View-based report for watched images with complex query",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_WATCHED,
-			},
-			query: "Severity:CRITICAL_VULNERABILITY_SEVERITY+Advisory Name:RHSA-2025-CVE-fixable",
-			expected: &viewBasedReportData{
-				deploymentNames: []string{},
-				imageNames:      []string{"w0_img", "w1_img"},
-				componentNames:  []string{"w0_img_comp", "w1_img_comp"},
-				cveNames: []string{
 					"CVE-fixable_critical-w0_img_comp",
 					"CVE-fixable_critical-w1_img_comp",
 				},
@@ -626,7 +498,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
 			log.Infof("Running test %s", tc.name)
-			reportSnap := testViewBasedReportSnapshot(tc.imageTypes, tc.query, nil)
+			reportSnap := testViewBasedReportSnapshot(tc.query, nil)
 			// Test get data using view-based approach
 			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap)
 			s.NoError(err)
@@ -657,24 +529,17 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedWithInvalidQuery
 		Return(namespaces, nil).AnyTimes()
 
 	testCases := []struct {
-		name       string
-		imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType
-		query      string
-		expectErr  bool
+		name      string
+		query     string
+		expectErr bool
 	}{
 		{
-			name: "Invalid field in query",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:      "Invalid field in query",
 			query:     "InvalidField:value",
 			expectErr: false, // Invalid fields are typically ignored by the query parser
 		},
 		{
-			name: "Malformed query syntax",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:      "Malformed query syntax",
 			query:     "CVE Severity:",
 			expectErr: false, // Empty values are typically handled gracefully
 		},
@@ -682,7 +547,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedWithInvalidQuery
 
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
-			reportSnap := testViewBasedReportSnapshot(tc.imageTypes, tc.query, nil)
+			reportSnap := testViewBasedReportSnapshot(tc.query, nil)
 			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap)
 			if tc.expectErr {
 				s.Error(err)
@@ -718,16 +583,12 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedAccessScope() {
 
 	testCases := []struct {
 		name       string
-		imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType
 		query      string
 		scopeRules []*storage.SimpleAccessScope_Rules
 		expected   *viewBasedReportData
 	}{
 		{
-			name: "View-based report with access scope rules",
-			imageTypes: []storage.ViewBasedVulnerabilityReportFilters_ImageType{
-				storage.ViewBasedVulnerabilityReportFilters_DEPLOYED,
-			},
+			name:  "View-based report with access scope rules",
 			query: "SEVERITY:CRITICAL_VULNERABILITY_SEVERITY",
 			scopeRules: []*storage.SimpleAccessScope_Rules{
 				{
@@ -741,12 +602,14 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedAccessScope() {
 			},
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
 				},
 			},
 		},
@@ -754,7 +617,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedAccessScope() {
 
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
-			reportSnap := testViewBasedReportSnapshot(tc.imageTypes, tc.query, tc.scopeRules)
+			reportSnap := testViewBasedReportSnapshot(tc.query, tc.scopeRules)
 			// Test get data using view-based approach
 			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap)
 			s.NoError(err)

--- a/central/reports/scheduler/v2/reportgenerator/testutils.go
+++ b/central/reports/scheduler/v2/reportgenerator/testutils.go
@@ -258,7 +258,7 @@ func testReportSnapshot(collectionID string,
 	return snap
 }
 
-func testViewBasedReportSnapshot(imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType, query string) *storage.ReportSnapshot {
+func testViewBasedReportSnapshot(imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType, query string, scopeRules []*storage.SimpleAccessScope_Rules) *storage.ReportSnapshot {
 	snap := fixtures.GetReportSnapshot()
 	snap.Filter = &storage.ReportSnapshot_ViewBasedVulnReportFilters{
 		ViewBasedVulnReportFilters: &storage.ViewBasedVulnerabilityReportFilters{
@@ -266,6 +266,7 @@ func testViewBasedReportSnapshot(imageTypes []storage.ViewBasedVulnerabilityRepo
 			IncludeNvdCvss:         true,
 			IncludeEpssProbability: true,
 			Query:                  query,
+			AccessScopeRules:       scopeRules,
 		},
 	}
 	return snap

--- a/central/reports/scheduler/v2/reportgenerator/testutils.go
+++ b/central/reports/scheduler/v2/reportgenerator/testutils.go
@@ -85,6 +85,14 @@ func testWatchedImages(numImages int) []*storage.Image {
 func testImage(prefix string) *storage.Image {
 	t, err := protocompat.ConvertTimeToTimestampOrError(time.Unix(0, 1000))
 	utils.CrashOnError(err)
+	nvdCvss := &storage.CVSSScore{
+		Source: storage.Source_SOURCE_NVD,
+		CvssScore: &storage.CVSSScore_Cvssv3{
+			Cvssv3: &storage.CVSSV3{
+				Score: 10,
+			},
+		},
+	}
 	return &storage.Image{
 		Id: fmt.Sprintf("%s_img", prefix),
 		Name: &storage.ImageName{
@@ -113,6 +121,7 @@ func testImage(prefix string) *storage.Image {
 							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
 								FixedBy: "1.1",
 							},
+							CvssMetrics: []*storage.CVSSScore{nvdCvss},
 							Advisory: &storage.Advisory{
 								Name: "RHSA-2025-CVE-fixable",
 								Link: "test-rhsa-link",

--- a/central/reports/scheduler/v2/reportgenerator/testutils.go
+++ b/central/reports/scheduler/v2/reportgenerator/testutils.go
@@ -258,15 +258,12 @@ func testReportSnapshot(collectionID string,
 	return snap
 }
 
-func testViewBasedReportSnapshot(imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType, query string, scopeRules []*storage.SimpleAccessScope_Rules) *storage.ReportSnapshot {
+func testViewBasedReportSnapshot(query string, scopeRules []*storage.SimpleAccessScope_Rules) *storage.ReportSnapshot {
 	snap := fixtures.GetReportSnapshot()
 	snap.Filter = &storage.ReportSnapshot_ViewBasedVulnReportFilters{
 		ViewBasedVulnReportFilters: &storage.ViewBasedVulnerabilityReportFilters{
-			ImageTypes:             imageTypes,
-			IncludeNvdCvss:         true,
-			IncludeEpssProbability: true,
-			Query:                  query,
-			AccessScopeRules:       scopeRules,
+			Query:            query,
+			AccessScopeRules: scopeRules,
 		},
 	}
 	return snap

--- a/central/reports/scheduler/v2/reportgenerator/testutils.go
+++ b/central/reports/scheduler/v2/reportgenerator/testutils.go
@@ -208,3 +208,16 @@ func testReportSnapshot(collectionID string,
 	}
 	return snap
 }
+
+func testViewBasedReportSnapshot(imageTypes []storage.ViewBasedVulnerabilityReportFilters_ImageType, query string) *storage.ReportSnapshot {
+	snap := fixtures.GetReportSnapshot()
+	snap.Filter = &storage.ReportSnapshot_ViewBasedVulnReportFilters{
+		ViewBasedVulnReportFilters: &storage.ViewBasedVulnerabilityReportFilters{
+			ImageTypes:             imageTypes,
+			IncludeNvdCvss:         true,
+			IncludeEpssProbability: true,
+			Query:                  query,
+		},
+	}
+	return snap
+}

--- a/central/reports/scheduler/v2/reportgenerator/testutils.go
+++ b/central/reports/scheduler/v2/reportgenerator/testutils.go
@@ -86,8 +86,13 @@ func testImage(prefix string) *storage.Image {
 	t, err := protocompat.ConvertTimeToTimestampOrError(time.Unix(0, 1000))
 	utils.CrashOnError(err)
 	return &storage.Image{
-		Id:   fmt.Sprintf("%s_img", prefix),
-		Name: &storage.ImageName{FullName: fmt.Sprintf("%s_img", prefix)},
+		Id: fmt.Sprintf("%s_img", prefix),
+		Name: &storage.ImageName{
+			FullName: fmt.Sprintf("%s_img", prefix),
+			Registry: "docker.io",
+			Remote:   fmt.Sprintf("library/%s_img", prefix),
+			Tag:      "latest",
+		},
 		SetComponents: &storage.Image_Components{
 			Components: 1,
 		},
@@ -98,8 +103,10 @@ func testImage(prefix string) *storage.Image {
 			ScanTime: t,
 			Components: []*storage.EmbeddedImageScanComponent{
 				{
-					Name:    fmt.Sprintf("%s_img_comp", prefix),
-					Version: "1.0",
+					Name:     fmt.Sprintf("%s_img_comp", prefix),
+					Version:  "1.0",
+					Source:   storage.SourceType_OS,
+					Location: "/usr/lib",
 					Vulns: []*storage.EmbeddedVulnerability{
 						{
 							Cve: fmt.Sprintf("CVE-fixable_critical-%s_img_comp", prefix),
@@ -110,8 +117,29 @@ func testImage(prefix string) *storage.Image {
 								Name: "RHSA-2025-CVE-fixable",
 								Link: "test-rhsa-link",
 							},
-							Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
-							Link:     "link",
+							Severity:              storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+							Link:                  "link",
+							Cvss:                  9.0,
+							State:                 storage.VulnerabilityState_OBSERVED,
+							FirstSystemOccurrence: t,
+							FirstImageOccurrence:  t,
+							NvdCvss:               8.5,
+							Epss: &storage.EPSS{
+								EpssProbability: 0.7,
+								EpssPercentile:  0.8,
+							},
+							CvssV2: &storage.CVSSV2{
+								Vector:              "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+								Score:               7.5,
+								ExploitabilityScore: 10.0,
+								ImpactScore:         6.4,
+							},
+							CvssV3: &storage.CVSSV3{
+								Vector:              "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+								Score:               9.8,
+								ExploitabilityScore: 3.9,
+								ImpactScore:         5.9,
+							},
 						},
 						{
 							Cve:      fmt.Sprintf("CVE-nonFixable_low-%s_img_comp", prefix),
@@ -120,6 +148,27 @@ func testImage(prefix string) *storage.Image {
 							Advisory: &storage.Advisory{
 								Name: "RHSA-2025-CVE-fixable",
 								Link: "test-rhsa-link",
+							},
+							Cvss:                  2.0,
+							State:                 storage.VulnerabilityState_OBSERVED,
+							FirstSystemOccurrence: t,
+							FirstImageOccurrence:  t,
+							NvdCvss:               1.8,
+							Epss: &storage.EPSS{
+								EpssProbability: 0.1,
+								EpssPercentile:  0.2,
+							},
+							CvssV2: &storage.CVSSV2{
+								Vector:              "AV:L/AC:H/Au:N/C:P/I:N/A:N",
+								Score:               1.9,
+								ExploitabilityScore: 1.9,
+								ImpactScore:         2.9,
+							},
+							CvssV3: &storage.CVSSV3{
+								Vector:              "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N",
+								Score:               2.3,
+								ExploitabilityScore: 1.0,
+								ImpactScore:         1.4,
 							},
 						},
 					},

--- a/central/reports/validation/validate.go
+++ b/central/reports/validation/validate.go
@@ -378,22 +378,11 @@ func (v *Validator) ValidateAndGenerateViewBasedReportRequest(
 	if vbFilters == nil {
 		return nil, errors.Wrap(errox.InvalidArgs, "view-based vulnerability report filters must be provided")
 	}
-	if len(vbFilters.GetImageTypes()) == 0 {
-		return nil, errors.Wrap(errox.InvalidArgs, "view-based report filters must specify image types")
-	}
 
 	// Convert API filters to storage filters.
 	storageFilters := &storage.ViewBasedVulnerabilityReportFilters{
-		ImageTypes: func() []storage.ViewBasedVulnerabilityReportFilters_ImageType {
-			imageTypes := make([]storage.ViewBasedVulnerabilityReportFilters_ImageType, 0, len(vbFilters.GetImageTypes()))
-			for _, imageType := range vbFilters.GetImageTypes() {
-				imageTypes = append(imageTypes, storage.ViewBasedVulnerabilityReportFilters_ImageType(imageType))
-			}
-			return imageTypes
-		}(),
-		IncludeNvdCvss:         vbFilters.GetIncludeNvdCvss(),
-		IncludeEpssProbability: vbFilters.GetIncludeEpssProbability(),
-		Query:                  vbFilters.GetQuery(),
+		Query:            vbFilters.GetQuery(),
+		AccessScopeRules: common.ExtractAccessScopeRules(requesterID),
 	}
 	requester := &storage.SlimUser{
 		Id:   requesterID.UID(),

--- a/generated/api/v1/report_configuration_service.swagger.json
+++ b/generated/api/v1/report_configuration_service.swagger.json
@@ -418,6 +418,14 @@
       ],
       "default": "BOTH"
     },
+    "VulnerabilityReportFiltersImageType": {
+      "type": "string",
+      "enum": [
+        "DEPLOYED",
+        "WATCHED"
+      ],
+      "default": "DEPLOYED"
+    },
     "googlerpcStatus": {
       "type": "object",
       "properties": {
@@ -652,7 +660,7 @@
         "imageTypes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/storageVulnerabilityReportFiltersImageType"
+            "$ref": "#/definitions/VulnerabilityReportFiltersImageType"
           }
         },
         "allVuln": {
@@ -682,14 +690,6 @@
           "type": "boolean"
         }
       }
-    },
-    "storageVulnerabilityReportFiltersImageType": {
-      "type": "string",
-      "enum": [
-        "DEPLOYED",
-        "WATCHED"
-      ],
-      "default": "DEPLOYED"
     },
     "storageVulnerabilitySeverity": {
       "type": "string",

--- a/generated/api/v2/report_service.pb.go
+++ b/generated/api/v2/report_service.pb.go
@@ -262,52 +262,6 @@ func (VulnerabilityReportFilters_ImageType) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_report_service_proto_rawDescGZIP(), []int{1, 2}
 }
 
-type ViewBasedVulnerabilityReportFilters_ImageType int32
-
-const (
-	ViewBasedVulnerabilityReportFilters_DEPLOYED ViewBasedVulnerabilityReportFilters_ImageType = 0
-	ViewBasedVulnerabilityReportFilters_WATCHED  ViewBasedVulnerabilityReportFilters_ImageType = 1
-)
-
-// Enum value maps for ViewBasedVulnerabilityReportFilters_ImageType.
-var (
-	ViewBasedVulnerabilityReportFilters_ImageType_name = map[int32]string{
-		0: "DEPLOYED",
-		1: "WATCHED",
-	}
-	ViewBasedVulnerabilityReportFilters_ImageType_value = map[string]int32{
-		"DEPLOYED": 0,
-		"WATCHED":  1,
-	}
-)
-
-func (x ViewBasedVulnerabilityReportFilters_ImageType) Enum() *ViewBasedVulnerabilityReportFilters_ImageType {
-	p := new(ViewBasedVulnerabilityReportFilters_ImageType)
-	*p = x
-	return p
-}
-
-func (x ViewBasedVulnerabilityReportFilters_ImageType) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (ViewBasedVulnerabilityReportFilters_ImageType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_v2_report_service_proto_enumTypes[5].Descriptor()
-}
-
-func (ViewBasedVulnerabilityReportFilters_ImageType) Type() protoreflect.EnumType {
-	return &file_api_v2_report_service_proto_enumTypes[5]
-}
-
-func (x ViewBasedVulnerabilityReportFilters_ImageType) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use ViewBasedVulnerabilityReportFilters_ImageType.Descriptor instead.
-func (ViewBasedVulnerabilityReportFilters_ImageType) EnumDescriptor() ([]byte, []int) {
-	return file_api_v2_report_service_proto_rawDescGZIP(), []int{2, 0}
-}
-
 type ReportSchedule_IntervalType int32
 
 const (
@@ -341,11 +295,11 @@ func (x ReportSchedule_IntervalType) String() string {
 }
 
 func (ReportSchedule_IntervalType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_v2_report_service_proto_enumTypes[6].Descriptor()
+	return file_api_v2_report_service_proto_enumTypes[5].Descriptor()
 }
 
 func (ReportSchedule_IntervalType) Type() protoreflect.EnumType {
-	return &file_api_v2_report_service_proto_enumTypes[6]
+	return &file_api_v2_report_service_proto_enumTypes[5]
 }
 
 func (x ReportSchedule_IntervalType) Number() protoreflect.EnumNumber {
@@ -396,11 +350,11 @@ func (x ReportStatus_RunState) String() string {
 }
 
 func (ReportStatus_RunState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_v2_report_service_proto_enumTypes[7].Descriptor()
+	return file_api_v2_report_service_proto_enumTypes[6].Descriptor()
 }
 
 func (ReportStatus_RunState) Type() protoreflect.EnumType {
-	return &file_api_v2_report_service_proto_enumTypes[7]
+	return &file_api_v2_report_service_proto_enumTypes[6]
 }
 
 func (x ReportStatus_RunState) Number() protoreflect.EnumNumber {
@@ -442,11 +396,11 @@ func (x ReportStatus_ReportMethod) String() string {
 }
 
 func (ReportStatus_ReportMethod) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_v2_report_service_proto_enumTypes[8].Descriptor()
+	return file_api_v2_report_service_proto_enumTypes[7].Descriptor()
 }
 
 func (ReportStatus_ReportMethod) Type() protoreflect.EnumType {
-	return &file_api_v2_report_service_proto_enumTypes[8]
+	return &file_api_v2_report_service_proto_enumTypes[7]
 }
 
 func (x ReportStatus_ReportMethod) Number() protoreflect.EnumNumber {
@@ -485,11 +439,11 @@ func (x ReportRequestViewBased_ReportType) String() string {
 }
 
 func (ReportRequestViewBased_ReportType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_v2_report_service_proto_enumTypes[9].Descriptor()
+	return file_api_v2_report_service_proto_enumTypes[8].Descriptor()
 }
 
 func (ReportRequestViewBased_ReportType) Type() protoreflect.EnumType {
-	return &file_api_v2_report_service_proto_enumTypes[9]
+	return &file_api_v2_report_service_proto_enumTypes[8]
 }
 
 func (x ReportRequestViewBased_ReportType) Number() protoreflect.EnumNumber {
@@ -772,13 +726,10 @@ func (*VulnerabilityReportFilters_SinceStartDate) isVulnerabilityReportFilters_C
 
 // filter for ondemand view based reports
 type ViewBasedVulnerabilityReportFilters struct {
-	state                  protoimpl.MessageState                          `protogen:"open.v1"`
-	ImageTypes             []ViewBasedVulnerabilityReportFilters_ImageType `protobuf:"varint,2,rep,packed,name=image_types,json=imageTypes,proto3,enum=v2.ViewBasedVulnerabilityReportFilters_ImageType" json:"image_types,omitempty"`
-	IncludeNvdCvss         bool                                            `protobuf:"varint,3,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`
-	IncludeEpssProbability bool                                            `protobuf:"varint,4,opt,name=include_epss_probability,json=includeEpssProbability,proto3" json:"include_epss_probability,omitempty"`
-	Query                  string                                          `protobuf:"bytes,5,opt,name=query,proto3" json:"query,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Query         string                 `protobuf:"bytes,5,opt,name=query,proto3" json:"query,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ViewBasedVulnerabilityReportFilters) Reset() {
@@ -809,27 +760,6 @@ func (x *ViewBasedVulnerabilityReportFilters) ProtoReflect() protoreflect.Messag
 // Deprecated: Use ViewBasedVulnerabilityReportFilters.ProtoReflect.Descriptor instead.
 func (*ViewBasedVulnerabilityReportFilters) Descriptor() ([]byte, []int) {
 	return file_api_v2_report_service_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *ViewBasedVulnerabilityReportFilters) GetImageTypes() []ViewBasedVulnerabilityReportFilters_ImageType {
-	if x != nil {
-		return x.ImageTypes
-	}
-	return nil
-}
-
-func (x *ViewBasedVulnerabilityReportFilters) GetIncludeNvdCvss() bool {
-	if x != nil {
-		return x.IncludeNvdCvss
-	}
-	return false
-}
-
-func (x *ViewBasedVulnerabilityReportFilters) GetIncludeEpssProbability() bool {
-	if x != nil {
-		return x.IncludeEpssProbability
-	}
-	return false
 }
 
 func (x *ViewBasedVulnerabilityReportFilters) GetQuery() string {
@@ -2143,16 +2073,9 @@ const file_api_v2_report_service_proto_rawDesc = "" +
 	"\bDEPLOYED\x10\x00\x12\v\n" +
 	"\aWATCHED\x10\x01B\f\n" +
 	"\n" +
-	"cves_since\"\x9b\x02\n" +
-	"#ViewBasedVulnerabilityReportFilters\x12R\n" +
-	"\vimage_types\x18\x02 \x03(\x0e21.v2.ViewBasedVulnerabilityReportFilters.ImageTypeR\n" +
-	"imageTypes\x12(\n" +
-	"\x10include_nvd_cvss\x18\x03 \x01(\bR\x0eincludeNvdCvss\x128\n" +
-	"\x18include_epss_probability\x18\x04 \x01(\bR\x16includeEpssProbability\x12\x14\n" +
-	"\x05query\x18\x05 \x01(\tR\x05query\"&\n" +
-	"\tImageType\x12\f\n" +
-	"\bDEPLOYED\x10\x00\x12\v\n" +
-	"\aWATCHED\x10\x01\"\x90\x03\n" +
+	"cves_since\";\n" +
+	"#ViewBasedVulnerabilityReportFilters\x12\x14\n" +
+	"\x05query\x18\x05 \x01(\tR\x05query\"\x90\x03\n" +
 	"\x0eReportSchedule\x12D\n" +
 	"\rinterval_type\x18\x01 \x01(\x0e2\x1f.v2.ReportSchedule.IntervalTypeR\fintervalType\x12\x12\n" +
 	"\x04hour\x18\x02 \x01(\x05R\x04hour\x12\x16\n" +
@@ -2285,7 +2208,7 @@ func file_api_v2_report_service_proto_rawDescGZIP() []byte {
 	return file_api_v2_report_service_proto_rawDescData
 }
 
-var file_api_v2_report_service_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_api_v2_report_service_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
 var file_api_v2_report_service_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_api_v2_report_service_proto_goTypes = []any{
 	(NotificationMethod)(0),                               // 0: v2.NotificationMethod
@@ -2293,109 +2216,107 @@ var file_api_v2_report_service_proto_goTypes = []any{
 	(VulnerabilityReportFilters_Fixability)(0),            // 2: v2.VulnerabilityReportFilters.Fixability
 	(VulnerabilityReportFilters_VulnerabilitySeverity)(0), // 3: v2.VulnerabilityReportFilters.VulnerabilitySeverity
 	(VulnerabilityReportFilters_ImageType)(0),             // 4: v2.VulnerabilityReportFilters.ImageType
-	(ViewBasedVulnerabilityReportFilters_ImageType)(0),    // 5: v2.ViewBasedVulnerabilityReportFilters.ImageType
-	(ReportSchedule_IntervalType)(0),                      // 6: v2.ReportSchedule.IntervalType
-	(ReportStatus_RunState)(0),                            // 7: v2.ReportStatus.RunState
-	(ReportStatus_ReportMethod)(0),                        // 8: v2.ReportStatus.ReportMethod
-	(ReportRequestViewBased_ReportType)(0),                // 9: v2.ReportRequestViewBased.ReportType
-	(*ReportConfiguration)(nil),                           // 10: v2.ReportConfiguration
-	(*VulnerabilityReportFilters)(nil),                    // 11: v2.VulnerabilityReportFilters
-	(*ViewBasedVulnerabilityReportFilters)(nil),           // 12: v2.ViewBasedVulnerabilityReportFilters
-	(*ReportSchedule)(nil),                                // 13: v2.ReportSchedule
-	(*ResourceScope)(nil),                                 // 14: v2.ResourceScope
-	(*CollectionReference)(nil),                           // 15: v2.CollectionReference
-	(*NotifierConfiguration)(nil),                         // 16: v2.NotifierConfiguration
-	(*EmailNotifierConfiguration)(nil),                    // 17: v2.EmailNotifierConfiguration
-	(*ListReportConfigurationsResponse)(nil),              // 18: v2.ListReportConfigurationsResponse
-	(*CountReportConfigurationsResponse)(nil),             // 19: v2.CountReportConfigurationsResponse
-	(*GetReportHistoryRequest)(nil),                       // 20: v2.GetReportHistoryRequest
-	(*ReportHistoryResponse)(nil),                         // 21: v2.ReportHistoryResponse
-	(*ReportStatusResponse)(nil),                          // 22: v2.ReportStatusResponse
-	(*CollectionSnapshot)(nil),                            // 23: v2.CollectionSnapshot
-	(*ReportSnapshot)(nil),                                // 24: v2.ReportSnapshot
-	(*ReportStatus)(nil),                                  // 25: v2.ReportStatus
-	(*RunReportRequest)(nil),                              // 26: v2.RunReportRequest
-	(*RunReportResponse)(nil),                             // 27: v2.RunReportResponse
-	(*DeleteReportRequest)(nil),                           // 28: v2.DeleteReportRequest
-	(*ReportRequestViewBased)(nil),                        // 29: v2.ReportRequestViewBased
-	(*RunReportResponseViewBased)(nil),                    // 30: v2.RunReportResponseViewBased
-	(*ReportSchedule_DaysOfWeek)(nil),                     // 31: v2.ReportSchedule.DaysOfWeek
-	(*ReportSchedule_DaysOfMonth)(nil),                    // 32: v2.ReportSchedule.DaysOfMonth
-	(*timestamppb.Timestamp)(nil),                         // 33: google.protobuf.Timestamp
-	(*RawQuery)(nil),                                      // 34: v2.RawQuery
-	(*SlimUser)(nil),                                      // 35: v2.SlimUser
-	(*ResourceByID)(nil),                                  // 36: v2.ResourceByID
-	(*Empty)(nil),                                         // 37: v2.Empty
+	(ReportSchedule_IntervalType)(0),                      // 5: v2.ReportSchedule.IntervalType
+	(ReportStatus_RunState)(0),                            // 6: v2.ReportStatus.RunState
+	(ReportStatus_ReportMethod)(0),                        // 7: v2.ReportStatus.ReportMethod
+	(ReportRequestViewBased_ReportType)(0),                // 8: v2.ReportRequestViewBased.ReportType
+	(*ReportConfiguration)(nil),                           // 9: v2.ReportConfiguration
+	(*VulnerabilityReportFilters)(nil),                    // 10: v2.VulnerabilityReportFilters
+	(*ViewBasedVulnerabilityReportFilters)(nil),           // 11: v2.ViewBasedVulnerabilityReportFilters
+	(*ReportSchedule)(nil),                                // 12: v2.ReportSchedule
+	(*ResourceScope)(nil),                                 // 13: v2.ResourceScope
+	(*CollectionReference)(nil),                           // 14: v2.CollectionReference
+	(*NotifierConfiguration)(nil),                         // 15: v2.NotifierConfiguration
+	(*EmailNotifierConfiguration)(nil),                    // 16: v2.EmailNotifierConfiguration
+	(*ListReportConfigurationsResponse)(nil),              // 17: v2.ListReportConfigurationsResponse
+	(*CountReportConfigurationsResponse)(nil),             // 18: v2.CountReportConfigurationsResponse
+	(*GetReportHistoryRequest)(nil),                       // 19: v2.GetReportHistoryRequest
+	(*ReportHistoryResponse)(nil),                         // 20: v2.ReportHistoryResponse
+	(*ReportStatusResponse)(nil),                          // 21: v2.ReportStatusResponse
+	(*CollectionSnapshot)(nil),                            // 22: v2.CollectionSnapshot
+	(*ReportSnapshot)(nil),                                // 23: v2.ReportSnapshot
+	(*ReportStatus)(nil),                                  // 24: v2.ReportStatus
+	(*RunReportRequest)(nil),                              // 25: v2.RunReportRequest
+	(*RunReportResponse)(nil),                             // 26: v2.RunReportResponse
+	(*DeleteReportRequest)(nil),                           // 27: v2.DeleteReportRequest
+	(*ReportRequestViewBased)(nil),                        // 28: v2.ReportRequestViewBased
+	(*RunReportResponseViewBased)(nil),                    // 29: v2.RunReportResponseViewBased
+	(*ReportSchedule_DaysOfWeek)(nil),                     // 30: v2.ReportSchedule.DaysOfWeek
+	(*ReportSchedule_DaysOfMonth)(nil),                    // 31: v2.ReportSchedule.DaysOfMonth
+	(*timestamppb.Timestamp)(nil),                         // 32: google.protobuf.Timestamp
+	(*RawQuery)(nil),                                      // 33: v2.RawQuery
+	(*SlimUser)(nil),                                      // 34: v2.SlimUser
+	(*ResourceByID)(nil),                                  // 35: v2.ResourceByID
+	(*Empty)(nil),                                         // 36: v2.Empty
 }
 var file_api_v2_report_service_proto_depIdxs = []int32{
 	1,  // 0: v2.ReportConfiguration.type:type_name -> v2.ReportConfiguration.ReportType
-	11, // 1: v2.ReportConfiguration.vuln_report_filters:type_name -> v2.VulnerabilityReportFilters
-	13, // 2: v2.ReportConfiguration.schedule:type_name -> v2.ReportSchedule
-	14, // 3: v2.ReportConfiguration.resource_scope:type_name -> v2.ResourceScope
-	16, // 4: v2.ReportConfiguration.notifiers:type_name -> v2.NotifierConfiguration
+	10, // 1: v2.ReportConfiguration.vuln_report_filters:type_name -> v2.VulnerabilityReportFilters
+	12, // 2: v2.ReportConfiguration.schedule:type_name -> v2.ReportSchedule
+	13, // 3: v2.ReportConfiguration.resource_scope:type_name -> v2.ResourceScope
+	15, // 4: v2.ReportConfiguration.notifiers:type_name -> v2.NotifierConfiguration
 	2,  // 5: v2.VulnerabilityReportFilters.fixability:type_name -> v2.VulnerabilityReportFilters.Fixability
 	3,  // 6: v2.VulnerabilityReportFilters.severities:type_name -> v2.VulnerabilityReportFilters.VulnerabilitySeverity
 	4,  // 7: v2.VulnerabilityReportFilters.image_types:type_name -> v2.VulnerabilityReportFilters.ImageType
-	33, // 8: v2.VulnerabilityReportFilters.since_start_date:type_name -> google.protobuf.Timestamp
-	5,  // 9: v2.ViewBasedVulnerabilityReportFilters.image_types:type_name -> v2.ViewBasedVulnerabilityReportFilters.ImageType
-	6,  // 10: v2.ReportSchedule.interval_type:type_name -> v2.ReportSchedule.IntervalType
-	31, // 11: v2.ReportSchedule.days_of_week:type_name -> v2.ReportSchedule.DaysOfWeek
-	32, // 12: v2.ReportSchedule.days_of_month:type_name -> v2.ReportSchedule.DaysOfMonth
-	15, // 13: v2.ResourceScope.collection_scope:type_name -> v2.CollectionReference
-	17, // 14: v2.NotifierConfiguration.email_config:type_name -> v2.EmailNotifierConfiguration
-	10, // 15: v2.ListReportConfigurationsResponse.report_configs:type_name -> v2.ReportConfiguration
-	34, // 16: v2.GetReportHistoryRequest.report_param_query:type_name -> v2.RawQuery
-	24, // 17: v2.ReportHistoryResponse.report_snapshots:type_name -> v2.ReportSnapshot
-	25, // 18: v2.ReportStatusResponse.status:type_name -> v2.ReportStatus
-	11, // 19: v2.ReportSnapshot.vuln_report_filters:type_name -> v2.VulnerabilityReportFilters
-	12, // 20: v2.ReportSnapshot.view_based_vuln_report_filters:type_name -> v2.ViewBasedVulnerabilityReportFilters
-	23, // 21: v2.ReportSnapshot.collection_snapshot:type_name -> v2.CollectionSnapshot
-	13, // 22: v2.ReportSnapshot.schedule:type_name -> v2.ReportSchedule
-	25, // 23: v2.ReportSnapshot.report_status:type_name -> v2.ReportStatus
-	16, // 24: v2.ReportSnapshot.notifiers:type_name -> v2.NotifierConfiguration
-	35, // 25: v2.ReportSnapshot.user:type_name -> v2.SlimUser
-	7,  // 26: v2.ReportStatus.run_state:type_name -> v2.ReportStatus.RunState
-	33, // 27: v2.ReportStatus.completed_at:type_name -> google.protobuf.Timestamp
-	8,  // 28: v2.ReportStatus.report_request_type:type_name -> v2.ReportStatus.ReportMethod
-	0,  // 29: v2.ReportStatus.report_notification_method:type_name -> v2.NotificationMethod
-	0,  // 30: v2.RunReportRequest.report_notification_method:type_name -> v2.NotificationMethod
-	9,  // 31: v2.ReportRequestViewBased.type:type_name -> v2.ReportRequestViewBased.ReportType
-	12, // 32: v2.ReportRequestViewBased.view_based_vuln_report_filters:type_name -> v2.ViewBasedVulnerabilityReportFilters
-	10, // 33: v2.ReportService.PostReportConfiguration:input_type -> v2.ReportConfiguration
-	10, // 34: v2.ReportService.UpdateReportConfiguration:input_type -> v2.ReportConfiguration
-	34, // 35: v2.ReportService.ListReportConfigurations:input_type -> v2.RawQuery
-	34, // 36: v2.ReportService.CountReportConfigurations:input_type -> v2.RawQuery
-	36, // 37: v2.ReportService.GetReportConfiguration:input_type -> v2.ResourceByID
-	36, // 38: v2.ReportService.DeleteReportConfiguration:input_type -> v2.ResourceByID
-	36, // 39: v2.ReportService.GetReportStatus:input_type -> v2.ResourceByID
-	20, // 40: v2.ReportService.GetReportHistory:input_type -> v2.GetReportHistoryRequest
-	20, // 41: v2.ReportService.GetMyReportHistory:input_type -> v2.GetReportHistoryRequest
-	26, // 42: v2.ReportService.RunReport:input_type -> v2.RunReportRequest
-	36, // 43: v2.ReportService.CancelReport:input_type -> v2.ResourceByID
-	28, // 44: v2.ReportService.DeleteReport:input_type -> v2.DeleteReportRequest
-	29, // 45: v2.ReportService.PostViewBasedReport:input_type -> v2.ReportRequestViewBased
-	34, // 46: v2.ReportService.GetViewBasedReportMyHistory:input_type -> v2.RawQuery
-	34, // 47: v2.ReportService.GetViewBasedReportHistory:input_type -> v2.RawQuery
-	10, // 48: v2.ReportService.PostReportConfiguration:output_type -> v2.ReportConfiguration
-	37, // 49: v2.ReportService.UpdateReportConfiguration:output_type -> v2.Empty
-	18, // 50: v2.ReportService.ListReportConfigurations:output_type -> v2.ListReportConfigurationsResponse
-	19, // 51: v2.ReportService.CountReportConfigurations:output_type -> v2.CountReportConfigurationsResponse
-	10, // 52: v2.ReportService.GetReportConfiguration:output_type -> v2.ReportConfiguration
-	37, // 53: v2.ReportService.DeleteReportConfiguration:output_type -> v2.Empty
-	22, // 54: v2.ReportService.GetReportStatus:output_type -> v2.ReportStatusResponse
-	21, // 55: v2.ReportService.GetReportHistory:output_type -> v2.ReportHistoryResponse
-	21, // 56: v2.ReportService.GetMyReportHistory:output_type -> v2.ReportHistoryResponse
-	27, // 57: v2.ReportService.RunReport:output_type -> v2.RunReportResponse
-	37, // 58: v2.ReportService.CancelReport:output_type -> v2.Empty
-	37, // 59: v2.ReportService.DeleteReport:output_type -> v2.Empty
-	30, // 60: v2.ReportService.PostViewBasedReport:output_type -> v2.RunReportResponseViewBased
-	21, // 61: v2.ReportService.GetViewBasedReportMyHistory:output_type -> v2.ReportHistoryResponse
-	21, // 62: v2.ReportService.GetViewBasedReportHistory:output_type -> v2.ReportHistoryResponse
-	48, // [48:63] is the sub-list for method output_type
-	33, // [33:48] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	32, // 8: v2.VulnerabilityReportFilters.since_start_date:type_name -> google.protobuf.Timestamp
+	5,  // 9: v2.ReportSchedule.interval_type:type_name -> v2.ReportSchedule.IntervalType
+	30, // 10: v2.ReportSchedule.days_of_week:type_name -> v2.ReportSchedule.DaysOfWeek
+	31, // 11: v2.ReportSchedule.days_of_month:type_name -> v2.ReportSchedule.DaysOfMonth
+	14, // 12: v2.ResourceScope.collection_scope:type_name -> v2.CollectionReference
+	16, // 13: v2.NotifierConfiguration.email_config:type_name -> v2.EmailNotifierConfiguration
+	9,  // 14: v2.ListReportConfigurationsResponse.report_configs:type_name -> v2.ReportConfiguration
+	33, // 15: v2.GetReportHistoryRequest.report_param_query:type_name -> v2.RawQuery
+	23, // 16: v2.ReportHistoryResponse.report_snapshots:type_name -> v2.ReportSnapshot
+	24, // 17: v2.ReportStatusResponse.status:type_name -> v2.ReportStatus
+	10, // 18: v2.ReportSnapshot.vuln_report_filters:type_name -> v2.VulnerabilityReportFilters
+	11, // 19: v2.ReportSnapshot.view_based_vuln_report_filters:type_name -> v2.ViewBasedVulnerabilityReportFilters
+	22, // 20: v2.ReportSnapshot.collection_snapshot:type_name -> v2.CollectionSnapshot
+	12, // 21: v2.ReportSnapshot.schedule:type_name -> v2.ReportSchedule
+	24, // 22: v2.ReportSnapshot.report_status:type_name -> v2.ReportStatus
+	15, // 23: v2.ReportSnapshot.notifiers:type_name -> v2.NotifierConfiguration
+	34, // 24: v2.ReportSnapshot.user:type_name -> v2.SlimUser
+	6,  // 25: v2.ReportStatus.run_state:type_name -> v2.ReportStatus.RunState
+	32, // 26: v2.ReportStatus.completed_at:type_name -> google.protobuf.Timestamp
+	7,  // 27: v2.ReportStatus.report_request_type:type_name -> v2.ReportStatus.ReportMethod
+	0,  // 28: v2.ReportStatus.report_notification_method:type_name -> v2.NotificationMethod
+	0,  // 29: v2.RunReportRequest.report_notification_method:type_name -> v2.NotificationMethod
+	8,  // 30: v2.ReportRequestViewBased.type:type_name -> v2.ReportRequestViewBased.ReportType
+	11, // 31: v2.ReportRequestViewBased.view_based_vuln_report_filters:type_name -> v2.ViewBasedVulnerabilityReportFilters
+	9,  // 32: v2.ReportService.PostReportConfiguration:input_type -> v2.ReportConfiguration
+	9,  // 33: v2.ReportService.UpdateReportConfiguration:input_type -> v2.ReportConfiguration
+	33, // 34: v2.ReportService.ListReportConfigurations:input_type -> v2.RawQuery
+	33, // 35: v2.ReportService.CountReportConfigurations:input_type -> v2.RawQuery
+	35, // 36: v2.ReportService.GetReportConfiguration:input_type -> v2.ResourceByID
+	35, // 37: v2.ReportService.DeleteReportConfiguration:input_type -> v2.ResourceByID
+	35, // 38: v2.ReportService.GetReportStatus:input_type -> v2.ResourceByID
+	19, // 39: v2.ReportService.GetReportHistory:input_type -> v2.GetReportHistoryRequest
+	19, // 40: v2.ReportService.GetMyReportHistory:input_type -> v2.GetReportHistoryRequest
+	25, // 41: v2.ReportService.RunReport:input_type -> v2.RunReportRequest
+	35, // 42: v2.ReportService.CancelReport:input_type -> v2.ResourceByID
+	27, // 43: v2.ReportService.DeleteReport:input_type -> v2.DeleteReportRequest
+	28, // 44: v2.ReportService.PostViewBasedReport:input_type -> v2.ReportRequestViewBased
+	33, // 45: v2.ReportService.GetViewBasedReportMyHistory:input_type -> v2.RawQuery
+	33, // 46: v2.ReportService.GetViewBasedReportHistory:input_type -> v2.RawQuery
+	9,  // 47: v2.ReportService.PostReportConfiguration:output_type -> v2.ReportConfiguration
+	36, // 48: v2.ReportService.UpdateReportConfiguration:output_type -> v2.Empty
+	17, // 49: v2.ReportService.ListReportConfigurations:output_type -> v2.ListReportConfigurationsResponse
+	18, // 50: v2.ReportService.CountReportConfigurations:output_type -> v2.CountReportConfigurationsResponse
+	9,  // 51: v2.ReportService.GetReportConfiguration:output_type -> v2.ReportConfiguration
+	36, // 52: v2.ReportService.DeleteReportConfiguration:output_type -> v2.Empty
+	21, // 53: v2.ReportService.GetReportStatus:output_type -> v2.ReportStatusResponse
+	20, // 54: v2.ReportService.GetReportHistory:output_type -> v2.ReportHistoryResponse
+	20, // 55: v2.ReportService.GetMyReportHistory:output_type -> v2.ReportHistoryResponse
+	26, // 56: v2.ReportService.RunReport:output_type -> v2.RunReportResponse
+	36, // 57: v2.ReportService.CancelReport:output_type -> v2.Empty
+	36, // 58: v2.ReportService.DeleteReport:output_type -> v2.Empty
+	29, // 59: v2.ReportService.PostViewBasedReport:output_type -> v2.RunReportResponseViewBased
+	20, // 60: v2.ReportService.GetViewBasedReportMyHistory:output_type -> v2.ReportHistoryResponse
+	20, // 61: v2.ReportService.GetViewBasedReportHistory:output_type -> v2.ReportHistoryResponse
+	47, // [47:62] is the sub-list for method output_type
+	32, // [32:47] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_report_service_proto_init() }
@@ -2436,7 +2357,7 @@ func file_api_v2_report_service_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_report_service_proto_rawDesc), len(file_api_v2_report_service_proto_rawDesc)),
-			NumEnums:      10,
+			NumEnums:      9,
 			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/generated/api/v2/report_service.swagger.json
+++ b/generated/api/v2/report_service.swagger.json
@@ -809,6 +809,14 @@
       ],
       "default": "BOTH"
     },
+    "VulnerabilityReportFiltersImageType": {
+      "type": "string",
+      "enum": [
+        "DEPLOYED",
+        "WATCHED"
+      ],
+      "default": "DEPLOYED"
+    },
     "protobufAny": {
       "type": "object",
       "properties": {
@@ -1272,31 +1280,11 @@
     "v2ViewBasedVulnerabilityReportFilters": {
       "type": "object",
       "properties": {
-        "imageTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v2ViewBasedVulnerabilityReportFiltersImageType"
-          }
-        },
-        "includeNvdCvss": {
-          "type": "boolean"
-        },
-        "includeEpssProbability": {
-          "type": "boolean"
-        },
         "query": {
           "type": "string"
         }
       },
       "title": "filter for ondemand view based reports"
-    },
-    "v2ViewBasedVulnerabilityReportFiltersImageType": {
-      "type": "string",
-      "enum": [
-        "DEPLOYED",
-        "WATCHED"
-      ],
-      "default": "DEPLOYED"
     },
     "v2VulnerabilityReportFilters": {
       "type": "object",
@@ -1313,7 +1301,7 @@
         "imageTypes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/v2VulnerabilityReportFiltersImageType"
+            "$ref": "#/definitions/VulnerabilityReportFiltersImageType"
           }
         },
         "allVuln": {
@@ -1336,14 +1324,6 @@
           "type": "boolean"
         }
       }
-    },
-    "v2VulnerabilityReportFiltersImageType": {
-      "type": "string",
-      "enum": [
-        "DEPLOYED",
-        "WATCHED"
-      ],
-      "default": "DEPLOYED"
     },
     "v2VulnerabilityReportFiltersVulnerabilitySeverity": {
       "type": "string",

--- a/generated/api/v2/report_service_vtproto.pb.go
+++ b/generated/api/v2/report_service_vtproto.pb.go
@@ -132,14 +132,7 @@ func (m *ViewBasedVulnerabilityReportFilters) CloneVT() *ViewBasedVulnerabilityR
 		return (*ViewBasedVulnerabilityReportFilters)(nil)
 	}
 	r := new(ViewBasedVulnerabilityReportFilters)
-	r.IncludeNvdCvss = m.IncludeNvdCvss
-	r.IncludeEpssProbability = m.IncludeEpssProbability
 	r.Query = m.Query
-	if rhs := m.ImageTypes; rhs != nil {
-		tmpContainer := make([]ViewBasedVulnerabilityReportFilters_ImageType, len(rhs))
-		copy(tmpContainer, rhs)
-		r.ImageTypes = tmpContainer
-	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -842,21 +835,6 @@ func (this *ViewBasedVulnerabilityReportFilters) EqualVT(that *ViewBasedVulnerab
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
-		return false
-	}
-	if len(this.ImageTypes) != len(that.ImageTypes) {
-		return false
-	}
-	for i, vx := range this.ImageTypes {
-		vy := that.ImageTypes[i]
-		if vx != vy {
-			return false
-		}
-	}
-	if this.IncludeNvdCvss != that.IncludeNvdCvss {
-		return false
-	}
-	if this.IncludeEpssProbability != that.IncludeEpssProbability {
 		return false
 	}
 	if this.Query != that.Query {
@@ -1954,47 +1932,6 @@ func (m *ViewBasedVulnerabilityReportFilters) MarshalToSizedBufferVT(dAtA []byte
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Query)))
 		i--
 		dAtA[i] = 0x2a
-	}
-	if m.IncludeEpssProbability {
-		i--
-		if m.IncludeEpssProbability {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x20
-	}
-	if m.IncludeNvdCvss {
-		i--
-		if m.IncludeNvdCvss {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x18
-	}
-	if len(m.ImageTypes) > 0 {
-		var pksize2 int
-		for _, num := range m.ImageTypes {
-			pksize2 += protohelpers.SizeOfVarint(uint64(num))
-		}
-		i -= pksize2
-		j1 := i
-		for _, num1 := range m.ImageTypes {
-			num := uint64(num1)
-			for num >= 1<<7 {
-				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
-				num >>= 7
-				j1++
-			}
-			dAtA[j1] = uint8(num)
-			j1++
-		}
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
-		i--
-		dAtA[i] = 0x12
 	}
 	return len(dAtA) - i, nil
 }
@@ -3357,19 +3294,6 @@ func (m *ViewBasedVulnerabilityReportFilters) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	if len(m.ImageTypes) > 0 {
-		l = 0
-		for _, e := range m.ImageTypes {
-			l += protohelpers.SizeOfVarint(uint64(e))
-		}
-		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
-	}
-	if m.IncludeNvdCvss {
-		n += 2
-	}
-	if m.IncludeEpssProbability {
-		n += 2
-	}
 	l = len(m.Query)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -4564,115 +4488,6 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVT(dAtA []byte) error {
 			return fmt.Errorf("proto: ViewBasedVulnerabilityReportFilters: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 2:
-			if wireType == 0 {
-				var v ViewBasedVulnerabilityReportFilters_ImageType
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				m.ImageTypes = append(m.ImageTypes, v)
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.ImageTypes) == 0 {
-					m.ImageTypes = make([]ViewBasedVulnerabilityReportFilters_ImageType, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v ViewBasedVulnerabilityReportFilters_ImageType
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					m.ImageTypes = append(m.ImageTypes, v)
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field ImageTypes", wireType)
-			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeNvdCvss = bool(v != 0)
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeEpssProbability = bool(v != 0)
 		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
@@ -8140,115 +7955,6 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVTUnsafe(dAtA []byte) err
 			return fmt.Errorf("proto: ViewBasedVulnerabilityReportFilters: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 2:
-			if wireType == 0 {
-				var v ViewBasedVulnerabilityReportFilters_ImageType
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				m.ImageTypes = append(m.ImageTypes, v)
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.ImageTypes) == 0 {
-					m.ImageTypes = make([]ViewBasedVulnerabilityReportFilters_ImageType, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v ViewBasedVulnerabilityReportFilters_ImageType
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					m.ImageTypes = append(m.ImageTypes, v)
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field ImageTypes", wireType)
-			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeNvdCvss = bool(v != 0)
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeEpssProbability = bool(v != 0)
 		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)

--- a/generated/storage/report_configuration.pb.go
+++ b/generated/storage/report_configuration.pb.go
@@ -740,6 +740,7 @@ type ViewBasedVulnerabilityReportFilters struct {
 	IncludeNvdCvss         bool                                            `protobuf:"varint,3,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`
 	IncludeEpssProbability bool                                            `protobuf:"varint,4,opt,name=include_epss_probability,json=includeEpssProbability,proto3" json:"include_epss_probability,omitempty"`
 	Query                  string                                          `protobuf:"bytes,5,opt,name=query,proto3" json:"query,omitempty"`
+	AccessScopeRules       []*SimpleAccessScope_Rules                      `protobuf:"bytes,6,rep,name=access_scope_rules,json=accessScopeRules,proto3" json:"access_scope_rules,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -800,6 +801,13 @@ func (x *ViewBasedVulnerabilityReportFilters) GetQuery() string {
 		return x.Query
 	}
 	return ""
+}
+
+func (x *ViewBasedVulnerabilityReportFilters) GetAccessScopeRules() []*SimpleAccessScope_Rules {
+	if x != nil {
+		return x.AccessScopeRules
+	}
+	return nil
 }
 
 var File_storage_report_configuration_proto protoreflect.FileDescriptor
@@ -865,13 +873,14 @@ const file_storage_report_configuration_proto_rawDesc = "" +
 	"cves_since\"I\n" +
 	"\rResourceScope\x12%\n" +
 	"\rcollection_id\x18\x01 \x01(\tH\x00R\fcollectionIdB\x11\n" +
-	"\x0fscope_reference\"\xa0\x02\n" +
+	"\x0fscope_reference\"\xf0\x02\n" +
 	"#ViewBasedVulnerabilityReportFilters\x12W\n" +
 	"\vimage_types\x18\x02 \x03(\x0e26.storage.ViewBasedVulnerabilityReportFilters.ImageTypeR\n" +
 	"imageTypes\x12(\n" +
 	"\x10include_nvd_cvss\x18\x03 \x01(\bR\x0eincludeNvdCvss\x128\n" +
 	"\x18include_epss_probability\x18\x04 \x01(\bR\x16includeEpssProbability\x12\x14\n" +
-	"\x05query\x18\x05 \x01(\tR\x05query\"&\n" +
+	"\x05query\x18\x05 \x01(\tR\x05query\x12N\n" +
+	"\x12access_scope_rules\x18\x06 \x03(\v2 .storage.SimpleAccessScope.RulesR\x10accessScopeRules\"&\n" +
 	"\tImageType\x12\f\n" +
 	"\bDEPLOYED\x10\x00\x12\v\n" +
 	"\aWATCHED\x10\x01B.\n" +
@@ -928,11 +937,12 @@ var file_storage_report_configuration_proto_depIdxs = []int32{
 	12, // 14: storage.VulnerabilityReportFilters.since_start_date:type_name -> google.protobuf.Timestamp
 	16, // 15: storage.VulnerabilityReportFilters.access_scope_rules:type_name -> storage.SimpleAccessScope.Rules
 	4,  // 16: storage.ViewBasedVulnerabilityReportFilters.image_types:type_name -> storage.ViewBasedVulnerabilityReportFilters.ImageType
-	17, // [17:17] is the sub-list for method output_type
-	17, // [17:17] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	16, // 17: storage.ViewBasedVulnerabilityReportFilters.access_scope_rules:type_name -> storage.SimpleAccessScope.Rules
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_storage_report_configuration_proto_init() }

--- a/generated/storage/report_configuration.pb.go
+++ b/generated/storage/report_configuration.pb.go
@@ -206,52 +206,6 @@ func (VulnerabilityReportFilters_ImageType) EnumDescriptor() ([]byte, []int) {
 	return file_storage_report_configuration_proto_rawDescGZIP(), []int{2, 1}
 }
 
-type ViewBasedVulnerabilityReportFilters_ImageType int32
-
-const (
-	ViewBasedVulnerabilityReportFilters_DEPLOYED ViewBasedVulnerabilityReportFilters_ImageType = 0
-	ViewBasedVulnerabilityReportFilters_WATCHED  ViewBasedVulnerabilityReportFilters_ImageType = 1
-)
-
-// Enum value maps for ViewBasedVulnerabilityReportFilters_ImageType.
-var (
-	ViewBasedVulnerabilityReportFilters_ImageType_name = map[int32]string{
-		0: "DEPLOYED",
-		1: "WATCHED",
-	}
-	ViewBasedVulnerabilityReportFilters_ImageType_value = map[string]int32{
-		"DEPLOYED": 0,
-		"WATCHED":  1,
-	}
-)
-
-func (x ViewBasedVulnerabilityReportFilters_ImageType) Enum() *ViewBasedVulnerabilityReportFilters_ImageType {
-	p := new(ViewBasedVulnerabilityReportFilters_ImageType)
-	*p = x
-	return p
-}
-
-func (x ViewBasedVulnerabilityReportFilters_ImageType) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (ViewBasedVulnerabilityReportFilters_ImageType) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_report_configuration_proto_enumTypes[4].Descriptor()
-}
-
-func (ViewBasedVulnerabilityReportFilters_ImageType) Type() protoreflect.EnumType {
-	return &file_storage_report_configuration_proto_enumTypes[4]
-}
-
-func (x ViewBasedVulnerabilityReportFilters_ImageType) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use ViewBasedVulnerabilityReportFilters_ImageType.Descriptor instead.
-func (ViewBasedVulnerabilityReportFilters_ImageType) EnumDescriptor() ([]byte, []int) {
-	return file_storage_report_configuration_proto_rawDescGZIP(), []int{4, 0}
-}
-
 type ReportConfiguration struct {
 	state       protoimpl.MessageState         `protogen:"open.v1"`
 	Id          string                         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk"`     // @gotags: sql:"pk"
@@ -735,14 +689,11 @@ func (*ResourceScope_CollectionId) isResourceScope_ScopeReference() {}
 
 // filter for view based reports
 type ViewBasedVulnerabilityReportFilters struct {
-	state                  protoimpl.MessageState                          `protogen:"open.v1"`
-	ImageTypes             []ViewBasedVulnerabilityReportFilters_ImageType `protobuf:"varint,2,rep,packed,name=image_types,json=imageTypes,proto3,enum=storage.ViewBasedVulnerabilityReportFilters_ImageType" json:"image_types,omitempty"`
-	IncludeNvdCvss         bool                                            `protobuf:"varint,3,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`
-	IncludeEpssProbability bool                                            `protobuf:"varint,4,opt,name=include_epss_probability,json=includeEpssProbability,proto3" json:"include_epss_probability,omitempty"`
-	Query                  string                                          `protobuf:"bytes,5,opt,name=query,proto3" json:"query,omitempty"`
-	AccessScopeRules       []*SimpleAccessScope_Rules                      `protobuf:"bytes,6,rep,name=access_scope_rules,json=accessScopeRules,proto3" json:"access_scope_rules,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state            protoimpl.MessageState     `protogen:"open.v1"`
+	Query            string                     `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	AccessScopeRules []*SimpleAccessScope_Rules `protobuf:"bytes,2,rep,name=access_scope_rules,json=accessScopeRules,proto3" json:"access_scope_rules,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ViewBasedVulnerabilityReportFilters) Reset() {
@@ -773,27 +724,6 @@ func (x *ViewBasedVulnerabilityReportFilters) ProtoReflect() protoreflect.Messag
 // Deprecated: Use ViewBasedVulnerabilityReportFilters.ProtoReflect.Descriptor instead.
 func (*ViewBasedVulnerabilityReportFilters) Descriptor() ([]byte, []int) {
 	return file_storage_report_configuration_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *ViewBasedVulnerabilityReportFilters) GetImageTypes() []ViewBasedVulnerabilityReportFilters_ImageType {
-	if x != nil {
-		return x.ImageTypes
-	}
-	return nil
-}
-
-func (x *ViewBasedVulnerabilityReportFilters) GetIncludeNvdCvss() bool {
-	if x != nil {
-		return x.IncludeNvdCvss
-	}
-	return false
-}
-
-func (x *ViewBasedVulnerabilityReportFilters) GetIncludeEpssProbability() bool {
-	if x != nil {
-		return x.IncludeEpssProbability
-	}
-	return false
 }
 
 func (x *ViewBasedVulnerabilityReportFilters) GetQuery() string {
@@ -873,17 +803,10 @@ const file_storage_report_configuration_proto_rawDesc = "" +
 	"cves_since\"I\n" +
 	"\rResourceScope\x12%\n" +
 	"\rcollection_id\x18\x01 \x01(\tH\x00R\fcollectionIdB\x11\n" +
-	"\x0fscope_reference\"\xf0\x02\n" +
-	"#ViewBasedVulnerabilityReportFilters\x12W\n" +
-	"\vimage_types\x18\x02 \x03(\x0e26.storage.ViewBasedVulnerabilityReportFilters.ImageTypeR\n" +
-	"imageTypes\x12(\n" +
-	"\x10include_nvd_cvss\x18\x03 \x01(\bR\x0eincludeNvdCvss\x128\n" +
-	"\x18include_epss_probability\x18\x04 \x01(\bR\x16includeEpssProbability\x12\x14\n" +
-	"\x05query\x18\x05 \x01(\tR\x05query\x12N\n" +
-	"\x12access_scope_rules\x18\x06 \x03(\v2 .storage.SimpleAccessScope.RulesR\x10accessScopeRules\"&\n" +
-	"\tImageType\x12\f\n" +
-	"\bDEPLOYED\x10\x00\x12\v\n" +
-	"\aWATCHED\x10\x01B.\n" +
+	"\x0fscope_reference\"\x8b\x01\n" +
+	"#ViewBasedVulnerabilityReportFilters\x12\x14\n" +
+	"\x05query\x18\x01 \x01(\tR\x05query\x12N\n" +
+	"\x12access_scope_rules\x18\x02 \x03(\v2 .storage.SimpleAccessScope.RulesR\x10accessScopeRulesB.\n" +
 	"\x19io.stackrox.proto.storageZ\x11./storage;storageb\x06proto3"
 
 var (
@@ -898,51 +821,49 @@ func file_storage_report_configuration_proto_rawDescGZIP() []byte {
 	return file_storage_report_configuration_proto_rawDescData
 }
 
-var file_storage_report_configuration_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_storage_report_configuration_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_storage_report_configuration_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_storage_report_configuration_proto_goTypes = []any{
-	(ReportConfiguration_ReportType)(0),                // 0: storage.ReportConfiguration.ReportType
-	(ReportLastRunStatus_RunStatus)(0),                 // 1: storage.ReportLastRunStatus.RunStatus
-	(VulnerabilityReportFilters_Fixability)(0),         // 2: storage.VulnerabilityReportFilters.Fixability
-	(VulnerabilityReportFilters_ImageType)(0),          // 3: storage.VulnerabilityReportFilters.ImageType
-	(ViewBasedVulnerabilityReportFilters_ImageType)(0), // 4: storage.ViewBasedVulnerabilityReportFilters.ImageType
-	(*ReportConfiguration)(nil),                        // 5: storage.ReportConfiguration
-	(*ReportLastRunStatus)(nil),                        // 6: storage.ReportLastRunStatus
-	(*VulnerabilityReportFilters)(nil),                 // 7: storage.VulnerabilityReportFilters
-	(*ResourceScope)(nil),                              // 8: storage.ResourceScope
-	(*ViewBasedVulnerabilityReportFilters)(nil),        // 9: storage.ViewBasedVulnerabilityReportFilters
-	(*EmailNotifierConfiguration)(nil),                 // 10: storage.EmailNotifierConfiguration
-	(*Schedule)(nil),                                   // 11: storage.Schedule
-	(*timestamppb.Timestamp)(nil),                      // 12: google.protobuf.Timestamp
-	(*NotifierConfiguration)(nil),                      // 13: storage.NotifierConfiguration
-	(*SlimUser)(nil),                                   // 14: storage.SlimUser
-	(VulnerabilitySeverity)(0),                         // 15: storage.VulnerabilitySeverity
-	(*SimpleAccessScope_Rules)(nil),                    // 16: storage.SimpleAccessScope.Rules
+	(ReportConfiguration_ReportType)(0),         // 0: storage.ReportConfiguration.ReportType
+	(ReportLastRunStatus_RunStatus)(0),          // 1: storage.ReportLastRunStatus.RunStatus
+	(VulnerabilityReportFilters_Fixability)(0),  // 2: storage.VulnerabilityReportFilters.Fixability
+	(VulnerabilityReportFilters_ImageType)(0),   // 3: storage.VulnerabilityReportFilters.ImageType
+	(*ReportConfiguration)(nil),                 // 4: storage.ReportConfiguration
+	(*ReportLastRunStatus)(nil),                 // 5: storage.ReportLastRunStatus
+	(*VulnerabilityReportFilters)(nil),          // 6: storage.VulnerabilityReportFilters
+	(*ResourceScope)(nil),                       // 7: storage.ResourceScope
+	(*ViewBasedVulnerabilityReportFilters)(nil), // 8: storage.ViewBasedVulnerabilityReportFilters
+	(*EmailNotifierConfiguration)(nil),          // 9: storage.EmailNotifierConfiguration
+	(*Schedule)(nil),                            // 10: storage.Schedule
+	(*timestamppb.Timestamp)(nil),               // 11: google.protobuf.Timestamp
+	(*NotifierConfiguration)(nil),               // 12: storage.NotifierConfiguration
+	(*SlimUser)(nil),                            // 13: storage.SlimUser
+	(VulnerabilitySeverity)(0),                  // 14: storage.VulnerabilitySeverity
+	(*SimpleAccessScope_Rules)(nil),             // 15: storage.SimpleAccessScope.Rules
 }
 var file_storage_report_configuration_proto_depIdxs = []int32{
 	0,  // 0: storage.ReportConfiguration.type:type_name -> storage.ReportConfiguration.ReportType
-	7,  // 1: storage.ReportConfiguration.vuln_report_filters:type_name -> storage.VulnerabilityReportFilters
-	10, // 2: storage.ReportConfiguration.email_config:type_name -> storage.EmailNotifierConfiguration
-	11, // 3: storage.ReportConfiguration.schedule:type_name -> storage.Schedule
-	6,  // 4: storage.ReportConfiguration.last_run_status:type_name -> storage.ReportLastRunStatus
-	12, // 5: storage.ReportConfiguration.last_successful_run_time:type_name -> google.protobuf.Timestamp
-	8,  // 6: storage.ReportConfiguration.resource_scope:type_name -> storage.ResourceScope
-	13, // 7: storage.ReportConfiguration.notifiers:type_name -> storage.NotifierConfiguration
-	14, // 8: storage.ReportConfiguration.creator:type_name -> storage.SlimUser
+	6,  // 1: storage.ReportConfiguration.vuln_report_filters:type_name -> storage.VulnerabilityReportFilters
+	9,  // 2: storage.ReportConfiguration.email_config:type_name -> storage.EmailNotifierConfiguration
+	10, // 3: storage.ReportConfiguration.schedule:type_name -> storage.Schedule
+	5,  // 4: storage.ReportConfiguration.last_run_status:type_name -> storage.ReportLastRunStatus
+	11, // 5: storage.ReportConfiguration.last_successful_run_time:type_name -> google.protobuf.Timestamp
+	7,  // 6: storage.ReportConfiguration.resource_scope:type_name -> storage.ResourceScope
+	12, // 7: storage.ReportConfiguration.notifiers:type_name -> storage.NotifierConfiguration
+	13, // 8: storage.ReportConfiguration.creator:type_name -> storage.SlimUser
 	1,  // 9: storage.ReportLastRunStatus.report_status:type_name -> storage.ReportLastRunStatus.RunStatus
-	12, // 10: storage.ReportLastRunStatus.last_run_time:type_name -> google.protobuf.Timestamp
+	11, // 10: storage.ReportLastRunStatus.last_run_time:type_name -> google.protobuf.Timestamp
 	2,  // 11: storage.VulnerabilityReportFilters.fixability:type_name -> storage.VulnerabilityReportFilters.Fixability
-	15, // 12: storage.VulnerabilityReportFilters.severities:type_name -> storage.VulnerabilitySeverity
+	14, // 12: storage.VulnerabilityReportFilters.severities:type_name -> storage.VulnerabilitySeverity
 	3,  // 13: storage.VulnerabilityReportFilters.image_types:type_name -> storage.VulnerabilityReportFilters.ImageType
-	12, // 14: storage.VulnerabilityReportFilters.since_start_date:type_name -> google.protobuf.Timestamp
-	16, // 15: storage.VulnerabilityReportFilters.access_scope_rules:type_name -> storage.SimpleAccessScope.Rules
-	4,  // 16: storage.ViewBasedVulnerabilityReportFilters.image_types:type_name -> storage.ViewBasedVulnerabilityReportFilters.ImageType
-	16, // 17: storage.ViewBasedVulnerabilityReportFilters.access_scope_rules:type_name -> storage.SimpleAccessScope.Rules
-	18, // [18:18] is the sub-list for method output_type
-	18, // [18:18] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	11, // 14: storage.VulnerabilityReportFilters.since_start_date:type_name -> google.protobuf.Timestamp
+	15, // 15: storage.VulnerabilityReportFilters.access_scope_rules:type_name -> storage.SimpleAccessScope.Rules
+	15, // 16: storage.ViewBasedVulnerabilityReportFilters.access_scope_rules:type_name -> storage.SimpleAccessScope.Rules
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_storage_report_configuration_proto_init() }
@@ -972,7 +893,7 @@ func file_storage_report_configuration_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_report_configuration_proto_rawDesc), len(file_storage_report_configuration_proto_rawDesc)),
-			NumEnums:      5,
+			NumEnums:      4,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/generated/storage/report_configuration_vtproto.pb.go
+++ b/generated/storage/report_configuration_vtproto.pb.go
@@ -208,14 +208,7 @@ func (m *ViewBasedVulnerabilityReportFilters) CloneVT() *ViewBasedVulnerabilityR
 		return (*ViewBasedVulnerabilityReportFilters)(nil)
 	}
 	r := new(ViewBasedVulnerabilityReportFilters)
-	r.IncludeNvdCvss = m.IncludeNvdCvss
-	r.IncludeEpssProbability = m.IncludeEpssProbability
 	r.Query = m.Query
-	if rhs := m.ImageTypes; rhs != nil {
-		tmpContainer := make([]ViewBasedVulnerabilityReportFilters_ImageType, len(rhs))
-		copy(tmpContainer, rhs)
-		r.ImageTypes = tmpContainer
-	}
 	if rhs := m.AccessScopeRules; rhs != nil {
 		tmpContainer := make([]*SimpleAccessScope_Rules, len(rhs))
 		for k, v := range rhs {
@@ -585,21 +578,6 @@ func (this *ViewBasedVulnerabilityReportFilters) EqualVT(that *ViewBasedVulnerab
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
-		return false
-	}
-	if len(this.ImageTypes) != len(that.ImageTypes) {
-		return false
-	}
-	for i, vx := range this.ImageTypes {
-		vy := that.ImageTypes[i]
-		if vx != vy {
-			return false
-		}
-	}
-	if this.IncludeNvdCvss != that.IncludeNvdCvss {
-		return false
-	}
-	if this.IncludeEpssProbability != that.IncludeEpssProbability {
 		return false
 	}
 	if this.Query != that.Query {
@@ -1177,7 +1155,7 @@ func (m *ViewBasedVulnerabilityReportFilters) MarshalToSizedBufferVT(dAtA []byte
 			i -= size
 			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
-			dAtA[i] = 0x32
+			dAtA[i] = 0x12
 		}
 	}
 	if len(m.Query) > 0 {
@@ -1185,48 +1163,7 @@ func (m *ViewBasedVulnerabilityReportFilters) MarshalToSizedBufferVT(dAtA []byte
 		copy(dAtA[i:], m.Query)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Query)))
 		i--
-		dAtA[i] = 0x2a
-	}
-	if m.IncludeEpssProbability {
-		i--
-		if m.IncludeEpssProbability {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x20
-	}
-	if m.IncludeNvdCvss {
-		i--
-		if m.IncludeNvdCvss {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x18
-	}
-	if len(m.ImageTypes) > 0 {
-		var pksize2 int
-		for _, num := range m.ImageTypes {
-			pksize2 += protohelpers.SizeOfVarint(uint64(num))
-		}
-		i -= pksize2
-		j1 := i
-		for _, num1 := range m.ImageTypes {
-			num := uint64(num1)
-			for num >= 1<<7 {
-				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
-				num >>= 7
-				j1++
-			}
-			dAtA[j1] = uint8(num)
-			j1++
-		}
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
-		i--
-		dAtA[i] = 0x12
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -1453,19 +1390,6 @@ func (m *ViewBasedVulnerabilityReportFilters) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	if len(m.ImageTypes) > 0 {
-		l = 0
-		for _, e := range m.ImageTypes {
-			l += protohelpers.SizeOfVarint(uint64(e))
-		}
-		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
-	}
-	if m.IncludeNvdCvss {
-		n += 2
-	}
-	if m.IncludeEpssProbability {
-		n += 2
-	}
 	l = len(m.Query)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -2648,116 +2572,7 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVT(dAtA []byte) error {
 			return fmt.Errorf("proto: ViewBasedVulnerabilityReportFilters: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 2:
-			if wireType == 0 {
-				var v ViewBasedVulnerabilityReportFilters_ImageType
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				m.ImageTypes = append(m.ImageTypes, v)
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.ImageTypes) == 0 {
-					m.ImageTypes = make([]ViewBasedVulnerabilityReportFilters_ImageType, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v ViewBasedVulnerabilityReportFilters_ImageType
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					m.ImageTypes = append(m.ImageTypes, v)
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field ImageTypes", wireType)
-			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeNvdCvss = bool(v != 0)
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeEpssProbability = bool(v != 0)
-		case 5:
+		case 1:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
 			}
@@ -2789,7 +2604,7 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Query = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 6:
+		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field AccessScopeRules", wireType)
 			}
@@ -4037,116 +3852,7 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVTUnsafe(dAtA []byte) err
 			return fmt.Errorf("proto: ViewBasedVulnerabilityReportFilters: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 2:
-			if wireType == 0 {
-				var v ViewBasedVulnerabilityReportFilters_ImageType
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				m.ImageTypes = append(m.ImageTypes, v)
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.ImageTypes) == 0 {
-					m.ImageTypes = make([]ViewBasedVulnerabilityReportFilters_ImageType, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v ViewBasedVulnerabilityReportFilters_ImageType
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						v |= ViewBasedVulnerabilityReportFilters_ImageType(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					m.ImageTypes = append(m.ImageTypes, v)
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field ImageTypes", wireType)
-			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeNvdCvss = bool(v != 0)
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeEpssProbability = bool(v != 0)
-		case 5:
+		case 1:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
 			}
@@ -4182,7 +3888,7 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVTUnsafe(dAtA []byte) err
 			}
 			m.Query = stringValue
 			iNdEx = postIndex
-		case 6:
+		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field AccessScopeRules", wireType)
 			}

--- a/generated/storage/report_configuration_vtproto.pb.go
+++ b/generated/storage/report_configuration_vtproto.pb.go
@@ -216,6 +216,13 @@ func (m *ViewBasedVulnerabilityReportFilters) CloneVT() *ViewBasedVulnerabilityR
 		copy(tmpContainer, rhs)
 		r.ImageTypes = tmpContainer
 	}
+	if rhs := m.AccessScopeRules; rhs != nil {
+		tmpContainer := make([]*SimpleAccessScope_Rules, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.AccessScopeRules = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -597,6 +604,23 @@ func (this *ViewBasedVulnerabilityReportFilters) EqualVT(that *ViewBasedVulnerab
 	}
 	if this.Query != that.Query {
 		return false
+	}
+	if len(this.AccessScopeRules) != len(that.AccessScopeRules) {
+		return false
+	}
+	for i, vx := range this.AccessScopeRules {
+		vy := that.AccessScopeRules[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &SimpleAccessScope_Rules{}
+			}
+			if q == nil {
+				q = &SimpleAccessScope_Rules{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -1144,6 +1168,18 @@ func (m *ViewBasedVulnerabilityReportFilters) MarshalToSizedBufferVT(dAtA []byte
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.AccessScopeRules) > 0 {
+		for iNdEx := len(m.AccessScopeRules) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.AccessScopeRules[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if len(m.Query) > 0 {
 		i -= len(m.Query)
 		copy(dAtA[i:], m.Query)
@@ -1433,6 +1469,12 @@ func (m *ViewBasedVulnerabilityReportFilters) SizeVT() (n int) {
 	l = len(m.Query)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.AccessScopeRules) > 0 {
+		for _, e := range m.AccessScopeRules {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2746,6 +2788,40 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Query = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccessScopeRules", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AccessScopeRules = append(m.AccessScopeRules, &SimpleAccessScope_Rules{})
+			if err := m.AccessScopeRules[len(m.AccessScopeRules)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -4105,6 +4181,40 @@ func (m *ViewBasedVulnerabilityReportFilters) UnmarshalVTUnsafe(dAtA []byte) err
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.Query = stringValue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccessScopeRules", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AccessScopeRules = append(m.AccessScopeRules, &SimpleAccessScope_Rules{})
+			if err := m.AccessScopeRules[len(m.AccessScopeRules)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/proto/api/v2/report_service.proto
+++ b/proto/api/v2/report_service.proto
@@ -63,13 +63,6 @@ message VulnerabilityReportFilters {
 
 //filter for ondemand view based reports
 message ViewBasedVulnerabilityReportFilters {
-  enum ImageType {
-    DEPLOYED = 0;
-    WATCHED = 1;
-  }
-  repeated ImageType image_types = 2;
-  bool include_nvd_cvss = 3;
-  bool include_epss_probability = 4;
   string query = 5;
 }
 

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -14568,18 +14568,6 @@
                 "integer": 1
               }
             ]
-          },
-          {
-            "name": "ViewBasedVulnerabilityReportFilters.ImageType",
-            "enum_fields": [
-              {
-                "name": "DEPLOYED"
-              },
-              {
-                "name": "WATCHED",
-                "integer": 1
-              }
-            ]
           }
         ],
         "messages": [
@@ -14762,25 +14750,15 @@
             "name": "ViewBasedVulnerabilityReportFilters",
             "fields": [
               {
-                "id": 2,
-                "name": "image_types",
-                "type": "ImageType",
-                "is_repeated": true
-              },
-              {
-                "id": 3,
-                "name": "include_nvd_cvss",
-                "type": "bool"
-              },
-              {
-                "id": 4,
-                "name": "include_epss_probability",
-                "type": "bool"
-              },
-              {
-                "id": 5,
+                "id": 1,
                 "name": "query",
                 "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "access_scope_rules",
+                "type": "SimpleAccessScope.Rules",
+                "is_repeated": true
               }
             ]
           }

--- a/proto/storage/report_configuration.proto
+++ b/proto/storage/report_configuration.proto
@@ -90,4 +90,5 @@ message ViewBasedVulnerabilityReportFilters {
   bool include_nvd_cvss = 3;
   bool include_epss_probability = 4;
   string query = 5;
+  repeated SimpleAccessScope.Rules access_scope_rules = 6;
 }

--- a/proto/storage/report_configuration.proto
+++ b/proto/storage/report_configuration.proto
@@ -82,13 +82,6 @@ message ResourceScope {
 
 // filter for view based reports
 message ViewBasedVulnerabilityReportFilters {
-  enum ImageType {
-    DEPLOYED = 0;
-    WATCHED = 1;
-  }
-  repeated ImageType image_types = 2;
-  bool include_nvd_cvss = 3;
-  bool include_epss_probability = 4;
-  string query = 5;
-  repeated SimpleAccessScope.Rules access_scope_rules = 6;
+  string query = 1;
+  repeated SimpleAccessScope.Rules access_scope_rules = 2;
 }


### PR DESCRIPTION
This PR adds a query builder for ondemand  reports. query builder uses filters in report snapshot to generate  access scope query and cve attribute query .query builder object is used by report generator to get data using select framework. 

Removed fields ImageType, include_nvd_cvss, include_epss from ViewBasedVulnerabilityReportFilters since we will show all columns by default and image type filter is not available in UI

Add  SimpleAccessScope.Rules to ViewBasedVulnerabilityReportFilters

Removed  extra fields from like image type, include nvd cvss etc from ViewBasedVulnerabilityReportFilters since for the first cut of this feature we only use query string(with search filters) to query data
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
