### PR TITLE
ROX-29840: access ocp console

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -49,7 +49,7 @@ case "$ci_job" in
 esac
 
 case "$ci_job" in
-    eks-qa-e2e-tests|osd*qa-e2e-tests)
+    eks-qa-e2e-tests|osd*qa-e2e-tests|ocp*e2e-tests)
         setup_automation_flavor_e2e_cluster "$ci_job"
         ;;
 esac

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 if [[ -n "${SHARED_DIR:-}" ]]; then
     echo "SHARED_DIR: ${SHARED_DIR}"
-    ls -l "${SHARED_DIR}"
+    ls -latr "${SHARED_DIR}"
     if [[ -f "${SHARED_DIR}/shared_env" ]]; then
         cat "${SHARED_DIR:-}/shared_env"
         # shellcheck disable=SC1091

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -202,11 +202,6 @@ export_test_environment() {
         # GKE uses this network for services. Consider it as a private subnet.
         ci_export ROX_NON_AGGREGATED_NETWORKS "${ROX_NON_AGGREGATED_NETWORKS:-34.118.224.0/20}"
     fi
-
-    ci_export OPENSHIFT_CONSOLE_URL "$OPENSHIFT_CONSOLE_URL"
-    ci_export OPENSHIFT_API_ENDPOINT "$OPENSHIFT_API_ENDPOINT"
-    ci_export OPENSHIFT_CONSOLE_USERNAME "$OPENSHIFT_CONSOLE_USERNAME"
-    ci_export OPENSHIFT_CONSOLE_PASSWORD "$OPENSHIFT_CONSOLE_PASSWORD"
 }
 
 deploy_stackrox_operator() {
@@ -1503,11 +1498,6 @@ setup_automation_flavor_e2e_cluster() {
                 --username "$OPENSHIFT_CONSOLE_USERNAME" \
                 --password "$OPENSHIFT_CONSOLE_PASSWORD" \
                 --insecure-skip-tls-verify=true
-
-        ci_export OPENSHIFT_CONSOLE_URL "$OPENSHIFT_CONSOLE_URL"
-        ci_export OPENSHIFT_API_ENDPOINT "$OPENSHIFT_API_ENDPOINT"
-        ci_export OPENSHIFT_CONSOLE_USERNAME "$OPENSHIFT_CONSOLE_USERNAME"
-        ci_export OPENSHIFT_CONSOLE_PASSWORD "$OPENSHIFT_CONSOLE_PASSWORD"
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1494,13 +1494,20 @@ setup_automation_flavor_e2e_cluster() {
     ls -l "${SHARED_DIR}"
     export KUBECONFIG="${SHARED_DIR}/kubeconfig"
 
-    if [[ "$ci_job" =~ ^osd ]]; then
-        info "Logging in to an OSD cluster"
+    if [[ "$ci_job" =~ ^(osd|ocp) ]]; then
+        info "Logging in to an ${ci_job:0:3} cluster"
         source "${SHARED_DIR}/dotenv"
 
-        oc login "$CLUSTER_API_ENDPOINT" \
-                --username "$CLUSTER_USERNAME" \
-                --password "$CLUSTER_PASSWORD" \
+        # OCP and OSD require one of (OPENSHIFT_CONSOLE_|CLUSTER_) var groups.
+        # Fail if neither are found from the dotenv.
+        export OPENSHIFT_CONSOLE_URL="${OPENSHIFT_CONSOLE_URL:-${CLUSTER_CONSOLE_ENDPOINT:-$(oc whoami --show-console)}}"
+        export OPENSHIFT_CONSOLE_API_ENDPOINT="${CLUSTER_API_ENDPOINT:-$(oc whoami --show-server)}"
+        export OPENSHIFT_CONSOLE_USERNAME="${OPENSHIFT_CONSOLE_USERNAME:-${CLUSTER_USERNAME:-kubeadmin}}"
+        export OPENSHIFT_CONSOLE_PASSWORD="${OPENSHIFT_CONSOLE_PASSWORD:-${CLUSTER_PASSWORD}}"
+
+        oc login "$OPENSHIFT_CONSOLE_API_ENDPOINT" \
+                --username "$OPENSHIFT_CONSOLE_USERNAME" \
+                --password "$OPENSHIFT_CONSOLE_PASSWORD" \
                 --insecure-skip-tls-verify=true
     fi
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1499,7 +1499,6 @@ setup_automation_flavor_e2e_cluster() {
                 --password "$OPENSHIFT_CONSOLE_PASSWORD" \
                 --insecure-skip-tls-verify=true
 
-        ci_export CLUSTER_API_ENDPOINT "$CLUSTER_API_ENDPOINT"
         ci_export OPENSHIFT_CONSOLE_URL "$OPENSHIFT_CONSOLE_URL"
         ci_export OPENSHIFT_API_ENDPOINT "$OPENSHIFT_API_ENDPOINT"
         ci_export OPENSHIFT_CONSOLE_USERNAME "$OPENSHIFT_CONSOLE_USERNAME"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -202,17 +202,6 @@ export_test_environment() {
         # GKE uses this network for services. Consider it as a private subnet.
         ci_export ROX_NON_AGGREGATED_NETWORKS "${ROX_NON_AGGREGATED_NETWORKS:-34.118.224.0/20}"
     fi
-
-    ci_export CLUSTER_API_ENDPOINT "$CLUSTER_API_ENDPOINT"
-    ci_export CLUSTER_USERNAME "$CLUSTER_USERNAME"
-    ci_export CLUSTER_PASSWORD "$CLUSTER_PASSWORD"
-    
-    if [[ "${CI_JOB_NAME:-}" =~ ocp-4-[0-9]+-ui-e2e-tests ]]; then
-        info "Exposing OCP cluster information for UI e2e tests"
-        # Expose OCP cluster information for UI e2e tests
-     else
-        info "Not exposing OCP cluster information for UI e2e tests"
-    fi
 }
 
 deploy_stackrox_operator() {

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -202,6 +202,11 @@ export_test_environment() {
         # GKE uses this network for services. Consider it as a private subnet.
         ci_export ROX_NON_AGGREGATED_NETWORKS "${ROX_NON_AGGREGATED_NETWORKS:-34.118.224.0/20}"
     fi
+
+    ci_export OPENSHIFT_CONSOLE_URL "$OPENSHIFT_CONSOLE_URL"
+    ci_export OPENSHIFT_API_ENDPOINT "$OPENSHIFT_API_ENDPOINT"
+    ci_export OPENSHIFT_CONSOLE_USERNAME "$OPENSHIFT_CONSOLE_USERNAME"
+    ci_export OPENSHIFT_CONSOLE_PASSWORD "$OPENSHIFT_CONSOLE_PASSWORD"
 }
 
 deploy_stackrox_operator() {

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1490,14 +1490,20 @@ setup_automation_flavor_e2e_cluster() {
         # OCP and OSD require one of (OPENSHIFT_CONSOLE_|CLUSTER_) var groups.
         # Fail if neither are found from the dotenv.
         export OPENSHIFT_CONSOLE_URL="${OPENSHIFT_CONSOLE_URL:-${CLUSTER_CONSOLE_ENDPOINT:-$(oc whoami --show-console)}}"
-        export OPENSHIFT_CONSOLE_API_ENDPOINT="${CLUSTER_API_ENDPOINT:-$(oc whoami --show-server)}"
+        export OPENSHIFT_API_ENDPOINT="${OPENSHIFT_API_ENDPOINT:-${CLUSTER_API_ENDPOINT:-$(oc whoami --show-server)}}"
         export OPENSHIFT_CONSOLE_USERNAME="${OPENSHIFT_CONSOLE_USERNAME:-${CLUSTER_USERNAME:-kubeadmin}}"
         export OPENSHIFT_CONSOLE_PASSWORD="${OPENSHIFT_CONSOLE_PASSWORD:-${CLUSTER_PASSWORD}}"
 
-        oc login "$OPENSHIFT_CONSOLE_API_ENDPOINT" \
+        oc login "$OPENSHIFT_API_ENDPOINT" \
                 --username "$OPENSHIFT_CONSOLE_USERNAME" \
                 --password "$OPENSHIFT_CONSOLE_PASSWORD" \
                 --insecure-skip-tls-verify=true
+
+        ci_export CLUSTER_API_ENDPOINT "$CLUSTER_API_ENDPOINT"
+        ci_export OPENSHIFT_CONSOLE_URL "$OPENSHIFT_CONSOLE_URL"
+        ci_export OPENSHIFT_API_ENDPOINT "$OPENSHIFT_API_ENDPOINT"
+        ci_export OPENSHIFT_CONSOLE_USERNAME "$OPENSHIFT_CONSOLE_USERNAME"
+        ci_export OPENSHIFT_CONSOLE_PASSWORD "$OPENSHIFT_CONSOLE_PASSWORD"
     fi
 }
 

--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -7,7 +7,8 @@
  */
 
 module.exports = {
-    blockHosts: ['*.*'], // Browser options
+    // TODO: can we allow the ocp console but block other internet access? do we need to?
+    // blockHosts: ['*.*'], // Browser options
     chromeWebSecurity: false, // Browser options
     defaultCommandTimeout: 8000, // Timeouts options
     numTestsKeptInMemory: 0, // Global options
@@ -25,7 +26,7 @@ module.exports = {
 
     e2e: {
         baseUrl: 'https://localhost:3000',
-        specPattern: 'cypress/integration/**/*.test.{js,ts}',
+        specPattern: 'cypress/integration*/**/*.test.{js,ts}',
         viewportHeight: 850, // Viewport options
         viewportWidth: 1440, // Viewport options
         setupNodeEvents: (on) => {

--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
     e2e: {
         baseUrl: 'https://localhost:3000',
-        specPattern: 'cypress/integration*/**/*.test.{js,ts}',
+        specPattern: 'cypress/integration/**/*.test.{js,ts}',
         viewportHeight: 850, // Viewport options
         viewportWidth: 1440, // Viewport options
         setupNodeEvents: (on) => {

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -6,10 +6,6 @@ export function withOcpAuth() {
     cy.session('ocp-session-auth', () => {
         cy.visit('/');
         cy.url().should('contain', '/login?');
-        cy.log('OPENSHIFT_CONSOLE_USERNAME:')
-        cy.log(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'))
-        cy.log('OPENSHIFT_CONSOLE_PASSWORD:')
-        cy.log(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'))
         cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
         cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
         cy.get('button[type="submit"]').click();

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -5,13 +5,13 @@ export function withOcpAuth() {
 
     cy.session('ocp-session-auth', () => {
         cy.visit('/');
-        cy.url().should("contain", "/login?");
+        cy.url().should('contain', '/login?');
         cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
         cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
         cy.get('button[type="submit"]').click();
-        cy.url().should("contain", "/dashboards");
-        cy.contains('Skip tour', { timeout: 10000 }).click()
-        cy.wait(1000)
+        cy.url().should('contain', '/dashboards');
+        cy.contains('Skip tour', { timeout: 10000 }).click();
+        cy.wait(1000);
         // TODO Handle OCP welcome modal
     });
 }

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -5,9 +5,13 @@ export function withOcpAuth() {
 
     cy.session('ocp-session-auth', () => {
         cy.visit('/');
-        cy.get('input[name="username"]').type(Cypress.env('CLUSTER_USERNAME'));
-        cy.get('input[name="password"]').type(Cypress.env('CLUSTER_PASSWORD'));
+        cy.url().should("contain", "/login?");
+        cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
+        cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
         cy.get('button[type="submit"]').click();
+        cy.url().should("contain", "/dashboards");
+        cy.contains('Skip tour', { timeout: 10000 }).click()
+        cy.wait(1000)
         // TODO Handle OCP welcome modal
     });
 }

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -6,6 +6,10 @@ export function withOcpAuth() {
     cy.session('ocp-session-auth', () => {
         cy.visit('/');
         cy.url().should('contain', '/login?');
+        cy.log('OPENSHIFT_CONSOLE_USERNAME:')
+        cy.log(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'))
+        cy.log('OPENSHIFT_CONSOLE_PASSWORD:')
+        cy.log(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'))
         cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
         cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
         cy.get('button[type="submit"]').click();

--- a/ui/apps/platform/cypress/integration-ocp/smoke.test.ts
+++ b/ui/apps/platform/cypress/integration-ocp/smoke.test.ts
@@ -2,7 +2,7 @@ import { withOcpAuth } from '../helpers/ocpAuth';
 
 describe('Basic connectivity to the OCP plugin', () => {
     it('should open the OCP web console', () => {
-        // withOcpAuth();
+        withOcpAuth();
 
         cy.visit('/');
         // TODO Handle auth/skip auth in dev

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-env | grep -o '^CLUSTER.*'
 set -x
+env | grep '^OPENSHIFT'
 
 # Opens cypress with environment variables for feature flags and auth
 OPENSHIFT_API_ENDPOINT="${OPENSHIFT_API_ENDPOINT:-http://localhost:9000}"
@@ -39,8 +39,8 @@ export CYPRESS_SPEC_PATTERN='cypress/integration-ocp/**/*.test.{js,ts}'
 export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
 
 export CYPRESS_OCP_BRIDGE_AUTH_DISABLED="${OCP_BRIDGE_AUTH_DISABLED}"
-export CYPRESS_CLUSTER_USERNAME="${OPENSHIFT_CONSOLE_USERNAME}"
-export CYPRESS_CLUSTER_PASSWORD="${OPENSHIFT_CONSOLE_PASSWORD}"
+export CYPRESS_OPENSHIFT_CONSOLE_USERNAME="${OPENSHIFT_CONSOLE_USERNAME}"
+export CYPRESS_OPENSHIFT_CONSOLE_PASSWORD="${OPENSHIFT_CONSOLE_PASSWORD}"
 
 # exit if ORCHESTRATOR_FLAVOR is not 'openshift'
 if [ "${ORCHESTRATOR_FLAVOR}" != "openshift" ]; then
@@ -55,5 +55,6 @@ if [ "$2" == "--spec" ]; then
     fi
     cypress run --spec "cypress/integration-ocp/$3"
 else
-    DEBUG="cypress*" NO_COLOR=1 cypress "$@" 2> /dev/null
+    DEBUG="cypress*" NO_COLOR=1 cypress "$@" #2> /dev/null
 fi
+cd ui/apps/platform/cypress/; export NO_PROXY=rox.systems,localhost; pnpm cypress open --browser chrome --e2e

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Opens cypress with environment variables for feature flags and auth
-OPENSHIFT_CONSOLE_API_ENDPOINT="${OPENSHIFT_CONSOLE_API_ENDPOINT:-http://localhost:9000}"
-API_PROXY_BASE_URL="${OPENSHIFT_CONSOLE_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"
+OPENSHIFT_API_ENDPOINT="${OPENSHIFT_API_ENDPOINT:-http://localhost:9000}"
+API_PROXY_BASE_URL="${OPENSHIFT_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"
 
 if [[ -z "$OPENSHIFT_CONSOLE_USERNAME" || -z "$OPENSHIFT_CONSOLE_PASSWORD" ]]; then
     echo "OPENSHIFT_CONSOLE_USERNAME and OPENSHIFT_CONSOLE_PASSWORD must be set"

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -x
-env | grep '^OPENSHIFT'
+env | grep '^OPENSHIFT_CONSOLE'
 
 # Opens cypress with environment variables for feature flags and auth
 OPENSHIFT_API_ENDPOINT="${OPENSHIFT_API_ENDPOINT:-http://localhost:9000}"
@@ -57,4 +57,3 @@ if [ "$2" == "--spec" ]; then
 else
     DEBUG="cypress*" NO_COLOR=1 cypress "$@" #2> /dev/null
 fi
-cd ui/apps/platform/cypress/; export NO_PROXY=rox.systems,localhost; pnpm cypress open --browser chrome --e2e

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -55,5 +55,5 @@ if [ "$2" == "--spec" ]; then
     fi
     cypress run --spec "cypress/integration-ocp/$3"
 else
-    DEBUG="cypress*" NO_COLOR=1 cypress "$@" #2> /dev/null
+    DEBUG="cypress*" NO_COLOR=1 cypress "$@" 2> /dev/null
 fi

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-env | sort
-
 # Opens cypress with environment variables for feature flags and auth
 OPENSHIFT_CONSOLE_API_ENDPOINT="${OPENSHIFT_CONSOLE_API_ENDPOINT:-http://localhost:9000}"
 API_PROXY_BASE_URL="${OPENSHIFT_CONSOLE_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -26,8 +26,8 @@ fi
 artifacts_dir="${TEST_RESULTS_OUTPUT_DIR:-cypress/test-results}/ocp-artifacts"
 export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
 export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
-if [[ -n "${OPENSHIFT_CONSOLE_API_ENDPOINT}" ]]; then
-  export CYPRESS_BASE_URL="${OPENSHIFT_CONSOLE_API_ENDPOINT}"
+if [[ -n "${OPENSHIFT_CONSOLE_URL}" ]]; then
+  export CYPRESS_BASE_URL="${OPENSHIFT_CONSOLE_URL}"
 fi
 
 export CYPRESS_SPEC_PATTERN='cypress/integration-ocp/**/*.test.{js,ts}'

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -3,11 +3,11 @@
 env | sort
 
 # Opens cypress with environment variables for feature flags and auth
-CLUSTER_API_ENDPOINT="${CLUSTER_API_ENDPOINT:-http://localhost:9000}"
-API_PROXY_BASE_URL="${CLUSTER_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"
+OPENSHIFT_CONSOLE_API_ENDPOINT="${OPENSHIFT_CONSOLE_API_ENDPOINT:-http://localhost:9000}"
+API_PROXY_BASE_URL="${OPENSHIFT_CONSOLE_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"
 
-if [[ -z "$CLUSTER_USERNAME" || -z "$CLUSTER_PASSWORD" ]]; then
-    echo "CLUSTER_USERNAME and CLUSTER_PASSWORD must be set"
+if [[ -z "$OPENSHIFT_CONSOLE_USERNAME" || -z "$OPENSHIFT_CONSOLE_PASSWORD" ]]; then
+    echo "OPENSHIFT_CONSOLE_USERNAME and OPENSHIFT_CONSOLE_PASSWORD must be set"
     exit 1
 fi
 
@@ -15,8 +15,8 @@ curl_cfg() { # Use built-in echo to not expose $2 in the process list.
   echo -n "$1 = \"${2//[\"\\]/\\&}\""
 }
 
-if [[ -n "$CLUSTER_PASSWORD" ]]; then
-  readarray -t arr < <(curl -sk --config <(curl_cfg user "$CLUSTER_USERNAME:$CLUSTER_PASSWORD") "${API_PROXY_BASE_URL}"/v1/featureflags | jq -cr '.featureFlags[] | {name: .envVar, enabled: .enabled}')
+if [[ -n "$OPENSHIFT_CONSOLE_PASSWORD" ]]; then
+  readarray -t arr < <(curl -sk --config <(curl_cfg user "$OPENSHIFT_CONSOLE_USERNAME:$OPENSHIFT_CONSOLE_PASSWORD") "${API_PROXY_BASE_URL}"/v1/featureflags | jq -cr '.featureFlags[] | {name: .envVar, enabled: .enabled}')
   for i in "${arr[@]}"; do
     name=$(echo "$i" | jq -rc .name)
     val=$(echo "$i" | jq -rc .enabled)
@@ -28,8 +28,8 @@ fi
 artifacts_dir="${TEST_RESULTS_OUTPUT_DIR:-cypress/test-results}/ocp-artifacts"
 export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
 export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
-if [[ -n "${CLUSTER_API_ENDPOINT}" ]]; then
-  export CYPRESS_BASE_URL="${CLUSTER_API_ENDPOINT}"
+if [[ -n "${OPENSHIFT_CONSOLE_API_ENDPOINT}" ]]; then
+  export CYPRESS_BASE_URL="${OPENSHIFT_CONSOLE_API_ENDPOINT}"
 fi
 
 export CYPRESS_SPEC_PATTERN='cypress/integration-ocp/**/*.test.{js,ts}'
@@ -38,8 +38,8 @@ export CYPRESS_SPEC_PATTERN='cypress/integration-ocp/**/*.test.{js,ts}'
 export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
 
 export CYPRESS_OCP_BRIDGE_AUTH_DISABLED="${OCP_BRIDGE_AUTH_DISABLED}"
-export CYPRESS_CLUSTER_USERNAME="${CLUSTER_USERNAME}"
-export CYPRESS_CLUSTER_PASSWORD="${CLUSTER_PASSWORD}"
+export CYPRESS_CLUSTER_USERNAME="${OPENSHIFT_CONSOLE_USERNAME}"
+export CYPRESS_CLUSTER_PASSWORD="${OPENSHIFT_CONSOLE_PASSWORD}"
 
 # exit if ORCHESTRATOR_FLAVOR is not 'openshift'
 if [ "${ORCHESTRATOR_FLAVOR}" != "openshift" ]; then

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+env | grep -o '^CLUSTER.*'
+set -x
+
 # Opens cypress with environment variables for feature flags and auth
 OPENSHIFT_API_ENDPOINT="${OPENSHIFT_API_ENDPOINT:-http://localhost:9000}"
 API_PROXY_BASE_URL="${OPENSHIFT_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"


### PR DESCRIPTION
The smoke test passes on OCP4.19 with these changes (https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/stackrox_stackrox/16415/pull-ci-stackrox-stackrox-master-ocp-4-19-ui-e2e-tests/1957866898653712384/artifacts/ui-e2e-tests/stackrox-stackrox-e2e-test/build-log.txt):
```
2025-08-19T19:36:15.932Z running test suite: smoke.test.ts

  Basic connectivity to the OCP plugin
    ✓ should open the OCP web console (16435ms)


  1 passing (16s)
```

The smoke test fails on ocp4.18 because of some text/intro changes (https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/16415/pull-ci-stackrox-stackrox-master-ocp-4-18-ui-e2e-tests/1957866898611769344):
```
2025-08-19T19:49:08.425Z running test suite: smoke.test.ts
  Basic connectivity to the OCP plugin
    1) should open the OCP web console
  0 passing (38s)
  1 failing
  1) Basic connectivity to the OCP plugin
       should open the OCP web console:
     AssertionError - 2025-08-19T19:49:46.437Z: Timed out retrying after 10000ms: Expected to find content: 'Skip tour' but never did.
This error occurred while creating the session. Because the session setup failed, we failed the test.
  AssertionError: Timed out retrying after 10000ms: Expected to find content: 'Skip tour' but never did.
```

Testing of this branch on PR: https://github.com/stackrox/stackrox/pull/16415
This uses the automation-flavors fix to prepare the dotenv file for use is here: https://github.com/stackrox/automation-flavors/pull/324
