### PR TITLE
fix(operator): defaults never override explicit values

### DIFF
--- a/operator/api/v1alpha1/central_defaults.go
+++ b/operator/api/v1alpha1/central_defaults.go
@@ -71,7 +71,7 @@ func MergeCentralDefaultsIntoSpec(central *Central) error {
 			scannerV4.ScannerComponent = nil
 		}
 	}
-	if err := mergo.Merge(&central.Spec, central.Defaults); err != nil {
+	if err := mergo.Merge(&central.Spec, central.Defaults, mergo.WithoutDereference); err != nil {
 		return errors.Wrap(err, "merging Central Defaults into Spec")
 	}
 	return nil

--- a/operator/api/v1alpha1/central_defaults.go
+++ b/operator/api/v1alpha1/central_defaults.go
@@ -67,7 +67,7 @@ func MergeCentralDefaultsIntoSpec(central *Central) error {
 	// Necessary for the below merging to be effectful in the sense that spec paths in the custom resource
 	// with explicit "Default" values are actually filled in with our runtime defaults.
 	if scannerV4 := central.Spec.ScannerV4; scannerV4 != nil {
-		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == "Default" {
+		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == ScannerV4ComponentDefault {
 			scannerV4.ScannerComponent = nil
 		}
 	}

--- a/operator/api/v1alpha1/central_defaults_test.go
+++ b/operator/api/v1alpha1/central_defaults_test.go
@@ -126,6 +126,54 @@ func TestMergeCentralDefaultsIntoSpec(t *testing.T) {
 				},
 			},
 		},
+		"defaulting false into empty struct works": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+		},
+		"defaulting true into empty struct works": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/operator/api/v1alpha1/central_defaults_test.go
+++ b/operator/api/v1alpha1/central_defaults_test.go
@@ -1,0 +1,137 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestMergeCentralDefaultsIntoSpec(t *testing.T) {
+	tests := map[string]struct {
+		before *Central
+		after  *Central
+	}{
+		"empty": {
+			before: &Central{},
+			after:  &Central{},
+		},
+		"untouched": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
+		"explicit true wins": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+		},
+		"explicit false wins": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
+		"defaulting true works": {
+			before: &Central{
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
+		"defaulting false works": {
+			before: &Central{
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			central := tt.before.DeepCopy()
+			require.NoError(t, MergeCentralDefaultsIntoSpec(central))
+			require.Equal(t, tt.after, central)
+		})
+	}
+}

--- a/operator/api/v1alpha1/securedcluster_defaults.go
+++ b/operator/api/v1alpha1/securedcluster_defaults.go
@@ -67,11 +67,11 @@ func MergeSecuredClusterDefaultsIntoSpec(securedCluster *SecuredCluster) error {
 	// Necessary for the below merging to be effectful in the situation that spec paths in the custom resource
 	// with explicit "Defaults" values are actually filled in with our computed defaults.
 	if scannerV4 := securedCluster.Spec.ScannerV4; scannerV4 != nil {
-		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == "Default" {
+		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == LocalScannerV4ComponentDefault {
 			scannerV4.ScannerComponent = nil
 		}
 	}
-	if err := mergo.Merge(&securedCluster.Spec, securedCluster.Defaults); err != nil {
+	if err := mergo.Merge(&securedCluster.Spec, securedCluster.Defaults, mergo.WithoutDereference); err != nil {
 		return errors.Wrap(err, "merging SecuredCluster Defaults into Spec")
 	}
 	return nil


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Looks like mergo by default treats pointers to zero values as unset (and thus in a bool case, would always cause us to override an _explicit_ `false` from a user with a default `true`).

In other words, without the production code change in this PR, the following sub-test (and only this one!) fails:
```
=== RUN   TestMergeCentralDefaultsIntoSpec/explicit_false_wins
    central_defaults_test.go:134: 
        	Error Trace:	/home/mowsiany/go/src/github.com/stackrox/stackrox/operator/api/v1alpha1/central_defaults_test.go:134
        	Error:      	Not equal: 
        	            	expected: &v1alpha1.Central{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1alpha1.CentralSpec{Central:(*v1alpha1.CentralComponentSpec)(nil), Scanner:(*v1alpha1.ScannerComponentSpec)(nil), ScannerV4:(*v1alpha1.ScannerV4Spec)(nil), Egress:(*v1alpha1.Egress)(nil), TLS:(*v1alpha1.TLSConfig)(nil), ImagePullSecrets:[]v1alpha1.LocalSecretReference(nil), Customize:(*v1alpha1.CustomizeSpec)(nil), Misc:(*v1alpha1.MiscSpec)(0xc0000c24a0), Overlays:[]*v1alpha1.K8sObjectOverlay(nil), Monitoring:(*v1alpha1.GlobalMonitoring)(nil), Network:(*v1alpha1.GlobalNetworkSpec)(nil), ConfigAsCode:(*v1alpha1.ConfigAsCodeSpec)(nil)}, Status:v1alpha1.CentralStatus{Conditions:[]v1alpha1.StackRoxCondition(nil), DeployedRelease:(*v1alpha1.StackRoxRelease)(nil), ProductVersion:"", Central:(*v1alpha1.CentralComponentStatus)(nil)}, Defaults:v1alpha1.CentralSpec{Central:(*v1alpha1.CentralComponentSpec)(nil), Scanner:(*v1alpha1.ScannerComponentSpec)(nil), ScannerV4:(*v1alpha1.ScannerV4Spec)(nil), Egress:(*v1alpha1.Egress)(nil), TLS:(*v1alpha1.TLSConfig)(nil), ImagePullSecrets:[]v1alpha1.LocalSecretReference(nil), Customize:(*v1alpha1.CustomizeSpec)(nil), Misc:(*v1alpha1.MiscSpec)(0xc0000c24a8), Overlays:[]*v1alpha1.K8sObjectOverlay(nil), Monitoring:(*v1alpha1.GlobalMonitoring)(nil), Network:(*v1alpha1.GlobalNetworkSpec)(nil), ConfigAsCode:(*v1alpha1.ConfigAsCodeSpec)(nil)}}
        	            	actual  : &v1alpha1.Central{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1alpha1.CentralSpec{Central:(*v1alpha1.CentralComponentSpec)(nil), Scanner:(*v1alpha1.ScannerComponentSpec)(nil), ScannerV4:(*v1alpha1.ScannerV4Spec)(nil), Egress:(*v1alpha1.Egress)(nil), TLS:(*v1alpha1.TLSConfig)(nil), ImagePullSecrets:[]v1alpha1.LocalSecretReference(nil), Customize:(*v1alpha1.CustomizeSpec)(nil), Misc:(*v1alpha1.MiscSpec)(0xc0000c2510), Overlays:[]*v1alpha1.K8sObjectOverlay(nil), Monitoring:(*v1alpha1.GlobalMonitoring)(nil), Network:(*v1alpha1.GlobalNetworkSpec)(nil), ConfigAsCode:(*v1alpha1.ConfigAsCodeSpec)(nil)}, Status:v1alpha1.CentralStatus{Conditions:[]v1alpha1.StackRoxCondition(nil), DeployedRelease:(*v1alpha1.StackRoxRelease)(nil), ProductVersion:"", Central:(*v1alpha1.CentralComponentStatus)(nil)}, Defaults:v1alpha1.CentralSpec{Central:(*v1alpha1.CentralComponentSpec)(nil), Scanner:(*v1alpha1.ScannerComponentSpec)(nil), ScannerV4:(*v1alpha1.ScannerV4Spec)(nil), Egress:(*v1alpha1.Egress)(nil), TLS:(*v1alpha1.TLSConfig)(nil), ImagePullSecrets:[]v1alpha1.LocalSecretReference(nil), Customize:(*v1alpha1.CustomizeSpec)(nil), Misc:(*v1alpha1.MiscSpec)(0xc0000c2518), Overlays:[]*v1alpha1.K8sObjectOverlay(nil), Monitoring:(*v1alpha1.GlobalMonitoring)(nil), Network:(*v1alpha1.GlobalNetworkSpec)(nil), ConfigAsCode:(*v1alpha1.ConfigAsCodeSpec)(nil)}}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -37,3 +37,3 @@
        	            	   Misc: (*v1alpha1.MiscSpec)({
        	            	-   CreateSCCs: (*bool)(false)
        	            	+   CreateSCCs: (*bool)(true)
        	            	   }),
        	Test:       	TestMergeCentralDefaultsIntoSpec/explicit_false_wins
--- FAIL: TestMergeCentralDefaultsIntoSpec/explicit_false_wins (0.00s)
```

The `WithoutDereference` option seems to be what we want, as long as we keep all our defaulted fields as pointers.

- [ ] TODO: add a check to make sure we do not have defaults for fields that are not pointers.

However this in turn has the effect, that sub-structs that are embedded as a pointer rather than direct struct, are never defaulted. Not sure what's the best way to approach this problem. Perhaps changing all structs to _not_ be pointers (but leaving leaf fields as pointers) would do the trick... 🤔 


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added regression tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI