### PR TITLE
fix(be): Fix incorrect proto field name in static config

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -1108,7 +1108,7 @@ func configureFromHelmConfig(cluster *storage.Cluster, helmConfig *storage.Compl
 	cluster.SlimCollector = staticConfig.GetSlimCollector()
 	cluster.AdmissionControllerFailOnError = false
 	if features.AdmissionControllerConfig.Enabled() {
-		cluster.AdmissionControllerFailOnError = staticConfig.GetAdmissionControllerFailureOnError()
+		cluster.AdmissionControllerFailOnError = staticConfig.GetAdmissionControllerFailOnError()
 	}
 }
 

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -1361,7 +1361,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	utils.Must(builder.AddType("StaticClusterConfig", []string{
 		"admissionController: Boolean!",
 		"admissionControllerEvents: Boolean!",
-		"admissionControllerFailureOnError: Boolean!",
+		"admissionControllerFailOnError: Boolean!",
 		"admissionControllerUpdates: Boolean!",
 		"centralApiEndpoint: String!",
 		"collectionMethod: CollectionMethod!",
@@ -14783,8 +14783,8 @@ func (resolver *staticClusterConfigResolver) AdmissionControllerEvents(ctx conte
 	return value
 }
 
-func (resolver *staticClusterConfigResolver) AdmissionControllerFailureOnError(ctx context.Context) bool {
-	value := resolver.data.GetAdmissionControllerFailureOnError()
+func (resolver *staticClusterConfigResolver) AdmissionControllerFailOnError(ctx context.Context) bool {
+	value := resolver.data.GetAdmissionControllerFailOnError()
 	return value
 }
 

--- a/generated/api/v1/cluster_service.swagger.json
+++ b/generated/api/v1/cluster_service.swagger.json
@@ -953,7 +953,7 @@
         "admissionControllerEvents": {
           "type": "boolean"
         },
-        "admissionControllerFailureOnError": {
+        "admissionControllerFailOnError": {
           "type": "boolean"
         }
       },

--- a/generated/storage/cluster.pb.go
+++ b/generated/storage/cluster.pb.go
@@ -1052,20 +1052,20 @@ func (x *TolerationsConfig) GetDisabled() bool {
 
 // The difference between Static and Dynamic cluster config is that Static values are not sent over the Central to Sensor gRPC connection. They are used, for example, to generate manifests that can be used to set up the Secured Cluster's k8s components. They are *not* dynamically reloaded.
 type StaticClusterConfig struct {
-	state                             protoimpl.MessageState `protogen:"open.v1"`
-	Type                              ClusterType            `protobuf:"varint,1,opt,name=type,proto3,enum=storage.ClusterType" json:"type,omitempty"`
-	MainImage                         string                 `protobuf:"bytes,2,opt,name=main_image,json=mainImage,proto3" json:"main_image,omitempty"`
-	CentralApiEndpoint                string                 `protobuf:"bytes,3,opt,name=central_api_endpoint,json=centralApiEndpoint,proto3" json:"central_api_endpoint,omitempty"`
-	CollectionMethod                  CollectionMethod       `protobuf:"varint,4,opt,name=collection_method,json=collectionMethod,proto3,enum=storage.CollectionMethod" json:"collection_method,omitempty"`
-	CollectorImage                    string                 `protobuf:"bytes,5,opt,name=collector_image,json=collectorImage,proto3" json:"collector_image,omitempty"`
-	AdmissionController               bool                   `protobuf:"varint,6,opt,name=admission_controller,json=admissionController,proto3" json:"admission_controller,omitempty"`
-	AdmissionControllerUpdates        bool                   `protobuf:"varint,7,opt,name=admission_controller_updates,json=admissionControllerUpdates,proto3" json:"admission_controller_updates,omitempty"`
-	TolerationsConfig                 *TolerationsConfig     `protobuf:"bytes,8,opt,name=tolerations_config,json=tolerationsConfig,proto3" json:"tolerations_config,omitempty"`
-	SlimCollector                     bool                   `protobuf:"varint,9,opt,name=slim_collector,json=slimCollector,proto3" json:"slim_collector,omitempty"`
-	AdmissionControllerEvents         bool                   `protobuf:"varint,10,opt,name=admission_controller_events,json=admissionControllerEvents,proto3" json:"admission_controller_events,omitempty"`
-	AdmissionControllerFailureOnError bool                   `protobuf:"varint,11,opt,name=admission_controller_failure_on_error,json=admissionControllerFailureOnError,proto3" json:"admission_controller_failure_on_error,omitempty"`
-	unknownFields                     protoimpl.UnknownFields
-	sizeCache                         protoimpl.SizeCache
+	state                          protoimpl.MessageState `protogen:"open.v1"`
+	Type                           ClusterType            `protobuf:"varint,1,opt,name=type,proto3,enum=storage.ClusterType" json:"type,omitempty"`
+	MainImage                      string                 `protobuf:"bytes,2,opt,name=main_image,json=mainImage,proto3" json:"main_image,omitempty"`
+	CentralApiEndpoint             string                 `protobuf:"bytes,3,opt,name=central_api_endpoint,json=centralApiEndpoint,proto3" json:"central_api_endpoint,omitempty"`
+	CollectionMethod               CollectionMethod       `protobuf:"varint,4,opt,name=collection_method,json=collectionMethod,proto3,enum=storage.CollectionMethod" json:"collection_method,omitempty"`
+	CollectorImage                 string                 `protobuf:"bytes,5,opt,name=collector_image,json=collectorImage,proto3" json:"collector_image,omitempty"`
+	AdmissionController            bool                   `protobuf:"varint,6,opt,name=admission_controller,json=admissionController,proto3" json:"admission_controller,omitempty"`
+	AdmissionControllerUpdates     bool                   `protobuf:"varint,7,opt,name=admission_controller_updates,json=admissionControllerUpdates,proto3" json:"admission_controller_updates,omitempty"`
+	TolerationsConfig              *TolerationsConfig     `protobuf:"bytes,8,opt,name=tolerations_config,json=tolerationsConfig,proto3" json:"tolerations_config,omitempty"`
+	SlimCollector                  bool                   `protobuf:"varint,9,opt,name=slim_collector,json=slimCollector,proto3" json:"slim_collector,omitempty"`
+	AdmissionControllerEvents      bool                   `protobuf:"varint,10,opt,name=admission_controller_events,json=admissionControllerEvents,proto3" json:"admission_controller_events,omitempty"`
+	AdmissionControllerFailOnError bool                   `protobuf:"varint,11,opt,name=admission_controller_fail_on_error,json=admissionControllerFailOnError,proto3" json:"admission_controller_fail_on_error,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
 }
 
 func (x *StaticClusterConfig) Reset() {
@@ -1168,9 +1168,9 @@ func (x *StaticClusterConfig) GetAdmissionControllerEvents() bool {
 	return false
 }
 
-func (x *StaticClusterConfig) GetAdmissionControllerFailureOnError() bool {
+func (x *StaticClusterConfig) GetAdmissionControllerFailOnError() bool {
 	if x != nil {
-		return x.AdmissionControllerFailureOnError
+		return x.AdmissionControllerFailOnError
 	}
 	return false
 }
@@ -2658,7 +2658,7 @@ const file_storage_cluster_proto_rawDesc = "" +
 	"\x0edisable_bypass\x18\x04 \x01(\bR\rdisableBypass\x12,\n" +
 	"\x12enforce_on_updates\x18\x05 \x01(\bR\x10enforceOnUpdates\"/\n" +
 	"\x11TolerationsConfig\x12\x1a\n" +
-	"\bdisabled\x18\x01 \x01(\bR\bdisabled\"\xfa\x04\n" +
+	"\bdisabled\x18\x01 \x01(\bR\bdisabled\"\xf4\x04\n" +
 	"\x13StaticClusterConfig\x12(\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x14.storage.ClusterTypeR\x04type\x12\x1d\n" +
 	"\n" +
@@ -2671,8 +2671,8 @@ const file_storage_cluster_proto_rawDesc = "" +
 	"\x12tolerations_config\x18\b \x01(\v2\x1a.storage.TolerationsConfigR\x11tolerationsConfig\x12%\n" +
 	"\x0eslim_collector\x18\t \x01(\bR\rslimCollector\x12>\n" +
 	"\x1badmission_controller_events\x18\n" +
-	" \x01(\bR\x19admissionControllerEvents\x12P\n" +
-	"%admission_controller_failure_on_error\x18\v \x01(\bR!admissionControllerFailureOnError\"\xd5\x01\n" +
+	" \x01(\bR\x19admissionControllerEvents\x12J\n" +
+	"\"admission_controller_fail_on_error\x18\v \x01(\bR\x1eadmissionControllerFailOnError\"\xd5\x01\n" +
 	"\x14DynamicClusterConfig\x12b\n" +
 	"\x1badmission_controller_config\x18\x01 \x01(\v2\".storage.AdmissionControllerConfigR\x19admissionControllerConfig\x12+\n" +
 	"\x11registry_override\x18\x02 \x01(\tR\x10registryOverride\x12,\n" +

--- a/generated/storage/cluster_vtproto.pb.go
+++ b/generated/storage/cluster_vtproto.pb.go
@@ -235,7 +235,7 @@ func (m *StaticClusterConfig) CloneVT() *StaticClusterConfig {
 	r.TolerationsConfig = m.TolerationsConfig.CloneVT()
 	r.SlimCollector = m.SlimCollector
 	r.AdmissionControllerEvents = m.AdmissionControllerEvents
-	r.AdmissionControllerFailureOnError = m.AdmissionControllerFailureOnError
+	r.AdmissionControllerFailOnError = m.AdmissionControllerFailOnError
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1053,7 +1053,7 @@ func (this *StaticClusterConfig) EqualVT(that *StaticClusterConfig) bool {
 	if this.AdmissionControllerEvents != that.AdmissionControllerEvents {
 		return false
 	}
-	if this.AdmissionControllerFailureOnError != that.AdmissionControllerFailureOnError {
+	if this.AdmissionControllerFailOnError != that.AdmissionControllerFailOnError {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2397,9 +2397,9 @@ func (m *StaticClusterConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.AdmissionControllerFailureOnError {
+	if m.AdmissionControllerFailOnError {
 		i--
-		if m.AdmissionControllerFailureOnError {
+		if m.AdmissionControllerFailOnError {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
@@ -4085,7 +4085,7 @@ func (m *StaticClusterConfig) SizeVT() (n int) {
 	if m.AdmissionControllerEvents {
 		n += 2
 	}
-	if m.AdmissionControllerFailureOnError {
+	if m.AdmissionControllerFailOnError {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -6042,7 +6042,7 @@ func (m *StaticClusterConfig) UnmarshalVT(dAtA []byte) error {
 			m.AdmissionControllerEvents = bool(v != 0)
 		case 11:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerFailureOnError", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerFailOnError", wireType)
 			}
 			var v int
 			for shift := uint(0); ; shift += 7 {
@@ -6059,7 +6059,7 @@ func (m *StaticClusterConfig) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
-			m.AdmissionControllerFailureOnError = bool(v != 0)
+			m.AdmissionControllerFailOnError = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10981,7 +10981,7 @@ func (m *StaticClusterConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 			m.AdmissionControllerEvents = bool(v != 0)
 		case 11:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerFailureOnError", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerFailOnError", wireType)
 			}
 			var v int
 			for shift := uint(0); ; shift += 7 {
@@ -10998,7 +10998,7 @@ func (m *StaticClusterConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
-			m.AdmissionControllerFailureOnError = bool(v != 0)
+			m.AdmissionControllerFailOnError = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/storage/cluster.proto
+++ b/proto/storage/cluster.proto
@@ -110,7 +110,7 @@ message StaticClusterConfig {
   TolerationsConfig tolerations_config = 8;
   bool slim_collector = 9;
   bool admission_controller_events = 10;
-  bool admission_controller_failure_on_error = 11;
+  bool admission_controller_fail_on_error = 11;
 }
 
 // The difference between Static and Dynamic cluster config is that Dynamic values are sent over the Central to Sensor gRPC connection. This has the benefit of allowing for "hot reloading" of values without restarting Secured cluster components.

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -2000,7 +2000,7 @@
               },
               {
                 "id": 11,
-                "name": "admission_controller_failure_on_error",
+                "name": "admission_controller_fail_on_error",
                 "type": "bool"
               }
             ]


### PR DESCRIPTION
## Description
Fixing a typo in the proto field name (wanted it to be consistent with the other fail_on_error). Thanks to @pedrottimark 's hawk eyes, for catching this.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
CI only.
