### PR TITLE
ROX-30691: Add no-Label-in-Link lint rule

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -269,6 +269,37 @@ const rules = {
     // If your rule only disallows something, prefix it with no.
     // However, we can write forbid instead of disallow as the verb in description and message.
 
+    'no-Label-in-Link': {
+        // PatternFly Label in (wrapped by) React Router Link element which is in LabelGroup
+        // affects the height other Label element that is wrapped in `Tooltip` element.
+        // Text in (wrapped by) Link has side effect to display underline on mouse hover
+        // compared to lack of visual indication for Label in Link.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Move React Router Link inside PatternFly Label element',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXElement(node) {
+                    if (node.openingElement?.name?.name === 'Label') {
+                        const ancestors = context.sourceCode.getAncestors(node);
+                        if (
+                            ancestors.length >= 1 &&
+                            ancestors[ancestors.length - 1].openingElement?.name?.name === 'Link'
+                        ) {
+                            context.report({
+                                node,
+                                message: 'Move React Router Link inside PatternFly Label element',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'no-Td-data-label': {
         // Although Td element renders prop as data-label attribute,
         // require dataLabel prop to simplify other lint rules.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/PendingExceptionLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/PendingExceptionLabel.tsx
@@ -28,16 +28,11 @@ function PendingExceptionLabel({ cve, isCompact, vulnerabilityState }: PendingEx
     const url = `${exceptionManagementPath}/pending-requests?${query}`;
 
     return (
-        <Link to={url}>
-            <Label
-                color="blue"
-                isCompact={isCompact}
-                icon={<OutlinedClockIcon />}
-                variant="outline"
-            >
+        <Label color="blue" isCompact={isCompact} icon={<OutlinedClockIcon />} variant="outline">
+            <Link to={url}>
                 {vulnerabilityState === 'OBSERVED' ? 'Pending exception' : 'Pending update'}
-            </Label>
-        </Link>
+            </Link>
+        </Label>
     );
 }
 


### PR DESCRIPTION
## Description

Although prerequisite for CISA KEV, omit from feature epic to prevent distraction.

### Problem

PatternFly `Label` in (wrapped by) React Router `Link` element which is in `LabelGroup`affects the height of other `Label` element that is wrapped in `Tooltip` element.

### Analysis

Not sure why, but the difference is apparent in Elements pane of browser.

Maybe difference between non-PatternFly and PatternFly element that wraps `Label` in `LableGroup` element?

Indirect support is example of `render` prop for `Link` element in PatternFly docs:
https://www.patternfly.org/components/label#using-router-links

Although notice below that I did not follow that guidance.

Text in (wrapped by) `Link` has side effect to display underline on mouse hover compared to lack of visual indication for `Label` in `Link` element.

### Solution

1. Edit PendingExceptionLabel.tsx file.
    * Move `Link` element inside `Label` element.

2. Edit pluginPatternFly.js file.
    * Add `no-Label-in-Link` lint rule to report future similar problem as an error.
        Use typescript-eslint playground:
        https://typescript-eslint.io/play/#ts=5.9.2&showAST=es&fileType=.tsx

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

With temporary code changes to simulate conditional rendering of `KnownExploitLabel` in the future.

1. Visit /main/vulnerabilities/user-workloads/deployments

    Before change with `Label` in (wrapped by) `Link` element:
    <img width="360" height="63" alt="Link_Label" src="https://github.com/user-attachments/assets/571b0e86-8f95-427d-83ec-21048df00052" />

    After change to move `Link` inside `Label` element:
    <img width="360" height="64" alt="Label_Link" src="https://github.com/user-attachments/assets/6aac6f8a-504f-4aa0-9c80-2937abcd6101" />
