### PR TITLE
chore(queue): add iterator

### DIFF
--- a/central/administration/events/handler/handler.go
+++ b/central/administration/events/handler/handler.go
@@ -51,16 +51,9 @@ func newHandler(ds datastore.DataStore, stream events.Stream) Handler {
 }
 
 func (h *handlerImpl) watchForEvents() {
-	for {
-		select {
-		case <-h.stopSignal.Done():
-			return
-		default:
-			if event := h.stream.Consume(&h.stopSignal); event != nil {
-				if err := h.ds.AddEvent(h.eventWriteCtx, event); err != nil {
-					log.Errorf("failed to store administration event(message: %q): %v", event.GetMessage(), err)
-				}
-			}
+	for event := range h.stream.Consume(&h.stopSignal) {
+		if err := h.ds.AddEvent(h.eventWriteCtx, event); err != nil {
+			log.Errorf("failed to store administration event(message: %q): %v", event.GetMessage(), err)
 		}
 	}
 }

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -481,48 +481,41 @@ func (m *managerImpl) handleReadyScan() {
 	if !features.ComplianceReporting.Enabled() || !features.ScanScheduleReportJobs.Enabled() {
 		return
 	}
-	for {
-		select {
-		case <-m.stopper.Flow().StopRequested():
-			return
-		default:
-			if scanWatcherResult := m.readyQueue.PullBlocking(m.stopper.LowLevel().GetStopRequestSignal()); scanWatcherResult != nil {
-				concurrency.WithLock(&m.watchingScansLock, func() {
-					delete(m.watchingScans, scanWatcherResult.WatcherID)
+	for scanWatcherResult := range m.readyQueue.Seq(m.stopper.LowLevel().GetStopRequestSignal()) {
+		concurrency.WithLock(&m.watchingScansLock, func() {
+			delete(m.watchingScans, scanWatcherResult.WatcherID)
 
-					m.maxScansInParallel.Store(int32(len(m.watchingScans)))
-					timeActive := time.Since(m.watchingScansStartTime[scanWatcherResult.WatcherID])
-					scanWatcherActiveTimeMinutes.WithLabelValues(scanWatcherResult.Scan.GetScanName()).
-						Observe(timeActive.Minutes())
-					delete(m.watchingScansStartTime, scanWatcherResult.WatcherID)
-				})
-				if err := watcher.DeleteOldResults(m.automaticReportingCtx, scanWatcherResult, m.checkResultDataStore); err != nil {
-					log.Errorf("unable to delete old CheckResults: %v", err)
-				}
-				if errors.Is(scanWatcherResult.Error, watcher.ErrScanRemoved) {
-					log.Debugf("Scan %s was removed", scanWatcherResult.Scan.GetScanName())
-					continue
-				}
-				log.Debugf("Scan %s done with %d checks", scanWatcherResult.Scan.GetScanName(), len(scanWatcherResult.CheckResults))
-				w, scanConfig, wasAlreadyRunning, err := m.getOrCreateScanConfigWatcher(scanWatcherResult.SensorCtx, scanWatcherResult, m.scanConfigDataStore, m.scanConfigReadyQueue)
-				if errors.Is(err, watcher.ErrScanAlreadyHandled) {
-					continue
-				}
-				if err != nil {
-					log.Errorf("Unable to create the ScanConfigWatcher: %v", err)
-					continue
-				}
-				if !wasAlreadyRunning {
-					// if there are no notifiers configured we need to still push the results as they might be on-demand request
-					if err := m.createAutomaticSnapshotAndSubscribe(m.automaticReportingCtx, scanConfig, w); err != nil && !errors.Is(err, report.ErrNoNotifiersConfigured) {
-						log.Errorf("Unable to create the snapshot: %v", err)
-						continue
-					}
-				}
-				if err := w.PushScanResults(scanWatcherResult); err != nil {
-					log.Errorf("Unable to push scan %s: %v", scanWatcherResult.Scan.GetScanName(), err)
-				}
+			m.maxScansInParallel.Store(int32(len(m.watchingScans)))
+			timeActive := time.Since(m.watchingScansStartTime[scanWatcherResult.WatcherID])
+			scanWatcherActiveTimeMinutes.WithLabelValues(scanWatcherResult.Scan.GetScanName()).
+				Observe(timeActive.Minutes())
+			delete(m.watchingScansStartTime, scanWatcherResult.WatcherID)
+		})
+		if err := watcher.DeleteOldResults(m.automaticReportingCtx, scanWatcherResult, m.checkResultDataStore); err != nil {
+			log.Errorf("unable to delete old CheckResults: %v", err)
+		}
+		if errors.Is(scanWatcherResult.Error, watcher.ErrScanRemoved) {
+			log.Debugf("Scan %s was removed", scanWatcherResult.Scan.GetScanName())
+			continue
+		}
+		log.Debugf("Scan %s done with %d checks", scanWatcherResult.Scan.GetScanName(), len(scanWatcherResult.CheckResults))
+		w, scanConfig, wasAlreadyRunning, err := m.getOrCreateScanConfigWatcher(scanWatcherResult.SensorCtx, scanWatcherResult, m.scanConfigDataStore, m.scanConfigReadyQueue)
+		if errors.Is(err, watcher.ErrScanAlreadyHandled) {
+			continue
+		}
+		if err != nil {
+			log.Errorf("Unable to create the ScanConfigWatcher: %v", err)
+			continue
+		}
+		if !wasAlreadyRunning {
+			// if there are no notifiers configured we need to still push the results as they might be on-demand request
+			if err := m.createAutomaticSnapshotAndSubscribe(m.automaticReportingCtx, scanConfig, w); err != nil && !errors.Is(err, report.ErrNoNotifiersConfigured) {
+				log.Errorf("Unable to create the snapshot: %v", err)
+				continue
 			}
+		}
+		if err := w.PushScanResults(scanWatcherResult); err != nil {
+			log.Errorf("Unable to push scan %s: %v", scanWatcherResult.Scan.GetScanName(), err)
 		}
 	}
 }
@@ -605,22 +598,15 @@ func (m *managerImpl) handleReadyScanConfig() {
 	if !features.ComplianceReporting.Enabled() || !features.ScanScheduleReportJobs.Enabled() {
 		return
 	}
-	for {
-		select {
-		case <-m.stopper.Flow().StopRequested():
-			return
-		default:
-			if scanConfigWatcherResult := m.scanConfigReadyQueue.PullBlocking(m.stopper.LowLevel().GetStopRequestSignal()); scanConfigWatcherResult != nil {
-				log.Debugf("Scan Config %s done with %d scans and %d reports", scanConfigWatcherResult.ScanConfig.GetScanConfigName(), len(scanConfigWatcherResult.ScanResults), len(scanConfigWatcherResult.ReportSnapshot))
-				concurrency.WithLock(&m.watchingScanConfigsLock, func() {
-					delete(m.watchingScanConfigs, scanConfigWatcherResult.WatcherID)
-				})
-				if err := watcher.DeleteOldResultsFromMissingScans(m.automaticReportingCtx, scanConfigWatcherResult, m.profileDataStore, m.scanDataStore, m.checkResultDataStore); err != nil {
-					log.Errorf("unable to delete old CheckResults: %v", err)
-				}
-				m.generateReportsFromWatcherResults(scanConfigWatcherResult)
-			}
+	for scanConfigWatcherResult := range m.scanConfigReadyQueue.Seq(m.stopper.LowLevel().GetStopRequestSignal()) {
+		log.Debugf("Scan Config %s done with %d scans and %d reports", scanConfigWatcherResult.ScanConfig.GetScanConfigName(), len(scanConfigWatcherResult.ScanResults), len(scanConfigWatcherResult.ReportSnapshot))
+		concurrency.WithLock(&m.watchingScanConfigsLock, func() {
+			delete(m.watchingScanConfigs, scanConfigWatcherResult.WatcherID)
+		})
+		if err := watcher.DeleteOldResultsFromMissingScans(m.automaticReportingCtx, scanConfigWatcherResult, m.profileDataStore, m.scanDataStore, m.checkResultDataStore); err != nil {
+			log.Errorf("unable to delete old CheckResults: %v", err)
 		}
+		m.generateReportsFromWatcherResults(scanConfigWatcherResult)
 	}
 }
 

--- a/pkg/administration/events/stream.go
+++ b/pkg/administration/events/stream.go
@@ -6,6 +6,6 @@ import (
 
 // Stream is an interface for the administration events stream.
 type Stream interface {
-	Consume(waitable concurrency.Waitable) *AdministrationEvent
+	Consume(waitable concurrency.Waitable) func(yield func(*AdministrationEvent) bool)
 	Produce(event *AdministrationEvent)
 }

--- a/pkg/administration/events/stream/stream.go
+++ b/pkg/administration/events/stream/stream.go
@@ -47,10 +47,10 @@ type streamImpl struct {
 	queue *queue.Queue[*events.AdministrationEvent]
 }
 
-// Consume returns an event.
-// Note that this is blocking and waits for events to be emitted before returning.
-func (s *streamImpl) Consume(waitable concurrency.Waitable) *events.AdministrationEvent {
-	return s.queue.PullBlocking(waitable)
+// Consume returns an events iterator.
+// Note that this is blocking and waits for all events (or waitable) to be emitted before returning.
+func (s *streamImpl) Consume(waitable concurrency.Waitable) func(yield func(*events.AdministrationEvent) bool) {
+	return s.queue.Seq(waitable)
 }
 
 // Produce adds an event to the stream.

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,4 +39,119 @@ func TestQueue(t *testing.T) {
 	// 5. Empty element should be available to pull
 	q.Push(nil)
 	assert.Nil(t, q.PullBlocking(context.Background()))
+}
+
+func TestQueueSeq(t *testing.T) {
+	t.Run("Basic Iteration", func(t *testing.T) {
+		q := NewQueue[int]()
+
+		q.Push(1)
+		q.Push(2)
+		q.Push(3)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		items := make([]int, 0, 3)
+		for item := range q.Seq(ctx) {
+			items = append(items, item)
+			if len(items) == cap(items) {
+				cancel()
+			}
+		}
+
+		assert.Equal(t, []int{1, 2, 3}, items)
+		assert.Equal(t, 0, q.Len())
+	})
+
+	t.Run("Seq Async Items", func(t *testing.T) {
+		q := NewQueue[int]()
+
+		expectedItems := []int{4, 5, 6}
+		items := make([]int, 0, len(expectedItems))
+		itemsAdded := make(chan struct{})
+		itemsRead := make(chan struct{})
+		ctx := context.Background()
+
+		go func() {
+			for item := range q.Seq(ctx) {
+				items = append(items, item)
+				if len(items) == len(expectedItems) {
+					break
+				}
+			}
+			close(itemsRead)
+		}()
+
+		go func() {
+			for _, item := range expectedItems {
+				q.Push(item)
+			}
+			close(itemsAdded)
+		}()
+
+		<-itemsAdded
+		<-itemsRead
+
+		assert.Equal(t, expectedItems, items)
+	})
+
+	t.Run("Seq Cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		q := NewQueue[int]()
+
+		items := make([]int, 0)
+		for item := range q.Seq(ctx) {
+			items = append(items, item)
+		}
+		assert.Empty(t, items)
+	})
+
+	t.Run("Seq Concurrent Iteration", func(t *testing.T) {
+		q := NewQueue[int]()
+
+		// Add items to the queue
+		numItems := 30
+		results := make(chan int, numItems)
+		expectedItems := make([]int, 0, numItems)
+		for i := 0; i < numItems; i++ {
+			q.Push(i)
+			expectedItems = append(expectedItems, i)
+		}
+
+		// Create multiple goroutines that will iterate over the queue
+		numGoroutines := 3
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			for q.Len() > 0 {
+			}
+			cancel()
+		}()
+
+		wg := sync.WaitGroup{}
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(goroutineID int) {
+				defer wg.Done()
+
+				for item := range q.Seq(ctx) {
+					results <- item
+				}
+			}(i)
+		}
+		wg.Wait()
+		close(results)
+
+		// Collect all items from all goroutines
+		items := make([]int, 0, numItems)
+		for item := range results {
+			items = append(items, item)
+		}
+
+		assert.ElementsMatch(t, expectedItems, items)
+
+	})
 }

--- a/sensor/common/detector/queue/queue.go
+++ b/sensor/common/detector/queue/queue.go
@@ -10,6 +10,7 @@ import (
 // SimpleQueue defines the pkg/queue that holds the items.
 type SimpleQueue[T comparable] interface {
 	Push(T)
+	PullBlocking(concurrency.Waitable) T
 	Seq(waitable concurrency.Waitable) func(yield func(T) bool)
 	Len() int
 }
@@ -61,12 +62,16 @@ func (q *Queue[T]) Push(item T) {
 
 func (q *Queue[T]) run() {
 	defer close(q.outputC)
-	select {
-	case <-q.stopper.Flow().StopRequested():
-		return
-	case <-q.isRunning.Done():
-		for item := range q.queue.Seq(q.stopper.LowLevel().GetStopRequestSignal()) {
-			q.outputC <- item
+	for {
+		select {
+		case <-q.stopper.Flow().StopRequested():
+			return
+		case <-q.isRunning.Done():
+			select {
+			case <-q.stopper.Flow().StopRequested():
+				return
+			case q.outputC <- q.queue.PullBlocking(q.stopper.LowLevel().GetStopRequestSignal()):
+			}
 		}
 	}
 }

--- a/sensor/common/detector/queue/queue_test.go
+++ b/sensor/common/detector/queue/queue_test.go
@@ -26,10 +26,12 @@ func (s *queueSuite) createAndStartQueue(stopper concurrency.Stopper, size int) 
 func (s *queueSuite) TestPauseAndResume() {
 	s.T().Setenv(features.SensorCapturesIntermediateEvents.EnvVar(), "true")
 	cases := map[string][]func(*Queue[*string], concurrency.Stopper){
-		"Pause":            {s.push, s.pause, s.noPull},
-		"Pause, resume":    {s.push, s.pause, s.push, s.resume, s.pull, s.pull},
-		"Pause, stop":      {s.push, s.pause, s.noPull, s.stopPull},
-		"Block until push": {s.resume, s.pushPullBlocking},
+		"Pause":                              {s.push, s.pause, s.noPull},
+		"Pause, resume":                      {s.push, s.pause, s.push, s.resume, s.pull, s.pull},
+		"Pause, stop":                        {s.push, s.pause, s.noPull, s.stopPull},
+		"2 push, pull, pause, pull":          {s.push, s.push, s.resume, s.pull, s.pause, s.pull, s.stopPull},
+		"2 Push, pull, pause, push, no pull": {s.push, s.push, s.resume, s.pull, s.pause, s.pull, s.push, s.noPull, s.stopPull},
+		"Block until push":                   {s.resume, s.pushPullBlocking},
 	}
 	for name, tc := range cases {
 		s.Run(name, func() {
@@ -76,7 +78,7 @@ func (s *queueSuite) noPull(q *Queue[*string], stopper concurrency.Stopper) {
 	case <-time.After(500 * time.Millisecond):
 		return
 	case item := <-ch:
-		s.Fail("should not pull from the queue, but %s was pulled", item)
+		s.Failf("should not pull from the queue", "%s was pulled", *item)
 	}
 }
 

--- a/sensor/common/detector/queue/queue_test.go
+++ b/sensor/common/detector/queue/queue_test.go
@@ -29,8 +29,8 @@ func (s *queueSuite) TestPauseAndResume() {
 		"Pause":                              {s.push, s.pause, s.noPull},
 		"Pause, resume":                      {s.push, s.pause, s.push, s.resume, s.pull, s.pull},
 		"Pause, stop":                        {s.push, s.pause, s.noPull, s.stopPull},
-		"2 push, pull, pause, pull":          {s.push, s.push, s.resume, s.pull, s.pause, s.pull, s.stopPull},
-		"2 Push, pull, pause, push, no pull": {s.push, s.push, s.resume, s.pull, s.pause, s.pull, s.push, s.noPull, s.stopPull},
+		"2 push, pull, pause, pull":          {s.push, s.push, s.resume, s.pull, s.wait, s.pause, s.pull, s.stopPull},
+		"2 Push, pull, pause, push, no pull": {s.push, s.push, s.resume, s.pull, s.wait, s.pause, s.pull, s.push, s.noPull, s.stopPull},
 		"Block until push":                   {s.resume, s.pushPullBlocking},
 	}
 	for name, tc := range cases {
@@ -51,6 +51,10 @@ func (s *queueSuite) TestPauseAndResume() {
 			}
 		})
 	}
+}
+
+func (s *queueSuite) wait(_ *Queue[*string], _ concurrency.Stopper) {
+	time.Sleep(time.Millisecond)
 }
 
 func (s *queueSuite) push(q *Queue[*string], _ concurrency.Stopper) {


### PR DESCRIPTION
This PR adds iterator to queue and uses it instead `PullBlocking` in `for` loops. This change should make code easier to follow.