### PR TITLE
ROX-30130: Update classic form to PatternFly for Cluster config

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/Clusters.selectors.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.selectors.js
@@ -1,5 +1,7 @@
 import scopeSelectors from '../../helpers/scopeSelectors';
 
+const clusterPageSelector = `#main-page-container:has('a.pf-v5-c-breadcrumb__link:contains("Clusters")')`;
+
 export const selectors = {
     clusters: {
         // Ignore the first checkbox column and last delete column.
@@ -8,7 +10,7 @@ export const selectors = {
     clusterForm: scopeSelectors('[data-testid="cluster-form"]', {
         nameInput: 'input[name="name"]',
     }),
-    clusterHealth: scopeSelectors('[data-testid="cluster-page"]', {
+    clusterHealth: scopeSelectors(clusterPageSelector, {
         clusterStatus: '[data-testid="clusterStatus"]',
         sensorStatus: '[data-testid="sensorStatus"]',
         collectorStatus: '[data-testid="collectorStatus"]',

--- a/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 
 import {
     visitClusterByNameWithFixtureMetadataDatetime,
@@ -245,7 +246,10 @@ describe('Clusters Health Status', () => {
                 datetimeISOString
             );
 
-            cy.get(selectors.clusterForm.nameInput).should('have.value', clusterName);
+            const nameInputSelector = hasFeatureFlag('ROX_ADMISSION_CONTROLLER_CONFIG')
+                ? `.pf-v5-c-form__group-label:contains("Cluster name") + .pf-v5-c-form__group-control input`
+                : selectors.clusterForm.nameInput;
+            cy.get(nameInputSelector).should('have.value', clusterName);
 
             // Cluster Status
             cy.get(selectors.clusterHealth.clusterStatus).should('have.text', clusterStatus);

--- a/ui/apps/platform/cypress/integration/clusters/clustersManager.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersManager.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
 
 import { visitClusterByNameWithFixture, visitClustersWithFixture } from './Clusters.helpers';
 
@@ -23,8 +24,14 @@ describe('Cluster managedBy', () => {
     });
 });
 
-describe('Cluster configuration', () => {
+describe('Cluster configuration classic', () => {
     withAuth();
+
+    before(function () {
+        if (hasFeatureFlag('ROX_ADMISSION_CONTROLLER_CONFIG')) {
+            this.skip(); // TODO write corresponding tests for PatternFly forms
+        }
+    });
 
     const fixturePath = 'clusters/health.json';
 

--- a/ui/apps/platform/cypress/integration/clusters/clustersManager.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersManager.test.js
@@ -24,7 +24,7 @@ describe('Cluster managedBy', () => {
     });
 });
 
-describe('Cluster configuration classic', () => {
+describe('Cluster configuration legacy', () => {
     withAuth();
 
     before(function () {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterEditFormLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterEditFormLegacy.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import type { ReactElement } from 'react';
+import { Alert, Flex, FlexItem } from '@patternfly/react-core';
+
+import { labelClassName } from 'constants/form.constants';
+import type { Cluster, ClusterManagerType } from 'types/cluster.proto';
+import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
+
+import ClusterSummaryLegacy from './Components/ClusterSummaryLegacy';
+import StaticConfigurationSectionLegacy from './StaticConfigurationSectionLegacy';
+import DynamicConfigurationSectionLegacy from './DynamicConfigurationSectionLegacy';
+import ClusterLabelsTable from './ClusterLabelsTable';
+
+type ClusterEditFormLegacyProps = {
+    centralVersion: string;
+    clusterRetentionInfo: DecommissionedClusterRetentionInfo;
+    selectedCluster: Cluster;
+    managerType: ClusterManagerType;
+    handleChange: (any) => void;
+    handleChangeLabels: (labels) => void;
+};
+
+function ClusterEditFormLegacy({
+    centralVersion,
+    clusterRetentionInfo,
+    selectedCluster,
+    managerType,
+    handleChange,
+    handleChangeLabels,
+}: ClusterEditFormLegacyProps): ReactElement {
+    const isManagerTypeNonConfigurable =
+        managerType === 'MANAGER_TYPE_KUBERNETES_OPERATOR' ||
+        managerType === 'MANAGER_TYPE_HELM_CHART';
+    return (
+        <div className="bg-base-200 px-4 w-full">
+            {/* @TODO, replace open prop with dynamic logic, based on clusterType */}
+            {selectedCluster.id && selectedCluster.healthStatus ? (
+                <ClusterSummaryLegacy
+                    healthStatus={selectedCluster.healthStatus}
+                    status={selectedCluster.status}
+                    centralVersion={centralVersion}
+                    clusterId={selectedCluster.id}
+                    autoRefreshEnabled={selectedCluster.sensorCapabilities?.includes(
+                        'SecuredClusterCertificatesRefresh'
+                    )}
+                    clusterRetentionInfo={clusterRetentionInfo}
+                    isManagerTypeNonConfigurable={isManagerTypeNonConfigurable}
+                />
+            ) : (
+                <Alert variant="warning" isInline title="Legacy installation method" component="p">
+                    <Flex direction={{ default: 'column' }}>
+                        <FlexItem>
+                            <p>
+                                To avoid extra operational complexity, use a{' '}
+                                <strong>cluster init bundle</strong> with either of the following
+                                installation methods:
+                            </p>
+                            <p>
+                                <strong>Operator</strong> for Red Hat OpenShift
+                            </p>
+                            <p>
+                                <strong>Helm chart</strong> for other platforms
+                            </p>
+                        </FlexItem>
+                        <FlexItem>
+                            <p>
+                                Only use the legacy installation method if you have a specific
+                                installation need that requires using this method.
+                            </p>
+                        </FlexItem>
+                    </Flex>
+                </Alert>
+            )}
+            <form
+                className="grid grid-columns-1 md:grid-columns-2 grid-gap-4 xl:grid-gap-6 mb-4 w-full"
+                data-testid="cluster-form"
+            >
+                <StaticConfigurationSectionLegacy
+                    isManagerTypeNonConfigurable={isManagerTypeNonConfigurable}
+                    handleChange={handleChange}
+                    selectedCluster={selectedCluster}
+                />
+                <div>
+                    <DynamicConfigurationSectionLegacy
+                        dynamicConfig={selectedCluster.dynamicConfig}
+                        helmConfig={selectedCluster.helmConfig}
+                        handleChange={handleChange}
+                        clusterType={selectedCluster.type}
+                        isManagerTypeNonConfigurable={isManagerTypeNonConfigurable}
+                    />
+                    <div className="pt-4">
+                        <label htmlFor="labels" className={labelClassName}>
+                            Cluster labels
+                        </label>
+                        <ClusterLabelsTable
+                            labels={selectedCluster?.labels ?? {}}
+                            handleChangeLabels={handleChangeLabels}
+                            hasAction
+                        />
+                    </div>
+                </div>
+            </form>
+        </div>
+    );
+}
+
+export default ClusterEditFormLegacy;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -1,12 +1,26 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { Alert, Button, Flex, FlexItem } from '@patternfly/react-core';
+import {
+    Alert,
+    Breadcrumb,
+    BreadcrumbItem,
+    Bullseye,
+    Button,
+    Divider,
+    Flex,
+    FlexItem,
+    PageSection,
+    Spinner,
+    Title,
+} from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import set from 'lodash/set';
 
-import PageHeader from 'Components/PageHeader';
-import { PanelNew, PanelBody, PanelHeadEnd } from 'Components/Panel';
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
+import useAnalytics, { CLUSTER_CREATED } from 'hooks/useAnalytics';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
 import usePermissions from 'hooks/usePermissions';
@@ -19,10 +33,10 @@ import {
 import { Cluster, ClusterManagerType } from 'types/cluster.proto';
 import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import useAnalytics, { CLUSTER_CREATED } from 'hooks/useAnalytics';
 import { clustersBasePath } from 'routePaths';
 
-import ClusterEditForm from './ClusterEditForm';
+import ClusterSummaryLabelsConfiguration from './ClusterSummaryLabelsConfiguration';
+import ClusterEditFormLegacy from './ClusterEditFormLegacy';
 import ClusterDeployment from './ClusterDeployment';
 import DownloadHelmValues from './DownloadHelmValues';
 import { clusterDetailPollingInterval, newClusterDefault } from './cluster.helpers';
@@ -62,6 +76,10 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
     const navigate = useNavigate();
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isAdmissionControllerConfigEnabled = !isFeatureFlagEnabled(
+        'ROX_ADMISSION_CONTROLLER_CONFIG'
+    );
 
     const metadata = useMetadata();
     const { analyticsTrack } = useAnalytics();
@@ -109,7 +127,7 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
                     }
                 })
                 .catch(() => {
-                    // TODO investigate how error affects ClusterEditForm
+                    // TODO investigate how error affects ClusterSummaryLabelsConfiguration
                 })
                 .finally(() => {
                     setLoadingCounter((prev) => prev - 1);
@@ -181,12 +199,39 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
         setPollingCount(pollingCount + 1);
     }, pollingDelay);
 
+    function onChange(path: string, value: boolean | number | string) {
+        // path can be a dot path to property like: tolerationsConfig.disabled
+        setSelectedCluster((oldClusterSettings) => {
+            if (get(oldClusterSettings, path) === undefined) {
+                return oldClusterSettings;
+            }
+
+            const newClusterSettings = cloneDeep(oldClusterSettings);
+            set(newClusterSettings, path, value);
+            return newClusterSettings;
+        });
+    }
+
+    function onChangeAdmissionControllerEnforcementBehavior(value: boolean) {
+        setSelectedCluster((oldClusterSettings) => {
+            const newClusterSettings = cloneDeep(oldClusterSettings);
+            // Special case because one selection for both values, starting in 4.9 release.
+            set(newClusterSettings, 'dynamicConfig.admissionControllerConfig.enabled', value);
+            set(
+                newClusterSettings,
+                'dynamicConfig.admissionControllerConfig.enforceOnUpdates',
+                value
+            );
+            return newClusterSettings;
+        });
+    }
+
     /**
      * @param   {Event}  event  native JS Event object from an onChange event in an input
      *
      * @return  {nothing}       Side effect: change the corresponding property in selectedCluster
      */
-    function onChange(event) {
+    function onChangeLegacy(event) {
         // Functional update computes new state from old state to solve data race:
         // `admissionControllerEvents: false` overwritten by `type: "OPENSHIFT_CLUSTER"`
         // See guardedClusterTypeChange
@@ -269,71 +314,87 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
     // @TODO: improve error handling when adding support for new clusters
     const isForm = wizardStep === 'FORM';
 
-    const panelButtons =
-        !hasWriteAccessForCluster || isBlocked ? (
-            <div />
-        ) : (
-            <Button
-                variant={isForm ? 'secondary' : 'primary'}
-                size="sm"
-                className="pf-v5-u-mr-md"
-                onClick={onNext}
-                disabled={isForm && Object.keys(validate(selectedCluster)).length !== 0}
-            >
-                {isForm ? 'Next' : 'Finish'}
-            </Button>
-        );
-
     return (
-        <section className="flex flex-1 flex-col h-full">
-            <PageHeader header={selectedClusterName} subHeader="Cluster">
-                <PanelHeadEnd>{panelButtons}</PanelHeadEnd>
-            </PageHeader>
-
-            <PanelNew testid="cluster-page">
-                <PanelBody>
-                    {!!messageState && (
-                        <div className="m-4">
-                            <Alert
-                                variant={messageState.variant}
-                                isInline
-                                title={messageState.title}
-                                component="p"
+        <>
+            <PageTitle title="Cluster" />
+            <PageSection variant="light">
+                <Breadcrumb>
+                    <BreadcrumbItemLink to={clustersBasePath}>Clusters</BreadcrumbItemLink>
+                    <BreadcrumbItem isActive>{selectedClusterName}</BreadcrumbItem>
+                </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light">
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+                    <Flex
+                        direction={{ default: 'row' }}
+                        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                    >
+                        <Title headingLevel="h1">{selectedClusterName}</Title>
+                        {hasWriteAccessForCluster && !isBlocked && (
+                            <Button
+                                variant={isForm ? 'secondary' : 'primary'}
+                                onClick={onNext}
+                                disabled={
+                                    isForm && Object.keys(validate(selectedCluster)).length !== 0
+                                }
                             >
-                                {messageState.text}
-                            </Alert>
-                        </div>
+                                {isForm ? 'Next' : 'Finish'}
+                            </Button>
+                        )}
+                    </Flex>
+                    {!!messageState && (
+                        <Alert
+                            variant={messageState.variant}
+                            isInline
+                            title={messageState.title}
+                            component="p"
+                        >
+                            {messageState.text}
+                        </Alert>
                     )}
                     {submissionError && (
-                        <div className="w-full">
-                            <div className="mb-4 mx-4">
-                                <Alert
-                                    type="danger"
-                                    isInline
-                                    title={submissionError.title}
-                                    component="p"
-                                >
-                                    {submissionError.text}
-                                </Alert>
-                            </div>
-                        </div>
+                        <Alert
+                            variant="danger"
+                            isInline
+                            title={submissionError.title}
+                            component="p"
+                        >
+                            {submissionError.text}
+                        </Alert>
                     )}
-                    {!isBlocked && wizardStep === 'FORM' && (
-                        <ClusterEditForm
-                            centralVersion={metadata.version}
-                            clusterRetentionInfo={clusterRetentionInfo}
-                            selectedCluster={selectedCluster}
-                            managerType={managerType(selectedCluster)}
-                            handleChange={onChange}
-                            handleChangeLabels={handleChangeLabels}
-                            isLoading={loadingCounter > 0}
-                        />
-                    )}
+                    {!isBlocked &&
+                        wizardStep === 'FORM' &&
+                        (loadingCounter > 0 ? (
+                            <Bullseye>
+                                <Spinner />
+                            </Bullseye>
+                        ) : isAdmissionControllerConfigEnabled ? (
+                            <ClusterSummaryLabelsConfiguration
+                                centralVersion={metadata.version}
+                                clusterRetentionInfo={clusterRetentionInfo}
+                                selectedCluster={selectedCluster}
+                                managerType={managerType(selectedCluster)}
+                                handleChange={onChange}
+                                handleChangeAdmissionControllerEnforcementBehavior={
+                                    onChangeAdmissionControllerEnforcementBehavior
+                                }
+                                handleChangeLabels={handleChangeLabels}
+                            />
+                        ) : (
+                            <ClusterEditFormLegacy
+                                centralVersion={metadata.version}
+                                clusterRetentionInfo={clusterRetentionInfo}
+                                selectedCluster={selectedCluster}
+                                managerType={managerType(selectedCluster)}
+                                handleChange={onChangeLegacy}
+                                handleChangeLabels={handleChangeLabels}
+                            />
+                        ))}
                     {!isBlocked && wizardStep === 'DEPLOYMENT' && (
                         <Flex
                             direction={{ default: 'column', lg: 'row' }}
                             flexWrap={{ default: 'nowrap' }}
-                            className="pf-v5-u-p-md"
                         >
                             <FlexItem flex={{ default: 'flex_1' }}>
                                 <ClusterDeployment
@@ -360,9 +421,9 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
                             )}
                         </Flex>
                     )}
-                </PanelBody>
-            </PanelNew>
-        </section>
+                </Flex>
+            </PageSection>
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -77,7 +77,7 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCluster = hasReadWriteAccess('Cluster');
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isAdmissionControllerConfigEnabled = !isFeatureFlagEnabled(
+    const isAdmissionControllerConfigEnabled = isFeatureFlagEnabled(
         'ROX_ADMISSION_CONTROLLER_CONFIG'
     );
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterStatusGrid.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterStatusGrid.tsx
@@ -16,16 +16,16 @@ type ClusterStatusGridProps = {
 export function ClusterStatusGrid({ healthStatus }: ClusterStatusGridProps) {
     return (
         <Grid hasGutter>
-            <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
+            <GridItem span={12} lg={6} xl={3}>
                 <SensorPanel healthStatus={healthStatus} />
             </GridItem>
-            <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
+            <GridItem span={12} lg={6} xl={3}>
                 <CollectorPanel healthStatus={healthStatus} />
             </GridItem>
-            <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
+            <GridItem span={12} lg={6} xl={3}>
                 <AdmissionControlPanel healthStatus={healthStatus} />
             </GridItem>
-            <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
+            <GridItem span={12} lg={6} xl={3}>
                 <ScannerPanel healthStatus={healthStatus} />
             </GridItem>
         </Grid>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterSummaryLabelsConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterSummaryLabelsConfiguration.tsx
@@ -34,7 +34,7 @@ function ClusterSummaryLabelsConfiguration({
         managerType === 'MANAGER_TYPE_HELM_CHART';
 
     return (
-        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
             {/* @TODO, replace open prop with dynamic logic, based on clusterType */}
             {selectedCluster.id && selectedCluster.healthStatus ? (
                 <ClusterSummaryLegacy

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummaryLegacy.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterSummaryLegacy.jsx
@@ -30,7 +30,7 @@ const tdClass = 'px-0 py-1';
  *
  * Metadata renders a special purpose Widget whose body has built-in p-3 (too bad, so sad)
  */
-const ClusterSummary = ({
+const ClusterSummaryLegacy = ({
     healthStatus,
     status,
     centralVersion,
@@ -139,7 +139,7 @@ const ClusterSummary = ({
     </CollapsibleSection>
 );
 
-ClusterSummary.propTypes = {
+ClusterSummaryLegacy.propTypes = {
     healthStatus: PropTypes.shape({
         collectorHealthInfo: PropTypes.shape({
             version: PropTypes.string,
@@ -188,4 +188,4 @@ ClusterSummary.propTypes = {
     autoRefreshEnabled: PropTypes.bool,
 };
 
-export default ClusterSummary;
+export default ClusterSummaryLegacy;

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmValueWarning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmValueWarning.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement } from 'react';
-
-import { inputTextClassName } from 'constants/form.constants';
+import React from 'react';
+import type { ReactElement } from 'react';
+import { Alert } from '@patternfly/react-core';
 
 export type HelmValueWarningProps = {
     currentValue: unknown;
@@ -34,9 +34,9 @@ function HelmValueWarning({ currentValue, helmValue }: HelmValueWarningProps): R
         }
     }
     return (
-        <div className={`${inputTextClassName} border-warning-300 bg-warning-300`}>
-            Value in current Helm chart is: <code>{normalizedValue}</code>
-        </div>
+        <Alert variant="warning" title="Value in current Helm chart" component="p" isInline>
+            {normalizedValue}
+        </Alert>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import {
+    Alert,
+    Form,
+    FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+    SelectOption,
+    TextInput,
+} from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import SelectSingle from 'Components/SelectSingle';
+import useMetadata from 'hooks/useMetadata';
+import type { ClusterType, CompleteClusterConfig, DynamicClusterConfig } from 'types/cluster.proto';
+import { getVersionedDocs } from 'utils/versioning';
+
+import HelmValueWarning from './Components/HelmValueWarning';
+
+export type DynamicConfigurationFormProps = {
+    clusterType: ClusterType;
+    dynamicConfig: DynamicClusterConfig;
+    handleChange: (path: string, value: boolean | string) => void;
+    handleChangeAdmissionControllerEnforcementBehavior: (value: boolean) => void;
+    helmConfig: CompleteClusterConfig;
+    isManagerTypeNonConfigurable: boolean;
+};
+
+function DynamicConfigurationForm({
+    clusterType,
+    dynamicConfig,
+    handleChange,
+    handleChangeAdmissionControllerEnforcementBehavior,
+    helmConfig,
+    isManagerTypeNonConfigurable,
+}: DynamicConfigurationFormProps) {
+    const { version } = useMetadata();
+
+    const isLoggingSupported = clusterType === 'OPENSHIFT4_CLUSTER';
+
+    // Assumptions:
+    // TextInput element: property path is same as first argument of handleChange.
+    // SelectSingle element: property path is same as value of id prop (which determines argument).
+    // HelmValueWarning precedes FormHelperText element.
+    return (
+        <Form isWidthLimited>
+            <FormGroup label="Custom default image registry">
+                <TextInput
+                    type="text"
+                    value={dynamicConfig.registryOverride}
+                    onChange={(_event, value) =>
+                        handleChange('dynamicConfig.registryOverride', value)
+                    }
+                    isDisabled={isManagerTypeNonConfigurable}
+                />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem>
+                            Set a value if the default registry is not docker.io in this cluster
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+            <FormGroup label="Admission controller enforcement behavior">
+                <SelectSingle
+                    id="dynamicConfig.admissionControllerConfig.enabled"
+                    value={
+                        dynamicConfig.admissionControllerConfig.enabled ||
+                        dynamicConfig.admissionControllerConfig.enforceOnUpdates
+                            ? 'enabled'
+                            : 'disabled'
+                    }
+                    handleSelect={(id, value) =>
+                        handleChangeAdmissionControllerEnforcementBehavior(value === 'enabled')
+                    }
+                    isDisabled={isManagerTypeNonConfigurable}
+                >
+                    <SelectOption value="enabled">Enforce policies</SelectOption>
+                    <SelectOption value="disabled">No enforcement</SelectOption>
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={
+                        dynamicConfig.admissionControllerConfig.enabled ||
+                        dynamicConfig.admissionControllerConfig.enforceOnUpdates
+                    }
+                    helmValue={
+                        helmConfig?.dynamicConfig?.admissionControllerConfig?.enabled ||
+                        helmConfig?.dynamicConfig?.admissionControllerConfig?.enforceOnUpdates
+                    }
+                />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem>
+                            Controls the policy enforcement configuration of the admission
+                            controller. It determines whether the admission controller actively
+                            blocks workloads and operations if they violate policies.
+                        </HelperTextItem>
+                        <HelperTextItem>
+                            For more information, see{' '}
+                            <ExternalLink>
+                                <a
+                                    href={getVersionedDocs(
+                                        version,
+                                        'operating/use-admission-controller-enforcement'
+                                    )}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    RHACS documentation
+                                </a>
+                            </ExternalLink>
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+            <FormGroup label="Admission controller bypass annotation">
+                <SelectSingle
+                    id="dynamicConfig.admissionControllerConfig.disableBypass"
+                    value={
+                        dynamicConfig.admissionControllerConfig.disableBypass
+                            ? 'disabled'
+                            : 'enabled'
+                    }
+                    handleSelect={(id, value) => handleChange(id, value === 'disabled')}
+                    isDisabled={isManagerTypeNonConfigurable}
+                >
+                    <SelectOption value="enabled">Enabled</SelectOption>
+                    <SelectOption value="disabled">Disabled</SelectOption>
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={dynamicConfig.admissionControllerConfig.disableBypass}
+                    helmValue={helmConfig?.dynamicConfig?.admissionControllerConfig?.disableBypass}
+                />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem>
+                            Allows teams to bypass admission controller in a monitored manner in the
+                            event of an emergency
+                        </HelperTextItem>
+                        <HelperTextItem>
+                            For more information, see{' '}
+                            <ExternalLink>
+                                <a
+                                    href={getVersionedDocs(
+                                        version,
+                                        'operating/use-admission-controller-enforcement'
+                                    )}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    RHACS documentation
+                                </a>
+                            </ExternalLink>
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+            <FormGroup label="Cluster audit logging">
+                <SelectSingle
+                    id="tolerationsConfig.disabled"
+                    value={dynamicConfig.disableAuditLogs ? 'disabled' : 'enabled'}
+                    handleSelect={(id, value) => handleChange(id, value === 'disabled')}
+                    isDisabled={isManagerTypeNonConfigurable || !isLoggingSupported}
+                >
+                    <SelectOption value="enabled">Enabled</SelectOption>
+                    <SelectOption value="disabled">Disabled</SelectOption>
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={dynamicConfig.disableAuditLogs}
+                    helmValue={helmConfig?.dynamicConfig?.disableAuditLogs}
+                />
+                {!isLoggingSupported && (
+                    <Alert
+                        variant="warning"
+                        title="Kubernetes and Openshift compatibility"
+                        component="p"
+                        isInline
+                    >
+                        This setting will not work for Kubernetes or OpenShift 3.x. To enable
+                        logging, you must upgrade your cluster to OpenShift 4 or higher.
+                    </Alert>
+                )}
+            </FormGroup>
+        </Form>
+    );
+}
+
+export default DynamicConfigurationForm;

--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationSectionLegacy.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationSectionLegacy.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Alert } from '@patternfly/react-core';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import ToggleSwitch from 'Components/ToggleSwitch';
@@ -16,7 +15,7 @@ import {
 import { clusterTypes } from './cluster.helpers';
 import HelmValueWarning from './Components/HelmValueWarning';
 
-const DynamicConfigurationSection = ({
+const DynamicConfigurationSectionLegacy = ({
     handleChange,
     dynamicConfig,
     helmConfig,
@@ -187,17 +186,6 @@ const DynamicConfigurationSection = ({
                             flipped
                         />
                     </div>
-                    {!isLoggingSupported && (
-                        <Alert
-                            variant="warning"
-                            isInline
-                            title="Kubernetes and Openshift compatibility"
-                            component="p"
-                        >
-                            This setting will not work for Kubernetes or OpenShift 3.x. To enable
-                            logging, you must upgrade your cluster to OpenShift 4 or higher.
-                        </Alert>
-                    )}
                     <HelmValueWarning
                         currentValue={dynamicConfig.disableAuditLogs}
                         helmValue={helmConfig?.dynamicConfig?.disableAuditLogs}
@@ -208,4 +196,4 @@ const DynamicConfigurationSection = ({
     );
 };
 
-export default DynamicConfigurationSection;
+export default DynamicConfigurationSectionLegacy;

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import {
+    Form,
+    FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+    SelectOption,
+    TextInput,
+} from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import SelectSingle from 'Components/SelectSingle';
+import useMetadata from 'hooks/useMetadata';
+import type { Cluster } from 'types/cluster.proto';
+import { getVersionedDocs } from 'utils/versioning';
+
+import { clusterTypeOptions, runtimeOptions } from './cluster.helpers';
+import HelmValueWarning from './Components/HelmValueWarning';
+
+export type StaticConfigurationFormProps = {
+    selectedCluster: Cluster;
+    isManagerTypeNonConfigurable: boolean;
+    handleChange: (path: string, value: boolean | string) => void;
+};
+
+function StaticConfigurationForm({
+    selectedCluster,
+    isManagerTypeNonConfigurable,
+    handleChange,
+}: StaticConfigurationFormProps) {
+    const { version } = useMetadata();
+
+    const filteredClusterTypeOptions = clusterTypeOptions.filter((option) => {
+        // For (majority) view scenario: display any type.
+        // For (minority) selection scenario: omit obsolete OpenShift 3 option.
+        return isManagerTypeNonConfigurable || option.value !== 'OPENSHIFT_CLUSTER';
+    });
+
+    const filteredRuntimeOptions = runtimeOptions.filter((option) => {
+        // EBPF has been removed for secured clusters >= 4.5, but
+        // needs to be displayed for clusters on older versions.
+        //
+        // If the manager type is configurable (i.e. not helm or operator)
+        // we don't want EBPF as a selectable option, so filter it out,
+        // otherwise include all options so it is displayed correctly.
+        return isManagerTypeNonConfigurable || option.value !== 'EBPF';
+    });
+
+    // Assumptions:
+    // TextInput element: property path is same as first argument of handleChange.
+    // SelectSingle element: property path is same as value of id prop (which determines argument).
+    // HelmValueWarning precedes FormHelperText element.
+    return (
+        <Form isWidthLimited>
+            <FormGroup label="Cluster name" isRequired>
+                <TextInput
+                    type="text"
+                    value={selectedCluster.name}
+                    onChange={(_event, value) => handleChange('name', value)}
+                    isDisabled={Boolean(selectedCluster.id)}
+                    isRequired
+                />
+            </FormGroup>
+            <FormGroup label="Cluster type" isRequired>
+                <SelectSingle
+                    id="type"
+                    value={selectedCluster.type}
+                    handleSelect={handleChange}
+                    isDisabled={isManagerTypeNonConfigurable}
+                >
+                    {filteredClusterTypeOptions.map(({ label, value }) => (
+                        <SelectOption key={value} value={value}>
+                            {label}
+                        </SelectOption>
+                    ))}
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={selectedCluster.type}
+                    helmValue={selectedCluster?.helmConfig?.staticConfig?.type}
+                />
+            </FormGroup>
+            <FormGroup label="Main image repository" isRequired>
+                <TextInput
+                    type="text"
+                    value={selectedCluster.mainImage}
+                    onChange={(_event, value) => handleChange('mainImage', value)}
+                    isDisabled={isManagerTypeNonConfigurable}
+                    isRequired
+                />
+                <HelmValueWarning
+                    currentValue={selectedCluster.mainImage}
+                    helmValue={selectedCluster?.helmConfig?.staticConfig?.mainImage}
+                />
+            </FormGroup>
+            <FormGroup label="Central API endpoint (include port)" isRequired>
+                <TextInput
+                    type="text"
+                    value={selectedCluster.centralApiEndpoint}
+                    onChange={(_event, value) => handleChange('centralApiEndpoint', value)}
+                    isDisabled={isManagerTypeNonConfigurable}
+                    isRequired
+                />
+                <HelmValueWarning
+                    currentValue={selectedCluster.centralApiEndpoint}
+                    helmValue={selectedCluster?.helmConfig?.staticConfig?.centralApiEndpoint}
+                />
+            </FormGroup>
+            <FormGroup label="Collection method" isRequired>
+                <SelectSingle
+                    id="collectionMethod"
+                    value={selectedCluster.collectionMethod}
+                    handleSelect={handleChange}
+                    isDisabled={isManagerTypeNonConfigurable}
+                >
+                    {filteredRuntimeOptions.map(({ label, value }) => (
+                        <SelectOption key={value} value={value}>
+                            {label}
+                        </SelectOption>
+                    ))}
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={selectedCluster.collectionMethod}
+                    helmValue={selectedCluster?.helmConfig?.staticConfig?.collectionMethod}
+                />
+            </FormGroup>
+            <FormGroup label="Collector image repository (uses Main image repository by default)">
+                <TextInput
+                    type="text"
+                    value={selectedCluster.collectorImage}
+                    onChange={(_event, value) => handleChange('collectorImage', value)}
+                    isDisabled={isManagerTypeNonConfigurable}
+                />
+                <HelmValueWarning
+                    currentValue={selectedCluster.collectorImage}
+                    helmValue={selectedCluster?.helmConfig?.staticConfig?.collectorImage}
+                />
+            </FormGroup>
+            <FormGroup label="Admission controller failure policy" isRequired>
+                <SelectSingle
+                    id="admissionControllerFailOnError"
+                    value={
+                        selectedCluster.admissionControllerFailOnError ? 'failClosed' : 'failOpen'
+                    }
+                    handleSelect={(id, value) => handleChange(id, value === 'failClosed')}
+                    isDisabled={isManagerTypeNonConfigurable}
+                >
+                    <SelectOption value="failOpen">Fail open</SelectOption>
+                    <SelectOption value="failClosed">Fail closed</SelectOption>
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={selectedCluster.admissionControllerFailOnError}
+                    helmValue={
+                        selectedCluster?.helmConfig?.staticConfig?.admissionControllerFailOnError
+                    }
+                />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem>
+                            Defines how the admission controller reacts when an error or timeout
+                            prevents policy evaluation.
+                        </HelperTextItem>
+                        <HelperTextItem>
+                            For more information, see{' '}
+                            <ExternalLink>
+                                <a
+                                    href={getVersionedDocs(
+                                        version,
+                                        'operating/use-admission-controller-enforcement'
+                                    )}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    RHACS documentation
+                                </a>
+                            </ExternalLink>
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+            <FormGroup label="Taint tolerations" isRequired>
+                <SelectSingle
+                    id="tolerationsConfig.disabled"
+                    value={selectedCluster.tolerationsConfig?.disabled ? 'disabled' : 'enabled'}
+                    handleSelect={(id, value) => handleChange(id, value === 'disabled')}
+                    isDisabled={isManagerTypeNonConfigurable}
+                >
+                    <SelectOption value="enabled">Enabled</SelectOption>
+                    <SelectOption value="eisabled">Disabled</SelectOption>
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={selectedCluster?.tolerationsConfig?.disabled}
+                    helmValue={
+                        selectedCluster?.helmConfig?.staticConfig?.tolerationsConfig?.disabled
+                    }
+                />
+                <FormHelperText>
+                    <HelperText>
+                        <HelperTextItem>
+                            Tolerate all taints to run on all nodes of this cluster
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+        </Form>
+    );
+}
+
+export default StaticConfigurationForm;

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSectionLegacy.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationSectionLegacy.jsx
@@ -38,7 +38,7 @@ function getSelectComparison(options, key, selectedCluster, handleChange) {
     };
 }
 
-const StaticConfigurationSection = ({
+const StaticConfigurationSectionLegacy = ({
     selectedCluster,
     isManagerTypeNonConfigurable,
     handleChange,
@@ -314,4 +314,4 @@ const StaticConfigurationSection = ({
     );
 };
 
-export default StaticConfigurationSection;
+export default StaticConfigurationSectionLegacy;

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -80,8 +80,9 @@ export const newClusterDefault = {
     collectionMethod: defaultCollectionMethod,
     DEPRECATEDProviderMetadata: null,
     admissionControllerEvents: true,
-    admissionController: false,
-    admissionControllerUpdates: false,
+    admissionController: true, // default changed in 4.9
+    admissionControllerUpdates: true, // default changed in 4.9
+    admissionControlFailOnError: false, // property added in 4.9 false means Fail open
     DEPRECATEDOrchestratorMetadata: null,
     status: undefined,
     tolerationsConfig: {
@@ -89,10 +90,10 @@ export const newClusterDefault = {
     },
     dynamicConfig: {
         admissionControllerConfig: {
-            enabled: false,
-            enforceOnUpdates: false,
-            timeoutSeconds: 3,
-            scanInline: false,
+            enabled: true, // default changed in 4.9
+            enforceOnUpdates: true, // default changed in 4.9
+            timeoutSeconds: 0, // default changed in 4.9
+            scanInline: true, // default changed in 4.9
             disableBypass: false,
         },
         registryOverride: '',

--- a/ui/apps/platform/src/types/cluster.proto.ts
+++ b/ui/apps/platform/src/types/cluster.proto.ts
@@ -74,6 +74,7 @@ export type StaticClusterConfig = {
     tolerationsConfig: TolerationsConfig;
     slimCollector: boolean;
     admissionControllerEvents: boolean;
+    admissionControllerFailOnError: boolean;
 };
 
 export type DynamicClusterConfig = {
@@ -137,6 +138,7 @@ export type Cluster = {
 
     initBundleId: string;
     managedBy: ClusterManagerType;
+    admissionControllerFailOnError: boolean; // false means Fail open and true means Fail closed
 };
 
 export type ClusterManagerType =


### PR DESCRIPTION
## Description

Dear reviewer:
* Hide space because some files have indentation changes.
* You have my apology in advance that it is hard to compare the 4 pairs of corresponding files.

### Objective

Align admission controller options in UI with changes for 4.9 release:
* Helm charts
* Operator
* `roxctl`

For almost all customers, **UI is view only** because they configure in the above places.

Admission controller configuration:
* Delete obsolete options
* Replace existing options
* Add new option

### Overview

1. Move **Cluster labels** preceding configuration forms.

    Potential future improvement might provide a separate button for changes to cluster labels, especially if they affect Central but not Sensor.

2. Convert static and dynamic configuration from classic to PatternFly forms.

3. Delete obsolete options.

    Static configuration:
    * Enable Admission Controller Webhook to listen on exec and port-forward events
    * Configure Admission Controller Webhook to listen on Object Creates
    * Configure Admission Controller Webhook to listen on Object Updates

    Dynamic configuraiton:
    * Enforce on Object Creates (superseded by Enforcement behavior)
    * Enforce on Object Updates (ditto)
    * Timeout (seconds)
    * Contact Image Scanners
    * Disable Use of Bypass Annotation (superseded by Bypass annotations)

4. Replace existing options.

    Dynamic configuration
    * Admission controller enforcement behavior

5. Add new option.

    Static configuration
    * Admission controller failure policy

6. Add links to **Using admission controller enforcement** in product docs.

7. Update property values in `newClusterDefault` object.

8. Minimally update integration tests:
    * Add conditional selector in clusterHealthStatus.test.js file.
    * Skip a test in clustersManager.test.js file pending corresponding test for PatternFly form fields.

### Residue

1. Display warning `Alert` element with link to (in progress) solutions article, if actual values are not same as default values.

2. Replace classic `ClusterSummaryLegacy` with `ClusterSummary` that includes:

    * **Cluster metadata**
    * `ClusterStatusGrid` element
    * `SensorUpgradePanel` element
    * **Credential expiration**
    * **Cluster deletion**

3. Update integration tests:
    * Delete commented out test for classic cluster creation.
    * Delete any obsolete selectors.
    * Optionally add fixtures and integration tests with more emphasis on view scenarios for realistic installation methods:
        * Helm chart
        * Operator

### Changes

1. Follow example from **Brad** on clusters table page:

    * Rename classic `Whatever` component as `WhateverLegacy` to delete after release.

        * `ClusterEditFormLegacy`
        * `ClusterSummaryLegacy`
        * `DynamicConfigurationSectionLegacy`
        * `StaticConfigurationSectionLegacy`

    * Add renamed `Whatever` component to survive after release.

        * `ClusterSummaryLabelsConfiguration`
            In theory, eventually, if `ClusterPage` replaced pseudo-form **Next** and **Finish** steps with buttons, it might be clearer to eliminate this middle layer component.
        * `ClusterSummary`
            See **Residue** item 2.
        * `DynamicConfigurationForm`
        * `StaticConfigurationForm`

2. Edit ClusterPage.tsx file.

    * Rename `onChange` as `onChangeLegacy` function.
    * Add `onChange` function that replaces `event` with `path` and `value` to uncouple form elements from form state.
    * Add `onChangeAdmissionControllerEnforcementBehavior` function because one selection for both values.
    * Replace Tailwind classes with PatternFly elements for flex layout.
        Thank you, **Brad** for page heading pattern in **OpenShift Compliance Schedule** page.

3. Edit ClusterStatusLabelsConfiguration.tsx file.

    * Replace Tailwind classes with PatternFly elements for flex layout.
    * Organize 3 sections with `Title` elements.

4. Edit DynamicConfigurationForm.tsx and StaticConfigurationForm files.

    * Replace Tailwind classes with PatternFly elements for flex layout.
    * Replace classic `CollapsibleSection` with PatternFly `Form` element.
    * Carefully distinguish disable/enable or enable/disable depending on the property.

2. Replace classic `ToggleSwitch` with PatternFly `Select` element.

    That is, instead of with PatternFly `Radio` elements.
    Design decision to follow precedents elsewhere in OpenShift.

    Thank you, **Saif** for providing pattern that leans toward PatternFly 6.

3. Delete conditional `Alert` elements for OpenShift 3.
    However, preserve conditional behavior, just in case.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] edited e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo central.

#### Manual testing

Non-PatternFly pictures from staging demo Central and UI from master with feature flag disabled.
PatternFly pictures from staging demo Central and UI with from branch feature flag enabled.

1. Visit /main/clusters, click a cluster name to visit cluster page

    Upper edge of page before changes (classic)
    <img width="1440" height="200" alt="Upper_classic" src="https://github.com/user-attachments/assets/9aa1ddbd-4c8c-4dba-941f-33970a4535fd" />

    Upper edge of page after changes (PatternFly)
    <img width="1440" height="250" alt="Upper_PatternFly" src="https://github.com/user-attachments/assets/8849e2b4-b838-4b89-bb00-79633f657ae0" />

2. Scroll down in **staging-secured-cluster** for which enforcement is **No enforcement**

     Configuration forms before changes (classic)

     * At left: **Static Configuration**
     * At right: **Dynamic Configuration** followed by **Cluster labels**
    <img width="1440" height="898" alt="Secured_configurations_classic" src="https://github.com/user-attachments/assets/4ac387d9-859e-4422-8da8-a634a6d70b5d" />

     Labels and configuration forms after changes (PatternFly)

     **Cluster labels**
    <img width="1440" height="160" alt="Secured_Cluster_labels_PatternFly" src="https://github.com/user-attachments/assets/c3806e07-73fc-4953-9bde-ddb10d1ebda9" />

     **Static configuration**
    <img width="1440" height="898" alt="Secured_Static_configuraton_PatternFly" src="https://github.com/user-attachments/assets/f006cc6b-3999-4802-9b50-8fbc08f28643" />

     **Dynamic configuration** with `spaceItemsMd` in first draft
    <img width="1440" height="898" alt="Secured_Dynamic_configuration_PatternFly" src="https://github.com/user-attachments/assets/2d534e90-5156-43dc-8ee2-d3e45ddd72c3" />

     **Dynamic configuration** with `spaceItemsLg` after requested change from **Saif** with thanks!
<img width="1440" height="898" alt="spaceItemsLg" src="https://github.com/user-attachments/assets/fac6a22b-c857-45f6-914d-b8de0e4de5e7" />

    Temporarily edit code to display `HelmValueWarning` elements with PatternFly `Alert` elements
    <img width="1440" height="898" alt="Secured_HelmWarning_PatternFly" src="https://github.com/user-attachments/assets/929e3855-8db9-47e5-b9a8-fcd0d9c15366" />

3. Scroll down in **staging-central-cluster** for which enforcement is **Enforce policies**

     Configuration forms before changes (classic)

     * At left: **Static Configuration**
     * At right: **Dynamic Configuration** followed by **Cluster labels**
    <img width="1440" height="898" alt="Central_configurations_classic" src="https://github.com/user-attachments/assets/68b4cfe9-5f20-4bb8-8030-79ed129eaaae" />

     Labels and configuration forms after changes (PatternFly)

     **Dynamic configuration**
    <img width="1440" height="898" alt="Central_Dynamic_configuration_PatternFly" src="https://github.com/user-attachments/assets/18dcacde-fa0a-49fb-95ff-6e6ee68a1fdc" />

4. Go back to clusters page, click **Secure a cluster**, click **Legacy installation method**, enter **Cluster name**, click **Next**, and then click **Download YAML file and keys**
    <img width="1440" height="898" alt="New_PatternFly" src="https://github.com/user-attachments/assets/6eb035e8-d0be-42f0-bdb4-2ece03806a85" />

    * See `timeoutSeconds: 0` in payload of POST /v1/clusters request.
    * See `timeout: 10` in downloaded helm-config.yaml file.