### PR TITLE
ROX-30523: Add Virtual Machines routing and navigation

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -49,6 +49,7 @@ import {
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesInactiveImagesPath,
     vulnerabilitiesImagesWithoutCvesPath,
+    vulnerabilitiesVirtualMachineCvesPath,
 } from 'routePaths';
 
 import PageNotFound from 'Components/PageNotFound';
@@ -250,6 +251,12 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
     'vulnerabilities/user-workloads': {
         component: makeVulnMgmtUserWorkloadView('user-workloads'),
         path: vulnerabilitiesUserWorkloadsPath,
+    },
+    'vulnerabilities/virtual-machine-cves': {
+        component: asyncComponent(
+            () => import('Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage')
+        ),
+        path: vulnerabilitiesVirtualMachineCvesPath,
     },
     // Note: currently 'platform' is an implementation of the user-workloads view and
     // it is expected that this will change in the future as these views diverge

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -23,6 +23,7 @@ import {
     violationsPlatformViewPath,
     violationsUserWorkloadsViewPath,
     vulnerabilitiesPlatformCvesPath,
+    vulnerabilitiesVirtualMachineCvesPath,
 } from 'routePaths';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -102,6 +103,12 @@ function getSubnavDescriptionGroups(
                       content: 'Nodes',
                       path: vulnerabilitiesNodeCvesPath,
                       routeKey: 'vulnerabilities/node-cves',
+                  },
+                  {
+                      type: 'link',
+                      content: 'Virtual Machines',
+                      path: vulnerabilitiesVirtualMachineCvesPath,
+                      routeKey: 'vulnerabilities/virtual-machine-cves',
                   },
                   {
                       type: 'parent',

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -42,6 +42,7 @@ import {
     vulnerabilitiesPlatformPath,
     vulnerabilitiesUserWorkloadsPath,
     vulnerabilitiesViewPath,
+    vulnerabilitiesVirtualMachineCvesPath,
     vulnerabilitiesWorkloadCvesPath,
     vulnerabilityReportsPath,
 } from 'routePaths';
@@ -80,6 +81,7 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
                           vulnerabilitiesImagesWithoutCvesPath,
                           vulnerabilitiesViewPath,
                           vulnerabilitiesPlatformCvesPath,
+                          vulnerabilitiesVirtualMachineCvesPath,
                       ];
 
                       return pathsToMatch.some((path) =>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function VirtualMachineCvesOverviewPage() {
+    return <>Virtual Machine CVEs</>;
+}
+
+export default VirtualMachineCvesOverviewPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom-v5-compat';
+import { PageSection } from '@patternfly/react-core';
+
+import PageNotFound from 'Components/PageNotFound';
+import PageTitle from 'Components/PageTitle';
+import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
+import usePermissions from 'hooks/usePermissions';
+import VirtualMachineCvesOverviewPage from './Overview/VirtualMachineCvesOverviewPage';
+
+function VirtualMachineCvesPage() {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForIntegration = hasReadAccess('Integration');
+
+    return (
+        <>
+            {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
+            <Routes>
+                <Route index element={<VirtualMachineCvesOverviewPage />} />
+                <Route
+                    path="*"
+                    element={
+                        <PageSection variant="light">
+                            <PageTitle title="Virtual Machine CVEs - Not Found" />
+                            <PageNotFound />
+                        </PageSection>
+                    }
+                />
+            </Routes>
+        </>
+    );
+}
+
+export default VirtualMachineCvesPage;

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -81,6 +81,7 @@ export const vulnerabilitiesPlatformCvesPath = `${vulnerabilitiesBasePath}/platf
 export const vulnerabilitiesUserWorkloadsPath = `${vulnerabilitiesBasePath}/user-workloads`;
 export const vulnerabilitiesPlatformPath = `${vulnerabilitiesBasePath}/platform`;
 export const vulnerabilitiesNodeCvesPath = `${vulnerabilitiesBasePath}/node-cves`;
+export const vulnerabilitiesVirtualMachineCvesPath = `${vulnerabilitiesBasePath}/virtual-machine-cves`;
 // System defined "views"
 export const vulnerabilitiesAllImagesPath = `${vulnerabilitiesBasePath}/all-images`;
 export const vulnerabilitiesInactiveImagesPath = `${vulnerabilitiesBasePath}/inactive-images`;
@@ -187,6 +188,7 @@ export type RouteKey =
     | 'vulnerabilities/images-without-cves'
     | 'vulnerabilities/platform-cves'
     | 'vulnerabilities/workload-cves'
+    | 'vulnerabilities/virtual-machine-cves'
     | 'vulnerability-management'
     ;
 
@@ -369,6 +371,9 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     'vulnerabilities/images-without-cves': {
         featureFlagRequirements: allEnabled(['ROX_PLATFORM_CVE_SPLIT']),
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),
+    },
+    'vulnerabilities/virtual-machine-cves': {
+        resourceAccessRequirements: everyResource(['Cluster']),
     },
     'vulnerability-management': {
         resourceAccessRequirements: everyResource([


### PR DESCRIPTION
## Description

Adds new Virtual Machine CVEs page

- Introduced `VirtualMachineCvesPage` and index component `VirtualMachineCvesOverviewPage`.
- Added `vulnerabilitiesVirtualMachineCvesPath` route and entry in `routePaths`.
- Integrated into `Body`, `HorizontalSubnav`, and `NavigationSidebar`.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
<img width="1215" height="831" alt="Screenshot 2025-08-18 at 11 25 13 AM" src="https://github.com/user-attachments/assets/373d39c7-ee20-4fce-b29c-19f9dd87902c" />


