### PR TITLE
fix(operator): Safety checks for CA promotion during rotation

### DIFF
--- a/operator/internal/central/carotation/rotation.go
+++ b/operator/internal/central/carotation/rotation.go
@@ -42,7 +42,7 @@ func DetermineAction(primary, secondary *x509.Certificate, current time.Time) Ac
 	// If no secondary CA exists at this point, the rotation will be done in two steps:
 	// first reconcile - AddSecondary, subsequent reconcile - PromoteSecondary
 	promoteSecondaryCATime := startTime.Add(4 * fifthOfValidityDuration)
-	if current.After(promoteSecondaryCATime) {
+	if current.After(promoteSecondaryCATime) && secondary != nil && secondary.NotBefore.After(primary.NotBefore) {
 		return PromoteSecondary
 	}
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds safety checks when promoting a secondary CA to primary during certificate rotation:
1. Verifies secondary CA exists before attempting promotion
2. Ensures secondary CA was created after the primary CA

With the default timing (secondary CA creation at 3 years, promotion at 4 years, deletion of the old primary at 5 years), these conditions should always be met. The checks protect against edge cases where manual certificate manipulation could affect certificate timestamps.

Related to https://issues.redhat.com/browse/ROX-27962

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Automated checks should be enough. Manually tested with different rotation timing as part of https://github.com/stackrox/stackrox/pull/15349
