### PR TITLE
fix: Use mergo transformer for pointer leaf types

### DIFF
--- a/operator/api/v1alpha1/central_defaults.go
+++ b/operator/api/v1alpha1/central_defaults.go
@@ -71,7 +71,7 @@ func MergeCentralDefaultsIntoSpec(central *Central) error {
 			scannerV4.ScannerComponent = nil
 		}
 	}
-	if err := mergo.Merge(&central.Spec, central.Defaults); err != nil {
+	if err := mergo.Merge(&central.Spec, central.Defaults, mergo.WithoutDereference); err != nil {
 		return errors.Wrap(err, "merging Central Defaults into Spec")
 	}
 	return nil

--- a/operator/api/v1alpha1/central_defaults.go
+++ b/operator/api/v1alpha1/central_defaults.go
@@ -67,7 +67,7 @@ func MergeCentralDefaultsIntoSpec(central *Central) error {
 	// Necessary for the below merging to be effectful in the sense that spec paths in the custom resource
 	// with explicit "Default" values are actually filled in with our runtime defaults.
 	if scannerV4 := central.Spec.ScannerV4; scannerV4 != nil {
-		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == "Default" {
+		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == ScannerV4ComponentDefault {
 			scannerV4.ScannerComponent = nil
 		}
 	}

--- a/operator/api/v1alpha1/central_defaults.go
+++ b/operator/api/v1alpha1/central_defaults.go
@@ -71,7 +71,7 @@ func MergeCentralDefaultsIntoSpec(central *Central) error {
 			scannerV4.ScannerComponent = nil
 		}
 	}
-	if err := mergo.Merge(&central.Spec, central.Defaults, mergo.WithoutDereference); err != nil {
+	if err := mergo.Merge(&central.Spec, central.Defaults, mergo.WithTransformers(nonDereferencingLeafTransformer{})); err != nil {
 		return errors.Wrap(err, "merging Central Defaults into Spec")
 	}
 	return nil

--- a/operator/api/v1alpha1/central_defaults_test.go
+++ b/operator/api/v1alpha1/central_defaults_test.go
@@ -126,6 +126,54 @@ func TestMergeCentralDefaultsIntoSpec(t *testing.T) {
 				},
 			},
 		},
+		"defaulting false into empty struct works": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+		},
+		"defaulting true into empty struct works": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/operator/api/v1alpha1/central_defaults_test.go
+++ b/operator/api/v1alpha1/central_defaults_test.go
@@ -1,0 +1,137 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestMergeCentralDefaultsIntoSpec(t *testing.T) {
+	tests := map[string]struct {
+		before *Central
+		after  *Central
+	}{
+		"empty": {
+			before: &Central{},
+			after:  &Central{},
+		},
+		"untouched": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
+		"explicit true wins": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+		},
+		"explicit false wins": {
+			before: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
+		"defaulting true works": {
+			before: &Central{
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(true),
+					},
+				},
+			},
+		},
+		"defaulting false works": {
+			before: &Central{
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+			after: &Central{
+				Spec: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+				Defaults: CentralSpec{
+					Misc: &MiscSpec{
+						CreateSCCs: ptr.To(false),
+					},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			central := tt.before.DeepCopy()
+			require.NoError(t, MergeCentralDefaultsIntoSpec(central))
+			require.Equal(t, tt.after, central)
+		})
+	}
+}

--- a/operator/api/v1alpha1/defaults_merging.go
+++ b/operator/api/v1alpha1/defaults_merging.go
@@ -1,0 +1,29 @@
+package v1alpha1
+
+import (
+	"reflect"
+)
+
+type nonDereferencingLeafTransformer struct{}
+
+func (t nonDereferencingLeafTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	// Only handle pointer types
+	if typ.Kind() == reflect.Ptr {
+		elem := typ.Elem()
+
+		// If pointer to struct: return no transformer function so that mergo continues traversing.
+		// Retain mergo's merging behaviour for maps and slices.
+		if elem.Kind() == reflect.Struct || elem.Kind() == reflect.Map || elem.Kind() == reflect.Slice {
+			return nil
+		}
+
+		// Use custom transformer function for other (leaf) types.
+		return func(dst, src reflect.Value) error {
+			if dst.IsNil() && !src.IsNil() {
+				dst.Set(src)
+			}
+			return nil
+		}
+	}
+	return nil
+}

--- a/operator/api/v1alpha1/securedcluster_defaults.go
+++ b/operator/api/v1alpha1/securedcluster_defaults.go
@@ -71,7 +71,7 @@ func MergeSecuredClusterDefaultsIntoSpec(securedCluster *SecuredCluster) error {
 			scannerV4.ScannerComponent = nil
 		}
 	}
-	if err := mergo.Merge(&securedCluster.Spec, securedCluster.Defaults, mergo.WithoutDereference); err != nil {
+	if err := mergo.Merge(&securedCluster.Spec, securedCluster.Defaults, mergo.WithTransformers(nonDereferencingLeafTransformer{})); err != nil {
 		return errors.Wrap(err, "merging SecuredCluster Defaults into Spec")
 	}
 	return nil

--- a/operator/api/v1alpha1/securedcluster_defaults.go
+++ b/operator/api/v1alpha1/securedcluster_defaults.go
@@ -67,11 +67,11 @@ func MergeSecuredClusterDefaultsIntoSpec(securedCluster *SecuredCluster) error {
 	// Necessary for the below merging to be effectful in the situation that spec paths in the custom resource
 	// with explicit "Defaults" values are actually filled in with our computed defaults.
 	if scannerV4 := securedCluster.Spec.ScannerV4; scannerV4 != nil {
-		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == "Default" {
+		if scannerComponent := scannerV4.ScannerComponent; scannerComponent != nil && *scannerComponent == LocalScannerV4ComponentDefault {
 			scannerV4.ScannerComponent = nil
 		}
 	}
-	if err := mergo.Merge(&securedCluster.Spec, securedCluster.Defaults); err != nil {
+	if err := mergo.Merge(&securedCluster.Spec, securedCluster.Defaults, mergo.WithoutDereference); err != nil {
 		return errors.Wrap(err, "merging SecuredCluster Defaults into Spec")
 	}
 	return nil


### PR DESCRIPTION
## Description

This is essentially https://github.com/stackrox/stackrox/pull/16450, plus one commit, which replaces the `WithoutDerefence` operation mode of `mergo` with a custom transformer for handling pointer leaf types.

Pro: doesn't require converting sub struct pointers to non-pointer sub structs.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
