### PR TITLE
fix: Propagate Admission Controller failure Policy to Central

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/cluster-config.yaml.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/cluster-config.yaml.tpl
@@ -16,6 +16,7 @@ clusterConfig:
     admissionController: {{ ._rox.admissionControl.listenOnCreates }}
     admissionControllerUpdates: {{ ._rox.admissionControl.listenOnUpdates }}
     admissionControllerEvents: {{ ._rox.admissionControl.listenOnEvents }}
+    admissionControllerFailOnError: {{ ._rox.admissionControl._failOnError }}
     tolerationsConfig:
       disabled: {{ ._rox.collector.disableTaintTolerations }}
     slimCollector: false

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -403,6 +403,10 @@ The following block checks for the validity of the provided init bundle. (`helm 
 {{ include "srox.configureImagePullSecrets" (list $ "mainImagePullSecrets" $._rox.mainImagePullSecrets "secured-cluster-services-main" (list "stackrox") $._rox._namespace) }}
 {{ include "srox.configureImagePullSecrets" (list $ "collectorImagePullSecrets" $._rox.collectorImagePullSecrets "secured-cluster-services-collector" (list "stackrox" "collector-stackrox") $._rox._namespace) }}
 
+{{/* Derive internal representation of specific chart configuration settings. */}}
+
+{{ $_ := set $._rox.admissionControl "_failOnError" (eq $._rox.admissionControl.failurePolicy "Fail") }}
+
 {{ end }}
 
 {{ end }}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -171,6 +171,7 @@ tests:
           listenOnEvents: false
       expect: |
         .validatingwebhookconfigurations[].webhooks[].failurePolicy | assertThat(. == "Ignore")
+        .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.staticConfig | assertThat(.admissionControllerFailOnError == false)
     - name: "override failurePolicy to fail"
       values:
         admissionControl:
@@ -179,6 +180,7 @@ tests:
           failurePolicy: "Fail"
       expect: |
         .validatingwebhookconfigurations[].webhooks[].failurePolicy | assertThat(. == "Fail")
+        .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.staticConfig | assertThat(.admissionControllerFailOnError == true)
 - name: "scanInline defaults to false"
   set:
     admissionControl.dynamic.scanInline: null


### PR DESCRIPTION
## Description

The `failurePolicy` configuration setting of the `secured-cluster-services` Helm chart needs to be propagated to Central.

## User-facing documentation

- [x] CHANGELOG.md updated is not needed.
- [x] documentation changes not needed.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] extended unit tests

### How I validated my change

Just automatic tests so far.
e2e test pending.
