### PR TITLE
fix(nil-handling): Handle nil message in the eventHandlers

### DIFF
--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -108,8 +108,7 @@ func (h *resourceEventHandlerImpl) sendResourceEvent(obj, oldObj interface{}, ac
 		kubernetes.TrimAnnotations(metaObj)
 	}
 
-	message := h.dispatcher.ProcessEvent(obj, oldObj, action)
-	if message != nil {
+	if message := h.dispatcher.ProcessEvent(obj, oldObj, action); message != nil {
 		message.Context = h.context
 		h.resolver.Send(message)
 	}

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -109,8 +109,10 @@ func (h *resourceEventHandlerImpl) sendResourceEvent(obj, oldObj interface{}, ac
 	}
 
 	message := h.dispatcher.ProcessEvent(obj, oldObj, action)
-	message.Context = h.context
-	h.resolver.Send(message)
+	if message != nil {
+		message.Context = h.context
+		h.resolver.Send(message)
+	}
 }
 
 func getObjUID(newObj interface{}) types.UID {

--- a/sensor/kubernetes/listener/resource_event_handler_impl_test.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl_test.go
@@ -116,6 +116,14 @@ func (suite *ResourceEventHandlerImplTestSuite) TestIDsAddedToSyncSet() {
 	suite.Empty(handler.missingInitialIDs)
 }
 
+func (suite *ResourceEventHandlerImplTestSuite) TestNilMessageDoesNotPanic() {
+	handler := suite.newHandlerImplWithContext(context.Background())
+	obj := randomID()
+	suite.dispatcher.EXPECT().ProcessEvent(obj, nil, central.ResourceAction_SYNC_RESOURCE).
+		Return(nil)
+	handler.OnAdd(obj, false)
+}
+
 func (suite *ResourceEventHandlerImplTestSuite) TestContextIsPassed() {
 	ctx := context.WithValue(context.Background(), ctxKeyTest, "abc")
 	handler := suite.newHandlerImplWithContext(ctx)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

If the message is `nil` the `eventHandler` will panic [here](https://github.com/stackrox/stackrox/blob/cfa0d8a2f699440efb4e1f389b1e6d418417768c/sensor/kubernetes/listener/resource_event_handler_impl.go#L112). Some dispatchers could send `nil` messages like the [profile dispatcher](https://github.com/stackrox/stackrox/blob/cfa0d8a2f699440efb4e1f389b1e6d418417768c/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go#L32-L41).

The `eventHandler` should handle `nil` messages.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit test added