### PR TITLE
chore(ai): enable AI for sensor & ecosystem

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -71,3 +71,14 @@ konflux-build:
     - '**/konflux*.Dockerfile'
     - .tekton/**/*
     - .konflux/**/*
+
+ai-review:
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/**/*
+    - .openshift-ci/**/*
+    - pkg/auth/**/*
+    - pkg/sac/**/*
+    - roxctl/**/*
+    - scripts/ci/**/
+    - sensor/**/*


### PR DESCRIPTION
This PR enables Sourcery AI reviews on paths owned by @stackrox/sensor-ecosystem 