### PR TITLE
ROX-30629: show nice error when external backup is used with external DB

### DIFF
--- a/central/externalbackups/service/externaldb/service.go
+++ b/central/externalbackups/service/externaldb/service.go
@@ -1,0 +1,23 @@
+package externaldb
+
+import (
+	"context"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/grpc"
+)
+
+// Service is the interface to the gRPC service for configuring backups when external db is enabled
+// This means most of the methods is currently unsupported
+type Service interface {
+	grpc.APIService
+
+	AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error)
+
+	v1.ExternalBackupServiceServer
+}
+
+// New returns a new Service instance using the given DataStore.
+func New() Service {
+	return &serviceImpl{}
+}

--- a/central/externalbackups/service/externaldb/service_impl.go
+++ b/central/externalbackups/service/externaldb/service_impl.go
@@ -1,0 +1,67 @@
+package externaldb
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/stackrox/rox/central/externalbackups/service/internal"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
+	"google.golang.org/grpc"
+)
+
+const cause = "the scheduled backup service is not applicable when using an external database. " +
+	"Please manage backups directly with your database provider."
+
+type serviceImpl struct {
+	v1.UnimplementedExternalBackupServiceServer
+}
+
+func (s *serviceImpl) RegisterServiceServer(grpcServer *grpc.Server) {
+	v1.RegisterExternalBackupServiceServer(grpcServer, s)
+}
+
+func (s *serviceImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return v1.RegisterExternalBackupServiceHandler(ctx, mux, conn)
+}
+
+func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, internal.Authorizer.Authorized(ctx, fullMethodName)
+}
+
+func (s *serviceImpl) GetExternalBackup(_ context.Context, _ *v1.ResourceByID) (*storage.ExternalBackup, error) {
+	return nil, errox.NotFound.CausedBy(cause)
+}
+
+func (s *serviceImpl) GetExternalBackups(_ context.Context, _ *v1.Empty) (*v1.GetExternalBackupsResponse, error) {
+	return nil, errox.NotFound.CausedBy(cause)
+}
+
+func (s *serviceImpl) TestExternalBackup(_ context.Context, _ *storage.ExternalBackup) (*v1.Empty, error) {
+	return nil, errox.NotFound.CausedBy(cause)
+}
+
+func (s *serviceImpl) TestUpdatedExternalBackup(_ context.Context, _ *v1.UpdateExternalBackupRequest) (*v1.Empty, error) {
+	return nil, errox.NotFound.CausedBy(cause)
+}
+
+func (s *serviceImpl) TriggerExternalBackup(_ context.Context, _ *v1.ResourceByID) (*v1.Empty, error) {
+	return nil, errox.NotFound.CausedBy(cause)
+}
+
+func (s *serviceImpl) PutExternalBackup(_ context.Context, _ *storage.ExternalBackup) (*storage.ExternalBackup, error) {
+	return nil, errox.NotImplemented.CausedBy(cause)
+}
+
+func (s *serviceImpl) UpdateExternalBackup(_ context.Context, _ *v1.UpdateExternalBackupRequest) (*storage.ExternalBackup, error) {
+	return nil, errox.NotFound.CausedBy(cause)
+}
+
+func (s *serviceImpl) PostExternalBackup(_ context.Context, _ *storage.ExternalBackup) (*storage.ExternalBackup, error) {
+	return nil, errox.NotImplemented.CausedBy(cause)
+}
+
+func (s *serviceImpl) DeleteExternalBackup(_ context.Context, _ *v1.ResourceByID) (*v1.Empty, error) {
+	return nil, errox.NotFound.CausedBy(cause)
+}

--- a/central/externalbackups/service/externaldb/singleton.go
+++ b/central/externalbackups/service/externaldb/singleton.go
@@ -1,0 +1,21 @@
+package externaldb
+
+import (
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once sync.Once
+
+	as Service
+)
+
+func initialize() {
+	as = New()
+}
+
+// Singleton provides the instance of the Service interface to register.
+func Singleton() Service {
+	once.Do(initialize)
+	return as
+}

--- a/central/externalbackups/service/internal/auth.go
+++ b/central/externalbackups/service/internal/auth.go
@@ -1,0 +1,28 @@
+package internal
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/grpc/authz"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
+	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/sac/resources"
+)
+
+var (
+	Authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
+		user.With(permissions.View(resources.Integration)): {
+			v1.ExternalBackupService_GetExternalBackup_FullMethodName,
+			v1.ExternalBackupService_GetExternalBackups_FullMethodName,
+		},
+		user.With(permissions.Modify(resources.Integration)): {
+			v1.ExternalBackupService_PutExternalBackup_FullMethodName,
+			v1.ExternalBackupService_PostExternalBackup_FullMethodName,
+			v1.ExternalBackupService_TestExternalBackup_FullMethodName,
+			v1.ExternalBackupService_DeleteExternalBackup_FullMethodName,
+			v1.ExternalBackupService_TriggerExternalBackup_FullMethodName,
+			v1.ExternalBackupService_UpdateExternalBackup_FullMethodName,
+			v1.ExternalBackupService_TestUpdatedExternalBackup_FullMethodName,
+		},
+	})
+)

