### PR TITLE
fix(scanner): run NVD downloader on all PRs

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -82,7 +82,7 @@ jobs:
         echo "$code" | grep -q 200
 
     - name: Download NVD
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-nvd')
       run: |
         set -eu
         since_time=$(date -u -d '24 hours ago' '+%a, %d %b %Y %H:%M:%S GMT')


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/16257 updated this file to only run the "Download NVD" steps on non-PRs. However... that was an accident. The intention was to ensure it does not run on PRs with the `pr-update-scanner-nvd` label. This PR fixes that.

Without this fix, PRs with the `pr-update-scanner-vulns` label cannot generate a vulnerability bundle.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

no

### How I validated my change

Actually made this change in https://github.com/stackrox/stackrox/pull/16420 which is where I noticed the problem. This change did allow me to build the vuln bundles.
