### PR TITLE
ROX-30664: Fix space and comment KnownExploitLabel in CvePageHeader

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ReactNode } from 'react';
 import { Flex, LabelGroup, Label, Text, Title, List, ListItem } from '@patternfly/react-core';
 import uniqBy from 'lodash/uniqBy';
 
@@ -14,6 +15,7 @@ import {
 import { getDistroLinkText } from '../utils/textUtils';
 import { sortCveDistroList } from '../utils/sortUtils';
 import HeaderLoadingSkeleton from './HeaderLoadingSkeleton';
+// import KnownExploitLabel from './KnownExploitLabel';
 
 export type CveMetadata = {
     cve: string;
@@ -48,37 +50,40 @@ function CvePageHeader({ data }: CvePageHeaderProps) {
     const epssProbability = cveBaseInfo?.epss?.epssProbability;
     const hasEpssProbabilityLabel = isEpssProbabilityColumnEnabled && Boolean(cveBaseInfo); // not (yet) for Node CVE
 
+    const labels: ReactNode[] = [];
+    /*
+    // Ross CISA KEV
+    if (isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_WHATEVER') && TODO) {
+        labels.push(<KnownExploitLabel key="knownExploit" isCompact={false} />);
+    }
+    */
+    if (hasEpssProbabilityLabel) {
+        labels.push(
+            <Label key="epssProbability">
+                EPSS probability: {formatEpssProbabilityAsPercent(epssProbability)}
+            </Label>
+        );
+    }
+    if (data.firstDiscoveredInSystem) {
+        labels.push(
+            <Label key="firstDiscoveredInSystem">
+                First discovered in system: {getDateTime(data.firstDiscoveredInSystem)}
+            </Label>,
+            <Label key="publishedOn">
+                Published: {data.publishedOn ? getDateTime(data.publishedOn) : 'Not available'}
+            </Label>
+        );
+    }
+
     const prioritizedDistros = uniqBy(sortCveDistroList(data.distroTuples), getDistroLinkText);
     const topDistro = prioritizedDistros[0];
-
-    const numLabels = (hasEpssProbabilityLabel ? 1 : 0) + (data.firstDiscoveredInSystem ? 2 : 0);
 
     return (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
             <Title headingLevel="h1" className="pf-v5-u-mb-sm">
                 {data.cve}
             </Title>
-            {numLabels !== 0 && (
-                <LabelGroup numLabels={numLabels}>
-                    {hasEpssProbabilityLabel && (
-                        <Label>
-                            EPSS probability: {formatEpssProbabilityAsPercent(epssProbability)}
-                        </Label>
-                    )}
-                    {data.firstDiscoveredInSystem && (
-                        <>
-                            <Label>
-                                First discovered in system:{' '}
-                                {getDateTime(data.firstDiscoveredInSystem)}
-                            </Label>
-                            <Label>
-                                Published:{' '}
-                                {data.publishedOn ? getDateTime(data.publishedOn) : 'Not available'}
-                            </Label>
-                        </>
-                    )}
-                </LabelGroup>
-            )}
+            {labels.length !== 0 && <LabelGroup numLabels={labels.length}>{labels}</LabelGroup>}
             {topDistro && (
                 <>
                     <Text>{topDistro.summary}</Text>


### PR DESCRIPTION
## Description

1. Fix spacing mistake that I made with fragment in #13892
2. Add `// Ross CISA KEV` comment for conditional rendering of `KnownExploitLabel` element

Sneak peek of future label and tooltip:
<img width="1440" height="400" alt="tooltip" src="https://github.com/user-attachments/assets/588ec292-4612-4d80-a033-1cb342d2725b" />

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/user-workloads/cves/CVE-2024-38475

    Before changes, compare:
    * presence of space following **EPSS probability** label
    * absence of space between **First discovered in system** and **Published** labels
    <img width="1920" height="898" alt="without_space_nor_label" src="https://github.com/user-attachments/assets/71161a68-6c54-474d-a797-8b211c371899" />

    After changes, see:
    * **Known exploit** label
    * presence of space between **First discovered in system** and **Published** labels
    <img width="1440" height="898" alt="with_space_and_label" src="https://github.com/user-attachments/assets/7bbc9d80-45bb-4726-87a8-9fe279350771" />