### PR TITLE
ROX-3024: roxctl grpc retry on deadline exceeded

### DIFF
--- a/roxctl/common/connection.go
+++ b/roxctl/common/connection.go
@@ -102,6 +102,9 @@ func shouldRetry(err error) bool {
 	}
 	if grpcErr, ok := status.FromError(err); ok {
 		code := grpcErr.Code()
+		if code == codes.DeadlineExceeded {
+			return true
+		}
 		if code != codes.Unavailable && code != codes.ResourceExhausted {
 			return false
 		}

--- a/roxctl/common/connection_test.go
+++ b/roxctl/common/connection_test.go
@@ -85,6 +85,11 @@ func Test_shouldRetry(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "GRPC Deadline Exceeded",
+			err:      status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+			expected: true,
+		},
+		{
 			name:     "GRPC Unavailable Error",
 			err:      status.Error(codes.Unavailable, "service unavailable"),
 			expected: true,


### PR DESCRIPTION
This PR aims to fix following error by adding retry when DeadlineExceeded occurs:
```prolog
[FAIL] Invalid password in ROX_ADMIN_PASSWORD causes failure even though valid password specified with --password
Captured output was:
ERROR:	getting auth status: rpc error: code = DeadlineExceeded desc = context deadline exceeded
[FAIL] Invalid password in ROX_ADMIN_PASSWORD causes failure even though valid token file specified with --token-file
Captured output was:
ERROR:	getting auth status: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```