### PR TITLE
fix(CI): set PR number to NULL if not defined

### DIFF
--- a/scripts/ci/metrics.sh
+++ b/scripts/ci/metrics.sh
@@ -84,7 +84,7 @@ _save_job_record() {
     local branch
     branch="$(get_branch_name)"
 
-    local pr_number=""
+    local pr_number="NULL"
     if is_in_PR_context; then
         pr_number="$(get_PR_number)"
     fi


### PR DESCRIPTION
Currently we pass empty string as a PR number but then it cannot be used as integer resulting in failure on saving job that was run on master. This PR should fix that by using `NULL` instead of empty string.

https://github.com/stackrox/stackrox/blob/651b9189b315ce13a4d5a1d1819e37a686016eea/scripts/ci/metrics.sh#L136

```sql
INSERT INTO acs-san-stackroxci.ci_metrics.stackrox_jobs 
(stopped_at, id, name, repo, branch, pr_number, commit_sha, ci_system, outcome, started_at, test_target, cut_product_version, cut_k8s_version, cut_os_image, cut_kernel_version, cut_container_runtime_version) '
VALUES 
(TIMESTAMP_SECONDS(1754929480), @id, @name, @repo, @branch, @pr_number, @commit_sha, @ci_system, @outcome, TIMESTAMP_SECONDS(@started_at), @test_target, @cut_product_version, @cut_k8s_version, @cut_os_image, @cut_kernel_version, @cut_container_runtime_version)
```
```js
BigQuery error in query operation: Error processing job 
'acs-san-stackroxci:bqjob_r67effc4dc5a037fc_0000019899f2cacb_1': 
Unparseable query parameter `pr_number` in type `TYPE_INT64`, Bad int64 value:  value: ''
WARNING: Job record creation failed
```