### PR TITLE
ROX-30488: increase wait for violation timeout

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -77,7 +77,7 @@ class SACTest extends BaseSpecification {
     // Increase the timeout conditionally based on whether we are running race-detection builds or within OpenShift
     // environments. Both take longer than the default values.
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
-            isRaceBuild() ? 600 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 60)
+            isRaceBuild() ? 600 : 100
 
     static final private Integer WAIT_FOR_RISK_RETRIES =
             isRaceBuild() ? 300 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 80 : 50)
@@ -87,7 +87,7 @@ class SACTest extends BaseSpecification {
     private Map<String, RoleOuterClass.Access> allResourcesAccess
 
     @Shared
-    private Map<String, List<String>> tokenToRoles
+    private Map<String, List<String>> tokenToRoles = [:]
 
     def setup() {
         BaseService.useBasicAuth()


### PR DESCRIPTION
This PR extends wait for violation timeout from 60 to 100 making it same for Openshift and other schedulers.
It also initializes variable with empty map to prevent NPE. 

```
at app//SACTest.setupSpec(SACTest.groovy:106)
Suppressed: java.lang.NullPointerException: Cannot invoke method values() on null object
at SACTest.cleanupSpec(SACTest.groovy:169)
```