### PR TITLE
ROX-29969: Remove bundle tag from Snapshot / 4.6

### DIFF
--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -821,7 +821,7 @@ spec:
           },
           {
             "name": "operator-bundle",
-            "containerImage": "$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)",
+            "containerImage": "$(params.output-image-repo)@$(tasks.build-container.results.IMAGE_DIGEST)",
             "repository": "$(params.git-url)",
             "revision": "$(params.revision)"
           },


### PR DESCRIPTION
## Description

Manual backport of https://github.com/stackrox/stackrox/pull/16497 to `release-4.6`

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Performed in https://github.com/stackrox/stackrox/pull/16497.
