### PR TITLE
fix(ci): replace CVE-2016-20013 with CVE-2024-28085

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -453,17 +453,17 @@ class ImageScanningTest extends BaseSpecification {
         where:
         "Data inputs are: "
 
-        scanner                          | component                  | version                       | idx | cve              | image           | registry
-        new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "RHSA-2019:0483" | RHEL7_IMAGE     | ""
-        new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "CVE-2018-0735"  | RHEL7_IMAGE     | ""
-        new StackroxScannerIntegration() | "systemd"                  | "229-4ubuntu21.29"            | 0   | "CVE-2021-33910" | OCI_IMAGE       | ""
-        new StackroxScannerIntegration() | "glibc"                    | "2.35-0ubuntu3.1"             | 4   | "CVE-2016-20013" | LIST_IMAGE_OCI_MANIFEST | ""
-        new ClairScannerIntegration()    | "apt"                      | "1.4.8"                       | 0   | "CVE-2011-3374"  | NGINX_IMAGE     | ""
-        new ClairScannerIntegration()    | "bash"                     | "4.4-5"                       | 0   | "CVE-2019-18276" | NGINX_IMAGE     | ""
-        new ClairV4ScannerIntegration()  | "openssl-libs"             | "1:1.1.1-8.el8"               | 0   | "RHSA-2021:1024" | UBI8_0_IMAGE    | ""
-        new ClairV4ScannerIntegration()  | "platform-python-pip"      | "9.0.3-13.el8"                | 0   | "RHSA-2020:4432" | UBI8_0_IMAGE    | ""
-        new StackroxScannerIntegration() | "java-17-openjdk-headless" | "1:17.0.11.0.9-2.el8.x86_64"  | 135 | ""               | LINEAGE_IMAGE_A | ""
-        new StackroxScannerIntegration() | "java-17-openjdk-headless" | "1:17.0.13.0.11-3.el8.x86_64" | 137 | ""               | LINEAGE_IMAGE_B | ""
+        scanner                          | component                  | version                       | idx | cve              | image                   | registry
+        new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "RHSA-2019:0483" | RHEL7_IMAGE             | ""
+        new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "CVE-2018-0735"  | RHEL7_IMAGE             | ""
+        new StackroxScannerIntegration() | "systemd"                  | "229-4ubuntu21.29"            | 0   | "CVE-2021-33910" | OCI_IMAGE               | ""
+        new StackroxScannerIntegration() | "libuuid1"                 | "2.37.2-4ubuntu3"             | 4   | "CVE-2024-28085" | LIST_IMAGE_OCI_MANIFEST | ""
+        new ClairScannerIntegration()    | "apt"                      | "1.4.8"                       | 0   | "CVE-2011-3374"  | NGINX_IMAGE             | ""
+        new ClairScannerIntegration()    | "bash"                     | "4.4-5"                       | 0   | "CVE-2019-18276" | NGINX_IMAGE             | ""
+        new ClairV4ScannerIntegration()  | "openssl-libs"             | "1:1.1.1-8.el8"               | 0   | "RHSA-2021:1024" | UBI8_0_IMAGE            | ""
+        new ClairV4ScannerIntegration()  | "platform-python-pip"      | "9.0.3-13.el8"                | 0   | "RHSA-2020:4432" | UBI8_0_IMAGE            | ""
+        new StackroxScannerIntegration() | "java-17-openjdk-headless" | "1:17.0.11.0.9-2.el8.x86_64"  | 135 | ""               | LINEAGE_IMAGE_A         | ""
+        new StackroxScannerIntegration() | "java-17-openjdk-headless" | "1:17.0.13.0.11-3.el8.x86_64" | 137 | ""               | LINEAGE_IMAGE_B         | ""
     }
 
     @Unroll


### PR DESCRIPTION
## Description

Ubuntu recently opted to ignore CVE-2016-20013 https://git.launchpad.net/ubuntu-cve-tracker/commit/active/CVE-2016-20013?id=f2b1cfd3260adb8c188b0ca0ce1ec17bb85bfcf0. This will cause CI to fail once we update to a version of Scanner v2 which knows about this change. This PR is meant to replace it with a different CVE so we can update Scanner v2 without worrying about breaking CI for others

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI
