### PR TITLE
ROX-30629: skip S3 tests on external PG 

### DIFF
--- a/tests/external_backup_test.go
+++ b/tests/external_backup_test.go
@@ -44,6 +44,10 @@ func verifyNumBackups(t *testing.T, numBackups int, numExpected int) {
 }
 
 func TestGCSExternalBackup(t *testing.T) {
+	if os.Getenv("BYODB_TEST") == "true" {
+		t.Skip("Backup service is not available with external db")
+	}
+
 	serviceAccount := os.Getenv("GOOGLE_GCS_BACKUP_SERVICE_ACCOUNT_V2")
 	require.NotEmpty(t, serviceAccount)
 


### PR DESCRIPTION
This PR skips nongroovy tests that uses backup service as it's not implemented when using external DB.

https://github.com/stackrox/stackrox/blob/2fbfc8a949f8c67eb9714a07fefaa217992950c2/central/main.go#L467-L470

- https://github.com/stackrox/stackrox/pull/16533