### PR TITLE
test: CI Preparations for enabling new Admission Controller Config

### DIFF
--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/feature_flags_test.go
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/feature_flags_test.go
@@ -18,12 +18,20 @@ func TestWithDifferentFeatureFlags(t *testing.T) {
 	testutils.SetVersion(t, testutils.GetExampleVersion(t))
 
 	testCases := map[string]struct {
-		featureFlags []string
+		featureFlags map[string]bool
 		flavor       defaults.ImageFlavor
 	}{
 		"admission-controller-config": {
-			featureFlags: []string{"ROX_ADMISSION_CONTROLLER_CONFIG"},
-			flavor:       defaults.RHACSReleaseImageFlavor(),
+			featureFlags: map[string]bool{
+				"ROX_ADMISSION_CONTROLLER_CONFIG": true,
+			},
+			flavor: defaults.RHACSReleaseImageFlavor(),
+		},
+		"admission-controller-config-disabled": {
+			featureFlags: map[string]bool{
+				"ROX_ADMISSION_CONTROLLER_CONFIG": false,
+			},
+			flavor: defaults.RHACSReleaseImageFlavor(),
 		},
 	}
 
@@ -36,8 +44,8 @@ func TestWithDifferentFeatureFlags(t *testing.T) {
 					if values.FeatureFlags == nil {
 						values.FeatureFlags = make(map[string]interface{})
 					}
-					for _, featureFlag := range testCaseSpec.featureFlags {
-						values.FeatureFlags[featureFlag] = true
+					for name, setting := range testCaseSpec.featureFlags {
+						values.FeatureFlags[name] = setting
 					}
 				},
 				HelmTestOpts: []helmTest.LoaderOpt{helmTest.WithAdditionalTestDirs(path.Join(testDir, testCaseName))},

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config-disabled/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config-disabled/admission-control.test.yaml
@@ -1,0 +1,38 @@
+values:
+  imagePullSecrets:
+    allowNone: true
+  monitoring:
+    openshift:
+      enabled: false
+server:
+  availableSchemas:
+  - openshift-4.1.0
+tests:
+- name: "Webhook timeout pads AdmissionController timeout by 2 seconds"
+  tests:
+    - name: "default AdmissionController timeout is 10s + 2s padding"
+      expect: |
+        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 10 + 2)
+    - name: "override sets value correctly"
+      values:
+        admissionControl:
+          dynamic:
+            timeout: 7
+      expect: |
+        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 7 + 2)
+- name: "OpenShift3 clusters do not support admission control sideEffects"
+  server:
+    availableSchemas:
+      - openshift-3.11.0
+  set:
+    env.openshift: 3
+    admissionControl:
+      listenOnEvents: true
+      listenOnCreates: true
+      listenOnUpdates: true
+  expectError: true
+- name: "scanInline defaults to false"
+  set:
+    admissionControl.dynamic.scanInline: null
+  expect: |
+    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == false)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -8,18 +8,6 @@ server:
   availableSchemas:
   - openshift-4.1.0
 tests:
-- name: "OpenShift3 clusters do not support admission control sideEffects"
-  server:
-    availableSchemas:
-      - openshift-3.11.0
-  set:
-    env.openshift: 3
-    admissionControl:
-      listenOnEvents: true
-      listenOnCreates: true
-      listenOnUpdates: true
-  expectError: true
-
 - name: "OpenShift4 clusters support admission control sideEffects"
   set:
     env.openshift: 4
@@ -62,19 +50,6 @@ tests:
   expect: |
     .validatingwebhookconfigurations[].apiVersion | assertThat(. == "admissionregistration.k8s.io/v1beta1")
     .validatingwebhookconfigurations[].webhooks[] | assertThat(.admissionReviewVersions == null)
-
-- name: "Webhook timeout pads AdmissionController timeout by 2 seconds"
-  tests:
-    - name: "default AdmissionController timeout is 10s + 2s padding"
-      expect: |
-        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 10 + 2)
-    - name: "override sets value correctly"
-      values:
-        admissionControl:
-          dynamic:
-            timeout: 7
-      expect: |
-        .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 7 + 2)
 
 - name: "Admission control deployment configuration"
   tests:
@@ -181,8 +156,3 @@ tests:
       expect: |
         .validatingwebhookconfigurations[].webhooks[].failurePolicy | assertThat(. == "Fail")
         .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.staticConfig | assertThat(.admissionControllerFailOnError == true)
-- name: "scanInline defaults to false"
-  set:
-    admissionControl.dynamic.scanInline: null
-  expect: |
-    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == false)

--- a/pkg/helm/config/testdata/helm-chart-configurations/simple.yaml
+++ b/pkg/helm/config/testdata/helm-chart-configurations/simple.yaml
@@ -10,7 +10,7 @@ admissionControl:
     enforceOnCreates: true
     scanInline: true
     disableBypass: true
-    timeout: 3
+    timeout: 10
     enforceOnUpdates: true
 
 collector:


### PR DESCRIPTION
## Description

Execute certain tests which specifically test the current Helm chart behaviour (i.e. ROX_ADMISSION_CONTROLLER_CONFIG=false) into a dedicated test suite which explicitly switches off this feature flag, thereby making these tests pass irregardless of the current defaulting setting of the feature flag.

## User-facing documentation

No doc changes needed, this is just about restructuring tests.

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected
- [ ] 
### Automated testing

- [x] modified existing tests

### How I validated my change

Just via unit tests -- the change only affects unit tests.
