### PR TITLE
ROX-29160: Remove feature flag ROX_RED_HAT_IMAGES_SIGNED_POLICY

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -131,9 +131,6 @@ var (
 
 	// Intgrate with LLM for risk recommendations
 	LLMRiskRecommendation = registerFeature("Intgrate with LLM for risk recommendations", "ROX_LLM_RISK_RECOMMENDATION")
-
-	// Adds built-in policy to ensure that Red Hat images are signed by Red Hat Release Key
-	RedHatImagesSignedPolicy = registerFeature("Adds built-in policy to ensure that Red Hat images are signed by the Red Hat release key", "ROX_RED_HAT_IMAGES_SIGNED_POLICY", unchangeableInProd)
 )
 
 // The following feature flags are related to Scanner V4.


### PR DESCRIPTION
## Description

While working with https://github.com/stackrox/stackrox/pull/15763, discussions revealed that it is not a good idea to hide default policies behind feature flags [1]. After flag usages were removed from open PRs [2][3], the flag itself can be removed.

[1] https://redhat-internal.slack.com/archives/C01DQH7UP8C/p1753527317603749?thread_ts=1751477193.410369&cid=C01DQH7UP8C
[2] https://github.com/stackrox/stackrox/pull/15761/commits/14ebb647a62e0ea63dac468a2f620f68f2d7ff04
[3] https://github.com/stackrox/stackrox/pull/15763/commits/73361e79e66cea6ea1d0ce63ad80781a02b3e9b9

## User-facing documentation

- [X] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [X] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [X] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

I grepped the repo to verify nothing uses the flag I'm removing, and ensured tests pass.
