### PR TITLE
ROX-18298: cleanup cluster health on delete

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -579,7 +579,7 @@ func (ds *datastoreImpl) RemoveCluster(ctx context.Context, id string, done *con
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
-	// Fetch the cluster an confirm it exists.
+	// Fetch the cluster and confirm it exists.
 	cluster, exists, err := ds.clusterStorage.Get(ctx, id)
 	if !exists {
 		return errors.Errorf("unable to find cluster %q", id)
@@ -605,6 +605,11 @@ func (ds *datastoreImpl) postRemoveCluster(ctx context.Context, cluster *storage
 		ds.cm.CloseConnection(cluster.GetId())
 	}
 	ds.removeClusterImageIntegrations(ctx, cluster)
+
+	// Remove the cluster health since the cluster no longer exists
+	if err := ds.clusterHealthStorage.Delete(ctx, cluster.GetId()); err != nil {
+		log.Errorf("failed to remove health status for cluster %s: %v", cluster.GetId(), err)
+	}
 
 	// Remove ranker record here since removal is not handled in risk store as no entry present for cluster
 	ds.clusterRanker.Remove(cluster.GetId())


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When a cluster is removed, the corresponding health status is not.  This PR addresses that.

(I suspect but didn't confirm this is due to the removal of a FK when processing migrations way back when the RocksDB -> Postgres conversion was on going.)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Added a unit test.  Also set up a cluster and verified this now works.  Before this fix it behaved as [ROX-18298](https://issues.redhat.com/browse/ROX-18298) stated.  See results below:

```
central_active=# select id from clusters;
                  id                  
--------------------------------------
 d4104718-6e6e-44c9-8940-27af71509a26
(1 row)

central_active=# select * from cluster_health_statuses;
                  id                  | sensorhealthstatus | collectorhealthstatus | overallhealthstatus | admissioncontrolhealthstatus | scannerhealthstatus |        lastcontact         |               
                                                                                            serialized                                                                                                     
      
--------------------------------------+--------------------+-----------------------+---------------------+------------------------------+---------------------+----------------------------+---------------
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
------
 d4104718-6e6e-44c9-8940-27af71509a26 |                  4 |                     4 |                   4 |                            4 |                   4 | 2025-08-19 18:34:04.034894 | \x0a1d0a15332e
32322e782d36342d67363637376364646461651005180520051004180420042a0b089c8793c50610b0e1d110300138044204080310034a2464343130343731382d366536652d343463392d383934302d3237616637313530396132365208080210021801200
15804
(1 row)

central_active=# select id from clusters;
 id 
----
(0 rows)

central_active=# select * from cluster_health_statuses;
 id | sensorhealthstatus | collectorhealthstatus | overallhealthstatus | admissioncontrolhealthstatus | scannerhealthstatus | lastcontact | serialized 
----+--------------------+-----------------------+---------------------+------------------------------+---------------------+-------------+------------
(0 rows)
```