### PR TITLE
chore: extract global goleak

### DIFF
--- a/pkg/contextutil/contextmerge_test.go
+++ b/pkg/contextutil/contextmerge_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/goleak"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 )
 
 func TestMergeContext(t *testing.T) {
 	t.Run("First context is canceled", func(tt *testing.T) {
-		defer goleak.VerifyNone(tt)
+		goleak.AssertNoGoroutineLeaks(tt)
 		ctx1, cancel := context.WithCancel(context.Background())
 		ctx2 := context.Background()
 		ctx, stopper := MergeContext(ctx1, ctx2)
@@ -32,7 +32,7 @@ func TestMergeContext(t *testing.T) {
 		}
 	})
 	t.Run("Second context is canceled", func(tt *testing.T) {
-		defer goleak.VerifyNone(tt)
+		goleak.AssertNoGoroutineLeaks(tt)
 		ctx1 := context.Background()
 		ctx2, cancel := context.WithCancel(context.Background())
 		ctx, stopper := MergeContext(ctx1, ctx2)
@@ -56,7 +56,7 @@ func TestMergeContext(t *testing.T) {
 		}
 	})
 	t.Run("Both contexts are canceled", func(tt *testing.T) {
-		defer goleak.VerifyNone(tt)
+		goleak.AssertNoGoroutineLeaks(tt)
 		ctx1, cancel1 := context.WithCancel(context.Background())
 		ctx2, cancel2 := context.WithCancel(context.Background())
 		ctx, stopper := MergeContext(ctx1, ctx2)
@@ -75,7 +75,7 @@ func TestMergeContext(t *testing.T) {
 		}
 	})
 	t.Run("Second context is canceled without calling stop should not leak", func(tt *testing.T) {
-		defer goleak.VerifyNone(tt)
+		goleak.AssertNoGoroutineLeaks(tt)
 		ctx1 := context.Background()
 		ctx2, cancel2 := context.WithCancel(context.Background())
 		// For this test we do not call the stop function,

--- a/pkg/testutils/goleak/assert_no_leak.go
+++ b/pkg/testutils/goleak/assert_no_leak.go
@@ -1,0 +1,20 @@
+package goleak
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func AssertNoGoroutineLeaks(t testing.TB) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			// Ignore a known leak: https://github.com/DataDog/dd-trace-go/issues/1469
+			goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
+			// Ignore a known leak caused by importing the GCP cscc SDK.
+			goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+			// Ignore a known leak from https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L77-L80
+			goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),
+		)
+	})
+}

