### PR TITLE
ROX-27150: Pull external index reports

### DIFF
--- a/generated/internalapi/scanner/v4/indexer_service.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service.pb.go
@@ -169,10 +169,11 @@ type CreateIndexReportRequest_ContainerImage struct {
 func (*CreateIndexReportRequest_ContainerImage) isCreateIndexReportRequest_ResourceLocator() {}
 
 type GetIndexReportRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	HashId        string                 `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	HashId          string                 `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
+	IncludeExternal bool                   `protobuf:"varint,2,opt,name=includeExternal,proto3" json:"includeExternal,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *GetIndexReportRequest) Reset() {
@@ -210,6 +211,13 @@ func (x *GetIndexReportRequest) GetHashId() string {
 		return x.HashId
 	}
 	return ""
+}
+
+func (x *GetIndexReportRequest) GetIncludeExternal() bool {
+	if x != nil {
+		return x.IncludeExternal
+	}
+	return false
 }
 
 type HasIndexReportRequest struct {
@@ -493,9 +501,10 @@ const file_internalapi_scanner_v4_indexer_service_proto_rawDesc = "" +
 	"\x18CreateIndexReportRequest\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12L\n" +
 	"\x0fcontainer_image\x18\x02 \x01(\v2!.scanner.v4.ContainerImageLocatorH\x00R\x0econtainerImageB\x12\n" +
-	"\x10resource_locator\"0\n" +
+	"\x10resource_locator\"Z\n" +
 	"\x15GetIndexReportRequest\x12\x17\n" +
-	"\ahash_id\x18\x01 \x01(\tR\x06hashId\"0\n" +
+	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12(\n" +
+	"\x0fincludeExternal\x18\x02 \x01(\bR\x0fincludeExternal\"0\n" +
 	"\x15HasIndexReportRequest\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\"0\n" +
 	"\x16HasIndexReportResponse\x12\x16\n" +

--- a/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/indexer_service_vtproto.pb.go
@@ -77,6 +77,7 @@ func (m *GetIndexReportRequest) CloneVT() *GetIndexReportRequest {
 	}
 	r := new(GetIndexReportRequest)
 	r.HashId = m.HashId
+	r.IncludeExternal = m.IncludeExternal
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -280,6 +281,9 @@ func (this *GetIndexReportRequest) EqualVT(that *GetIndexReportRequest) bool {
 		return false
 	}
 	if this.HashId != that.HashId {
+		return false
+	}
+	if this.IncludeExternal != that.IncludeExternal {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -595,6 +599,16 @@ func (m *GetIndexReportRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.IncludeExternal {
+		i--
+		if m.IncludeExternal {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
 	}
 	if len(m.HashId) > 0 {
 		i -= len(m.HashId)
@@ -923,6 +937,9 @@ func (m *GetIndexReportRequest) SizeVT() (n int) {
 	l = len(m.HashId)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.IncludeExternal {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1374,6 +1391,26 @@ func (m *GetIndexReportRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.HashId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeExternal", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeExternal = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2280,6 +2317,26 @@ func (m *GetIndexReportRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.HashId = stringValue
 			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeExternal", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeExternal = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -123,7 +123,7 @@ func (s *scannerv4) GetSBOM(image *storage.Image) ([]byte, bool, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
-	sbom, found, err := s.scannerClient.GetSBOM(ctx, image.GetName().GetFullName(), digest, uri)
+	sbom, found, err := s.scannerClient.GetSBOM(ctx, image.GetName().GetFullName(), digest, uri, client.IncludeExternalIndexReports())
 	return sbom, found, err
 }
 

--- a/proto/internalapi/scanner/v4/indexer_service.proto
+++ b/proto/internalapi/scanner/v4/indexer_service.proto
@@ -28,6 +28,7 @@ message CreateIndexReportRequest {
 
 message GetIndexReportRequest {
   string hash_id = 1;
+  bool includeExternal = 2;
 }
 
 message HasIndexReportRequest {

--- a/scanner/datastore/postgres/external_index_store.go
+++ b/scanner/datastore/postgres/external_index_store.go
@@ -23,6 +23,7 @@ type ExternalIndexStore interface {
 		expiration time.Time,
 		shouldUpdateStoredReportFn func(iv string) bool,
 	) error
+	GetIndexReport(ctx context.Context, hashID string) (*claircore.IndexReport, bool, error)
 	GCIndexReports(
 		ctx context.Context,
 		expiration time.Time,

--- a/scanner/indexer/indexer_test.go
+++ b/scanner/indexer/indexer_test.go
@@ -96,7 +96,7 @@ func TestGetIndexReport(t *testing.T) {
 	metadataStore.EXPECT().
 		ManifestExists(gomock.Any(), gomock.Any()).
 		Return(false, errors.New("error"))
-	ir, exists, err := indexer.GetIndexReport(ctx, "test")
+	ir, exists, err := indexer.GetIndexReport(ctx, "test", false)
 	assert.Nil(t, ir)
 	assert.False(t, exists)
 	assert.Error(t, err)
@@ -105,7 +105,7 @@ func TestGetIndexReport(t *testing.T) {
 	metadataStore.EXPECT().
 		ManifestExists(gomock.Any(), gomock.Any()).
 		Return(false, nil)
-	ir, exists, err = indexer.GetIndexReport(ctx, "test")
+	ir, exists, err = indexer.GetIndexReport(ctx, "test", false)
 	assert.Nil(t, ir)
 	assert.False(t, exists)
 	assert.NoError(t, err)
@@ -117,7 +117,7 @@ func TestGetIndexReport(t *testing.T) {
 	store.EXPECT().
 		ManifestScanned(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(false, errors.New("error"))
-	ir, exists, err = indexer.GetIndexReport(ctx, "test")
+	ir, exists, err = indexer.GetIndexReport(ctx, "test", false)
 	assert.Nil(t, ir)
 	assert.False(t, exists)
 	assert.Error(t, err)
@@ -129,7 +129,7 @@ func TestGetIndexReport(t *testing.T) {
 	store.EXPECT().
 		ManifestScanned(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(false, nil)
-	ir, exists, err = indexer.GetIndexReport(ctx, "test")
+	ir, exists, err = indexer.GetIndexReport(ctx, "test", false)
 	assert.Nil(t, ir)
 	assert.False(t, exists)
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestGetIndexReport(t *testing.T) {
 	store.EXPECT().
 		IndexReport(gomock.Any(), gomock.Any()).
 		Return(nil, false, errors.New("error"))
-	ir, exists, err = indexer.GetIndexReport(ctx, "test")
+	ir, exists, err = indexer.GetIndexReport(ctx, "test", false)
 	assert.Nil(t, ir)
 	assert.False(t, exists)
 	assert.Error(t, err)
@@ -159,7 +159,7 @@ func TestGetIndexReport(t *testing.T) {
 	store.EXPECT().
 		IndexReport(gomock.Any(), gomock.Any()).
 		Return(nil, false, nil)
-	ir, exists, err = indexer.GetIndexReport(ctx, "test")
+	ir, exists, err = indexer.GetIndexReport(ctx, "test", false)
 	assert.Nil(t, ir)
 	assert.False(t, exists)
 	assert.NoError(t, err)
@@ -177,7 +177,7 @@ func TestGetIndexReport(t *testing.T) {
 	store.EXPECT().
 		IndexReport(gomock.Any(), gomock.Any()).
 		Return(blankReport, true, nil)
-	ir, exists, err = indexer.GetIndexReport(ctx, "test")
+	ir, exists, err = indexer.GetIndexReport(ctx, "test", false)
 	assert.Equal(t, blankReport, ir)
 	assert.True(t, exists)
 	assert.NoError(t, err)

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -43,9 +43,9 @@ func (m *MockReportGetter) EXPECT() *MockReportGetterMockRecorder {
 }
 
 // GetIndexReport mocks base method.
-func (m *MockReportGetter) GetIndexReport(arg0 context.Context, arg1 string) (*claircore.IndexReport, bool, error) {
+func (m *MockReportGetter) GetIndexReport(arg0 context.Context, arg1 string, arg2 bool) (*claircore.IndexReport, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIndexReport", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetIndexReport", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*claircore.IndexReport)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -53,9 +53,9 @@ func (m *MockReportGetter) GetIndexReport(arg0 context.Context, arg1 string) (*c
 }
 
 // GetIndexReport indicates an expected call of GetIndexReport.
-func (mr *MockReportGetterMockRecorder) GetIndexReport(arg0, arg1 any) *gomock.Call {
+func (mr *MockReportGetterMockRecorder) GetIndexReport(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockReportGetter)(nil).GetIndexReport), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockReportGetter)(nil).GetIndexReport), arg0, arg1, arg2)
 }
 
 // MockReportStorer is a mock of ReportStorer interface.
@@ -136,9 +136,9 @@ func (mr *MockIndexerMockRecorder) Close(arg0 any) *gomock.Call {
 }
 
 // GetIndexReport mocks base method.
-func (m *MockIndexer) GetIndexReport(arg0 context.Context, arg1 string) (*claircore.IndexReport, bool, error) {
+func (m *MockIndexer) GetIndexReport(arg0 context.Context, arg1 string, arg2 bool) (*claircore.IndexReport, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIndexReport", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetIndexReport", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*claircore.IndexReport)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -146,9 +146,9 @@ func (m *MockIndexer) GetIndexReport(arg0 context.Context, arg1 string) (*clairc
 }
 
 // GetIndexReport indicates an expected call of GetIndexReport.
-func (mr *MockIndexerMockRecorder) GetIndexReport(arg0, arg1 any) *gomock.Call {
+func (mr *MockIndexerMockRecorder) GetIndexReport(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockIndexer)(nil).GetIndexReport), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockIndexer)(nil).GetIndexReport), arg0, arg1, arg2)
 }
 
 // IndexContainerImage mocks base method.

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -38,7 +38,7 @@ func (r *remoteIndexer) Close(_ context.Context) error {
 }
 
 // GetIndexReport calls the remote service to retrieve an IndexReport for the given hash ID.
-func (r *remoteIndexer) GetIndexReport(ctx context.Context, hashID string) (*claircore.IndexReport, bool, error) {
+func (r *remoteIndexer) GetIndexReport(ctx context.Context, hashID string, _ bool) (*claircore.IndexReport, bool, error) {
 	ctx = zlog.ContextWithValues(ctx,
 		"component", "scanner/backend/remoteIndexer.GetIndexReport",
 		"hash_id", hashID,

--- a/scanner/services/common.go
+++ b/scanner/services/common.go
@@ -13,8 +13,8 @@ import (
 
 // getClairIndexReport is a wrapper around indexer.GetIndexReport to return
 // errox.NotFound when the report does not exist or if it is not successful.
-func getClairIndexReport(ctx context.Context, indexer indexer.ReportGetter, hashID string) (*claircore.IndexReport, error) {
-	ir, found, err := indexer.GetIndexReport(ctx, hashID)
+func getClairIndexReport(ctx context.Context, indexer indexer.ReportGetter, hashID string, includeExternal bool) (*claircore.IndexReport, error) {
+	ir, found, err := indexer.GetIndexReport(ctx, hashID, includeExternal)
 	if err != nil {
 		return nil, err
 	}

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -116,7 +116,7 @@ func (s *indexerService) GetIndexReport(ctx context.Context, req *v4.GetIndexRep
 		"hash_id", req.GetHashId(),
 	)
 	zlog.Info(ctx).Msg("getting index report for container image")
-	ir, err := s.getIndexReport(ctx, req.GetHashId())
+	ir, err := s.getIndexReport(ctx, req.GetHashId(), req.IncludeExternal)
 	switch {
 	case errors.Is(err, errox.NotFound):
 		zlog.Warn(ctx).Err(err).Send()
@@ -130,8 +130,8 @@ func (s *indexerService) GetIndexReport(ctx context.Context, req *v4.GetIndexRep
 // No logging is performed; however, callers of this method may be
 // interested in logging the error. Returns errox.NotFound when the report does
 // not exist.
-func (s *indexerService) getIndexReport(ctx context.Context, hashID string) (*v4.IndexReport, error) {
-	ccIR, err := getClairIndexReport(ctx, s.indexer, hashID)
+func (s *indexerService) getIndexReport(ctx context.Context, hashID string, includeExternal bool) (*v4.IndexReport, error) {
+	ccIR, err := getClairIndexReport(ctx, s.indexer, hashID, includeExternal)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (s *indexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.Get
 	)
 
 	zlog.Info(ctx).Msg("getting index report for container image")
-	ir, err := s.getIndexReport(ctx, req.GetHashId())
+	ir, err := s.getIndexReport(ctx, req.GetHashId(), false)
 	switch {
 	case errors.Is(err, nil):
 		return ir, nil
@@ -178,7 +178,7 @@ func (s *indexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexRep
 		"component", "scanner/service/indexer.HasIndexReport",
 		"hash_id", req.GetHashId(),
 	)
-	_, err := getClairIndexReport(ctx, s.indexer, req.GetHashId())
+	_, err := getClairIndexReport(ctx, s.indexer, req.GetHashId(), false)
 	var exists bool
 	switch {
 	case errors.Is(err, nil):

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -116,7 +116,7 @@ func (s *indexerService) GetIndexReport(ctx context.Context, req *v4.GetIndexRep
 		"hash_id", req.GetHashId(),
 	)
 	zlog.Info(ctx).Msg("getting index report for container image")
-	ir, err := s.getIndexReport(ctx, req.GetHashId(), req.IncludeExternal)
+	ir, err := s.getIndexReport(ctx, req.GetHashId(), req.GetIncludeExternal())
 	switch {
 	case errors.Is(err, errox.NotFound):
 		zlog.Warn(ctx).Err(err).Send()

--- a/scanner/services/indexer_test.go
+++ b/scanner/services/indexer_test.go
@@ -201,7 +201,7 @@ func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 	s.Run("when get index report returns an error", func() {
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(nil, false, errors.New("ouch"))
 		r, err := s.service.GetIndexReport(s.ctx, req)
 		s.ErrorContains(err, "ouch")
@@ -210,7 +210,7 @@ func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 
 	s.Run("when get index report returns an unsuccessful report", func() {
 		s.indexerMock.EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(&claircore.IndexReport{State: "sample state"}, true, nil)
 		r, err := s.service.GetIndexReport(s.ctx, req)
 		s.ErrorContains(err, "sample state")
@@ -220,7 +220,7 @@ func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 	s.Run("when get index report returns not found", func() {
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(nil, false, nil)
 		r, err := s.service.GetIndexReport(s.ctx, req)
 		s.ErrorContains(err, "not found")
@@ -230,7 +230,7 @@ func (s *indexerServiceTestSuite) Test_GetIndexReport() {
 	s.Run("when get index report returns an index report", func() {
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(&claircore.IndexReport{Success: true, State: "sample state"}, true, nil)
 		r, err := s.service.GetIndexReport(s.ctx, req)
 		s.NoError(err)
@@ -258,7 +258,7 @@ func (s *indexerServiceTestSuite) Test_GetOrCreateIndexReport() {
 
 	s.Run("when index report does not exist then create", func() {
 		s.indexerMock.EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(nil, false, nil)
 		s.indexerMock.EXPECT().
 			IndexContainerImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -271,7 +271,7 @@ func (s *indexerServiceTestSuite) Test_GetOrCreateIndexReport() {
 
 	s.Run("when index report exists but not successful then create", func() {
 		s.indexerMock.EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(&claircore.IndexReport{}, true, nil)
 		s.indexerMock.EXPECT().
 			IndexContainerImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -284,7 +284,7 @@ func (s *indexerServiceTestSuite) Test_GetOrCreateIndexReport() {
 
 	s.Run("when index report does exist then get", func() {
 		s.indexerMock.EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(&claircore.IndexReport{Success: true, State: "sample state"}, true, nil)
 		got, err := s.service.GetOrCreateIndexReport(s.ctx, req)
 		s.NoError(err)
@@ -299,7 +299,7 @@ func (s *indexerServiceTestSuite) Test_HasIndexReport() {
 	s.Run("when get index report returns an error then return error", func() {
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(nil, false, errors.New("ouch"))
 		r, err := s.service.HasIndexReport(s.ctx, req)
 		s.ErrorContains(err, "ouch")
@@ -309,7 +309,7 @@ func (s *indexerServiceTestSuite) Test_HasIndexReport() {
 	s.Run("when index report is unsuccessful then does not exist", func() {
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(&claircore.IndexReport{}, true, nil)
 		r, err := s.service.HasIndexReport(s.ctx, req)
 		s.NoError(err)
@@ -319,7 +319,7 @@ func (s *indexerServiceTestSuite) Test_HasIndexReport() {
 	s.Run("when index report not found then does not exist", func() {
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(nil, false, nil)
 		r, err := s.service.HasIndexReport(s.ctx, req)
 		s.NoError(err)
@@ -329,7 +329,7 @@ func (s *indexerServiceTestSuite) Test_HasIndexReport() {
 	s.Run("when get index report returns an index report then exists", func() {
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(&claircore.IndexReport{Success: true, State: "sample state"}, true, nil)
 		r, err := s.service.HasIndexReport(s.ctx, req)
 		s.NoError(err)

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -76,7 +76,7 @@ func (s *matcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVuln
 			return nil, errox.InvalidArgs.New("empty contents is disabled")
 		}
 		zlog.Debug(ctx).Msg("no contents, retrieving")
-		ir, err = getClairIndexReport(ctx, s.indexer, req.GetHashId())
+		ir, err = getClairIndexReport(ctx, s.indexer, req.GetHashId(), false)
 	} else {
 		zlog.Info(ctx).Msg("has contents, parsing")
 		ir, err = parseIndexReport(req.GetContents())

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -94,7 +94,7 @@ func (s *matcherServiceTestSuite) Test_matcherService_GetVulnerabilities_empty_c
 		ir := &claircore.IndexReport{Success: true}
 		s.indexerMock.
 			EXPECT().
-			GetIndexReport(gomock.Any(), gomock.Eq(hashID)).
+			GetIndexReport(gomock.Any(), gomock.Eq(hashID), false).
 			Return(ir, true, nil)
 		s.matcherMock.
 			EXPECT().


### PR DESCRIPTION
## Description

- Modifies the `Indexer.GetIndexReport` gRPC request to include a new field, `includeExternalReports`, which includes getting external index reports from the Scanner V4 Indexer. This is plumbed through the entire system, including the common Scanner V4 client; however, it's only used in the `GetSBOM()` abstraction.
- Adds a new method to `ExternalIndexStore`, `GetIndexReport()`, which returns the external index report from a provided `hashID`.
- Implemented `ExternalIndexStore.GetIndexReport()` for `externalIndexStore`.

PR stack:
- `master`
  - https://github.com/stackrox/stackrox/pull/16527
    - https://github.com/stackrox/stackrox/pull/16398
      - 👉 https://github.com/stackrox/stackrox/pull/16526
        -  https://github.com/stackrox/stackrox/pull/16884

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- ~~added unit tests~~
- ~~added e2e tests~~
- ~~added regression tests~~
- ~~added compatibility tests~~
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deploy stackrox (Central Services):
```
❯ export MAIN_IMAGE_TAG=4.9.x-861-g25f87ad59a
❯ ./deploy/deploy.sh
...
```

Deploy stackrox (Secured Cluster):
```
❯ export MAIN_IMAGE_TAG=4.9.x-861-g25f87ad59a
❯ ./deploy/sensor.sh
...
```

Configure delegated scanning on the Central Services cluster. I configured all registry scans to the delegated Secured Cluster.

Configure a watched image.

Generate an SBOM via the unwatched images page.