### PR TITLE
fix(queue): handle empty elements

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -80,12 +80,33 @@ func NewQueue[T comparable](opts ...OptionFunc[T]) *Queue[T] {
 // Pull will pull an item from the queue. If the queue is empty, the default value of T will be returned.
 // Note that his does not wait for items to be available in the queue, use PullBlocking instead.
 func (q *Queue[T]) Pull() T {
+	item, _ := q.pull()
+	return item
+}
+
+// PullBlocking will pull an item from the queue, potentially waiting until one is available.
+// In case the waitable signals done, the default value of T will be returned.
+func (q *Queue[T]) PullBlocking(waitable concurrency.Waitable) T {
+	item, ok := q.pull()
+	// In case multiple go routines are pull blocking, we have to ensure that the result of pull
+	// is valid, hence the additional for loop here.
+	for ; !ok; item, ok = q.pull() {
+		select {
+		case <-waitable.Done():
+			return item
+		case <-q.notEmptySignal.Done():
+		}
+	}
+	return item
+}
+
+func (q *Queue[T]) pull() (T, bool) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
 	if q.queue.Len() == 0 {
 		var nilT T
-		return nilT
+		return nilT, false
 	}
 
 	item := q.queue.Remove(q.queue.Front()).(T)
@@ -98,24 +119,7 @@ func (q *Queue[T]) Pull() T {
 		q.notEmptySignal.Reset()
 	}
 
-	return item
-}
-
-// PullBlocking will pull an item from the queue, potentially waiting until one is available.
-// In case the waitable signals done, the default value of T will be returned.
-func (q *Queue[T]) PullBlocking(waitable concurrency.Waitable) T {
-	var item T
-	// In case multiple go routines are pull blocking, we have to ensure that the result of pull
-	// is non-zero, hence the additional for loop here.
-	for item == *new(T) {
-		select {
-		case <-waitable.Done():
-			return item
-		case <-q.notEmptySignal.Done():
-			item = q.Pull()
-		}
-	}
-	return item
+	return item, true
 }
 
 // Push adds an item to the queue.

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -34,4 +34,8 @@ func TestQueue(t *testing.T) {
 	// 4. Another pull should now return an empty value.
 	queueItem = q.Pull()
 	assert.Nil(t, queueItem)
+
+	// 5. Empty element should be available to pull
+	q.Push(nil)
+	assert.Nil(t, q.PullBlocking(context.Background()))
 }


### PR DESCRIPTION
This PR fixes queue PullBlocking function that ignores empty elements. 
Added tests timeouts on previous implementation as it checks for nil instead of checking if queue was empty.