### PR TITLE
ROX-30390: Extract Update Computer

### DIFF
--- a/sensor/common/networkflow/manager/enrichment_test.go
+++ b/sensor/common/networkflow/manager/enrichment_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
+	"github.com/stackrox/rox/sensor/common/networkflow/updatecomputer"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -240,7 +241,7 @@ func TestEnrichConnection_BusinessLogicPaths(t *testing.T) {
 			enrichTickerC := make(chan time.Time)
 			defer close(enrichTickerC)
 
-			m, mockEntityStore, mockExternalSrc, _ := createManager(mockCtrl, enrichTickerC)
+			m, mockEntityStore, mockExternalSrc, _ := createManager(mockCtrl, updatecomputer.NewLegacy(), enrichTickerC)
 
 			// Setup mocks
 			mocks := newMockExpectations(mockEntityStore, mockExternalSrc)
@@ -363,7 +364,7 @@ func TestEnrichContainerEndpoint_EdgeCases(t *testing.T) {
 			enrichTickerC := make(chan time.Time)
 			defer close(enrichTickerC)
 
-			m, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
+			m, mockEntityStore, _, _ := createManager(mockCtrl, updatecomputer.NewLegacy(), enrichTickerC)
 
 			// Setup mocks
 			mocks := newMockExpectations(mockEntityStore, nil)

--- a/sensor/common/networkflow/manager/manager_enrich_test.go
+++ b/sensor/common/networkflow/manager/manager_enrich_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
+	"github.com/stackrox/rox/sensor/common/networkflow/updatecomputer"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -30,7 +31,7 @@ func (s *TestNetworkFlowManagerEnrichmentTestSuite) TestEnrichConnection() {
 	enrichTickerC := make(chan time.Time)
 	defer close(enrichTickerC)
 	defer mockCtrl.Finish()
-	m, mockEntityStore, mockExternalSrc, _ := createManager(mockCtrl, enrichTickerC)
+	m, mockEntityStore, mockExternalSrc, _ := createManager(mockCtrl, updatecomputer.NewLegacy(), enrichTickerC)
 	srcID := "src-id"
 	dstID := "dst-id"
 
@@ -493,7 +494,7 @@ func (s *TestNetworkFlowManagerEnrichmentTestSuite) TestEnrichContainerEndpoint(
 
 	for name, tc := range cases {
 		s.Run(name, func() {
-			m, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
+			m, mockEntityStore, _, _ := createManager(mockCtrl, updatecomputer.NewLegacy(), enrichTickerC)
 
 			// Setup environment variables
 			s.T().Setenv(env.ProcessesListeningOnPort.EnvVar(), strconv.FormatBool(tc.plopFeatEnabled))

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -34,10 +34,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 )
 
-const (
-	connectionDeletionGracePeriod = 5 * time.Minute
-	loggingRateLimiter            = "plop-feature-disabled"
-)
+const connectionDeletionGracePeriod = 5 * time.Minute
 
 var (
 	emptyProcessInfo = indicator.ProcessInfo{}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -146,11 +146,10 @@ func NewManager(
 	externalSrcs externalsrcs.Store,
 	policyDetector detector.Detector,
 	pubSub *internalmessage.MessageSubscriber,
+	updateComputer updatecomputer.UpdateComputer,
 	opts ...Option,
 ) Manager {
 	enricherTicker := time.NewTicker(enricherCycle)
-	updateComp := updatecomputer.NewLegacy()
-
 	mgr := &networkFlowManager{
 		connectionsByHost: make(map[string]*hostConnections),
 		clusterEntities:   clusterEntities,
@@ -159,7 +158,7 @@ func NewManager(
 		policyDetector:    policyDetector,
 		enricherTicker:    enricherTicker,
 		enricherTickerC:   enricherTicker.C,
-		updateComputer:    updateComp,
+		updateComputer:    updateComputer,
 		initialSync:       &atomic.Bool{},
 		activeConnections: make(map[connection]*networkConnIndicatorWithAge),
 		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicatorWithAge),

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -393,7 +393,7 @@ func (m *networkFlowManager) updateEnrichmentCollectionsSize() {
 
 	// Length and byte sizes of collections used internally by updatecomputer
 	if m.updateComputer != nil {
-		m.updateComputer.RecordSizeMetrics("", flowMetrics.EnrichmentCollectionsSize, flowMetrics.EnrichmentCollectionsSizeBytes)
+		m.updateComputer.RecordSizeMetrics(flowMetrics.EnrichmentCollectionsSize, flowMetrics.EnrichmentCollectionsSizeBytes)
 	}
 }
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -191,7 +191,6 @@ func NewManager(
 	}); err != nil {
 		log.Errorf("unable to subscribe to %s: %+v", internalmessage.SensorMessageResourceSyncFinished, err)
 	}
-
 	for _, o := range opts {
 		o(mgr)
 	}
@@ -351,9 +350,6 @@ func (m *networkFlowManager) resetLastSentState() {
 	}
 }
 
-// updateConnectionStates and updateProcessesState functions removed
-// State management is now handled by UpdateComputer implementations
-
 func (m *networkFlowManager) enrichConnections(tickerC <-chan time.Time) {
 	defer m.stopper.Flow().ReportStopped()
 	for {
@@ -416,8 +412,8 @@ func (m *networkFlowManager) enrichAndSend() {
 	updatedEndpoints := m.updateComputer.ComputeUpdatedEndpoints(currentEndpoints)
 	updatedProcesses := m.updateComputer.ComputeUpdatedProcesses(currentProcesses)
 
-	// Update the UpdateComputer's internal state after sending updates to Central
-	// This ensures each implementation tracks what was sent for future comparisons
+	// Update the UpdateComputer's internal state after sending updates to Central.
+	// This is important for update computers that rely on the state from the previous tick.
 	if len(updatedConns)+len(updatedEndpoints)+len(updatedProcesses) > 0 {
 		m.updateComputer.UpdateState(currentConns, currentEndpoints, currentProcesses)
 	}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -15,11 +15,9 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/netutil"
 	"github.com/stackrox/rox/pkg/process/normalize"
-
-	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sensor/queue"
 	"github.com/stackrox/rox/pkg/sync"
@@ -32,6 +30,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
 	flowMetrics "github.com/stackrox/rox/sensor/common/networkflow/metrics"
+	"github.com/stackrox/rox/sensor/common/networkflow/updatecomputer"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 )
 
@@ -150,6 +149,7 @@ func NewManager(
 	opts ...Option,
 ) Manager {
 	enricherTicker := time.NewTicker(enricherCycle)
+	updateComp := updatecomputer.NewLegacy()
 
 	mgr := &networkFlowManager{
 		connectionsByHost: make(map[string]*hostConnections),
@@ -159,6 +159,7 @@ func NewManager(
 		policyDetector:    policyDetector,
 		enricherTicker:    enricherTicker,
 		enricherTickerC:   enricherTicker.C,
+		updateComputer:    updateComp,
 		initialSync:       &atomic.Bool{},
 		activeConnections: make(map[connection]*networkConnIndicatorWithAge),
 		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicatorWithAge),
@@ -190,6 +191,7 @@ func NewManager(
 	}); err != nil {
 		log.Errorf("unable to subscribe to %s: %+v", internalmessage.SensorMessageResourceSyncFinished, err)
 	}
+
 	for _, o := range opts {
 		o(mgr)
 	}
@@ -212,10 +214,8 @@ type networkFlowManager struct {
 	clusterEntities EntityStore
 	externalSrcs    externalsrcs.Store
 
-	lastSentStateMutex             sync.RWMutex
-	enrichedConnsLastSentState     map[indicator.NetworkConn]timestamp.MicroTS
-	enrichedEndpointsLastSentState map[indicator.ContainerEndpoint]timestamp.MicroTS
-	enrichedProcessesLastSentState map[indicator.ProcessListening]timestamp.MicroTS
+	// UpdateComputer implementation for computing flow updates that are sent to Central on each tick.
+	updateComputer updatecomputer.UpdateComputer
 
 	activeConnectionsMutex sync.RWMutex
 	// activeConnections tracks all connections reported by Collector that are believed to be active.
@@ -345,25 +345,14 @@ func (m *networkFlowManager) sendToCentral(msg *central.MsgFromSensor) bool {
 }
 
 func (m *networkFlowManager) resetLastSentState() {
-	m.lastSentStateMutex.Lock()
-	defer m.lastSentStateMutex.Unlock()
-	m.enrichedConnsLastSentState = nil
-	m.enrichedEndpointsLastSentState = nil
-	m.enrichedProcessesLastSentState = nil
+	// Reset state in the UpdateComputer implementation
+	if m.updateComputer != nil {
+		m.updateComputer.ResetState()
+	}
 }
 
-func (m *networkFlowManager) updateConnectionStates(newConns map[indicator.NetworkConn]timestamp.MicroTS, newEndpoints map[indicator.ContainerEndpoint]timestamp.MicroTS) {
-	m.lastSentStateMutex.Lock()
-	defer m.lastSentStateMutex.Unlock()
-	m.enrichedConnsLastSentState = newConns
-	m.enrichedEndpointsLastSentState = newEndpoints
-}
-
-func (m *networkFlowManager) updateProcessesState(newProcesses map[indicator.ProcessListening]timestamp.MicroTS) {
-	m.lastSentStateMutex.Lock()
-	defer m.lastSentStateMutex.Unlock()
-	m.enrichedProcessesLastSentState = newProcesses
-}
+// updateConnectionStates and updateProcessesState functions removed
+// State management is now handled by UpdateComputer implementations
 
 func (m *networkFlowManager) enrichConnections(tickerC <-chan time.Time) {
 	defer m.stopper.Flow().ReportStopped()
@@ -390,6 +379,7 @@ func (m *networkFlowManager) getCurrentContext() context.Context {
 }
 
 func (m *networkFlowManager) updateEnrichmentCollectionsSize() {
+	// Number of entities (connections, endpoints) waiting for enrichment
 	numConnections := 0
 	numEndpoints := 0
 	concurrency.WithRLock(&m.connectionsByHostMutex, func() {
@@ -403,16 +393,16 @@ func (m *networkFlowManager) updateEnrichmentCollectionsSize() {
 	flowMetrics.EnrichmentCollectionsSize.WithLabelValues("connectionsInEnrichQueue", "connections").Set(float64(numConnections))
 	flowMetrics.EnrichmentCollectionsSize.WithLabelValues("endpointsInEnrichQueue", "endpoints").Set(float64(numEndpoints))
 
+	// Number of entities (connections, endpoints) stored in memory for the purposes of not losing data while offline.
 	concurrency.WithRLock(&m.activeConnectionsMutex, func() {
 		flowMetrics.EnrichmentCollectionsSize.WithLabelValues("activeConnections", "connections").Set(float64(len(m.activeConnections)))
 		flowMetrics.EnrichmentCollectionsSize.WithLabelValues("activeEndpoints", "endpoints").Set(float64(len(m.activeEndpoints)))
 	})
 
-	concurrency.WithRLock(&m.lastSentStateMutex, func() {
-		flowMetrics.EnrichmentCollectionsSize.WithLabelValues("enrichedConnectionsLastSentState", "connections").Set(float64(len(m.enrichedConnsLastSentState)))
-		flowMetrics.EnrichmentCollectionsSize.WithLabelValues("enrichedEndpointsLastSentState", "endpoints").Set(float64(len(m.enrichedEndpointsLastSentState)))
-		flowMetrics.EnrichmentCollectionsSize.WithLabelValues("enrichedProcessesLastSentState", "processes").Set(float64(len(m.enrichedProcessesLastSentState)))
-	})
+	// Length and byte sizes of collections used internally by updatecomputer
+	if m.updateComputer != nil {
+		m.updateComputer.RecordSizeMetrics("", flowMetrics.EnrichmentCollectionsSize, flowMetrics.EnrichmentCollectionsSizeBytes)
+	}
 }
 
 func (m *networkFlowManager) enrichAndSend() {
@@ -421,27 +411,26 @@ func (m *networkFlowManager) enrichAndSend() {
 	// Updates m.activeEndpoints and m.activeConnections if lastSeen was reported as null by the Collector.
 	currentConns, currentEndpoints, currentProcesses := m.currentEnrichedConnsAndEndpoints()
 
-	// Compares currently enriched connections & endpoints with those enriched in the previous cycle.
-	// The new changes are sent to Central.
-	updatedConns := computeUpdatedConns(currentConns, m.enrichedConnsLastSentState, &m.lastSentStateMutex)
-	updatedEndpoints := computeUpdatedEndpoints(currentEndpoints, m.enrichedEndpointsLastSentState, &m.lastSentStateMutex)
-	updatedProcesses := computeUpdatedProcesses(currentProcesses, m.enrichedProcessesLastSentState, &m.lastSentStateMutex)
-	flowMetrics.NumUpdatesSentToCentral.WithLabelValues("connections").Add(float64(len(updatedConns)))
-	flowMetrics.NumUpdatesSentToCentral.WithLabelValues("endpoints").Add(float64(len(updatedEndpoints)))
-	flowMetrics.NumUpdatesSentToCentral.WithLabelValues("processes").Add(float64(len(updatedProcesses)))
+	// The new changes are sent to Central using the update computer implementation.
+	updatedConns := m.updateComputer.ComputeUpdatedConns(currentConns)
+	updatedEndpoints := m.updateComputer.ComputeUpdatedEndpoints(currentEndpoints)
+	updatedProcesses := m.updateComputer.ComputeUpdatedProcesses(currentProcesses)
+
+	// Update the UpdateComputer's internal state after sending updates to Central
+	// This ensures each implementation tracks what was sent for future comparisons
+	if len(updatedConns)+len(updatedEndpoints)+len(updatedProcesses) > 0 {
+		m.updateComputer.UpdateState(currentConns, currentEndpoints, currentProcesses)
+	}
 
 	if len(updatedConns)+len(updatedEndpoints) > 0 {
-		if sent := m.sendConnsEps(updatedConns, updatedEndpoints); sent {
-			m.updateConnectionStates(currentConns, currentEndpoints)
-		}
+		m.sendConnsEps(updatedConns, updatedEndpoints)
 		metrics.SetNetworkFlowBufferSizeGauge(len(m.sensorUpdates))
 	}
 	if env.ProcessesListeningOnPort.BooleanSetting() && len(updatedProcesses) > 0 {
-		if sent := m.sendProcesses(updatedProcesses); sent {
-			m.updateProcessesState(currentProcesses)
-		}
+		m.sendProcesses(updatedProcesses)
 	}
 }
+
 func (m *networkFlowManager) sendConnsEps(conns []*storage.NetworkFlow, eps []*storage.NetworkEndpoint) bool {
 	protoToSend := &central.NetworkFlowUpdate{
 		Updated:          conns,
@@ -496,107 +485,6 @@ func (m *networkFlowManager) currentEnrichedConnsAndEndpoints() (
 		m.enrichHostContainerEndpoints(now, hostConns, enrichedEndpoints, enrichedProcesses)
 	}
 	return enrichedConnections, enrichedEndpoints, enrichedProcesses
-}
-
-// isUpdated determines if a connection/endpoint should be sent to Central based on timestamp comparison.
-//
-// Timestamp Convention:
-// - timestamp.InfiniteFuture = connection/endpoint is OPEN (still active)
-// - Any other timestamp value = connection/endpoint is CLOSED (lastSeen/closeTime)
-//
-// This function detects updates when:
-// 1. New connection/endpoint (not seen before)
-// 2. More recent activity (newer timestamp)
-// 3. State transition from OPEN -> CLOSED (InfiniteFuture -> actual timestamp)
-func isUpdated(prevTS, currTS timestamp.MicroTS, seenPreviously bool) bool {
-	// Connection has not been seen in the last tick.
-	if !seenPreviously {
-		return true
-	}
-	// Collector saw this connection more recently.
-	if currTS > prevTS {
-		return true
-	}
-	// Connection was active (unclosed) in the last tick, now it is closed.
-	if prevTS == timestamp.InfiniteFuture && currTS != timestamp.InfiniteFuture {
-		return true
-	}
-	return false
-}
-
-func computeUpdatedConns(current map[indicator.NetworkConn]timestamp.MicroTS, previous map[indicator.NetworkConn]timestamp.MicroTS, previousMutex *sync.RWMutex) []*storage.NetworkFlow {
-	previousMutex.RLock()
-	defer previousMutex.RUnlock()
-	var updates []*storage.NetworkFlow
-
-	for conn, currTS := range current {
-		prevTS, seenPreviously := previous[conn]
-		if isUpdated(prevTS, currTS, seenPreviously) {
-			updates = append(updates, conn.ToProto(currTS))
-		}
-	}
-
-	for conn, prevTS := range previous {
-		if _, ok := current[conn]; !ok {
-			updates = append(updates, conn.ToProto(prevTS))
-		}
-	}
-
-	return updates
-}
-
-func computeUpdatedEndpoints(current map[indicator.ContainerEndpoint]timestamp.MicroTS, previous map[indicator.ContainerEndpoint]timestamp.MicroTS, previousMutex *sync.RWMutex) []*storage.NetworkEndpoint {
-	previousMutex.RLock()
-	defer previousMutex.RUnlock()
-	var updates []*storage.NetworkEndpoint
-
-	for ep, currTS := range current {
-		prevTS, seenPreviously := previous[ep]
-		if isUpdated(prevTS, currTS, seenPreviously) {
-			updates = append(updates, ep.ToProto(currTS))
-		}
-	}
-
-	for ep, prevTS := range previous {
-		if _, ok := current[ep]; !ok {
-			updates = append(updates, ep.ToProto(prevTS))
-		}
-	}
-
-	return updates
-}
-
-func computeUpdatedProcesses(current map[indicator.ProcessListening]timestamp.MicroTS, previous map[indicator.ProcessListening]timestamp.MicroTS, previousMutex *sync.RWMutex) []*storage.ProcessListeningOnPortFromSensor {
-	if !env.ProcessesListeningOnPort.BooleanSetting() {
-		if len(current) > 0 {
-			logging.GetRateLimitedLogger().WarnL(loggingRateLimiter,
-				"Received process while ProcessesListeningOnPort feature is disabled. This may indicate a misconfiguration.")
-		}
-		return []*storage.ProcessListeningOnPortFromSensor{}
-	}
-	previousMutex.RLock()
-	defer previousMutex.RUnlock()
-	var updates []*storage.ProcessListeningOnPortFromSensor
-
-	for pl, currTS := range current {
-		prevTS, seenPreviously := previous[pl]
-		if isUpdated(prevTS, currTS, seenPreviously) {
-			updates = append(updates, pl.ToProto(currTS))
-		}
-	}
-
-	for ep, prevTS := range previous {
-		if _, ok := current[ep]; !ok {
-			// This condition means the deployment was removed before we got the
-			// close timestamp for the endpoint. Use the current timestamp instead.
-			if prevTS == timestamp.InfiniteFuture {
-				prevTS = timestamp.Now()
-			}
-			updates = append(updates, ep.ToProto(prevTS))
-		}
-	}
-
-	return updates
 }
 
 func (m *networkFlowManager) getAllHostConnections() []*hostConnections {

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
+	"github.com/stackrox/rox/sensor/common/networkflow/updatecomputer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -211,7 +212,7 @@ func (s *NetworkFlowManagerTestSuite) TestManagerOfflineMode() {
 	enrichTickerC := make(chan time.Time)
 	defer close(enrichTickerC)
 	defer mockCtrl.Finish()
-	m, mockEntity, _, mockDetector := createManager(mockCtrl, enrichTickerC)
+	m, mockEntity, _, mockDetector := createManager(mockCtrl, updatecomputer.NewLegacy(), enrichTickerC)
 	states := []struct {
 		testName                    string
 		notify                      common.SensorComponentEvent
@@ -374,7 +375,7 @@ func (s *NetworkFlowManagerTestSuite) TestExpireMessage() {
 	enrichTickerC := make(chan time.Time)
 	defer close(enrichTickerC)
 	defer mockCtrl.Finish()
-	m, mockEntity, _, mockDetector := createManager(mockCtrl, enrichTickerC)
+	m, mockEntity, _, mockDetector := createManager(mockCtrl, updatecomputer.NewLegacy(), enrichTickerC)
 	go m.enrichConnections(enrichTickerC)
 	mockEntity.EXPECT().LookupByContainerID(gomock.Any()).Times(1).DoAndReturn(func(_ any) (clusterentities.ContainerMetadata, bool, bool) {
 		return clusterentities.ContainerMetadata{

--- a/sensor/common/networkflow/manager/manager_sending_test.go
+++ b/sensor/common/networkflow/manager/manager_sending_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
 	mocksManager "github.com/stackrox/rox/sensor/common/networkflow/manager/mocks"
+	"github.com/stackrox/rox/sensor/common/networkflow/updatecomputer"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -47,7 +48,7 @@ func (b *sendNetflowsSuite) SetupTest() {
 	b.mockCtrl = gomock.NewController(b.T())
 	enrichTickerC := make(chan time.Time)
 	defer close(enrichTickerC)
-	b.m, b.mockEntity, _, b.mockDetector = createManager(b.mockCtrl, enrichTickerC)
+	b.m, b.mockEntity, _, b.mockDetector = createManager(b.mockCtrl, updatecomputer.NewLegacy(), enrichTickerC)
 
 	b.fakeTicker = make(chan time.Time)
 	go b.m.enrichConnections(b.fakeTicker)

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
 	mocksManager "github.com/stackrox/rox/sensor/common/networkflow/manager/mocks"
+	"github.com/stackrox/rox/sensor/common/networkflow/updatecomputer"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -28,6 +29,7 @@ func createManager(mockCtrl *gomock.Controller, enrichTicker <-chan time.Time) (
 		clusterEntities:   mockEntityStore,
 		externalSrcs:      mockExternalStore,
 		policyDetector:    mockDetector,
+		updateComputer:    updatecomputer.NewLegacy(),
 		connectionsByHost: make(map[string]*hostConnections),
 		sensorUpdates:     make(chan *message.ExpiringMessage, 5),
 		publicIPs:         newPublicIPsManager(),

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func createManager(mockCtrl *gomock.Controller, enrichTicker <-chan time.Time) (*networkFlowManager, *mocksManager.MockEntityStore, *mocksExternalSrc.MockStore, *mocksDetector.MockDetector) {
+func createManager(mockCtrl *gomock.Controller, updateComputer updatecomputer.UpdateComputer, enrichTicker <-chan time.Time) (*networkFlowManager, *mocksManager.MockEntityStore, *mocksExternalSrc.MockStore, *mocksDetector.MockDetector) {
 	mockEntityStore := mocksManager.NewMockEntityStore(mockCtrl)
 	mockExternalStore := mocksExternalSrc.NewMockStore(mockCtrl)
 	mockDetector := mocksDetector.NewMockDetector(mockCtrl)
@@ -29,7 +29,7 @@ func createManager(mockCtrl *gomock.Controller, enrichTicker <-chan time.Time) (
 		clusterEntities:   mockEntityStore,
 		externalSrcs:      mockExternalStore,
 		policyDetector:    mockDetector,
-		updateComputer:    updatecomputer.NewLegacy(),
+		updateComputer:    updateComputer,
 		connectionsByHost: make(map[string]*hostConnections),
 		sensorUpdates:     make(chan *message.ExpiringMessage, 5),
 		publicIPs:         newPublicIPsManager(),

--- a/sensor/common/networkflow/metrics/metrics.go
+++ b/sensor/common/networkflow/metrics/metrics.go
@@ -45,13 +45,13 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      hostConnectionsPrefix + "collections_size_current",
-		Help:      "Current size of given collection involved in enrichment",
+		Help:      "Current size (number of elements) of given collection involved in enrichment",
 	}, []string{"Name", "Type"})
 	EnrichmentCollectionsSizeBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      hostConnectionsPrefix + "collections_size_current_bytes",
-		Help:      "Current size of given collection involved in enrichment",
+		Help:      "Current size in bytes of given collection involved in enrichment",
 	}, []string{"Name", "Type"})
 	// A networkConnectionInfo message arrives from collector
 

--- a/sensor/common/networkflow/metrics/metrics.go
+++ b/sensor/common/networkflow/metrics/metrics.go
@@ -8,6 +8,7 @@ import (
 func init() {
 	prometheus.MustRegister(
 		EnrichmentCollectionsSize,
+		EnrichmentCollectionsSizeBytes,
 
 		// Host Connections
 		NetworkConnectionInfoMessagesRcvd,
@@ -46,7 +47,12 @@ var (
 		Name:      hostConnectionsPrefix + "collections_size_current",
 		Help:      "Current size of given collection involved in enrichment",
 	}, []string{"Name", "Type"})
-
+	EnrichmentCollectionsSizeBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      hostConnectionsPrefix + "collections_size_current_bytes",
+		Help:      "Current size of given collection involved in enrichment",
+	}, []string{"Name", "Type"})
 	// A networkConnectionInfo message arrives from collector
 
 	// NetworkConnectionInfoMessagesRcvd - 1. Collector sends NetworkConnection Info messages where each contains endpoints and connections

--- a/sensor/common/networkflow/updatecomputer/interface.go
+++ b/sensor/common/networkflow/updatecomputer/interface.go
@@ -24,5 +24,5 @@ type UpdateComputer interface {
 	ResetState()
 
 	// RecordSizeMetrics records metrics for length and byte-size of the collections used in updateComputer.
-	RecordSizeMetrics(name string, gv1, gv2 *prometheus.GaugeVec)
+	RecordSizeMetrics(gv1, gv2 *prometheus.GaugeVec)
 }

--- a/sensor/common/networkflow/updatecomputer/interface.go
+++ b/sensor/common/networkflow/updatecomputer/interface.go
@@ -7,22 +7,22 @@ import (
 	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
 )
 
-// UpdateComputer defines the interface for computing network flow updates to send to Central
-// Each implementation manages its own state and computation strategy
+// UpdateComputer defines the interface for computing network flow updates sent to Central.
 type UpdateComputer interface {
 	// ComputeUpdatedConns updates based on currentState state and implementation-specific tracking
 	ComputeUpdatedConns(current map[indicator.NetworkConn]timestamp.MicroTS) []*storage.NetworkFlow
 	ComputeUpdatedEndpoints(current map[indicator.ContainerEndpoint]timestamp.MicroTS) []*storage.NetworkEndpoint
 	ComputeUpdatedProcesses(current map[indicator.ProcessListening]timestamp.MicroTS) []*storage.ProcessListeningOnPortFromSensor
 
-	// UpdateState brings the update computer to the desired state. // TODO: Used only in tests - candidate to delete maybe?
+	// UpdateState brings the update computer to the desired state.
+	// Required for tests and implementations that store the last sent state (e.g., Legacy).
 	UpdateState(currentConns map[indicator.NetworkConn]timestamp.MicroTS,
 		currentEndpoints map[indicator.ContainerEndpoint]timestamp.MicroTS,
 		currentProcesses map[indicator.ProcessListening]timestamp.MicroTS)
 
-	// ResetState resets all internal state (used when clearing historical data)
+	// ResetState resets all internal state (used when clearing historical data).
 	ResetState()
 
-	// RecordSizeMetrics records metrics for length and byte-size of the collections used in updateComputer
+	// RecordSizeMetrics records metrics for length and byte-size of the collections used in updateComputer.
 	RecordSizeMetrics(name string, gv1, gv2 *prometheus.GaugeVec)
 }

--- a/sensor/common/networkflow/updatecomputer/interface.go
+++ b/sensor/common/networkflow/updatecomputer/interface.go
@@ -1,0 +1,28 @@
+package updatecomputer
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
+)
+
+// UpdateComputer defines the interface for computing network flow updates to send to Central
+// Each implementation manages its own state and computation strategy
+type UpdateComputer interface {
+	// ComputeUpdatedConns updates based on currentState state and implementation-specific tracking
+	ComputeUpdatedConns(current map[indicator.NetworkConn]timestamp.MicroTS) []*storage.NetworkFlow
+	ComputeUpdatedEndpoints(current map[indicator.ContainerEndpoint]timestamp.MicroTS) []*storage.NetworkEndpoint
+	ComputeUpdatedProcesses(current map[indicator.ProcessListening]timestamp.MicroTS) []*storage.ProcessListeningOnPortFromSensor
+
+	// UpdateState brings the update computer to the desired state. // TODO: Used only in tests - candidate to delete maybe?
+	UpdateState(currentConns map[indicator.NetworkConn]timestamp.MicroTS,
+		currentEndpoints map[indicator.ContainerEndpoint]timestamp.MicroTS,
+		currentProcesses map[indicator.ProcessListening]timestamp.MicroTS)
+
+	// ResetState resets all internal state (used when clearing historical data)
+	ResetState()
+
+	// RecordSizeMetrics records metrics for length and byte-size of the collections used in updateComputer
+	RecordSizeMetrics(name string, gv1, gv2 *prometheus.GaugeVec)
+}

--- a/sensor/common/networkflow/updatecomputer/legacy.go
+++ b/sensor/common/networkflow/updatecomputer/legacy.go
@@ -1,6 +1,8 @@
 package updatecomputer
 
 import (
+	"maps"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -65,7 +67,9 @@ func (l *Legacy) ComputeUpdatedProcesses(current map[indicator.ProcessListening]
 	})
 }
 
-// UpdateState updates the internal LastSentState maps with the currentState state
+// UpdateState updates the internal LastSentState maps with the currentState state.
+// Providing nil will skip updates for respective map.
+// Providing empty map will reset the state for given state.
 func (l *Legacy) UpdateState(currentConns map[indicator.NetworkConn]timestamp.MicroTS,
 	currentEndpoints map[indicator.ContainerEndpoint]timestamp.MicroTS,
 	currentProcesses map[indicator.ProcessListening]timestamp.MicroTS,
@@ -74,21 +78,18 @@ func (l *Legacy) UpdateState(currentConns map[indicator.NetworkConn]timestamp.Mi
 	defer l.lastSentStateMutex.Unlock()
 
 	// Update connections state
-	l.enrichedConnsLastSentState = make(map[indicator.NetworkConn]timestamp.MicroTS, len(currentConns))
-	for conn, ts := range currentConns {
-		l.enrichedConnsLastSentState[conn] = ts
+	if currentConns != nil {
+		l.enrichedConnsLastSentState = maps.Clone(currentConns)
 	}
 
 	// Update endpoints state
-	l.enrichedEndpointsLastSentState = make(map[indicator.ContainerEndpoint]timestamp.MicroTS, len(currentEndpoints))
-	for ep, ts := range currentEndpoints {
-		l.enrichedEndpointsLastSentState[ep] = ts
+	if currentEndpoints != nil {
+		l.enrichedEndpointsLastSentState = maps.Clone(currentEndpoints)
 	}
 
 	// Update processes state
-	l.enrichedProcessesLastSentState = make(map[indicator.ProcessListening]timestamp.MicroTS, len(currentProcesses))
-	for proc, ts := range currentProcesses {
-		l.enrichedProcessesLastSentState[proc] = ts
+	if currentProcesses != nil {
+		l.enrichedProcessesLastSentState = maps.Clone(currentProcesses)
 	}
 }
 

--- a/sensor/common/networkflow/updatecomputer/legacy.go
+++ b/sensor/common/networkflow/updatecomputer/legacy.go
@@ -145,6 +145,8 @@ func computeUpdates[K comparable, V any](
 		if _, ok := current[key]; !ok {
 			// For removed items, use the previous timestamp or currentState time if it was infinite
 			finalTS := prevTS
+			// This closes all connections that were opened in the last tick and disappeared in the current tick.
+			// This literally forces sensor to remember all open connections until they are closed.
 			if prevTS == timestamp.InfiniteFuture {
 				finalTS = timestamp.Now()
 			}

--- a/sensor/common/networkflow/updatecomputer/legacy.go
+++ b/sensor/common/networkflow/updatecomputer/legacy.go
@@ -114,14 +114,17 @@ func (l *Legacy) RecordSizeMetrics(name string, lenSize, byteSize *prometheus.Ga
 	})
 	lenSize.WithLabelValues("lastSent", "conns").Set(float64(lenConn))
 	lenSize.WithLabelValues("lastSent", "endpoints").Set(float64(lenEp))
-	lenSize.WithLabelValues("lastSent", "endpoints").Set(float64(lenProc))
+	lenSize.WithLabelValues("lastSent", "processes").Set(float64(lenProc))
 
-	// Avg. byte-size of single element including go map overhead (estimated with Cursor)
+	// Avg. byte-size of single element including go map overhead.
+	// Estimated with by creating a map with 100k elements, measuring memory consumption (including map overhead)
+	// and dividing again by 100k.
 	connsSize := 480 * lenConn
 	epSize := 330 * lenEp
+	procSize := 406 * lenProc
 	byteSize.WithLabelValues("lastSent", "conns").Set(float64(connsSize))
 	byteSize.WithLabelValues("lastSent", "endpoints").Set(float64(epSize))
-	// TODO: Processes size
+	byteSize.WithLabelValues("lastSent", "processes").Set(float64(procSize))
 }
 
 // computeUpdates is a generic helper for computing updates using the legacy LastSentState approach

--- a/sensor/common/networkflow/updatecomputer/legacy.go
+++ b/sensor/common/networkflow/updatecomputer/legacy.go
@@ -103,7 +103,7 @@ func (l *Legacy) ResetState() {
 	l.enrichedProcessesLastSentState = nil
 }
 
-func (l *Legacy) RecordSizeMetrics(name string, lenSize, byteSize *prometheus.GaugeVec) {
+func (l *Legacy) RecordSizeMetrics(lenSize, byteSize *prometheus.GaugeVec) {
 	lenConn := concurrency.WithRLock1(&l.lastSentStateMutex, func() int {
 		return len(l.enrichedConnsLastSentState)
 	})

--- a/sensor/common/networkflow/updatecomputer/legacy.go
+++ b/sensor/common/networkflow/updatecomputer/legacy.go
@@ -1,0 +1,177 @@
+package updatecomputer
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
+)
+
+const loggingRateLimiter = "plop-feature-disabled"
+
+// Legacy implements the original update computation logic using LastSentState maps
+// It owns and manages the LastSentState maps that were previously in the manager
+type Legacy struct {
+	// State tracking maps - these were previously in networkFlowManager
+	enrichedConnsLastSentState     map[indicator.NetworkConn]timestamp.MicroTS
+	enrichedEndpointsLastSentState map[indicator.ContainerEndpoint]timestamp.MicroTS
+	enrichedProcessesLastSentState map[indicator.ProcessListening]timestamp.MicroTS
+
+	// Mutex to protect the LastSentState maps
+	lastSentStateMutex sync.RWMutex
+}
+
+// NewLegacy creates a new instance of the legacy update computer
+func NewLegacy() *Legacy {
+	return &Legacy{
+		enrichedConnsLastSentState:     make(map[indicator.NetworkConn]timestamp.MicroTS),
+		enrichedEndpointsLastSentState: make(map[indicator.ContainerEndpoint]timestamp.MicroTS),
+		enrichedProcessesLastSentState: make(map[indicator.ProcessListening]timestamp.MicroTS),
+	}
+}
+
+func (l *Legacy) ComputeUpdatedConns(current map[indicator.NetworkConn]timestamp.MicroTS) []*storage.NetworkFlow {
+	return concurrency.WithRLock1(&l.lastSentStateMutex, func() []*storage.NetworkFlow {
+		return computeUpdates(current, l.enrichedConnsLastSentState, func(conn indicator.NetworkConn, ts timestamp.MicroTS) *storage.NetworkFlow {
+			return (&conn).ToProto(ts)
+		})
+	})
+}
+
+func (l *Legacy) ComputeUpdatedEndpoints(current map[indicator.ContainerEndpoint]timestamp.MicroTS) []*storage.NetworkEndpoint {
+	return concurrency.WithRLock1(&l.lastSentStateMutex, func() []*storage.NetworkEndpoint {
+		return computeUpdates(current, l.enrichedEndpointsLastSentState, func(ep indicator.ContainerEndpoint, ts timestamp.MicroTS) *storage.NetworkEndpoint {
+			return (&ep).ToProto(ts)
+		})
+	})
+}
+
+func (l *Legacy) ComputeUpdatedProcesses(current map[indicator.ProcessListening]timestamp.MicroTS) []*storage.ProcessListeningOnPortFromSensor {
+	if !env.ProcessesListeningOnPort.BooleanSetting() {
+		if len(current) > 0 {
+			logging.GetRateLimitedLogger().Warn(loggingRateLimiter,
+				"Received process(es) while ProcessesListeningOnPort feature is disabled. This may indicate a misconfiguration.")
+		}
+		return []*storage.ProcessListeningOnPortFromSensor{}
+	}
+	return concurrency.WithRLock1(&l.lastSentStateMutex, func() []*storage.ProcessListeningOnPortFromSensor {
+		return computeUpdates(current, l.enrichedProcessesLastSentState, func(proc indicator.ProcessListening, ts timestamp.MicroTS) *storage.ProcessListeningOnPortFromSensor {
+			return (&proc).ToProto(ts)
+		})
+	})
+}
+
+// UpdateState updates the internal LastSentState maps with the currentState state
+func (l *Legacy) UpdateState(currentConns map[indicator.NetworkConn]timestamp.MicroTS,
+	currentEndpoints map[indicator.ContainerEndpoint]timestamp.MicroTS,
+	currentProcesses map[indicator.ProcessListening]timestamp.MicroTS,
+) {
+	l.lastSentStateMutex.Lock()
+	defer l.lastSentStateMutex.Unlock()
+
+	// Update connections state
+	l.enrichedConnsLastSentState = make(map[indicator.NetworkConn]timestamp.MicroTS, len(currentConns))
+	for conn, ts := range currentConns {
+		l.enrichedConnsLastSentState[conn] = ts
+	}
+
+	// Update endpoints state
+	l.enrichedEndpointsLastSentState = make(map[indicator.ContainerEndpoint]timestamp.MicroTS, len(currentEndpoints))
+	for ep, ts := range currentEndpoints {
+		l.enrichedEndpointsLastSentState[ep] = ts
+	}
+
+	// Update processes state
+	l.enrichedProcessesLastSentState = make(map[indicator.ProcessListening]timestamp.MicroTS, len(currentProcesses))
+	for proc, ts := range currentProcesses {
+		l.enrichedProcessesLastSentState[proc] = ts
+	}
+}
+
+// ResetState clears all internal LastSentState maps
+func (l *Legacy) ResetState() {
+	l.lastSentStateMutex.Lock()
+	defer l.lastSentStateMutex.Unlock()
+
+	l.enrichedConnsLastSentState = nil
+	l.enrichedEndpointsLastSentState = nil
+	l.enrichedProcessesLastSentState = nil
+}
+
+func (l *Legacy) RecordSizeMetrics(name string, lenSize, byteSize *prometheus.GaugeVec) {
+	lenConn := concurrency.WithRLock1(&l.lastSentStateMutex, func() int {
+		return len(l.enrichedConnsLastSentState)
+	})
+	lenEp := concurrency.WithRLock1(&l.lastSentStateMutex, func() int {
+		return len(l.enrichedEndpointsLastSentState)
+	})
+	lenProc := concurrency.WithRLock1(&l.lastSentStateMutex, func() int {
+		return len(l.enrichedProcessesLastSentState)
+	})
+	lenSize.WithLabelValues("lastSent", "conns").Set(float64(lenConn))
+	lenSize.WithLabelValues("lastSent", "endpoints").Set(float64(lenEp))
+	lenSize.WithLabelValues("lastSent", "endpoints").Set(float64(lenProc))
+
+	// Avg. byte-size of single element including go map overhead (estimated with Cursor)
+	connsSize := 480 * lenConn
+	epSize := 330 * lenEp
+	byteSize.WithLabelValues("lastSent", "conns").Set(float64(connsSize))
+	byteSize.WithLabelValues("lastSent", "endpoints").Set(float64(epSize))
+	// TODO: Processes size
+}
+
+// computeUpdates is a generic helper for computing updates using the legacy LastSentState approach
+func computeUpdates[K comparable, V any](
+	current map[K]timestamp.MicroTS,
+	lastSentState map[K]timestamp.MicroTS,
+	toProto func(K, timestamp.MicroTS) V,
+) []V {
+	var updates []V
+
+	// Check currentState items for updates
+	for key, currTS := range current {
+		prevTS, seenPreviously := lastSentState[key]
+		if isUpdated(prevTS, currTS, seenPreviously) {
+			updates = append(updates, toProto(key, currTS))
+		}
+	}
+
+	// Check for items that are no longer currentState (removed items)
+	for key, prevTS := range lastSentState {
+		if _, ok := current[key]; !ok {
+			// For removed items, use the previous timestamp or currentState time if it was infinite
+			finalTS := prevTS
+			if prevTS == timestamp.InfiniteFuture {
+				finalTS = timestamp.Now()
+			}
+			updates = append(updates, toProto(key, finalTS))
+		}
+	}
+
+	return updates
+}
+
+// isUpdated determines whether a connection/endpoint should be included in updates to Central.
+// Returns true in the following scenarios:
+// 1. New connection/endpoint (!seenPreviously)
+// 2. Connection/endpoint timestamp advanced (currTS > prevTS)
+// 3. State transition from OPEN -> CLOSED (InfiniteFuture -> actual timestamp)
+func isUpdated(prevTS, currTS timestamp.MicroTS, seenPreviously bool) bool {
+	// Connection has not been seen in the last tick.
+	if !seenPreviously {
+		return true
+	}
+	// Collector saw this connection more recently.
+	if currTS > prevTS {
+		return true
+	}
+	// Connection was active (unclosed) in the last tick, now it is closed.
+	if prevTS == timestamp.InfiniteFuture && currTS != timestamp.InfiniteFuture {
+		return true
+	}
+	return false
+}

--- a/sensor/common/networkflow/updatecomputer/update_computer_test.go
+++ b/sensor/common/networkflow/updatecomputer/update_computer_test.go
@@ -1,0 +1,262 @@
+package updatecomputer
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/networkgraph"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stackrox/rox/sensor/common/networkflow/manager/indicator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeUpdatedConns(t *testing.T) {
+	// Test data setup
+	entity1 := networkgraph.Entity{Type: storage.NetworkEntityInfo_DEPLOYMENT, ID: "deployment-1"}
+	entity2 := networkgraph.Entity{Type: storage.NetworkEntityInfo_DEPLOYMENT, ID: "deployment-2"}
+
+	conn1 := indicator.NetworkConn{
+		SrcEntity: entity1,
+		DstEntity: entity2,
+		DstPort:   80,
+		Protocol:  storage.L4Protocol_L4_PROTOCOL_TCP,
+	}
+
+	now := timestamp.Now()
+	closedRecently := now - 100
+	closedInThePast := now - 1000
+	closedInTheFuture := now + 1000
+	closedLongAgo := now - 2000
+
+	// We want to notify Central only in the following cases:
+	// - When we see a new connection
+	// - When we see a closed connection
+	// - When we see a connection that was previously open, but is now closed
+	// - When we see a connection that was previously closed, but is now closed with younger timestamp.
+	// In all other cases, we don't need to notify Central as there is no relevant change that affects any features.
+	// Any such notification would be treated by Central as redundant.
+	tests := map[string]struct {
+		initialState   map[indicator.NetworkConn]timestamp.MicroTS
+		currentState   map[indicator.NetworkConn]timestamp.MicroTS
+		expectedCount  int
+		expectWarnings bool
+	}{
+		// Test-cases for: the most frequent scenarios, i.e., a connection being closed, or continues to be open.
+		"should send when connection closes": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: timestamp.InfiniteFuture, // was open
+			},
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedInThePast, // closed connection
+			},
+			expectedCount: 1,
+		},
+		"closing connection in the future should be treated as any other update about connection closing": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: timestamp.InfiniteFuture,
+			},
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedInTheFuture,
+			},
+			expectedCount: 1,
+		},
+		"should not send duplicate open connections": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: timestamp.InfiniteFuture,
+			},
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: timestamp.InfiniteFuture,
+			},
+			expectedCount: 0,
+		},
+		// Test-cases for: disappearance, i.e., the current state is empty.
+		// The disappearance tests ensure that the categorized update computer does not send updates when
+		// we deliberately decide to not track a given connection anymore.
+		// This opens up the possibility for Sensor to delete a connection from its state without notifying Central.
+		"disappearance of open connection: categorized should not send update": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: timestamp.InfiniteFuture,
+			},
+			currentState:   map[indicator.NetworkConn]timestamp.MicroTS{},
+			expectedCount:  1,    // Legacy method would still produce a message
+			expectWarnings: true, // Things should rather not disappear without message from collector - warning.
+		},
+		"disappearance of closed connection: categorized should not send update": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedInThePast,
+			},
+			currentState:   map[indicator.NetworkConn]timestamp.MicroTS{},
+			expectedCount:  1,    // Legacy method would still produce a message
+			expectWarnings: true, // Things should rather not disappear without message from collector - warning.
+		},
+		"handling nils": {
+			initialState:   nil,
+			currentState:   nil,
+			expectedCount:  0,
+			expectWarnings: true,
+		},
+		// Test-cases for: Initial state is empty - behavior when a connection is seen for the first time.
+		"new closed connection should always be sent as required update": {
+			initialState: nil,
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedRecently, // Closed connection
+			},
+			expectedCount: 1,
+		},
+		"new open connections should be sent as required update": {
+			initialState: nil,
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: timestamp.InfiniteFuture, // Open connection
+			},
+			expectedCount: 1,
+		},
+		// Test-cases for: Handling similar messages for connection closing
+		"duplicate updates for closed connection with same timestamp should be skipped": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedRecently, // Closed connection
+			},
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedRecently, // Closed connection
+			},
+			expectedCount: 0,
+		},
+		"recent updates for closed connection with younger close timestamps should be sent": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedLongAgo, // Closed connection, but long ago
+			},
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedRecently, // Closed connection, but younger than the previous close
+			},
+			expectedCount: 1,
+		},
+		"recent updates for closed connection with older close timestamps should be ignored": {
+			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedRecently, // Closed connection, but younger than the previous close
+			},
+			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
+				conn1: closedLongAgo, // Closed connection, but older than the previous close
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			computer := NewLegacy()
+			if tc.initialState != nil {
+				computer.UpdateState(tc.initialState, nil, nil)
+			}
+			// Legacy implementation never returns warnings (although it theoretically could)
+			updates := computer.ComputeUpdatedConns(tc.currentState)
+			assert.Len(t, updates, tc.expectedCount)
+		})
+	}
+}
+
+// TestComputeUpdatedEndpoints tests endpoint update computation for both implementations
+func TestComputeUpdatedEndpoints(t *testing.T) {
+	entity1 := networkgraph.Entity{Type: storage.NetworkEntityInfo_DEPLOYMENT, ID: "deployment-1"}
+
+	endpoint1 := indicator.ContainerEndpoint{
+		Entity:   entity1,
+		Port:     8080,
+		Protocol: storage.L4Protocol_L4_PROTOCOL_TCP,
+	}
+
+	now := timestamp.Now()
+	past := now - 1000
+
+	testCases := map[string]struct {
+		current     map[indicator.ContainerEndpoint]timestamp.MicroTS
+		expectCount int
+	}{
+		"Should send new closed endpoints": {
+			current: map[indicator.ContainerEndpoint]timestamp.MicroTS{
+				endpoint1: now,
+			},
+			expectCount: 1,
+		},
+		"Should send closed endpoints": {
+			current: map[indicator.ContainerEndpoint]timestamp.MicroTS{
+				endpoint1: past, // closed endpoint
+			},
+			expectCount: 1,
+		},
+		"Should produce no updates on empty input": {
+			current:     map[indicator.ContainerEndpoint]timestamp.MicroTS{},
+			expectCount: 0,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			updates := NewLegacy().ComputeUpdatedEndpoints(tc.current)
+			assert.Len(t, updates, tc.expectCount)
+
+			// Verify protobuf conversion
+			for _, update := range updates {
+				assert.NotNil(t, update.Props)
+				assert.Equal(t, uint32(8080), update.Props.Port)
+				assert.Equal(t, storage.L4Protocol_L4_PROTOCOL_TCP, update.Props.L4Protocol)
+			}
+		})
+	}
+}
+
+// TestComputeUpdatedProcesses tests process update computation for both implementations
+func TestComputeUpdatedProcesses(t *testing.T) {
+	process1 := indicator.ProcessListening{
+		Process: indicator.ProcessInfo{
+			ProcessName: "nginx",
+			ProcessArgs: "-g daemon off;",
+			ProcessExec: "/usr/sbin/nginx",
+		},
+		PodID:         "pod-1",
+		ContainerName: "nginx-container",
+		DeploymentID:  "nginx-deployment",
+		PodUID:        "uid-123",
+		Namespace:     "default",
+		Port:          80,
+		Protocol:      storage.L4Protocol_L4_PROTOCOL_TCP,
+	}
+
+	now := timestamp.Now()
+	past := now - 1000
+
+	testCases := map[string]struct {
+		current     map[indicator.ProcessListening]timestamp.MicroTS
+		description string
+	}{
+		"new process": {
+			current: map[indicator.ProcessListening]timestamp.MicroTS{
+				process1: now,
+			},
+			description: "Should handle new processes",
+		},
+		"closed process": {
+			current: map[indicator.ProcessListening]timestamp.MicroTS{
+				process1: past, // closed process
+			},
+			description: "Should handle closed processes",
+		},
+		"no processes": {
+			current:     map[indicator.ProcessListening]timestamp.MicroTS{},
+			description: "Should handle empty input",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			updates := NewLegacy().ComputeUpdatedProcesses(tc.current)
+
+			// The actual behavior depends on the ProcessesListeningOnPort feature flag
+			// We just ensure no panics and verify structure when updates exist
+			for _, update := range updates {
+				assert.NotNil(t, update.Process)
+				assert.Equal(t, uint32(80), update.Port)
+				assert.Equal(t, storage.L4Protocol_L4_PROTOCOL_TCP, update.Protocol)
+				assert.Equal(t, "nginx", update.Process.ProcessName)
+			}
+		})
+	}
+}

--- a/sensor/common/networkflow/updatecomputer/update_computer_test.go
+++ b/sensor/common/networkflow/updatecomputer/update_computer_test.go
@@ -146,6 +146,9 @@ func TestComputeUpdatedConns(t *testing.T) {
 			if tc.initialState != nil {
 				computer.UpdateState(tc.initialState, nil, nil)
 			}
+			// Call to UpdateState with nils should not change anything in the state
+			computer.UpdateState(nil, nil, nil)
+
 			// Legacy implementation never returns warnings (although it theoretically could)
 			updates := computer.ComputeUpdatedConns(tc.currentState)
 			assert.Len(t, updates, tc.expectedCount)
@@ -237,6 +240,8 @@ func TestComputeUpdatedEndpoints(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			l := NewLegacy()
 			l.UpdateState(nil, tc.initial, nil)
+			// Call to UpdateState with nils should not change anything in the state
+			l.UpdateState(nil, nil, nil)
 			updates := l.ComputeUpdatedEndpoints(tc.current)
 			assert.Len(t, updates, tc.expectNumUpdates)
 
@@ -355,6 +360,8 @@ func TestComputeUpdatedProcesses(t *testing.T) {
 			}
 			l := NewLegacy()
 			l.UpdateState(nil, nil, tc.initial)
+			// Call to UpdateState with nils should not change anything in the state
+			l.UpdateState(nil, nil, nil)
 			updates := l.ComputeUpdatedProcesses(tc.current)
 			assert.Len(t, updates, tc.expectNumUpdates)
 			// The actual behavior depends on the ProcessesListeningOnPort feature flag, here we do basic checks.

--- a/sensor/common/networkflow/updatecomputer/update_computer_test.go
+++ b/sensor/common/networkflow/updatecomputer/update_computer_test.go
@@ -28,6 +28,7 @@ func TestComputeUpdatedConns(t *testing.T) {
 	closedInThePast := now - 1000
 	closedInTheFuture := now + 1000
 	closedLongAgo := now - 2000
+	open := timestamp.InfiniteFuture
 
 	// We want to notify Central only in the following cases:
 	// - When we see a new connection
@@ -47,7 +48,7 @@ func TestComputeUpdatedConns(t *testing.T) {
 		// (i.e., a connection is being closed, or continues to be open).
 		"should send when connection closes": {
 			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
-				conn1: timestamp.InfiniteFuture,
+				conn1: open,
 			},
 			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
 				conn1: closedInThePast,
@@ -56,7 +57,7 @@ func TestComputeUpdatedConns(t *testing.T) {
 		},
 		"closing connection in the future should be treated as any other update about connection closing": {
 			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
-				conn1: timestamp.InfiniteFuture,
+				conn1: open,
 			},
 			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
 				conn1: closedInTheFuture,
@@ -65,10 +66,10 @@ func TestComputeUpdatedConns(t *testing.T) {
 		},
 		"should not send duplicate open connections": {
 			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
-				conn1: timestamp.InfiniteFuture,
+				conn1: open,
 			},
 			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
-				conn1: timestamp.InfiniteFuture,
+				conn1: open,
 			},
 			expectedCount: 0,
 		},
@@ -77,7 +78,7 @@ func TestComputeUpdatedConns(t *testing.T) {
 		// for Sensor to delete a connection from its state without notifying Central.
 		"disappearance of open connection: legacy should send an update": {
 			initialState: map[indicator.NetworkConn]timestamp.MicroTS{
-				conn1: timestamp.InfiniteFuture,
+				conn1: open,
 			},
 			currentState:  map[indicator.NetworkConn]timestamp.MicroTS{},
 			expectedCount: 1, // Legacy tracks deletions and would still produce a message (although undesired).
@@ -105,7 +106,7 @@ func TestComputeUpdatedConns(t *testing.T) {
 		"new open connections should be sent as required update": {
 			initialState: nil,
 			currentState: map[indicator.NetworkConn]timestamp.MicroTS{
-				conn1: timestamp.InfiniteFuture, // Open connection
+				conn1: open,
 			},
 			expectedCount: 1,
 		},

--- a/sensor/common/networkflow/updatecomputer/update_computer_test.go
+++ b/sensor/common/networkflow/updatecomputer/update_computer_test.go
@@ -226,6 +226,11 @@ func TestComputeUpdatedEndpoints(t *testing.T) {
 			current:          map[indicator.ContainerEndpoint]timestamp.MicroTS{},
 			expectNumUpdates: 1,
 		},
+		"handling nils": {
+			initial:          nil,
+			current:          nil,
+			expectNumUpdates: 0,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -334,6 +339,11 @@ func TestComputeUpdatedProcesses(t *testing.T) {
 			},
 			current:          map[indicator.ProcessListening]timestamp.MicroTS{},
 			expectNumUpdates: 1,
+		},
+		"handling nils": {
+			initial:          nil,
+			current:          nil,
+			expectNumUpdates: 0,
 		},
 	}
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager"
 	"github.com/stackrox/rox/sensor/common/networkflow/service"
+	"github.com/stackrox/rox/sensor/common/networkflow/updatecomputer"
 	"github.com/stackrox/rox/sensor/common/processfilter"
 	"github.com/stackrox/rox/sensor/common/processsignal"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
@@ -128,7 +129,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		processSignals = signalService.New(processPipeline, indicators, signalService.WithTraceWriter(cfg.processIndicatorWriter))
 	}
 	networkFlowManager :=
-		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), policyDetector, pubSub, manager.WithEnrichTicker(cfg.networkFlowTicker))
+		manager.NewManager(storeProvider.Entities(), externalsrcs.StoreInstance(), policyDetector, pubSub, updatecomputer.NewLegacy(), manager.WithEnrichTicker(cfg.networkFlowTicker))
 	enhancer := deploymentenhancer.CreateEnhancer(storeProvider)
 	components := []common.SensorComponent{
 		admCtrlMsgForwarder,


### PR DESCRIPTION
🐑 Shepherd of this stack is @lvalerom and @rhybrillou (when back)

## Description

This PR extracts the calculation logic for sending updates to Central. A new `updateComputer` package is introduced that is responsible for determining what should be sent to central and what skipped. In this PR, there is only one implementation of the `updateComputer` called `Legacy`. The `Legacy` implements the update calculation behavior without any changes to the logic.

Some metrics and dedicated tests are added for the new `updateComputer` package.


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI should be enough
