### PR TITLE
refactor(ui): Lift Workload CVE column overrides up to parent

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -9,11 +9,10 @@ import useMap from 'hooks/useMap';
 import { VulnerabilityState } from 'types/cve.proto';
 
 import { getTableUIState } from 'utils/getTableUIState';
-import useHasRequestExceptionsAbility from 'Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility';
 import { SearchFilter } from 'types/search';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
-import useFeatureFlags from 'hooks/useFeatureFlags';
-import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import WorkloadCVEOverviewTable, {
     defaultColumns,
@@ -40,6 +39,8 @@ export type CVEsTableContainerProps = {
     sort: ReturnType<typeof useURLSort>;
     workloadCvesScopedQueryString: string;
     isFiltered: boolean;
+    showDeferralUI: boolean;
+    cveTableColumnOverrides: ColumnConfigOverrides<keyof typeof defaultColumns>;
 };
 
 function CVEsTableContainer({
@@ -53,6 +54,8 @@ function CVEsTableContainer({
     sort,
     workloadCvesScopedQueryString,
     isFiltered,
+    showDeferralUI,
+    cveTableColumnOverrides,
 }: CVEsTableContainerProps) {
     const { sortOption, getSortParams } = sort;
 
@@ -67,11 +70,6 @@ function CVEsTableContainer({
 
     const { invalidateAll: refetchAll } = useInvalidateVulnerabilityQueries();
 
-    const hasRequestExceptionsAbility = useHasRequestExceptionsAbility();
-
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
     const selectedCves = useMap<string, ExceptionRequestModalProps['cves'][number]>();
     const {
@@ -81,18 +79,13 @@ function CVEsTableContainer({
         closeModals,
         createExceptionModalActions,
     } = useExceptionRequestModal();
-    const showDeferralUI = hasRequestExceptionsAbility && vulnerabilityState === 'OBSERVED';
-    const canSelectRows = showDeferralUI;
 
     const createTableActions = showDeferralUI ? createExceptionModalActions : undefined;
 
-    const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        cveSelection: hideColumnIf(!canSelectRows),
-        topNvdCvss: hideColumnIf(!isNvdCvssColumnEnabled),
-        epssProbability: hideColumnIf(!isEpssProbabilityColumnEnabled),
-        requestDetails: hideColumnIf(vulnerabilityState === 'OBSERVED'),
-        rowActions: hideColumnIf(createTableActions === undefined),
-    });
+    const columnConfig = overrideManagedColumns(
+        managedColumnState.columns,
+        cveTableColumnOverrides
+    );
 
     const tableState = getTableUIState({
         isLoading: loading,
@@ -135,7 +128,7 @@ function CVEsTableContainer({
                         onApplyColumns={managedColumnState.setVisibility}
                     />
                 </ToolbarItem>
-                {canSelectRows && (
+                {showDeferralUI && (
                     <ToolbarItem>
                         <MenuDropdown
                             toggleText="Bulk actions"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -6,7 +6,8 @@ import useURLPagination from 'hooks/useURLPagination';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import { SearchFilter } from 'types/search';
-import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import DeploymentsTable, { defaultColumns, tableId } from '../Tables/DeploymentOverviewTable';
 import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
@@ -23,7 +24,7 @@ type DeploymentsTableContainerProps = {
     sort: ReturnType<typeof useURLSort>;
     workloadCvesScopedQueryString: string;
     isFiltered: boolean;
-    showCveDetailFields: boolean;
+    deploymentTableColumnOverrides: ColumnConfigOverrides<keyof typeof defaultColumns>;
 };
 
 function DeploymentsTableContainer({
@@ -36,7 +37,7 @@ function DeploymentsTableContainer({
     sort,
     workloadCvesScopedQueryString,
     isFiltered,
-    showCveDetailFields,
+    deploymentTableColumnOverrides,
 }: DeploymentsTableContainerProps) {
     const { sortOption, getSortParams } = sort;
 
@@ -55,9 +56,10 @@ function DeploymentsTableContainer({
 
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
-    const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        cvesBySeverity: hideColumnIf(!showCveDetailFields),
-    });
+    const columnConfig = overrideManagedColumns(
+        managedColumnState.columns,
+        deploymentTableColumnOverrides
+    );
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -3,11 +3,11 @@ import { Divider, ToolbarItem } from '@patternfly/react-core';
 
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
-import usePermissions from 'hooks/usePermissions';
 
 import { getTableUIState } from 'utils/getTableUIState';
 import { SearchFilter } from 'types/search';
-import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import ImageOverviewTable, {
     ImageOverviewTableProps,
@@ -31,7 +31,7 @@ type ImagesTableContainerProps = {
     hasWriteAccessForWatchedImage: boolean;
     onWatchImage: ImageOverviewTableProps['onWatchImage'];
     onUnwatchImage: ImageOverviewTableProps['onUnwatchImage'];
-    showCveDetailFields: boolean;
+    imageTableColumnOverrides: ColumnConfigOverrides<keyof typeof defaultColumns>;
 };
 
 function ImagesTableContainer({
@@ -47,7 +47,7 @@ function ImagesTableContainer({
     hasWriteAccessForWatchedImage,
     onWatchImage,
     onUnwatchImage,
-    showCveDetailFields,
+    imageTableColumnOverrides,
 }: ImagesTableContainerProps) {
     const { sortOption, getSortParams } = sort;
 
@@ -66,14 +66,10 @@ function ImagesTableContainer({
 
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
-    const { hasReadWriteAccess } = usePermissions();
-    const hasWriteAccessForImage = hasReadWriteAccess('Image'); // SBOM Generation mutates image scan state.
-    const hasActionColumn = hasWriteAccessForWatchedImage || hasWriteAccessForImage;
-
-    const columnConfig = overrideManagedColumns(managedColumnState.columns, {
-        cvesBySeverity: hideColumnIf(!showCveDetailFields),
-        rowActions: hideColumnIf(!hasActionColumn),
-    });
+    const columnConfig = overrideManagedColumns(
+        managedColumnState.columns,
+        imageTableColumnOverrides
+    );
 
     return (
         <>

--- a/ui/apps/platform/src/hooks/useManagedColumns.ts
+++ b/ui/apps/platform/src/hooks/useManagedColumns.ts
@@ -74,9 +74,13 @@ export function filterManagedColumns<T extends Record<string, InitialColumnConfi
     return fromEntries;
 }
 
+export type ColumnConfigOverrides<ColumnKey extends string> = Partial<
+    Record<ColumnKey, Partial<ColumnConfig>>
+>;
+
 export function overrideManagedColumns<ColumnKey extends string>(
     managedColumns: Record<ColumnKey, ColumnConfig>,
-    overrides: Partial<Record<ColumnKey, Partial<ColumnConfig>>>
+    overrides: ColumnConfigOverrides<ColumnKey>
 ): Record<ColumnKey, ColumnConfig> {
     return merge({}, managedColumns, overrides);
 }


### PR DESCRIPTION
## Description

Moves the column overrides out of the CVE, Image, and Deployment table containers and into the parent. This will allow us to pass a different set of overrides to the same components in both the standalone and plugin versions.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual smoke test. Existing e2e tests that exercise column management in Workload CVE Overview.