### PR TITLE
ROX-27149: Store Index Report API

### DIFF
--- a/generated/internalapi/scanner/v4/indexer_service.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service.pb.go
@@ -378,8 +378,7 @@ func (*GetOrCreateIndexReportRequest_ContainerImage) isGetOrCreateIndexReportReq
 type StoreIndexReportRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	HashId        string                 `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
-	ClusterName   string                 `protobuf:"bytes,2,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
-	Contents      *Contents              `protobuf:"bytes,3,opt,name=contents,proto3" json:"contents,omitempty"`
+	Contents      *Contents              `protobuf:"bytes,2,opt,name=contents,proto3" json:"contents,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -421,13 +420,6 @@ func (x *StoreIndexReportRequest) GetHashId() string {
 	return ""
 }
 
-func (x *StoreIndexReportRequest) GetClusterName() string {
-	if x != nil {
-		return x.ClusterName
-	}
-	return ""
-}
-
 func (x *StoreIndexReportRequest) GetContents() *Contents {
 	if x != nil {
 		return x.Contents
@@ -437,6 +429,7 @@ func (x *StoreIndexReportRequest) GetContents() *Contents {
 
 type StoreIndexReportResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -471,6 +464,13 @@ func (*StoreIndexReportResponse) Descriptor() ([]byte, []int) {
 	return file_internalapi_scanner_v4_indexer_service_proto_rawDescGZIP(), []int{7}
 }
 
+func (x *StoreIndexReportResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
 var File_internalapi_scanner_v4_indexer_service_proto protoreflect.FileDescriptor
 
 const file_internalapi_scanner_v4_indexer_service_proto_rawDesc = "" +
@@ -495,18 +495,18 @@ const file_internalapi_scanner_v4_indexer_service_proto_rawDesc = "" +
 	"\x1dGetOrCreateIndexReportRequest\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12L\n" +
 	"\x0fcontainer_image\x18\x02 \x01(\v2!.scanner.v4.ContainerImageLocatorH\x00R\x0econtainerImageB\x12\n" +
-	"\x10resource_locator\"\x87\x01\n" +
+	"\x10resource_locator\"d\n" +
 	"\x17StoreIndexReportRequest\x12\x17\n" +
-	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12!\n" +
-	"\fcluster_name\x18\x02 \x01(\tR\vclusterName\x120\n" +
-	"\bcontents\x18\x03 \x01(\v2\x14.scanner.v4.ContentsR\bcontents\"\x1a\n" +
-	"\x18StoreIndexReportResponse2\xb5\x03\n" +
+	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x120\n" +
+	"\bcontents\x18\x02 \x01(\v2\x14.scanner.v4.ContentsR\bcontents\"2\n" +
+	"\x18StoreIndexReportResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status2\xc1\x03\n" +
 	"\aIndexer\x12R\n" +
 	"\x11CreateIndexReport\x12$.scanner.v4.CreateIndexReportRequest\x1a\x17.scanner.v4.IndexReport\x12L\n" +
 	"\x0eGetIndexReport\x12!.scanner.v4.GetIndexReportRequest\x1a\x17.scanner.v4.IndexReport\x12\\\n" +
 	"\x16GetOrCreateIndexReport\x12).scanner.v4.GetOrCreateIndexReportRequest\x1a\x17.scanner.v4.IndexReport\x12W\n" +
-	"\x0eHasIndexReport\x12!.scanner.v4.HasIndexReportRequest\x1a\".scanner.v4.HasIndexReportResponse\x12Q\n" +
-	"\x10StoreIndexReport\x12\x17.scanner.v4.IndexReport\x1a$.scanner.v4.StoreIndexReportResponseB\x1dZ\x1b./internalapi/scanner/v4;v4b\x06proto3"
+	"\x0eHasIndexReport\x12!.scanner.v4.HasIndexReportRequest\x1a\".scanner.v4.HasIndexReportResponse\x12]\n" +
+	"\x10StoreIndexReport\x12#.scanner.v4.StoreIndexReportRequest\x1a$.scanner.v4.StoreIndexReportResponseB\x1dZ\x1b./internalapi/scanner/v4;v4b\x06proto3"
 
 var (
 	file_internalapi_scanner_v4_indexer_service_proto_rawDescOnce sync.Once
@@ -541,7 +541,7 @@ var file_internalapi_scanner_v4_indexer_service_proto_depIdxs = []int32{
 	2, // 4: scanner.v4.Indexer.GetIndexReport:input_type -> scanner.v4.GetIndexReportRequest
 	5, // 5: scanner.v4.Indexer.GetOrCreateIndexReport:input_type -> scanner.v4.GetOrCreateIndexReportRequest
 	3, // 6: scanner.v4.Indexer.HasIndexReport:input_type -> scanner.v4.HasIndexReportRequest
-	9, // 7: scanner.v4.Indexer.StoreIndexReport:input_type -> scanner.v4.IndexReport
+	6, // 7: scanner.v4.Indexer.StoreIndexReport:input_type -> scanner.v4.StoreIndexReportRequest
 	9, // 8: scanner.v4.Indexer.CreateIndexReport:output_type -> scanner.v4.IndexReport
 	9, // 9: scanner.v4.Indexer.GetIndexReport:output_type -> scanner.v4.IndexReport
 	9, // 10: scanner.v4.Indexer.GetOrCreateIndexReport:output_type -> scanner.v4.IndexReport

--- a/generated/internalapi/scanner/v4/indexer_service.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service.pb.go
@@ -375,12 +375,108 @@ type GetOrCreateIndexReportRequest_ContainerImage struct {
 func (*GetOrCreateIndexReportRequest_ContainerImage) isGetOrCreateIndexReportRequest_ResourceLocator() {
 }
 
+type StoreIndexReportRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	HashId        string                 `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
+	ClusterName   string                 `protobuf:"bytes,2,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
+	Contents      *Contents              `protobuf:"bytes,3,opt,name=contents,proto3" json:"contents,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StoreIndexReportRequest) Reset() {
+	*x = StoreIndexReportRequest{}
+	mi := &file_internalapi_scanner_v4_indexer_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StoreIndexReportRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StoreIndexReportRequest) ProtoMessage() {}
+
+func (x *StoreIndexReportRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_scanner_v4_indexer_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StoreIndexReportRequest.ProtoReflect.Descriptor instead.
+func (*StoreIndexReportRequest) Descriptor() ([]byte, []int) {
+	return file_internalapi_scanner_v4_indexer_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *StoreIndexReportRequest) GetHashId() string {
+	if x != nil {
+		return x.HashId
+	}
+	return ""
+}
+
+func (x *StoreIndexReportRequest) GetClusterName() string {
+	if x != nil {
+		return x.ClusterName
+	}
+	return ""
+}
+
+func (x *StoreIndexReportRequest) GetContents() *Contents {
+	if x != nil {
+		return x.Contents
+	}
+	return nil
+}
+
+type StoreIndexReportResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StoreIndexReportResponse) Reset() {
+	*x = StoreIndexReportResponse{}
+	mi := &file_internalapi_scanner_v4_indexer_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StoreIndexReportResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StoreIndexReportResponse) ProtoMessage() {}
+
+func (x *StoreIndexReportResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_scanner_v4_indexer_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StoreIndexReportResponse.ProtoReflect.Descriptor instead.
+func (*StoreIndexReportResponse) Descriptor() ([]byte, []int) {
+	return file_internalapi_scanner_v4_indexer_service_proto_rawDescGZIP(), []int{7}
+}
+
 var File_internalapi_scanner_v4_indexer_service_proto protoreflect.FileDescriptor
 
 const file_internalapi_scanner_v4_indexer_service_proto_rawDesc = "" +
 	"\n" +
 	",internalapi/scanner/v4/indexer_service.proto\x12\n" +
-	"scanner.v4\x1a)internalapi/scanner/v4/index_report.proto\"\x9a\x01\n" +
+	"scanner.v4\x1a#internalapi/scanner/v4/common.proto\x1a)internalapi/scanner/v4/index_report.proto\"\x9a\x01\n" +
 	"\x15ContainerImageLocator\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1a\n" +
@@ -399,12 +495,18 @@ const file_internalapi_scanner_v4_indexer_service_proto_rawDesc = "" +
 	"\x1dGetOrCreateIndexReportRequest\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12L\n" +
 	"\x0fcontainer_image\x18\x02 \x01(\v2!.scanner.v4.ContainerImageLocatorH\x00R\x0econtainerImageB\x12\n" +
-	"\x10resource_locator2\xe2\x02\n" +
+	"\x10resource_locator\"\x87\x01\n" +
+	"\x17StoreIndexReportRequest\x12\x17\n" +
+	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12!\n" +
+	"\fcluster_name\x18\x02 \x01(\tR\vclusterName\x120\n" +
+	"\bcontents\x18\x03 \x01(\v2\x14.scanner.v4.ContentsR\bcontents\"\x1a\n" +
+	"\x18StoreIndexReportResponse2\xb5\x03\n" +
 	"\aIndexer\x12R\n" +
 	"\x11CreateIndexReport\x12$.scanner.v4.CreateIndexReportRequest\x1a\x17.scanner.v4.IndexReport\x12L\n" +
 	"\x0eGetIndexReport\x12!.scanner.v4.GetIndexReportRequest\x1a\x17.scanner.v4.IndexReport\x12\\\n" +
 	"\x16GetOrCreateIndexReport\x12).scanner.v4.GetOrCreateIndexReportRequest\x1a\x17.scanner.v4.IndexReport\x12W\n" +
-	"\x0eHasIndexReport\x12!.scanner.v4.HasIndexReportRequest\x1a\".scanner.v4.HasIndexReportResponseB\x1dZ\x1b./internalapi/scanner/v4;v4b\x06proto3"
+	"\x0eHasIndexReport\x12!.scanner.v4.HasIndexReportRequest\x1a\".scanner.v4.HasIndexReportResponse\x12Q\n" +
+	"\x10StoreIndexReport\x12\x17.scanner.v4.IndexReport\x1a$.scanner.v4.StoreIndexReportResponseB\x1dZ\x1b./internalapi/scanner/v4;v4b\x06proto3"
 
 var (
 	file_internalapi_scanner_v4_indexer_service_proto_rawDescOnce sync.Once
@@ -418,7 +520,7 @@ func file_internalapi_scanner_v4_indexer_service_proto_rawDescGZIP() []byte {
 	return file_internalapi_scanner_v4_indexer_service_proto_rawDescData
 }
 
-var file_internalapi_scanner_v4_indexer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_internalapi_scanner_v4_indexer_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_internalapi_scanner_v4_indexer_service_proto_goTypes = []any{
 	(*ContainerImageLocator)(nil),         // 0: scanner.v4.ContainerImageLocator
 	(*CreateIndexReportRequest)(nil),      // 1: scanner.v4.CreateIndexReportRequest
@@ -426,24 +528,30 @@ var file_internalapi_scanner_v4_indexer_service_proto_goTypes = []any{
 	(*HasIndexReportRequest)(nil),         // 3: scanner.v4.HasIndexReportRequest
 	(*HasIndexReportResponse)(nil),        // 4: scanner.v4.HasIndexReportResponse
 	(*GetOrCreateIndexReportRequest)(nil), // 5: scanner.v4.GetOrCreateIndexReportRequest
-	(*IndexReport)(nil),                   // 6: scanner.v4.IndexReport
+	(*StoreIndexReportRequest)(nil),       // 6: scanner.v4.StoreIndexReportRequest
+	(*StoreIndexReportResponse)(nil),      // 7: scanner.v4.StoreIndexReportResponse
+	(*Contents)(nil),                      // 8: scanner.v4.Contents
+	(*IndexReport)(nil),                   // 9: scanner.v4.IndexReport
 }
 var file_internalapi_scanner_v4_indexer_service_proto_depIdxs = []int32{
 	0, // 0: scanner.v4.CreateIndexReportRequest.container_image:type_name -> scanner.v4.ContainerImageLocator
 	0, // 1: scanner.v4.GetOrCreateIndexReportRequest.container_image:type_name -> scanner.v4.ContainerImageLocator
-	1, // 2: scanner.v4.Indexer.CreateIndexReport:input_type -> scanner.v4.CreateIndexReportRequest
-	2, // 3: scanner.v4.Indexer.GetIndexReport:input_type -> scanner.v4.GetIndexReportRequest
-	5, // 4: scanner.v4.Indexer.GetOrCreateIndexReport:input_type -> scanner.v4.GetOrCreateIndexReportRequest
-	3, // 5: scanner.v4.Indexer.HasIndexReport:input_type -> scanner.v4.HasIndexReportRequest
-	6, // 6: scanner.v4.Indexer.CreateIndexReport:output_type -> scanner.v4.IndexReport
-	6, // 7: scanner.v4.Indexer.GetIndexReport:output_type -> scanner.v4.IndexReport
-	6, // 8: scanner.v4.Indexer.GetOrCreateIndexReport:output_type -> scanner.v4.IndexReport
-	4, // 9: scanner.v4.Indexer.HasIndexReport:output_type -> scanner.v4.HasIndexReportResponse
-	6, // [6:10] is the sub-list for method output_type
-	2, // [2:6] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	8, // 2: scanner.v4.StoreIndexReportRequest.contents:type_name -> scanner.v4.Contents
+	1, // 3: scanner.v4.Indexer.CreateIndexReport:input_type -> scanner.v4.CreateIndexReportRequest
+	2, // 4: scanner.v4.Indexer.GetIndexReport:input_type -> scanner.v4.GetIndexReportRequest
+	5, // 5: scanner.v4.Indexer.GetOrCreateIndexReport:input_type -> scanner.v4.GetOrCreateIndexReportRequest
+	3, // 6: scanner.v4.Indexer.HasIndexReport:input_type -> scanner.v4.HasIndexReportRequest
+	9, // 7: scanner.v4.Indexer.StoreIndexReport:input_type -> scanner.v4.IndexReport
+	9, // 8: scanner.v4.Indexer.CreateIndexReport:output_type -> scanner.v4.IndexReport
+	9, // 9: scanner.v4.Indexer.GetIndexReport:output_type -> scanner.v4.IndexReport
+	9, // 10: scanner.v4.Indexer.GetOrCreateIndexReport:output_type -> scanner.v4.IndexReport
+	4, // 11: scanner.v4.Indexer.HasIndexReport:output_type -> scanner.v4.HasIndexReportResponse
+	7, // 12: scanner.v4.Indexer.StoreIndexReport:output_type -> scanner.v4.StoreIndexReportResponse
+	8, // [8:13] is the sub-list for method output_type
+	3, // [3:8] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_scanner_v4_indexer_service_proto_init() }
@@ -451,6 +559,7 @@ func file_internalapi_scanner_v4_indexer_service_proto_init() {
 	if File_internalapi_scanner_v4_indexer_service_proto != nil {
 		return
 	}
+	file_internalapi_scanner_v4_common_proto_init()
 	file_internalapi_scanner_v4_index_report_proto_init()
 	file_internalapi_scanner_v4_indexer_service_proto_msgTypes[1].OneofWrappers = []any{
 		(*CreateIndexReportRequest_ContainerImage)(nil),
@@ -464,7 +573,7 @@ func file_internalapi_scanner_v4_indexer_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_scanner_v4_indexer_service_proto_rawDesc), len(file_internalapi_scanner_v4_indexer_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/internalapi/scanner/v4/indexer_service.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service.pb.go
@@ -376,11 +376,12 @@ func (*GetOrCreateIndexReportRequest_ContainerImage) isGetOrCreateIndexReportReq
 }
 
 type StoreIndexReportRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	HashId        string                 `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
-	Contents      *Contents              `protobuf:"bytes,2,opt,name=contents,proto3" json:"contents,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	HashId         string                 `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
+	IndexerVersion string                 `protobuf:"bytes,2,opt,name=indexer_version,json=indexerVersion,proto3" json:"indexer_version,omitempty"`
+	Contents       *Contents              `protobuf:"bytes,3,opt,name=contents,proto3" json:"contents,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *StoreIndexReportRequest) Reset() {
@@ -416,6 +417,13 @@ func (*StoreIndexReportRequest) Descriptor() ([]byte, []int) {
 func (x *StoreIndexReportRequest) GetHashId() string {
 	if x != nil {
 		return x.HashId
+	}
+	return ""
+}
+
+func (x *StoreIndexReportRequest) GetIndexerVersion() string {
+	if x != nil {
+		return x.IndexerVersion
 	}
 	return ""
 }
@@ -495,10 +503,11 @@ const file_internalapi_scanner_v4_indexer_service_proto_rawDesc = "" +
 	"\x1dGetOrCreateIndexReportRequest\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12L\n" +
 	"\x0fcontainer_image\x18\x02 \x01(\v2!.scanner.v4.ContainerImageLocatorH\x00R\x0econtainerImageB\x12\n" +
-	"\x10resource_locator\"d\n" +
+	"\x10resource_locator\"\x8d\x01\n" +
 	"\x17StoreIndexReportRequest\x12\x17\n" +
-	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x120\n" +
-	"\bcontents\x18\x02 \x01(\v2\x14.scanner.v4.ContentsR\bcontents\"2\n" +
+	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12'\n" +
+	"\x0findexer_version\x18\x02 \x01(\tR\x0eindexerVersion\x120\n" +
+	"\bcontents\x18\x03 \x01(\v2\x14.scanner.v4.ContentsR\bcontents\"2\n" +
 	"\x18StoreIndexReportResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status2\xc1\x03\n" +
 	"\aIndexer\x12R\n" +

--- a/generated/internalapi/scanner/v4/indexer_service_grpc.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service_grpc.pb.go
@@ -46,9 +46,8 @@ type IndexerClient interface {
 	GetOrCreateIndexReport(ctx context.Context, in *GetOrCreateIndexReportRequest, opts ...grpc.CallOption) (*IndexReport, error)
 	// HasIndexReport checks if an index report for the specified resource exists.
 	HasIndexReport(ctx context.Context, in *HasIndexReportRequest, opts ...grpc.CallOption) (*HasIndexReportResponse, error)
-	// TODO(DO NOT MERGE): Improve this comment.
-	// StoreIndexReport saves an index report to the database.
-	StoreIndexReport(ctx context.Context, in *IndexReport, opts ...grpc.CallOption) (*StoreIndexReportResponse, error)
+	// StoreIndexReport stores an external index report to the datastore.
+	StoreIndexReport(ctx context.Context, in *StoreIndexReportRequest, opts ...grpc.CallOption) (*StoreIndexReportResponse, error)
 }
 
 type indexerClient struct {
@@ -99,7 +98,7 @@ func (c *indexerClient) HasIndexReport(ctx context.Context, in *HasIndexReportRe
 	return out, nil
 }
 
-func (c *indexerClient) StoreIndexReport(ctx context.Context, in *IndexReport, opts ...grpc.CallOption) (*StoreIndexReportResponse, error) {
+func (c *indexerClient) StoreIndexReport(ctx context.Context, in *StoreIndexReportRequest, opts ...grpc.CallOption) (*StoreIndexReportResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(StoreIndexReportResponse)
 	err := c.cc.Invoke(ctx, Indexer_StoreIndexReport_FullMethodName, in, out, cOpts...)
@@ -125,9 +124,8 @@ type IndexerServer interface {
 	GetOrCreateIndexReport(context.Context, *GetOrCreateIndexReportRequest) (*IndexReport, error)
 	// HasIndexReport checks if an index report for the specified resource exists.
 	HasIndexReport(context.Context, *HasIndexReportRequest) (*HasIndexReportResponse, error)
-	// TODO(DO NOT MERGE): Improve this comment.
-	// StoreIndexReport saves an index report to the database.
-	StoreIndexReport(context.Context, *IndexReport) (*StoreIndexReportResponse, error)
+	// StoreIndexReport stores an external index report to the datastore.
+	StoreIndexReport(context.Context, *StoreIndexReportRequest) (*StoreIndexReportResponse, error)
 }
 
 // UnimplementedIndexerServer should be embedded to have
@@ -149,7 +147,7 @@ func (UnimplementedIndexerServer) GetOrCreateIndexReport(context.Context, *GetOr
 func (UnimplementedIndexerServer) HasIndexReport(context.Context, *HasIndexReportRequest) (*HasIndexReportResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method HasIndexReport not implemented")
 }
-func (UnimplementedIndexerServer) StoreIndexReport(context.Context, *IndexReport) (*StoreIndexReportResponse, error) {
+func (UnimplementedIndexerServer) StoreIndexReport(context.Context, *StoreIndexReportRequest) (*StoreIndexReportResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StoreIndexReport not implemented")
 }
 func (UnimplementedIndexerServer) testEmbeddedByValue() {}
@@ -245,7 +243,7 @@ func _Indexer_HasIndexReport_Handler(srv interface{}, ctx context.Context, dec f
 }
 
 func _Indexer_StoreIndexReport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(IndexReport)
+	in := new(StoreIndexReportRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -257,7 +255,7 @@ func _Indexer_StoreIndexReport_Handler(srv interface{}, ctx context.Context, dec
 		FullMethod: Indexer_StoreIndexReport_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(IndexerServer).StoreIndexReport(ctx, req.(*IndexReport))
+		return srv.(IndexerServer).StoreIndexReport(ctx, req.(*StoreIndexReportRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }

--- a/generated/internalapi/scanner/v4/indexer_service_grpc.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	Indexer_GetIndexReport_FullMethodName         = "/scanner.v4.Indexer/GetIndexReport"
 	Indexer_GetOrCreateIndexReport_FullMethodName = "/scanner.v4.Indexer/GetOrCreateIndexReport"
 	Indexer_HasIndexReport_FullMethodName         = "/scanner.v4.Indexer/HasIndexReport"
+	Indexer_StoreIndexReport_FullMethodName       = "/scanner.v4.Indexer/StoreIndexReport"
 )
 
 // IndexerClient is the client API for Indexer service.
@@ -45,6 +46,9 @@ type IndexerClient interface {
 	GetOrCreateIndexReport(ctx context.Context, in *GetOrCreateIndexReportRequest, opts ...grpc.CallOption) (*IndexReport, error)
 	// HasIndexReport checks if an index report for the specified resource exists.
 	HasIndexReport(ctx context.Context, in *HasIndexReportRequest, opts ...grpc.CallOption) (*HasIndexReportResponse, error)
+	// TODO(DO NOT MERGE): Improve this comment.
+	// StoreIndexReport saves an index report to the database.
+	StoreIndexReport(ctx context.Context, in *IndexReport, opts ...grpc.CallOption) (*StoreIndexReportResponse, error)
 }
 
 type indexerClient struct {
@@ -95,6 +99,16 @@ func (c *indexerClient) HasIndexReport(ctx context.Context, in *HasIndexReportRe
 	return out, nil
 }
 
+func (c *indexerClient) StoreIndexReport(ctx context.Context, in *IndexReport, opts ...grpc.CallOption) (*StoreIndexReportResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StoreIndexReportResponse)
+	err := c.cc.Invoke(ctx, Indexer_StoreIndexReport_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // IndexerServer is the server API for Indexer service.
 // All implementations should embed UnimplementedIndexerServer
 // for forward compatibility.
@@ -111,6 +125,9 @@ type IndexerServer interface {
 	GetOrCreateIndexReport(context.Context, *GetOrCreateIndexReportRequest) (*IndexReport, error)
 	// HasIndexReport checks if an index report for the specified resource exists.
 	HasIndexReport(context.Context, *HasIndexReportRequest) (*HasIndexReportResponse, error)
+	// TODO(DO NOT MERGE): Improve this comment.
+	// StoreIndexReport saves an index report to the database.
+	StoreIndexReport(context.Context, *IndexReport) (*StoreIndexReportResponse, error)
 }
 
 // UnimplementedIndexerServer should be embedded to have
@@ -131,6 +148,9 @@ func (UnimplementedIndexerServer) GetOrCreateIndexReport(context.Context, *GetOr
 }
 func (UnimplementedIndexerServer) HasIndexReport(context.Context, *HasIndexReportRequest) (*HasIndexReportResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method HasIndexReport not implemented")
+}
+func (UnimplementedIndexerServer) StoreIndexReport(context.Context, *IndexReport) (*StoreIndexReportResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StoreIndexReport not implemented")
 }
 func (UnimplementedIndexerServer) testEmbeddedByValue() {}
 
@@ -224,6 +244,24 @@ func _Indexer_HasIndexReport_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Indexer_StoreIndexReport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(IndexReport)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(IndexerServer).StoreIndexReport(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Indexer_StoreIndexReport_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(IndexerServer).StoreIndexReport(ctx, req.(*IndexReport))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Indexer_ServiceDesc is the grpc.ServiceDesc for Indexer service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -246,6 +284,10 @@ var Indexer_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "HasIndexReport",
 			Handler:    _Indexer_HasIndexReport_Handler,
+		},
+		{
+			MethodName: "StoreIndexReport",
+			Handler:    _Indexer_StoreIndexReport_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
@@ -159,7 +159,6 @@ func (m *StoreIndexReportRequest) CloneVT() *StoreIndexReportRequest {
 	}
 	r := new(StoreIndexReportRequest)
 	r.HashId = m.HashId
-	r.ClusterName = m.ClusterName
 	r.Contents = m.Contents.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -177,6 +176,7 @@ func (m *StoreIndexReportResponse) CloneVT() *StoreIndexReportResponse {
 		return (*StoreIndexReportResponse)(nil)
 	}
 	r := new(StoreIndexReportResponse)
+	r.Status = m.Status
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -394,9 +394,6 @@ func (this *StoreIndexReportRequest) EqualVT(that *StoreIndexReportRequest) bool
 	if this.HashId != that.HashId {
 		return false
 	}
-	if this.ClusterName != that.ClusterName {
-		return false
-	}
 	if !this.Contents.EqualVT(that.Contents) {
 		return false
 	}
@@ -414,6 +411,9 @@ func (this *StoreIndexReportResponse) EqualVT(that *StoreIndexReportResponse) bo
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Status != that.Status {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -795,13 +795,6 @@ func (m *StoreIndexReportRequest) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
-		dAtA[i] = 0x1a
-	}
-	if len(m.ClusterName) > 0 {
-		i -= len(m.ClusterName)
-		copy(dAtA[i:], m.ClusterName)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterName)))
-		i--
 		dAtA[i] = 0x12
 	}
 	if len(m.HashId) > 0 {
@@ -843,6 +836,13 @@ func (m *StoreIndexReportResponse) MarshalToSizedBufferVT(dAtA []byte) (int, err
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Status) > 0 {
+		i -= len(m.Status)
+		copy(dAtA[i:], m.Status)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Status)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -985,10 +985,6 @@ func (m *StoreIndexReportRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	l = len(m.ClusterName)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
 	if m.Contents != nil {
 		l = m.Contents.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -1003,6 +999,10 @@ func (m *StoreIndexReportResponse) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
+	l = len(m.Status)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1722,38 +1722,6 @@ func (m *StoreIndexReportRequest) UnmarshalVT(dAtA []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ClusterName", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.ClusterName = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Contents", wireType)
 			}
 			var msglen int
@@ -1839,6 +1807,38 @@ func (m *StoreIndexReportResponse) UnmarshalVT(dAtA []byte) error {
 			return fmt.Errorf("proto: StoreIndexReportResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Status = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2608,42 +2608,6 @@ func (m *StoreIndexReportRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ClusterName", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			var stringValue string
-			if intStringLen > 0 {
-				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
-			}
-			m.ClusterName = stringValue
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Contents", wireType)
 			}
 			var msglen int
@@ -2729,6 +2693,42 @@ func (m *StoreIndexReportResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 			return fmt.Errorf("proto: StoreIndexReportResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Status = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
@@ -159,6 +159,7 @@ func (m *StoreIndexReportRequest) CloneVT() *StoreIndexReportRequest {
 	}
 	r := new(StoreIndexReportRequest)
 	r.HashId = m.HashId
+	r.IndexerVersion = m.IndexerVersion
 	r.Contents = m.Contents.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -392,6 +393,9 @@ func (this *StoreIndexReportRequest) EqualVT(that *StoreIndexReportRequest) bool
 		return false
 	}
 	if this.HashId != that.HashId {
+		return false
+	}
+	if this.IndexerVersion != that.IndexerVersion {
 		return false
 	}
 	if !this.Contents.EqualVT(that.Contents) {
@@ -795,6 +799,13 @@ func (m *StoreIndexReportRequest) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.IndexerVersion) > 0 {
+		i -= len(m.IndexerVersion)
+		copy(dAtA[i:], m.IndexerVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.IndexerVersion)))
+		i--
 		dAtA[i] = 0x12
 	}
 	if len(m.HashId) > 0 {
@@ -982,6 +993,10 @@ func (m *StoreIndexReportRequest) SizeVT() (n int) {
 	var l int
 	_ = l
 	l = len(m.HashId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.IndexerVersion)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -1721,6 +1736,38 @@ func (m *StoreIndexReportRequest) UnmarshalVT(dAtA []byte) error {
 			m.HashId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IndexerVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.IndexerVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Contents", wireType)
 			}
@@ -2607,6 +2654,42 @@ func (m *StoreIndexReportRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 			m.HashId = stringValue
 			iNdEx = postIndex
 		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IndexerVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.IndexerVersion = stringValue
+			iNdEx = postIndex
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Contents", wireType)
 			}

--- a/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
@@ -153,6 +153,41 @@ func (m *GetOrCreateIndexReportRequest_ContainerImage) CloneVT() isGetOrCreateIn
 	return r
 }
 
+func (m *StoreIndexReportRequest) CloneVT() *StoreIndexReportRequest {
+	if m == nil {
+		return (*StoreIndexReportRequest)(nil)
+	}
+	r := new(StoreIndexReportRequest)
+	r.HashId = m.HashId
+	r.ClusterName = m.ClusterName
+	r.Contents = m.Contents.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *StoreIndexReportRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *StoreIndexReportResponse) CloneVT() *StoreIndexReportResponse {
+	if m == nil {
+		return (*StoreIndexReportResponse)(nil)
+	}
+	r := new(StoreIndexReportResponse)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *StoreIndexReportResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *ContainerImageLocator) EqualVT(that *ContainerImageLocator) bool {
 	if this == that {
 		return true
@@ -350,6 +385,47 @@ func (this *GetOrCreateIndexReportRequest_ContainerImage) EqualVT(thatIface isGe
 	return true
 }
 
+func (this *StoreIndexReportRequest) EqualVT(that *StoreIndexReportRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.HashId != that.HashId {
+		return false
+	}
+	if this.ClusterName != that.ClusterName {
+		return false
+	}
+	if !this.Contents.EqualVT(that.Contents) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *StoreIndexReportRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*StoreIndexReportRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *StoreIndexReportResponse) EqualVT(that *StoreIndexReportResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *StoreIndexReportResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*StoreIndexReportResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *ContainerImageLocator) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -681,6 +757,96 @@ func (m *GetOrCreateIndexReportRequest_ContainerImage) MarshalToSizedBufferVT(dA
 	}
 	return len(dAtA) - i, nil
 }
+func (m *StoreIndexReportRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StoreIndexReportRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *StoreIndexReportRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Contents != nil {
+		size, err := m.Contents.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.ClusterName) > 0 {
+		i -= len(m.ClusterName)
+		copy(dAtA[i:], m.ClusterName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterName)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.HashId) > 0 {
+		i -= len(m.HashId)
+		copy(dAtA[i:], m.HashId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.HashId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StoreIndexReportResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StoreIndexReportResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *StoreIndexReportResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ContainerImageLocator) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -809,6 +975,38 @@ func (m *GetOrCreateIndexReportRequest_ContainerImage) SizeVT() (n int) {
 	}
 	return n
 }
+func (m *StoreIndexReportRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.HashId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ClusterName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Contents != nil {
+		l = m.Contents.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *StoreIndexReportResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *ContainerImageLocator) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1439,6 +1637,208 @@ func (m *GetOrCreateIndexReportRequest) UnmarshalVT(dAtA []byte) error {
 				m.ResourceLocator = &GetOrCreateIndexReportRequest_ContainerImage{ContainerImage: v}
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoreIndexReportRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoreIndexReportRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoreIndexReportRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HashId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.HashId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Contents", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Contents == nil {
+				m.Contents = &Contents{}
+			}
+			if err := m.Contents.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoreIndexReportResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoreIndexReportResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoreIndexReportResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2119,6 +2519,216 @@ func (m *GetOrCreateIndexReportRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.ResourceLocator = &GetOrCreateIndexReportRequest_ContainerImage{ContainerImage: v}
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoreIndexReportRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoreIndexReportRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoreIndexReportRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HashId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.HashId = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ClusterName = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Contents", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Contents == nil {
+				m.Contents = &Contents{}
+			}
+			if err := m.Contents.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoreIndexReportResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoreIndexReportResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoreIndexReportResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -172,4 +172,8 @@ var (
 	ScannerV4MavenSearch = registerFeature("Enables Scanner V4 to reach out to ROX_SCANNER_V4_MAVEN_SEARCH_URL for additional information about Java packages", "ROX_SCANNER_V4_MAVEN_SEARCH")
 
 	VirtualMachines = registerFeature("Enables virtual machine management", "ROX_VIRTUAL_MACHINES")
+
+	// StoreDelegatedScans enables storing delegated scans to Central's Scanner V4 Indexer. Currently, both
+	// StoreDelegatedScans and SBOMGeneration must be enabled to store delegated scans.
+	StoreDelegatedScans = registerFeature("Enables storing delegated scans to Central's Scanner V4 Indexer", "ROX_STORE_DELEGATED_SCANS", enabled)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -173,7 +173,7 @@ var (
 
 	VirtualMachines = registerFeature("Enables virtual machine management", "ROX_VIRTUAL_MACHINES")
 
-	// StoreDelegatedScans enables storing delegated scans to Central's Scanner V4 Indexer. Currently, both
-	// StoreDelegatedScans and SBOMGeneration must be enabled to store delegated scans.
-	StoreDelegatedScans = registerFeature("Enables storing delegated scans to Central's Scanner V4 Indexer", "ROX_STORE_DELEGATED_SCANS", enabled)
+	// ScannerV4StoreExternalIndexReports enables storing delegated scans to Central's Scanner V4 Indexer. Currently,
+	// both ScannerV4StoreExternalIndexReports and SBOMGeneration must be enabled to store delegated scans.
+	ScannerV4StoreExternalIndexReports = registerFeature("Enables storing delegated scans to Central's Scanner V4 Indexer", "ROX_SCANNER_V4_STORE_EXTERNAL_INDEX_REPORTS", enabled)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -173,7 +173,7 @@ var (
 
 	VirtualMachines = registerFeature("Enables virtual machine management", "ROX_VIRTUAL_MACHINES")
 
-	// ScannerV4StoreExternalIndexReports enables storing delegated scans to Central's Scanner V4 Indexer. Currently,
-	// both ScannerV4StoreExternalIndexReports and SBOMGeneration must be enabled to store delegated scans.
-	ScannerV4StoreExternalIndexReports = registerFeature("Enables storing delegated scans to Central's Scanner V4 Indexer", "ROX_SCANNER_V4_STORE_EXTERNAL_INDEX_REPORTS", enabled)
+	// ScannerV4StoreExternalIndexReports enables storing index reports from delegated scans to Central's Scanner V4 Indexer.
+	// Both ScannerV4StoreExternalIndexReports and SBOMGeneration features must be enabled to store the index reports.
+	ScannerV4StoreExternalIndexReports = registerFeature("Enables storing index reports from delegated scans to Central's Scanner V4 Indexer", "ROX_SCANNER_V4_STORE_EXTERNAL_INDEX_REPORTS", enabled)
 )

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -230,7 +230,7 @@ func (s *scannerv4) GetVulnerabilities(image *storage.Image, components *types.S
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
 
-	if features.SBOMGeneration.Enabled() && features.StoreDelegatedScans.Enabled() {
+	if features.SBOMGeneration.Enabled() && features.ScannerV4StoreExternalIndexReports.Enabled() {
 		// Store the index report from external scanners. Note that this will use
 		// some time from the scan timeout.
 		imageScanScannerVersion, err := pkgscanner.DecodeVersion(components.IndexerVersion)

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -229,9 +229,9 @@ func (s *scannerv4) GetVulnerabilities(image *storage.Image, components *types.S
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
 
-	// Store the index report from external scanners. Note that this will
-	// use some time from the scan timeout.
-	imageScanScannerVersion, err := pkgscanner.DecodeVersion(image.Scan.ScannerVersion)
+	// Store the index report from external scanners. Note that this will use
+	// some time from the scan timeout.
+	imageScanScannerVersion, err := pkgscanner.DecodeVersion(components.IndexerVersion)
 	if err != nil {
 		log.Warnf("Failed to decode image scan scanner version: %v", err)
 	} else {

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -229,6 +229,16 @@ func (s *scannerv4) GetVulnerabilities(image *storage.Image, components *types.S
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
 
+	imageScanScannerVersion, err := pkgscanner.DecodeVersion(image.Scan.ScannerVersion)
+	if err != nil {
+		log.Warnf("Failed to decode image scan scanner version: %v", err)
+	} else {
+		err := s.scannerClient.StoreIndexReport(ctx, digest, imageScanScannerVersion.Indexer, v4Contents)
+		if err != nil {
+			log.Warnf("Failed to store external index report: %v", err)
+		}
+	}
+
 	var scannerVersion pkgscanner.Version
 	vr, err := s.scannerClient.GetVulnerabilities(ctx, digest, v4Contents, client.Version(&scannerVersion))
 	if err != nil {

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -229,11 +229,13 @@ func (s *scannerv4) GetVulnerabilities(image *storage.Image, components *types.S
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
 
+	// Store the index report from external scanners. Note that this will
+	// use some time from the scan timeout.
 	imageScanScannerVersion, err := pkgscanner.DecodeVersion(image.Scan.ScannerVersion)
 	if err != nil {
 		log.Warnf("Failed to decode image scan scanner version: %v", err)
 	} else {
-		err := s.scannerClient.StoreIndexReport(ctx, digest, imageScanScannerVersion.Indexer, v4Contents)
+		err := s.scannerClient.StoreImageIndex(ctx, digest, imageScanScannerVersion.Indexer, v4Contents)
 		if err != nil {
 			log.Warnf("Failed to store external index report: %v", err)
 		}

--- a/pkg/scanners/types/components.go
+++ b/pkg/scanners/types/components.go
@@ -10,7 +10,7 @@ import (
 type ScanComponents struct {
 	v1comps        *v1.Components
 	v4comps        *v4.Contents
-	indexerVersion string
+	IndexerVersion string
 }
 
 // NewScanComponents creates a new ScanComponents.
@@ -18,7 +18,7 @@ func NewScanComponents(indexerVersion string, v1comps *v1.Components, v4comps *v
 	return &ScanComponents{
 		v1comps:        v1comps,
 		v4comps:        v4comps,
-		indexerVersion: indexerVersion,
+		IndexerVersion: indexerVersion,
 	}
 }
 
@@ -35,7 +35,7 @@ func (s *ScanComponents) ScannerV4() *v4.Contents {
 // ScannerType returns the scanner type for which components
 // have been populated for.
 func (s *ScanComponents) ScannerType() string {
-	if ScannerV4IndexerVersion(s.indexerVersion) {
+	if ScannerV4IndexerVersion(s.IndexerVersion) {
 		return ScannerV4
 	}
 

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -423,14 +423,13 @@ func (c *gRPCScanner) StoreImageIndex(ctx context.Context, ref name.Digest, inde
 		Contents:       contents,
 	}
 	var r *v4.StoreIndexReportResponse
-	var responseMetadata metadata.MD
 	err := retryWithBackoff(ctx, defaultBackoff(), "indexer.StoreImageIndex", func() error {
 		var err error
-		r, err = c.indexer.StoreIndexReport(ctx, req, grpc.Header(&responseMetadata))
+		r, err = c.indexer.StoreIndexReport(ctx, req)
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("store external index report: %w", err)
+		return fmt.Errorf("storing external index report: %w", err)
 	}
 	zlog.Debug(ctx).Err(err).Str("status", r.Status).Msg("received response from StoreIndexReport")
 

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -423,7 +423,7 @@ func (c *gRPCScanner) StoreImageIndex(ctx context.Context, ref name.Digest, inde
 	}
 
 	req := &v4.StoreIndexReportRequest{
-		HashId:         ref.DigestStr(),
+		HashId:         getImageManifestID(ref),
 		IndexerVersion: indexerVersion,
 		Contents:       contents,
 	}

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -82,7 +82,11 @@ type Scanner interface {
 	// GetSBOM to get sbom for an image
 	GetSBOM(ctx context.Context, name string, ref name.Digest, uri string, callOpts ...CallOption) ([]byte, bool, error)
 
-	StoreIndexReport(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...CallOption) error
+	// StoreImageIndex stores the contents provided. Particularly useful for
+	// storing contents from delegated Scanners. indexerVersion is used to
+	// hint to the Scanner whether it should overwrite the contents of ref
+	// if ref already exists in its datastore.
+	StoreImageIndex(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...CallOption) error
 
 	// Close cleans up any resources used by the implementation.
 	Close() error
@@ -404,12 +408,13 @@ func (c *gRPCScanner) GetMatcherMetadata(ctx context.Context, callOpts ...CallOp
 	return m, nil
 }
 
-func (c *gRPCScanner) StoreIndexReport(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...CallOption) error {
+// StoreIndexIndex calls the Indexer's gRPC endpoint StoreIndexReport.
+func (c *gRPCScanner) StoreImageIndex(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...CallOption) error {
 	if c.indexer == nil {
 		return errIndexerNotConfigured
 	}
 
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/client", "method", "StoreIndexReport")
+	ctx = zlog.ContextWithValues(ctx, "component", "scanner/client", "method", "StoreImageIndex")
 
 	// Process call options
 	var options callOptions

--- a/pkg/scannerv4/client/mocks/client.go
+++ b/pkg/scannerv4/client/mocks/client.go
@@ -180,21 +180,21 @@ func (mr *MockScannerMockRecorder) IndexAndScanImage(arg0, arg1, arg2, arg3 any,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexAndScanImage", reflect.TypeOf((*MockScanner)(nil).IndexAndScanImage), varargs...)
 }
 
-// StoreIndexReport mocks base method.
-func (m *MockScanner) StoreIndexReport(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...client.CallOption) error {
+// StoreImageIndex mocks base method.
+func (m *MockScanner) StoreImageIndex(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...client.CallOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, ref, indexerVersion, contents}
 	for _, a := range callOpts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "StoreIndexReport", varargs...)
+	ret := m.ctrl.Call(m, "StoreImageIndex", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// StoreIndexReport indicates an expected call of StoreIndexReport.
-func (mr *MockScannerMockRecorder) StoreIndexReport(ctx, ref, indexerVersion, contents any, callOpts ...any) *gomock.Call {
+// StoreImageIndex indicates an expected call of StoreImageIndex.
+func (mr *MockScannerMockRecorder) StoreImageIndex(ctx, ref, indexerVersion, contents any, callOpts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, ref, indexerVersion, contents}, callOpts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockScanner)(nil).StoreIndexReport), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreImageIndex", reflect.TypeOf((*MockScanner)(nil).StoreImageIndex), varargs...)
 }

--- a/pkg/scannerv4/client/mocks/client.go
+++ b/pkg/scannerv4/client/mocks/client.go
@@ -179,3 +179,22 @@ func (mr *MockScannerMockRecorder) IndexAndScanImage(arg0, arg1, arg2, arg3 any,
 	varargs := append([]any{arg0, arg1, arg2, arg3}, arg4...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexAndScanImage", reflect.TypeOf((*MockScanner)(nil).IndexAndScanImage), varargs...)
 }
+
+// StoreIndexReport mocks base method.
+func (m *MockScanner) StoreIndexReport(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...client.CallOption) error {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, ref, indexerVersion, contents}
+	for _, a := range callOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StoreIndexReport", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StoreIndexReport indicates an expected call of StoreIndexReport.
+func (mr *MockScannerMockRecorder) StoreIndexReport(ctx, ref, indexerVersion, contents any, callOpts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, ref, indexerVersion, contents}, callOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockScanner)(nil).StoreIndexReport), varargs...)
+}

--- a/proto/internalapi/scanner/v4/indexer_service.proto
+++ b/proto/internalapi/scanner/v4/indexer_service.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 
 package scanner.v4;
 
+import "internalapi/scanner/v4/common.proto";
 import "internalapi/scanner/v4/index_report.proto";
 
 option go_package = "./internalapi/scanner/v4;v4";
@@ -44,6 +45,14 @@ message GetOrCreateIndexReportRequest {
   }
 }
 
+message StoreIndexReportRequest {
+  string hash_id = 1;
+  string cluster_name = 2;
+  Contents contents = 3;
+}
+
+message StoreIndexReportResponse { }
+
 // Indexer service creates manifests and store index reports.
 service Indexer {
   // CreateIndexReport creates an index report for the specified resource and returns the report.
@@ -59,4 +68,8 @@ service Indexer {
 
   // HasIndexReport checks if an index report for the specified resource exists.
   rpc HasIndexReport(HasIndexReportRequest) returns (HasIndexReportResponse);
+
+  // TODO(DO NOT MERGE): Improve this comment.
+  // StoreIndexReport saves an index report to the database.
+  rpc StoreIndexReport(IndexReport) returns (StoreIndexReportResponse);
 }

--- a/proto/internalapi/scanner/v4/indexer_service.proto
+++ b/proto/internalapi/scanner/v4/indexer_service.proto
@@ -50,7 +50,9 @@ message StoreIndexReportRequest {
   Contents contents = 2;
 }
 
-message StoreIndexReportResponse { }
+message StoreIndexReportResponse {
+  string status = 1;
+}
 
 // Indexer service creates manifests and store index reports.
 service Indexer {
@@ -68,7 +70,6 @@ service Indexer {
   // HasIndexReport checks if an index report for the specified resource exists.
   rpc HasIndexReport(HasIndexReportRequest) returns (HasIndexReportResponse);
 
-  // TODO(DO NOT MERGE): Improve this comment.
-  // StoreIndexReport saves an index report to the database.
-  rpc StoreIndexReport(IndexReport) returns (StoreIndexReportResponse);
+  // StoreIndexReport stores an external index report to the datastore.
+  rpc StoreIndexReport(StoreIndexReportRequest) returns (StoreIndexReportResponse);
 }

--- a/proto/internalapi/scanner/v4/indexer_service.proto
+++ b/proto/internalapi/scanner/v4/indexer_service.proto
@@ -47,7 +47,8 @@ message GetOrCreateIndexReportRequest {
 
 message StoreIndexReportRequest {
   string hash_id = 1;
-  Contents contents = 2;
+  string indexer_version = 2;
+  Contents contents = 3;
 }
 
 message StoreIndexReportResponse {

--- a/proto/internalapi/scanner/v4/indexer_service.proto
+++ b/proto/internalapi/scanner/v4/indexer_service.proto
@@ -47,8 +47,7 @@ message GetOrCreateIndexReportRequest {
 
 message StoreIndexReportRequest {
   string hash_id = 1;
-  string cluster_name = 2;
-  Contents contents = 3;
+  Contents contents = 2;
 }
 
 message StoreIndexReportResponse { }

--- a/scanner/datastore/postgres/external_index_report.go
+++ b/scanner/datastore/postgres/external_index_report.go
@@ -25,7 +25,7 @@ func (e *externalIndexStore) StoreIndexReport(
 	indexerVersion string,
 	indexReport *claircore.IndexReport,
 	expiration time.Time,
-	versionCmpFn func(iv string) bool,
+	shouldUpdateStoredReportFn func(iv string) bool,
 ) error {
 	ctx = zlog.ContextWithValues(
 		ctx,
@@ -62,7 +62,7 @@ func (e *externalIndexStore) StoreIndexReport(
 		return fmt.Errorf("querying external index reports: %w", err)
 	}
 
-	if !versionCmpFn(storedIndexerVersion) {
+	if !shouldUpdateStoredReportFn(storedIndexerVersion) {
 		return fmt.Errorf("stored index report was produced with more recent indexer: %w", ErrDidNotUpdateRow)
 	}
 

--- a/scanner/datastore/postgres/external_index_report.go
+++ b/scanner/datastore/postgres/external_index_report.go
@@ -21,7 +21,7 @@ func (e *externalIndexStore) StoreIndexReport(ctx context.Context, hashID string
 			index_report = $2,
 			expiration = $3`
 
-	_, err := e.pool.Exec(ctx, hashID, indexReport, expiration)
+	_, err := e.pool.Exec(ctx, insertIndexReport, hashID, indexReport, expiration.UTC())
 	if err != nil {
 		return err
 	}

--- a/scanner/datastore/postgres/external_index_report.go
+++ b/scanner/datastore/postgres/external_index_report.go
@@ -15,10 +15,10 @@ func (e *externalIndexStore) StoreIndexReport(ctx context.Context, hashID string
 	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/externalIndexStore.StoreIndexReport")
 
 	const insertIndexReport = `
-		INSERT INTO external_index_report (hash_id, indexReport, expiration) VALUES
+		INSERT INTO external_index_report (hash_id, index_report, expiration) VALUES
 			($1, $2, $3)
 		ON CONFLICT (hash_id) DO UPDATE SET
-			indexReport = $2,
+			index_report = $2,
 			expiration = $3`
 
 	_, err := e.pool.Exec(ctx, hashID, indexReport, expiration)

--- a/scanner/datastore/postgres/external_index_report.go
+++ b/scanner/datastore/postgres/external_index_report.go
@@ -67,8 +67,8 @@ func (e *externalIndexStore) StoreIndexReport(
 	}
 
 	const updateIndexReport = `
-		UPDATE external_index_report SET (indexer_version, index_report, expiration) =
-			($2, $3, $4) WHERE hash_id = $1`
+		UPDATE external_index_report SET (indexer_version, index_report, expiration, updated_at) =
+			($2, $3, $4, DEFAULT) WHERE hash_id = $1`
 
 	_, err = e.pool.Exec(ctx, updateIndexReport, hashID, indexerVersion, indexReport, expiration.UTC())
 	if err != nil {

--- a/scanner/datastore/postgres/external_index_report.go
+++ b/scanner/datastore/postgres/external_index_report.go
@@ -1,0 +1,91 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/quay/claircore"
+	"github.com/quay/zlog"
+)
+
+func (e *externalIndexStore) StoreIndexReport(ctx context.Context, hashID string, clusterName string, indexReport *claircore.IndexReport) error {
+	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/externalIndexStore.StoreIndexReport")
+
+	const insertIndexReport = `
+		INSERT INTO external_index_report (hash_id, clusterName, indexReport) VALUES
+			($1, $2, $3)
+		ON CONFLICT (hash_id, clusterName) DO UPDATE SET indexReport = $3`
+
+	_, err := e.pool.Exec(ctx, hashID, clusterName, indexReport)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *externalIndexStore) StoreIndexReportWithExpiration(ctx context.Context, hashID string, clusterName string, indexReport *claircore.IndexReport, expiration time.Time) error {
+	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/externalIndexStore.StoreIndexReportWithExpiration")
+
+	const insertIndexReport = `
+		INSERT INTO external_index_report (hash_id, clusterName, indexReport, expiration) VALUES
+			($1, $2, $3, $4)
+		ON CONFLICT (hash_id, clusterName) DO UPDATE SET
+			indexReport = $3,
+			expiration = $4`
+
+	_, err := e.pool.Exec(ctx, hashID, clusterName, indexReport, expiration)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *externalIndexStore) GCIndexReports(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error) {
+	o := makeReindexGCOpts(opts)
+
+	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/externalIndexStore.GCIndexReports")
+
+	const deleteIndexReports = `
+		DELETE FROM external_index_report
+		WHERE hash_id IN (
+		    SELECT hash_id FROM external_index_report WHERE expiration < $1 LIMIT $2
+		)
+		RETURNING hash_id`
+
+	// Make this a transaction, as failure to delete the index report should stop deletion.
+	tx, err := e.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning ReindexGC transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	// Delete expired rows from external_index_report
+	rows, err := tx.Query(ctx, deleteIndexReports, expiration.UTC(), o.gcThrottle)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var deletedHashes []string
+	for rows.Next() {
+		var hashID string
+		if err := rows.Scan(&hashID); err != nil {
+			zlog.Warn(ctx).Err(err).Msg("scanning deleted external index report row")
+			continue
+		}
+		deletedHashes = append(deletedHashes, hashID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading deleted external index report rows: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing deleted external index reports: %w", err)
+	}
+
+	return deletedHashes, nil
+}

--- a/scanner/datastore/postgres/external_index_report_test.go
+++ b/scanner/datastore/postgres/external_index_report_test.go
@@ -15,7 +15,7 @@ import (
 func Test_ExternalIndexReport_GCIndexReports(t *testing.T) {
 	ctx := context.Background()
 	pool := testDB(t, ctx, "external_index_report_test")
-	store, err := InitPostgresExternalIndexStore(ctx, pool)
+	store, err := InitPostgresExternalIndexStore(ctx, pool, true)
 	require.NoError(t, err)
 	now := time.Now()
 

--- a/scanner/datastore/postgres/external_index_report_test.go
+++ b/scanner/datastore/postgres/external_index_report_test.go
@@ -19,10 +19,12 @@ func Test_ExternalIndexReport_GCIndexReports(t *testing.T) {
 	require.NoError(t, err)
 	now := time.Now()
 
+	iv := "indexer=v4.0.1"
 	ir := &claircore.IndexReport{State: "sample state", Success: true}
+	fn := func(iv string) bool { return true }
 
 	// Add an index report which should not be deleted.
-	err = store.StoreIndexReport(ctx, "sha512:abc", ir, now.Add(1*time.Hour))
+	err = store.StoreIndexReport(ctx, "sha512:abc", iv, ir, now.Add(1*time.Hour), fn)
 	assert.NoError(t, err)
 	// Run GC but do not delete.
 	ids, err := store.GCIndexReports(ctx, now)
@@ -31,11 +33,11 @@ func Test_ExternalIndexReport_GCIndexReports(t *testing.T) {
 
 	// Add an index report to be deleted.
 	// First, add it an hour ahead.
-	err = store.StoreIndexReport(ctx, "sha512:def", ir, now.Add(1*time.Hour))
+	err = store.StoreIndexReport(ctx, "sha512:def", iv, ir, now.Add(1*time.Hour), fn)
 	assert.NoError(t, err)
 	// Next, add it an hour behind.
 	// This ensures the row is overwritten.
-	err = store.StoreIndexReport(ctx, "sha512:def", ir, now.Add(-1*time.Hour))
+	err = store.StoreIndexReport(ctx, "sha512:def", iv, ir, now.Add(-1*time.Hour), fn)
 	assert.NoError(t, err)
 	// Delete the index report.
 	ids, err = store.GCIndexReports(ctx, now)
@@ -44,7 +46,7 @@ func Test_ExternalIndexReport_GCIndexReports(t *testing.T) {
 	assert.Equal(t, "sha512:def", ids[0])
 
 	// Add an index report which manages to have the same time as now.
-	err = store.StoreIndexReport(ctx, "sha512:ghi", ir, now)
+	err = store.StoreIndexReport(ctx, "sha512:ghi", iv, ir, now, fn)
 	assert.NoError(t, err)
 	// This index report gets lucky, and it does not get deleted. Yet...
 	// Note the index report from the previous test is also not deleted (again).

--- a/scanner/datastore/postgres/external_index_report_test.go
+++ b/scanner/datastore/postgres/external_index_report_test.go
@@ -1,0 +1,54 @@
+//go:build scanner_db_integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/quay/claircore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExternalIndexReport_GCIndexReports(t *testing.T) {
+	ctx := context.Background()
+	pool := testDB(t, ctx, "external_index_report_test")
+	store, err := InitPostgresExternalIndexStore(ctx, pool)
+	require.NoError(t, err)
+	now := time.Now()
+
+	ir := &claircore.IndexReport{State: "sample state", Success: true}
+
+	// Add an index report which should not be deleted.
+	err = store.StoreIndexReport(ctx, "sha512:abc", ir, now.Add(1*time.Hour))
+	assert.NoError(t, err)
+	// Run GC but do not delete.
+	ids, err := store.GCIndexReports(ctx, now)
+	require.NoError(t, err)
+	assert.Len(t, ids, 0)
+
+	// Add an index report to be deleted.
+	// First, add it an hour ahead.
+	err = store.StoreIndexReport(ctx, "sha512:def", ir, now.Add(1*time.Hour))
+	assert.NoError(t, err)
+	// Next, add it an hour behind.
+	// This ensures the row is overwritten.
+	err = store.StoreIndexReport(ctx, "sha512:def", ir, now.Add(-1*time.Hour))
+	assert.NoError(t, err)
+	// Delete the index report.
+	ids, err = store.GCIndexReports(ctx, now)
+	require.NoError(t, err)
+	assert.Len(t, ids, 1)
+	assert.Equal(t, "sha512:def", ids[0])
+
+	// Add an index report which manages to have the same time as now.
+	err = store.StoreIndexReport(ctx, "sha512:ghi", ir, now)
+	assert.NoError(t, err)
+	// This index report gets lucky, and it does not get deleted. Yet...
+	// Note the index report from the previous test is also not deleted (again).
+	ids, err = store.GCIndexReports(ctx, now)
+	require.NoError(t, err)
+	assert.Len(t, ids, 0)
+}

--- a/scanner/datastore/postgres/external_index_store.go
+++ b/scanner/datastore/postgres/external_index_store.go
@@ -1,0 +1,37 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/pkg/errors"
+	"github.com/quay/claircore"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+//go:generate mockgen-wrapper
+type ExternalIndexStore interface {
+	StoreIndexReport(ctx context.Context, hashID string, clusterName string, indexReport *claircore.IndexReport) error
+	StoreIndexReportWithExpiration(ctx context.Context, hashID string, clusterName string, indexReport *claircore.IndexReport, expiration time.Time) error
+	GCIndexReports(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error)
+}
+
+type externalIndexStore struct {
+	pool *pgxpool.Pool
+}
+
+// InitPostgresExternalIndexStore initializes an external index report datastore.
+func InitPostgresExternalIndexStore(_ context.Context, pool *pgxpool.Pool) (ExternalIndexStore, error) {
+	if pool == nil {
+		return nil, errors.New("pool must be non-nil")
+	}
+
+	db := stdlib.OpenDB(*pool.Config().ConnConfig)
+	defer utils.IgnoreError(db.Close)
+
+	return &externalIndexStore{
+		pool: pool,
+	}, nil
+}

--- a/scanner/datastore/postgres/external_index_store.go
+++ b/scanner/datastore/postgres/external_index_store.go
@@ -15,8 +15,19 @@ import (
 )
 
 type ExternalIndexStore interface {
-	StoreIndexReport(ctx context.Context, hashID string, indexReport *claircore.IndexReport, expiration time.Time) error
-	GCIndexReports(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error)
+	StoreIndexReport(
+		ctx context.Context,
+		hashID string,
+		scannerVersion string,
+		indexReport *claircore.IndexReport,
+		expiration time.Time,
+		versionCmpFn func(iv string) bool,
+	) error
+	GCIndexReports(
+		ctx context.Context,
+		expiration time.Time,
+		opts ...ReindexGCOption,
+	) ([]string, error)
 }
 
 type externalIndexStore struct {
@@ -24,7 +35,10 @@ type externalIndexStore struct {
 }
 
 // InitPostgresExternalIndexStore initializes an external index report datastore.
-func InitPostgresExternalIndexStore(_ context.Context, pool *pgxpool.Pool) (ExternalIndexStore, error) {
+func InitPostgresExternalIndexStore(
+	_ context.Context,
+	pool *pgxpool.Pool,
+) (ExternalIndexStore, error) {
 	if pool == nil {
 		return nil, errors.New("pool must be non-nil")
 	}

--- a/scanner/datastore/postgres/external_index_store.go
+++ b/scanner/datastore/postgres/external_index_store.go
@@ -21,7 +21,7 @@ type ExternalIndexStore interface {
 		scannerVersion string,
 		indexReport *claircore.IndexReport,
 		expiration time.Time,
-		versionCmpFn func(iv string) bool,
+		shouldUpdateStoredReportFn func(iv string) bool,
 	) error
 	GCIndexReports(
 		ctx context.Context,

--- a/scanner/datastore/postgres/external_index_store.go
+++ b/scanner/datastore/postgres/external_index_store.go
@@ -13,8 +13,7 @@ import (
 
 //go:generate mockgen-wrapper
 type ExternalIndexStore interface {
-	StoreIndexReport(ctx context.Context, hashID string, clusterName string, indexReport *claircore.IndexReport) error
-	StoreIndexReportWithExpiration(ctx context.Context, hashID string, clusterName string, indexReport *claircore.IndexReport, expiration time.Time) error
+	StoreIndexReport(ctx context.Context, hashID string, indexReport *claircore.IndexReport, expiration time.Time) error
 	GCIndexReports(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error)
 }
 

--- a/scanner/datastore/postgres/external_index_store.go
+++ b/scanner/datastore/postgres/external_index_store.go
@@ -2,16 +2,18 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
 	"github.com/quay/claircore"
+	"github.com/remind101/migrate"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/scanner/datastore/postgres/migrations"
 )
 
-//go:generate mockgen-wrapper
 type ExternalIndexStore interface {
 	StoreIndexReport(ctx context.Context, hashID string, indexReport *claircore.IndexReport, expiration time.Time) error
 	GCIndexReports(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error)
@@ -29,6 +31,13 @@ func InitPostgresExternalIndexStore(_ context.Context, pool *pgxpool.Pool) (Exte
 
 	db := stdlib.OpenDB(*pool.Config().ConnConfig)
 	defer utils.IgnoreError(db.Close)
+
+	migrator := migrate.NewPostgresMigrator(db)
+	migrator.Table = migrations.IndexerMigrationTable
+	err := migrator.Exec(migrate.Up, migrations.IndexerMigrations...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform migrations: %w", err)
+	}
 
 	return &externalIndexStore{
 		pool: pool,

--- a/scanner/datastore/postgres/indexer_metadata_store.go
+++ b/scanner/datastore/postgres/indexer_metadata_store.go
@@ -32,7 +32,7 @@ type IndexerMetadataStore interface {
 	ManifestExists(ctx context.Context, manifestID string) (bool, error)
 	// GCManifests deletes manifests from the manifest_metadata table with timestamps older than expiration (converted to UTC)
 	// and returns their respective IDs.
-	GCManifests(ctx context.Context, expiration time.Time, opts ...GCManifestsOption) ([]string, error)
+	GCManifests(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error)
 }
 
 type indexerMetadataStore struct {
@@ -46,34 +46,6 @@ type IndexerMetadataStoreOpts struct {
 	// IndexerStore represents the indexer.Store to query when MigrateManifests and GCManifests are called.
 	// If undefined, then MigrateManifests will fail.
 	IndexerStore indexer.Store
-}
-
-// GCManifestsOption is a configuration option for the GCManifests method.
-type GCManifestsOption func(o *gcManifestsOpts)
-
-type gcManifestsOpts struct {
-	gcThrottle int
-}
-
-// WithGCThrottle sets the maximum number of manifests to GC.
-// Default: 100
-func WithGCThrottle(gcThrottle int) GCManifestsOption {
-	return func(o *gcManifestsOpts) {
-		o.gcThrottle = gcThrottle
-	}
-}
-
-func makeGCManifestsOpts(opts []GCManifestsOption) gcManifestsOpts {
-	var o gcManifestsOpts
-	for _, opt := range opts {
-		opt(&o)
-	}
-
-	if o.gcThrottle == 0 {
-		o.gcThrottle = 100
-	}
-
-	return o
 }
 
 // InitPostgresIndexerMetadataStore initializes an indexer metadata datastore.

--- a/scanner/datastore/postgres/manifest_metadata.go
+++ b/scanner/datastore/postgres/manifest_metadata.go
@@ -90,8 +90,8 @@ func (i *indexerMetadataStore) ManifestExists(ctx context.Context, manifestID st
 	return value == 1, nil
 }
 
-func (i *indexerMetadataStore) GCManifests(ctx context.Context, expiration time.Time, opts ...GCManifestsOption) ([]string, error) {
-	o := makeGCManifestsOpts(opts)
+func (i *indexerMetadataStore) GCManifests(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error) {
+	o := makeReindexGCOpts(opts)
 
 	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/indexerMetadataStore.GCManifests")
 

--- a/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
+++ b/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
@@ -1,4 +1,4 @@
---- the jsonb serialized result of an index report from a delegated scanner.
+--- the jsonb serialized result of an index report from a delegated scan.
 CREATE TABLE IF NOT EXISTS external_index_report (
     hash_id TEXT PRIMARY KEY,
     indexer_version TEXT NOT NULL,

--- a/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
+++ b/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
@@ -1,6 +1,7 @@
 --- the jsonb serialized result of an index report from a delegated scanner.
 CREATE TABLE IF NOT EXISTS external_index_report (
     hash_id TEXT PRIMARY KEY,
+    indexer_version TEXT NOT NULL,
     index_report JSONB NOT NULL,
     expiration TIMESTAMP NOT NULL
 );

--- a/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
+++ b/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
@@ -1,0 +1,8 @@
+--- the jsonb serialized result of an index report from a delegated scanner.
+CREATE TABLE IF NOT EXISTS external_index_report (
+    hash_id TEXT PRIMARY KEY,
+    index_report JSONB NOT NULL,
+    expiration TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS external_index_report_expiration_idx ON external_index_report(expiration);

--- a/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
+++ b/scanner/datastore/postgres/migrations/indexer/02-external-index-report.sql
@@ -3,7 +3,8 @@ CREATE TABLE IF NOT EXISTS external_index_report (
     hash_id TEXT PRIMARY KEY,
     indexer_version TEXT NOT NULL,
     index_report JSONB NOT NULL,
-    expiration TIMESTAMP NOT NULL
+    expiration TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT now()
 );
 
 CREATE INDEX IF NOT EXISTS external_index_report_expiration_idx ON external_index_report(expiration);

--- a/scanner/datastore/postgres/migrations/migrations.go
+++ b/scanner/datastore/postgres/migrations/migrations.go
@@ -16,8 +16,13 @@ const (
 	MatcherMigrationTable = "matcher_migrations"
 )
 
-// IndexerMigrations lists the indexer migrations, in order.
-var IndexerMigrations []migrate.Migration
+// IndexerMigrations lists the indexer migrations (not necessarily in order).
+var IndexerMigrations = []migrate.Migration{
+	{
+		ID: 2,
+		Up: runFile("indexer/02-external-index-report.sql"),
+	},
+}
 
 func init() {
 	if features.ScannerV4ReIndex.Enabled() {

--- a/scanner/datastore/postgres/migrations/migrations.go
+++ b/scanner/datastore/postgres/migrations/migrations.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 
 	"github.com/remind101/migrate"
-	"github.com/stackrox/rox/pkg/features"
 )
 
 const (
@@ -16,23 +15,16 @@ const (
 	MatcherMigrationTable = "matcher_migrations"
 )
 
-// IndexerMigrations lists the indexer migrations. Some items are added during
-// init() so these may not be in order. Note that the ordering is reconciled
-// via their IDs.
+// IndexerMigrations lists the indexer migrations, in order.
 var IndexerMigrations = []migrate.Migration{
+	{
+		ID: 1,
+		Up: runFile("indexer/01-init.sql"),
+	},
 	{
 		ID: 2,
 		Up: runFile("indexer/02-external-index-report.sql"),
 	},
-}
-
-func init() {
-	if features.ScannerV4ReIndex.Enabled() {
-		IndexerMigrations = append(IndexerMigrations, migrate.Migration{
-			ID: 1,
-			Up: runFile("indexer/01-init.sql"),
-		})
-	}
 }
 
 // MatcherMigrations lists the matcher migrations, in order.

--- a/scanner/datastore/postgres/migrations/migrations.go
+++ b/scanner/datastore/postgres/migrations/migrations.go
@@ -16,7 +16,9 @@ const (
 	MatcherMigrationTable = "matcher_migrations"
 )
 
-// IndexerMigrations lists the indexer migrations (not necessarily in order).
+// IndexerMigrations lists the indexer migrations. Some items are added during
+// init() so these may not be in order. Note that the ordering is reconciled
+// via their IDs.
 var IndexerMigrations = []migrate.Migration{
 	{
 		ID: 2,

--- a/scanner/datastore/postgres/mocks/indexer_metadata_store.go
+++ b/scanner/datastore/postgres/mocks/indexer_metadata_store.go
@@ -43,7 +43,7 @@ func (m *MockIndexerMetadataStore) EXPECT() *MockIndexerMetadataStoreMockRecorde
 }
 
 // GCManifests mocks base method.
-func (m *MockIndexerMetadataStore) GCManifests(ctx context.Context, expiration time.Time, opts ...postgres.GCManifestsOption) ([]string, error) {
+func (m *MockIndexerMetadataStore) GCManifests(ctx context.Context, expiration time.Time, opts ...postgres.ReindexGCOption) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, expiration}
 	for _, a := range opts {

--- a/scanner/datastore/postgres/reindex_gc.go
+++ b/scanner/datastore/postgres/reindex_gc.go
@@ -1,0 +1,29 @@
+package postgres
+
+// ReindexGCOption is a configuration option for the GCManifests method.
+type ReindexGCOption func(o *reindexGCOpts)
+
+type reindexGCOpts struct {
+	gcThrottle int
+}
+
+// WithGCThrottle sets the maximum number of manifests to GC.
+// Default: 100
+func WithGCThrottle(gcThrottle int) ReindexGCOption {
+	return func(o *reindexGCOpts) {
+		o.gcThrottle = gcThrottle
+	}
+}
+
+func makeReindexGCOpts(opts []ReindexGCOption) reindexGCOpts {
+	var o reindexGCOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	if o.gcThrottle == 0 {
+		o.gcThrottle = 100
+	}
+
+	return o
+}

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -138,7 +138,7 @@ type ReportGetter interface {
 	GetIndexReport(context.Context, string) (*claircore.IndexReport, bool, error)
 }
 
-// ReportStorer stores claircore.IndexReport
+// ReportStorer stores a claircore.IndexReport
 type ReportStorer interface {
 	StoreIndexReport(ctx context.Context, hashID string, scannerVersion string, report *claircore.IndexReport) error
 }
@@ -614,7 +614,7 @@ func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, scan
 				semver.Compare(sv.Indexer, v.Indexer) >= 0
 		})
 	if err != nil {
-		return fmt.Errorf("storing external index report: %w", err)
+		return fmt.Errorf("storing external index report with (hashID %q): %w", hashID, err)
 	}
 
 	return nil

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -214,7 +214,7 @@ func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) 
 		}
 	}
 
-	externalIndexStore, err := postgres.InitPostgresExternalIndexStore(ctx, pool)
+	externalIndexStore, err := postgres.InitPostgresExternalIndexStore(ctx, pool, true)
 	if err != nil {
 		return nil, fmt.Errorf("initializing postgres external index store: %w", err)
 	}

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/quay/claircore/dpkg"
 	"github.com/quay/claircore/gobin"
 	ccindexer "github.com/quay/claircore/indexer"
+	"github.com/quay/claircore/indexer/controller"
 	"github.com/quay/claircore/java"
 	"github.com/quay/claircore/libindex"
 	"github.com/quay/claircore/nodejs"

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -252,7 +252,7 @@ func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) 
 
 	var manifestManager *manifest.Manager
 	if features.ScannerV4ReIndex.Enabled() {
-		manifestManager = manifest.NewManager(ctx, metadataStore, locker)
+		manifestManager = manifest.NewManager(ctx, metadataStore, externalIndexStore, locker)
 		// Set any manifests indexed prior to the existence of the manifest_metadata table
 		// to expire immediately.
 		// TODO(ROX-26957): Consider moving this elsewhere so we do not block initialization.

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -43,12 +43,12 @@ import (
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	pkgscanner "github.com/stackrox/rox/pkg/scannerv4"
 	"github.com/stackrox/rox/pkg/utils"
+	pkgversion "github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/scanner/config"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
 	"github.com/stackrox/rox/scanner/indexer/manifest"
 	"github.com/stackrox/rox/scanner/internal/httputil"
 	"github.com/stackrox/rox/scanner/internal/version"
-	"golang.org/x/mod/semver"
 )
 
 var (
@@ -138,9 +138,9 @@ type ReportGetter interface {
 	GetIndexReport(context.Context, string) (*claircore.IndexReport, bool, error)
 }
 
-// ReportStorer stores a claircore.IndexReport
+// ReportStorer stores a claircore.IndexReport.
 type ReportStorer interface {
-	StoreIndexReport(ctx context.Context, hashID string, scannerVersion string, report *claircore.IndexReport) error
+	StoreIndexReport(ctx context.Context, hashID string, indexerVersion string, report *claircore.IndexReport) error
 }
 
 // Indexer represents an image indexer.
@@ -586,17 +586,14 @@ func createManifestDigest(hashID string) (claircore.Digest, error) {
 	return d, nil
 }
 
-func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, scannerVersion string, report *claircore.IndexReport) error {
+func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, indexerVersion string, report *claircore.IndexReport) error {
 	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/indexer.StoreIndexReport")
 
-	sv, err := pkgscanner.DecodeVersion(scannerVersion)
-	if err != nil {
-		return err
-	}
-	// Ensure the version strings contain valid semantic versions. This is
-	// important for comparability.
-	if !semver.IsValid(sv.Indexer) {
-		return fmt.Errorf("indexer version %q is not a valid semantic version", sv.Indexer)
+	// Ensure the provided indexer version string is valid. This is important
+	// for comparability because pkgversion.CompareVersions returns 0 if the
+	// versions aren't comparable.
+	if pkgversion.GetVersionKind(indexerVersion) == pkgversion.InvalidKind {
+		return fmt.Errorf("indexer version %q is not a valid semantic version", indexerVersion)
 	}
 	// Note that the conversion to and from v4.Contents truncates the
 	// claircore.IndexReport's Success and State fields. If the index report
@@ -604,14 +601,14 @@ func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, scan
 	report.Success = true
 	report.State = controller.IndexFinished.String()
 
-	err = i.externalIndexStore.StoreIndexReport(ctx, hashID, sv.Indexer, report, i.randomExpiry(time.Now()),
+	err := i.externalIndexStore.StoreIndexReport(ctx, hashID, indexerVersion, report, i.randomExpiry(time.Now()),
 		func(iv string) bool {
 			// If the stored indexer version is not valid, let the datastore
 			// overwrite the record.
 			v, err := pkgscanner.DecodeVersion(iv)
-			return err != nil ||
-				!semver.IsValid(v.Indexer) ||
-				semver.Compare(sv.Indexer, v.Indexer) >= 0
+			return err != nil &&
+				pkgversion.GetVersionKind(indexerVersion) != pkgversion.InvalidKind &&
+				pkgversion.CompareVersions(indexerVersion, v.Indexer) >= 0
 		})
 	if err != nil {
 		return fmt.Errorf("storing external index report with (hashID %q): %w", hashID, err)

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -138,7 +138,7 @@ type ReportGetter interface {
 
 // ReportStorer stores claircore.IndexReport
 type ReportStorer interface {
-	StoreIndexReport(ctx context.Context, hashID string, clusterName string, report *claircore.IndexReport) error
+	StoreIndexReport(ctx context.Context, hashID string, report *claircore.IndexReport) error
 }
 
 // Indexer represents an image indexer.
@@ -584,17 +584,10 @@ func createManifestDigest(hashID string) (claircore.Digest, error) {
 	return d, nil
 }
 
-func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, clusterName string, report *claircore.IndexReport) error {
-	if features.ScannerV4ReIndex.Enabled() {
-		err := i.externalIndexStore.StoreIndexReportWithExpiration(ctx, hashID, clusterName, report, i.randomExpiry(time.Now()))
-		if err != nil {
-			return err
-		}
-	} else {
-		err := i.externalIndexStore.StoreIndexReport(ctx, hashID, clusterName, report)
-		if err != nil {
-			return err
-		}
+func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, report *claircore.IndexReport) error {
+	err := i.externalIndexStore.StoreIndexReport(ctx, hashID, report, i.randomExpiry(time.Now()))
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/scanner/indexer/indexer_test.go
+++ b/scanner/indexer/indexer_test.go
@@ -254,3 +254,77 @@ func TestRandomExpiry(t *testing.T) {
 		assert.True(t, expiry.Before(threeMinutes))
 	}
 }
+
+// Testing the unexported shouldUpdateExternalIndexReport function because its
+// output is particularly important to get right since it determines whether
+// a record will be updated on conflict.
+func Test_shouldUpdateExternalIndexReport(t *testing.T) {
+	tests := []struct {
+		name                 string
+		incomingIndexVersion string
+		savedIndexerVersion  string
+		want                 bool
+	}{
+		{
+			name:                 "incoming version is newer",
+			incomingIndexVersion: "4.8.3",
+			savedIndexerVersion:  "4.7.5",
+			want:                 true,
+		},
+		{
+			name:                 "saved version is newer",
+			incomingIndexVersion: "4.7.5",
+			savedIndexerVersion:  "4.8.3",
+			want:                 false,
+		},
+		{
+			name:                 "both versions are valid and the same",
+			incomingIndexVersion: "4.8.3",
+			savedIndexerVersion:  "4.8.3",
+			want:                 true,
+		},
+		{
+			name:                 "saved version is v4",
+			incomingIndexVersion: "4.8.3",
+			savedIndexerVersion:  "v4",
+			want:                 true,
+		},
+		{
+			name:                 "incoming versions are v4",
+			incomingIndexVersion: "v4",
+			savedIndexerVersion:  "4.8.3",
+			want:                 false,
+		},
+		{
+			name:                 "both versions are v4",
+			incomingIndexVersion: "v4",
+			savedIndexerVersion:  "v4",
+			want:                 true,
+		},
+		{
+			name:                 "incoming version is considered invalid",
+			incomingIndexVersion: "vX.Y.Z",
+			savedIndexerVersion:  "4.8.3",
+			want:                 false,
+		},
+		{
+			name:                 "saved version is considered invalid",
+			incomingIndexVersion: "4.8.3",
+			savedIndexerVersion:  "vX.Y.Z",
+			want:                 true,
+		},
+		{
+			name:                 "both versions are considered invalid",
+			incomingIndexVersion: "vX.Y.Z",
+			savedIndexerVersion:  "vX.Y.Z",
+			want:                 true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := shouldUpdateExternalIndexReport(tt.incomingIndexVersion)
+			got := f(tt.savedIndexerVersion)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/scanner/indexer/indexer_test.go
+++ b/scanner/indexer/indexer_test.go
@@ -284,21 +284,21 @@ func Test_shouldUpdateExternalIndexReport(t *testing.T) {
 			want:                 true,
 		},
 		{
-			name:                 "saved version is v4",
+			name:                 "saved version is empty",
 			incomingIndexVersion: "4.8.3",
-			savedIndexerVersion:  "v4",
+			savedIndexerVersion:  "",
 			want:                 true,
 		},
 		{
-			name:                 "incoming versions are v4",
-			incomingIndexVersion: "v4",
+			name:                 "incoming version is empty",
+			incomingIndexVersion: "",
 			savedIndexerVersion:  "4.8.3",
 			want:                 false,
 		},
 		{
-			name:                 "both versions are v4",
-			incomingIndexVersion: "v4",
-			savedIndexerVersion:  "v4",
+			name:                 "both versions are empty",
+			incomingIndexVersion: "",
+			savedIndexerVersion:  "",
 			want:                 true,
 		},
 		{

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -83,17 +83,17 @@ func (m *MockReportStorer) EXPECT() *MockReportStorerMockRecorder {
 }
 
 // StoreIndexReport mocks base method.
-func (m *MockReportStorer) StoreIndexReport(ctx context.Context, hashID, scannerVersion string, report *claircore.IndexReport) error {
+func (m *MockReportStorer) StoreIndexReport(ctx context.Context, hashID, indexerVersion string, report *claircore.IndexReport) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, scannerVersion, report)
+	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, indexerVersion, report)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreIndexReport indicates an expected call of StoreIndexReport.
-func (mr *MockReportStorerMockRecorder) StoreIndexReport(ctx, hashID, scannerVersion, report any) *gomock.Call {
+func (mr *MockReportStorerMockRecorder) StoreIndexReport(ctx, hashID, indexerVersion, report any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockReportStorer)(nil).StoreIndexReport), ctx, hashID, scannerVersion, report)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockReportStorer)(nil).StoreIndexReport), ctx, hashID, indexerVersion, report)
 }
 
 // MockIndexer is a mock of Indexer interface.
@@ -185,15 +185,15 @@ func (mr *MockIndexerMockRecorder) Ready(arg0 any) *gomock.Call {
 }
 
 // StoreIndexReport mocks base method.
-func (m *MockIndexer) StoreIndexReport(ctx context.Context, hashID, scannerVersion string, report *claircore.IndexReport) error {
+func (m *MockIndexer) StoreIndexReport(ctx context.Context, hashID, indexerVersion string, report *claircore.IndexReport) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, scannerVersion, report)
+	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, indexerVersion, report)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreIndexReport indicates an expected call of StoreIndexReport.
-func (mr *MockIndexerMockRecorder) StoreIndexReport(ctx, hashID, scannerVersion, report any) *gomock.Call {
+func (mr *MockIndexerMockRecorder) StoreIndexReport(ctx, hashID, indexerVersion, report any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockIndexer)(nil).StoreIndexReport), ctx, hashID, scannerVersion, report)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockIndexer)(nil).StoreIndexReport), ctx, hashID, indexerVersion, report)
 }

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -58,6 +58,44 @@ func (mr *MockReportGetterMockRecorder) GetIndexReport(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockReportGetter)(nil).GetIndexReport), arg0, arg1)
 }
 
+// MockReportStorer is a mock of ReportStorer interface.
+type MockReportStorer struct {
+	ctrl     *gomock.Controller
+	recorder *MockReportStorerMockRecorder
+	isgomock struct{}
+}
+
+// MockReportStorerMockRecorder is the mock recorder for MockReportStorer.
+type MockReportStorerMockRecorder struct {
+	mock *MockReportStorer
+}
+
+// NewMockReportStorer creates a new mock instance.
+func NewMockReportStorer(ctrl *gomock.Controller) *MockReportStorer {
+	mock := &MockReportStorer{ctrl: ctrl}
+	mock.recorder = &MockReportStorerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockReportStorer) EXPECT() *MockReportStorerMockRecorder {
+	return m.recorder
+}
+
+// StoreIndexReport mocks base method.
+func (m *MockReportStorer) StoreIndexReport(ctx context.Context, hashID string, report *claircore.IndexReport) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, report)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StoreIndexReport indicates an expected call of StoreIndexReport.
+func (mr *MockReportStorerMockRecorder) StoreIndexReport(ctx, hashID, report any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockReportStorer)(nil).StoreIndexReport), ctx, hashID, report)
+}
+
 // MockIndexer is a mock of Indexer interface.
 type MockIndexer struct {
 	ctrl     *gomock.Controller
@@ -144,4 +182,18 @@ func (m *MockIndexer) Ready(arg0 context.Context) error {
 func (mr *MockIndexerMockRecorder) Ready(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockIndexer)(nil).Ready), arg0)
+}
+
+// StoreIndexReport mocks base method.
+func (m *MockIndexer) StoreIndexReport(ctx context.Context, hashID string, report *claircore.IndexReport) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, report)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StoreIndexReport indicates an expected call of StoreIndexReport.
+func (mr *MockIndexerMockRecorder) StoreIndexReport(ctx, hashID, report any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockIndexer)(nil).StoreIndexReport), ctx, hashID, report)
 }

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -83,17 +83,17 @@ func (m *MockReportStorer) EXPECT() *MockReportStorerMockRecorder {
 }
 
 // StoreIndexReport mocks base method.
-func (m *MockReportStorer) StoreIndexReport(ctx context.Context, hashID string, report *claircore.IndexReport) error {
+func (m *MockReportStorer) StoreIndexReport(ctx context.Context, hashID, scannerVersion string, report *claircore.IndexReport) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, report)
+	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, scannerVersion, report)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreIndexReport indicates an expected call of StoreIndexReport.
-func (mr *MockReportStorerMockRecorder) StoreIndexReport(ctx, hashID, report any) *gomock.Call {
+func (mr *MockReportStorerMockRecorder) StoreIndexReport(ctx, hashID, scannerVersion, report any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockReportStorer)(nil).StoreIndexReport), ctx, hashID, report)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockReportStorer)(nil).StoreIndexReport), ctx, hashID, scannerVersion, report)
 }
 
 // MockIndexer is a mock of Indexer interface.
@@ -185,15 +185,15 @@ func (mr *MockIndexerMockRecorder) Ready(arg0 any) *gomock.Call {
 }
 
 // StoreIndexReport mocks base method.
-func (m *MockIndexer) StoreIndexReport(ctx context.Context, hashID string, report *claircore.IndexReport) error {
+func (m *MockIndexer) StoreIndexReport(ctx context.Context, hashID, scannerVersion string, report *claircore.IndexReport) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, report)
+	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, scannerVersion, report)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreIndexReport indicates an expected call of StoreIndexReport.
-func (mr *MockIndexerMockRecorder) StoreIndexReport(ctx, hashID, report any) *gomock.Call {
+func (mr *MockIndexerMockRecorder) StoreIndexReport(ctx, hashID, scannerVersion, report any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockIndexer)(nil).StoreIndexReport), ctx, hashID, report)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreIndexReport", reflect.TypeOf((*MockIndexer)(nil).StoreIndexReport), ctx, hashID, scannerVersion, report)
 }

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -83,11 +83,12 @@ func (m *MockReportStorer) EXPECT() *MockReportStorerMockRecorder {
 }
 
 // StoreIndexReport mocks base method.
-func (m *MockReportStorer) StoreIndexReport(ctx context.Context, hashID, indexerVersion string, report *claircore.IndexReport) error {
+func (m *MockReportStorer) StoreIndexReport(ctx context.Context, hashID, indexerVersion string, report *claircore.IndexReport) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, indexerVersion, report)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // StoreIndexReport indicates an expected call of StoreIndexReport.
@@ -185,11 +186,12 @@ func (mr *MockIndexerMockRecorder) Ready(arg0 any) *gomock.Call {
 }
 
 // StoreIndexReport mocks base method.
-func (m *MockIndexer) StoreIndexReport(ctx context.Context, hashID, indexerVersion string, report *claircore.IndexReport) error {
+func (m *MockIndexer) StoreIndexReport(ctx context.Context, hashID, indexerVersion string, report *claircore.IndexReport) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreIndexReport", ctx, hashID, indexerVersion, report)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // StoreIndexReport indicates an expected call of StoreIndexReport.

--- a/scanner/services/common.go
+++ b/scanner/services/common.go
@@ -2,9 +2,12 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/quay/claircore"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/scannerv4/mappers"
 	"github.com/stackrox/rox/scanner/indexer"
 )
 
@@ -20,6 +23,16 @@ func getClairIndexReport(ctx context.Context, indexer indexer.ReportGetter, hash
 	}
 	if !ir.Success {
 		return nil, errox.NotFound.Newf("report failed in state %q: %s", ir.State, ir.Err)
+	}
+	return ir, nil
+}
+
+// parseIndexReport will generate an index report from a Contents payload.
+func parseIndexReport(contents *v4.Contents) (*claircore.IndexReport, error) {
+	ir, err := mappers.ToClairCoreIndexReport(contents)
+	if err != nil {
+		// Validation should have captured all conversion errors.
+		return nil, fmt.Errorf("internal error: %w", err)
 	}
 	return ir, nil
 }

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -31,6 +31,7 @@ var indexerAuth = perrpc.FromMap(map[authz.Authorizer][]string{
 		// Matcher should never attempt to create an index report.
 		v4.Indexer_CreateIndexReport_FullMethodName,
 		v4.Indexer_GetOrCreateIndexReport_FullMethodName,
+		v4.Indexer_StoreIndexReport_FullMethodName,
 	},
 })
 

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -31,6 +31,8 @@ var indexerAuth = perrpc.FromMap(map[authz.Authorizer][]string{
 		// Matcher should never attempt to create an index report.
 		v4.Indexer_CreateIndexReport_FullMethodName,
 		v4.Indexer_GetOrCreateIndexReport_FullMethodName,
+	},
+	or.Or(idcheck.CentralOnly()): {
 		v4.Indexer_StoreIndexReport_FullMethodName,
 	},
 })

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -198,25 +198,24 @@ func (s *indexerService) StoreIndexReport(ctx context.Context, req *v4.StoreInde
 		"hash_id", req.GetHashId(),
 	)
 
-	zlog.Info(ctx).Msg("storing external index report for delegated scan")
-
+	resp := &v4.StoreIndexReportResponse{Status: "ERROR"}
 	if req.GetContents() == nil {
 		zlog.Debug(ctx).Msg("no contents, rejecting")
-		return nil, errox.InvalidArgs.New("empty contents")
+		return resp, errox.InvalidArgs.New("empty contents")
 	}
 
-	zlog.Info(ctx).Msg("has contents, parsing")
+	zlog.Info(ctx).Msg("storing external index report")
 	ir, err := parseIndexReport(req.GetContents())
 	if err != nil {
-		return nil, fmt.Errorf("parsing contents to index report: %w", err)
+		return resp, fmt.Errorf("parsing contents to index report: %w", err)
 	}
 
-	err = s.indexer.StoreIndexReport(ctx, req.GetHashId(), req.GetIndexerVersion(), ir)
+	resp.Status, err = s.indexer.StoreIndexReport(ctx, req.GetHashId(), req.GetIndexerVersion(), ir)
 	if err != nil {
-		return nil, fmt.Errorf("storing external index report: %w", err)
+		return resp, fmt.Errorf("storing external index report: %w", err)
 	}
 
-	return &v4.StoreIndexReportResponse{Status: "completed"}, nil
+	return resp, nil
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -79,7 +79,7 @@ func (s *matcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVuln
 		ir, err = getClairIndexReport(ctx, s.indexer, req.GetHashId())
 	} else {
 		zlog.Info(ctx).Msg("has contents, parsing")
-		ir, err = s.parseIndexReport(req.GetContents())
+		ir, err = parseIndexReport(req.GetContents())
 	}
 	if err != nil {
 		return nil, err
@@ -98,16 +98,6 @@ func (s *matcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVuln
 	report.HashId = req.GetHashId()
 	report.Notes = s.notes(ctx, report)
 	return report, nil
-}
-
-// parseIndexReport will generate an index report from a Contents payload.
-func (s *matcherService) parseIndexReport(contents *v4.Contents) (*claircore.IndexReport, error) {
-	ir, err := mappers.ToClairCoreIndexReport(contents)
-	if err != nil {
-		// Validation should have captured all conversion errors.
-		return nil, fmt.Errorf("internal error: %w", err)
-	}
-	return ir, nil
 }
 
 func (s *matcherService) GetMetadata(ctx context.Context, _ *protocompat.Empty) (*v4.Metadata, error) {
@@ -187,7 +177,7 @@ func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*
 	// The remote indexer is not used. This creates flexibility and enables SBOMs to be generated
 	// from index reports not stored in the local indexer (such as from node scans and from things not
 	// indexed by indexer, such as Central scans from third party scanners).
-	ir, err := s.parseIndexReport(req.GetContents())
+	ir, err := parseIndexReport(req.GetContents())
 	if err != nil {
 		zlog.Error(ctx).Err(err).Msg("parsing index report")
 		return nil, err


### PR DESCRIPTION
## Description

- Adds a new Scanner V4 gRPC API, `StoreIndexReport`, to store index reports from other scanners. This API will initially be used to store index reports from delegated scans, supporting the generation of SBOMs from those index reports.
- Adds a new table to the Indexer's `external_index_report` that will house the delegated scan index reports, along with some metadata to make decisions on whether to overwrite the data on conflict and garbage collect the data.
- Adds a feature flag, `ROX_SCANNER_V4_STORE_EXTERNAL_INDEX_REPORTS` (subject to change based on reviews), to toggle storing external index reports from delegated scans to Central's Scanner V4 Indexer. It's on by default, and can be toggled off to disable storing external index reports. Not that disabling `ROX_SBOM_GENERATION` will also disable storing external index reports.
- Adds a new method to the common Scanner V4 client, `StoreImageIndex`, abstracting the logic associated with storing an external index report. This method is currently only used in scanner's `GetVulnerabilities()` abstraction.
- Exports `IndexerVersion` from `ScanComponents` (`pkg/scanners/types/components.go`) to get the indexer version used for deciding whether to overwrite an existing external index report with the same hashID.
- Reuses much of the `manifest.Manager` implementation to handle garbage collection of external index reports.

PR stack:
- `master`
  - https://github.com/stackrox/stackrox/pull/16527
    - 👉 https://github.com/stackrox/stackrox/pull/16398
      - https://github.com/stackrox/stackrox/pull/16526
        -  https://github.com/stackrox/stackrox/pull/16884

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- ~~[ ] added e2e tests~~
- ~~[ ] added regression tests~~
- ~~[ ] added compatibility tests~~
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deploy stackrox:
```
❯ export MAIN_IMAGE_TAG=4.9.x-859-gcb8dc222c8
❯ ./deploy/deploy.sh
...
```

Example gRPC request:
```json
{
  "hash_id": "sha256:f2516e808dd108b17014693eff2be3d29a3c987d845114e506aa0380e488672e",
  "indexer_version": "4.8.3",
  "contents": {
    "distributions": [
      {
        "id": "062038fa-9ff9-4c55-8b64-2278bbbeeb60",
        "did": "rhel",
        "name": "Red Hat Enterprise Linux Server",
        "version": "9",
        "version_code_name": "",
        "version_id": "9",
        "arch": "",
        "cpe": "cpe:2.3:o:redhat:enterprise_linux:9:*:*:*:*:*:*:*",
        "pretty_name": "Red Hat Enterprise Linux Server 9"
      }
    ]
  }
}
```

Call the StoreIndexReport API:
```
❯ grpcurl -d @ -import-path ./proto -proto internalapi/scanner/v4/indexer_service.proto -v -insecure localhost:8443 scanner.v4.Indexer.StoreIndexReport < example.json
```

Examine the Scanner V4 database:
```
# In a separate terminal or pipe stdout and stderr to /dev/null
❯ k -n stackrox port-forward svc/scanner-v4-db 5433:5432
# Get password (can be piped into pbcopy on macOS)
❯ oc extract secret/scanner-v4-db-password -n stackrox --to=- | tr -d '\n'
❯ k -n stackrox exec <PODNAME> -c db -- psql "password=<copied password>" -c 'SELECT * FROM external_index_report'
```