--- a/central/externalbackups/service/service_impl.go
+++ b/central/externalbackups/service/service_impl.go
@@ -7,39 +7,17 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/externalbackups/datastore"
 	"github.com/stackrox/rox/central/externalbackups/manager"
+	"github.com/stackrox/rox/central/externalbackups/service/internal"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/endpoints"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/grpc/authz"
-	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
-	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/integrationhealth"
 	"github.com/stackrox/rox/pkg/protoconv/schedule"
-	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/secrets"
 	"github.com/stackrox/rox/pkg/uuid"
 	"google.golang.org/grpc"
-)
-
-var (
-	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
-		user.With(permissions.View(resources.Integration)): {
-			v1.ExternalBackupService_GetExternalBackup_FullMethodName,
-			v1.ExternalBackupService_GetExternalBackups_FullMethodName,
-		},
-		user.With(permissions.Modify(resources.Integration)): {
-			v1.ExternalBackupService_PutExternalBackup_FullMethodName,
-			v1.ExternalBackupService_PostExternalBackup_FullMethodName,
-			v1.ExternalBackupService_TestExternalBackup_FullMethodName,
-			v1.ExternalBackupService_DeleteExternalBackup_FullMethodName,
-			v1.ExternalBackupService_TriggerExternalBackup_FullMethodName,
-			v1.ExternalBackupService_UpdateExternalBackup_FullMethodName,
-			v1.ExternalBackupService_TestUpdatedExternalBackup_FullMethodName,
-		},
-	})
 )
 
 // serviceImpl is the struct that manages the external backups API
@@ -63,7 +41,7 @@ func (s *serviceImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.S
 
 // AuthFuncOverride specifies the auth criteria for this API.
 func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
-	return ctx, authorizer.Authorized(ctx, fullMethodName)
+	return ctx, internal.Authorizer.Authorized(ctx, fullMethodName)
 }
 
 // GetExternalBackup retrieves the external backup based on the id passed

--- a/central/main.go
+++ b/central/main.go
@@ -84,6 +84,7 @@ import (
 	externalbackupsDS "github.com/stackrox/rox/central/externalbackups/datastore"
 	_ "github.com/stackrox/rox/central/externalbackups/plugins/all" // Import all of the external backup plugins
 	backupService "github.com/stackrox/rox/central/externalbackups/service"
+	"github.com/stackrox/rox/central/externalbackups/service/externaldb"
 	featureFlagService "github.com/stackrox/rox/central/featureflags/service"
 	"github.com/stackrox/rox/central/globaldb"
 	dbAuthz "github.com/stackrox/rox/central/globaldb/authz"
@@ -467,6 +468,8 @@ func servicesToRegister() []pkgGRPC.APIService {
 	// The scheduled backup service is not applicable when using an external database
 	if !env.ManagedCentral.BooleanSetting() && !pgconfig.IsExternalDatabase() {
 		servicesToRegister = append(servicesToRegister, backupService.Singleton())
+	} else {
+		servicesToRegister = append(servicesToRegister, externaldb.Singleton())
 	}
 
 	servicesToRegister = append(servicesToRegister, reportServiceV2.Singleton())

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -496,6 +496,19 @@ class IntegrationsTest extends BaseSpecification {
 
     @Unroll
     @Tag("Integration")
+    @IgnoreIf({ !Env.IS_BYODB })
+    def "Verify external backup errors on external DB"() {
+        when:
+        def backup = ExternalBackupService.getS3IntegrationConfig("this shall not work")
+        ExternalBackupService.getExternalBackupClient().testExternalBackup(backup)
+
+        then:
+        def exception = thrown(StatusRuntimeException)
+        assert exception.message.contains('Please manage backups directly with your database provider.')
+    }
+
+    @Unroll
+    @Tag("Integration")
     @IgnoreIf(reason = "Backup service is not available with external db", value = { Env.IS_BYODB })
     def "Verify AWS S3 Integration: #integrationName"() {
         when:


### PR DESCRIPTION
  Description

  This PR adds a dummy implementation for the external backup service that provides clear error messages when external databases are used.   When StackRox is configured with an external database (BYODB), backup operations should be managed directly by the database provider  rather than through StackRox's backup service.

  Key changes:
  - Added new central/externalbackups/service/externaldb/ package with stub implementation
  - Returns user-friendly error message: "Please manage backups directly with your database provider."
  - Returns NOT_FOUND for backup ID-related requests and UNIMPLEMENTED for new backup operations
  - Integrated the service into main application when external DB mode is detected
