### PR TITLE
ROX-30503: Replace find, text, and wrap methods in namespaceView test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -472,11 +472,6 @@ export function interactAndWaitForDeploymentList(callback) {
     return interactAndWaitForResponses(callback, deploymentListRouteMatcherMap);
 }
 
-export function waitForTableLoadCompleteIndicator() {
-    cy.get(`table ${selectors.loadingSpinner}`);
-    cy.get(`table ${selectors.loadingSpinner}`).should('not.exist');
-}
-
 export function visitNamespaceView() {
     interactAndWaitForResponses(
         () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -37,17 +37,5 @@ describe('Workload CVE Namespace View', () => {
                         cy.get(selectors.filterChipGroupItem('Cluster', `^${cluster}$`));
                     });
             });
-
-        cy.get(selectors.firstTableRow).then(($row) => {
-            const namespace = $row.find('td[data-label="Namespace"]').text();
-            const cluster = $row.find('td[data-label="Cluster"]').text();
-
-            cy.wrap($row.find('td[data-label="Deployments"] a')).click();
-
-            cy.get(`h1:contains("Platform vulnerabilities")`);
-
-            cy.get(selectors.filterChipGroupItem('Namespace', `^${namespace}$`));
-            cy.get(selectors.filterChipGroupItem('Cluster', `^${cluster}$`));
-        });
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -1,9 +1,10 @@
 import withAuth from '../../../helpers/basicAuth';
 
 import {
+    interactAndWaitForDeploymentList,
     visitWorkloadCveOverview,
     visitNamespaceView,
-    // waitForTableLoadCompleteIndicator,
+    // waitForTableLoadCompleteIndicator, // because of ROX-30492
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 
@@ -15,11 +16,27 @@ describe('Workload CVE Namespace View', () => {
 
         visitNamespaceView();
 
-        // ROX-30492: DOM assertion often, but not always, times out, even with retry on CI
-        // for gke but not ocp-4-19 starting about 2025-08-07
-        // David observed in video that request finishes ahead of assertion about loading spinner.
-        // Instead, wait for request in visit function.
-        // waitForTableLoadCompleteIndicator();
+        // ROX-30503: need to wait for each table cell to exist in the DOM.
+        const namespaceSelector = `${selectors.firstTableRow} td[data-label="Namespace"]`;
+        const clusterSelector = `${selectors.firstTableRow} td[data-label="Cluster"]`;
+        const deploymentsLinkSelector = `${selectors.firstTableRow} td[data-label="Deployments"] a`;
+
+        cy.get(namespaceSelector)
+            .invoke('text')
+            .then((namespace) => {
+                cy.get(clusterSelector)
+                    .invoke('text')
+                    .then((cluster) => {
+                        interactAndWaitForDeploymentList(() => {
+                            cy.get(deploymentsLinkSelector).click();
+                        });
+
+                        cy.get(`h1:contains("Platform vulnerabilities")`);
+
+                        cy.get(selectors.filterChipGroupItem('Namespace', `^${namespace}$`));
+                        cy.get(selectors.filterChipGroupItem('Cluster', `^${cluster}$`));
+                    });
+            });
 
         cy.get(selectors.firstTableRow).then(($row) => {
             const namespace = $row.find('td[data-label="Namespace"]').text();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -4,7 +4,6 @@ import {
     interactAndWaitForDeploymentList,
     visitWorkloadCveOverview,
     visitNamespaceView,
-    // waitForTableLoadCompleteIndicator, // because of ROX-30492
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 


### PR DESCRIPTION
## Description

### Problem

Different DOM assertion failure after fix in #16347

Workload CVE Namespace View should display the correct search filter chips on the main list page when clicking the deployment link in the table

> Timed out retrying after 8000ms: Expected to find element: `undefined`, but never found it.

cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js:28:15

```js
cy.wrap($row.find('td[data-label="Deployments"] a')).click();
```

<img width="1282" height="721" alt="ROX-30503" src="https://github.com/user-attachments/assets/995fcc8b-f2da-4c2b-9576-7a62cffb90ed" />

### Analysis

This feels familiar. Hypothesis is that cy.get(…).then(($row) => { … })` gets row too soon:
* after React rendered **Namespace** and **Cluster** columns
* before React renders **Deployments** link

### Solution

1. Replace `find` with `get` method which waits until element exists in the DOM.
2. Replace `find` and `text` methods with:
    * `invoke('text').then((namespace) => { … })`
    * `invoke('text').then((cluster) => { … })`
3. Replace `find` and `wrap` methods with `cy.get(…).click()` call

### Residue

1. Investigate responsive behavior for screen size of Cypress in CI.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] edited e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

With local deployment, I can see replacement of assertion with wait in Cypress console, but the table assertions fail because **No results found**.

Given the number of failures on CI, we will soon know if this change helps.

#### Manual testing

1. Visit /main/vulnerabilities/platform/namespace-view and then think what might have gone wrong.