--- a/sensor/common/compliance/auditlog_manager_test.go
+++ b/sensor/common/compliance/auditlog_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -48,7 +49,7 @@ type AuditLogCollectionManagerTestSuite struct {
 }
 
 func (s *AuditLogCollectionManagerTestSuite) TearDownTest() {
-	defer assertNoGoroutineLeaks(s.T())
+	goleak.AssertNoGoroutineLeaks(s.T())
 }
 
 func (s *AuditLogCollectionManagerTestSuite) getFakeServersAndStates() (map[string]sensor.ComplianceService_CommunicateServer, map[string]*storage.AuditLogFileState) {

--- a/sensor/common/compliance/command_handler_test.go
+++ b/sensor/common/compliance/command_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/compliance"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/compliance/mocks"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -43,7 +44,7 @@ func (s *CommandHandlerTestSuite) SetupTest() {
 }
 
 func (s *CommandHandlerTestSuite) TearDownTest() {
-	defer assertNoGoroutineLeaks(s.T())
+	goleak.AssertNoGoroutineLeaks(s.T())
 	_ = s.cHandler.Stopped().Wait()
 }
 

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/compliance/index"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/goleak"
 )
 
 func TestNodeInventoryHandler(t *testing.T) {
@@ -104,17 +104,8 @@ type NodeInventoryHandlerTestSuite struct {
 	suite.Suite
 }
 
-func assertNoGoroutineLeaks(t *testing.T) {
-	goleak.VerifyNone(t,
-		// Ignore a known leak: https://github.com/DataDog/dd-trace-go/issues/1469
-		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
-		// Ignore a known leak caused by importing the GCP cscc SDK.
-		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
-	)
-}
-
 func (s *NodeInventoryHandlerTestSuite) TearDownTest() {
-	assertNoGoroutineLeaks(s.T())
+	goleak.AssertNoGoroutineLeaks(s.T())
 }
 
 func (s *NodeInventoryHandlerTestSuite) TestExtractArch() {

--- a/sensor/common/compliance/service_impl_test.go
+++ b/sensor/common/compliance/service_impl_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	mocksCompliance "github.com/stackrox/rox/sensor/common/compliance/mocks"
@@ -75,7 +76,7 @@ func (s *complianceServiceSuite) TearDownTest() {
 	if s.stopServerFn != nil {
 		s.stopServerFn()
 	}
-	assertNoGoroutineLeaks(s.T())
+	goleak.AssertNoGoroutineLeaks(s.T())
 }
 
 func (s *complianceServiceSuite) TestServiceOfflineMode() {

--- a/sensor/common/deploymentenhancer/component_test.go
+++ b/sensor/common/deploymentenhancer/component_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -12,7 +13,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 )
 
@@ -46,17 +46,8 @@ func (s *ComponentTestSuite) SetupTest() {
 }
 
 func (s *ComponentTestSuite) TearDownTest() {
-	defer assertNoGoroutineLeaks(s.T())
+	goleak.AssertNoGoroutineLeaks(s.T())
 	s.T().Cleanup(s.mockCtrl.Finish)
-}
-
-func assertNoGoroutineLeaks(t *testing.T) {
-	goleak.VerifyNone(t,
-		// Ignore a known leak: https://github.com/DataDog/dd-trace-go/issues/1469
-		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
-		// Ignore a known leak caused by importing the GCP cscc SDK.
-		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
-	)
 }
 
 func (s *ComponentTestSuite) TestComponentLifecycle() {

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stackrox/rox/pkg/sensor/hash"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/sensor/common"
 	configMocks "github.com/stackrox/rox/sensor/common/config/mocks"
 	mocksDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
@@ -22,7 +23,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/store/mocks"
 	debuggerMessage "github.com/stackrox/rox/sensor/debugger/message"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -121,11 +121,7 @@ func (c *centralCommunicationSuite) Test_StartCentralCommunication() {
 }
 
 func (c *centralCommunicationSuite) Test_StopCentralCommunication() {
-	defer goleak.VerifyNone(c.T(),
-		// Ignore a known leak: https://github.com/DataDog/dd-trace-go/issues/1469
-		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
-		goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),
-	)
+	goleak.AssertNoGoroutineLeaks(c.T())
 
 	_, closeFn := c.createCentralCommunication(false)
 	defer closeFn()

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/goleak"
 )
 
 func TestVirtualMachineHandler(t *testing.T) {
@@ -36,16 +36,7 @@ func (s *virtualMachineHandlerSuite) SetupTest() {
 }
 
 func (s *virtualMachineHandlerSuite) TearDownTest() {
-	assertNoGoroutineLeaks(s.T())
-}
-
-func assertNoGoroutineLeaks(t *testing.T) {
-	goleak.VerifyNone(t,
-		// Ignore a known leak: https://github.com/DataDog/dd-trace-go/issues/1469
-		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
-		// Ignore a known leak caused by importing the GCP cscc SDK.
-		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
-	)
+	goleak.AssertNoGoroutineLeaks(s.T())
 }
 
 func (s *virtualMachineHandlerSuite) TestSend() {

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -105,6 +105,9 @@ var (
 		"github.com/golang/protobuf/jsonpb": {
 			replacement: "google.golang.org/protobuf/encoding/protojson",
 		},
+		"go.uber.org/goleak": {
+			replacement: "github.com/stackrox/rox/pkg/testutils/goleak",
+		},
 		"k8s.io/helm/...": {
 			replacement: "package from helm.sh/v3",
 		},


### PR DESCRIPTION
This PR creates a helper to run goleak. It replaces all direct usages of gleak and adds a linter to prevent them in the future.

- https://github.com/stackrox/stackrox/pull/16520