### PR TITLE
ROX-29970: Disable image expiration for the staging release

### DIFF
--- a/.tekton/basic-component-pipeline.yaml
+++ b/.tekton/basic-component-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -201,7 +201,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -217,7 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -201,7 +201,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -217,7 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -237,7 +237,7 @@ spec:
       - name: name
         value: fetch-external-networks
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -303,7 +303,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -319,7 +319,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -356,7 +356,7 @@ spec:
       - name: name
         value: wait-for-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -854,7 +854,7 @@ spec:
       - name: name
         value: create-snapshot
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/retag-pipeline.yaml
+++ b/.tekton/retag-pipeline.yaml
@@ -35,7 +35,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -136,7 +136,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -154,7 +154,7 @@ spec:
       - name: name
         value: determine-dependency-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -170,7 +170,7 @@ spec:
       - name: name
         value: wait-for-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -195,7 +195,7 @@ spec:
       - name: name
         value: retag-image
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -49,7 +49,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -201,7 +201,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -217,7 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles
@@ -237,7 +237,7 @@ spec:
       - name: name
         value: fetch-scanner-v4-vuln-mappings
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:6a4915f707e62cd3e563e1bc9c7f286744d803ae60de349e55fea3a38ed1f26b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:0ac677308887d8368a08de94bb5ea60aeba2450f35a545946a3d77de6c90fa5b
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

By using the most recent custom tasks from https://github.com/stackrox/konflux-tasks/pull/72 merge.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Ran staging release from this PR and saw no Conforma complains - https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/acs-4-8/pipelineruns/managed-2s9xm
