### PR TITLE
ROX-30629: skip S3 tests on external PG

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -496,6 +496,7 @@ class IntegrationsTest extends BaseSpecification {
 
     @Unroll
     @Tag("Integration")
+    @IgnoreIf(reason = "Backup service is not available with external db", value = { Env.IS_BYODB })
     def "Verify AWS S3 Integration: #integrationName"() {
         when:
         "the integration is tested"
@@ -525,6 +526,7 @@ class IntegrationsTest extends BaseSpecification {
 
     @Unroll
     @Tag("Integration")
+    @IgnoreIf(reason = "Backup service is not available with external db", value = { Env.IS_BYODB })
     def "Verify S3 Compatible Integration: #integrationName"() {
         when:
         "the integration is tested"
@@ -556,6 +558,7 @@ class IntegrationsTest extends BaseSpecification {
 
     @Unroll
     @Tag("Integration")
+    @IgnoreIf(reason = "Backup service is not available with external db", value = { Env.IS_BYODB })
     def "Verify GCS Integration: #integrationName"() {
         setup:
         Assume.assumeTrue(!useWorkloadId || Env.HAS_WORKLOAD_IDENTITIES)


### PR DESCRIPTION
This PR skips integration tests that uses backup service as it's not implemented when using external DB.

https://github.com/stackrox/stackrox/blob/2fbfc8a949f8c67eb9714a07fefaa217992950c2/central/main.go#L467-L470
