### PR TITLE
ROX-30682: Generalize ImageOverviewTable for multiple labels

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -4,6 +4,48 @@ const rules = {
     // ESLint naming convention for positive rules:
     // If your rule is enforcing the inclusion of something, use a short name without a special prefix.
 
+    'Label-in-Popover-isClickable': {
+        // PatternFly Label in (wrapped by) Popover needs visual indication that it is clickable.
+        // PatternFly 5 use style={{ cursor: 'pointer' }} prop.
+        // TODO Update if PatternFly 6 isClickable prop has the same effect.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Label in Popover needs visual indication that it is clickable',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXElement(node) {
+                    if (node.openingElement?.name?.name === 'Label') {
+                        const ancestors = context.sourceCode.getAncestors(node);
+                        if (
+                            ancestors.length >= 1 &&
+                            ancestors[ancestors.length - 1].openingElement?.name?.name ===
+                                'Popover' &&
+                            !node.openingElement?.attributes.some(
+                                (attribute) =>
+                                    attribute.name?.name === 'style' &&
+                                    Array.isArray(attribute.value?.expression?.properties) &&
+                                    attribute.value?.expression?.properties.length === 1 &&
+                                    attribute.value?.expression?.properties?.[0]?.key?.name ===
+                                        'cursor' &&
+                                    attribute.value?.expression?.properties?.[0]?.value?.value ===
+                                        'pointer'
+                            )
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    "Label in Popover needs visual indication that it is clickable via style={{ cursor: 'pointer' }} prop",
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'Td-dataLabel-Th-text': {
         // Require that if Td element has dataLabel prop with string value,
         // then Th element with same index has corresponding text (or screenReaderText).
@@ -293,6 +335,38 @@ const rules = {
                             context.report({
                                 node,
                                 message: 'Move React Router Link inside PatternFly Label element',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
+    'no-Label-in-Button-in-Popover': {
+        // PatternFly Label in (wrapped by) in Button (wrapped by) in Popover which is in LabelGroup
+        // affects the height other Label elements.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Do not wrap Label in unneeded Button to wrap it in Popover',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXElement(node) {
+                    if (node.openingElement?.name?.name === 'Label') {
+                        const ancestors = context.sourceCode.getAncestors(node);
+                        if (
+                            ancestors.length >= 2 &&
+                            ancestors[ancestors.length - 1].openingElement?.name?.name ===
+                                'Button' &&
+                            ancestors[ancestors.length - 2].openingElement?.name?.name === 'Popover'
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'Do not wrap Label in unneeded Button to wrap it in Popover',
                             });
                         }
                     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -392,7 +392,7 @@ function ImageOverviewTable({
                                 {labels.length !== 0 && (
                                     <Tr>
                                         <Td colSpan={colSpan} style={{ paddingTop: 0 }}>
-                                            <LabelGroup numLabels={labels.length}>
+                                            <LabelGroup isCompact numLabels={labels.length}>
                                                 {labels}
                                             </LabelGroup>
                                         </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -296,6 +296,7 @@ function ImageOverviewTable({
                         if (verifiedSignatureResults.length !== 0) {
                             labels.push(
                                 <VerifiedSignatureLabel
+                                    key="verifiedSignatureResults"
                                     verifiedSignatureResults={verifiedSignatureResults}
                                     isCompact
                                     variant="outline"
@@ -304,13 +305,24 @@ function ImageOverviewTable({
                         }
                         if (isWatchedImage) {
                             labels.push(
-                                <Label isCompact variant="outline" color="grey" icon={<EyeIcon />}>
+                                <Label
+                                    key="isWatchedImage"
+                                    isCompact
+                                    variant="outline"
+                                    color="grey"
+                                    icon={<EyeIcon />}
+                                >
                                     Watched image
                                 </Label>
                             );
                         }
                         if (hasScanMessage) {
-                            labels.push(<ImageScanningIncompleteLabel scanMessage={scanMessage} />);
+                            labels.push(
+                                <ImageScanningIncompleteLabel
+                                    key="hasScanMessage"
+                                    scanMessage={scanMessage}
+                                />
+                            );
                         }
 
                         // Td style={{ paddingTop: 0 }} prop emulates vertical space when label was in cell instead of row

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
+import type { ReactNode } from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Flex, Label } from '@patternfly/react-core';
+import { Flex, Label, LabelGroup } from '@patternfly/react-core';
 import { EyeIcon } from '@patternfly/react-icons';
 import isEmpty from 'lodash/isEmpty';
 
@@ -27,7 +28,9 @@ import ImageNameLink from '../components/ImageNameLink';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { SignatureVerificationResult, VulnerabilitySeverityLabel, WatchStatus } from '../../types';
 import ImageScanningIncompleteLabel from '../components/ImageScanningIncompleteLabel';
-import VerifiedSignatureLabel from '../components/VerifiedSignatureLabel';
+import VerifiedSignatureLabel, {
+    getVerifiedSignatureInResults,
+} from '../components/VerifiedSignatureLabel';
 import getImageScanMessage from '../utils/getImageScanMessage';
 import { getSeveritySortOptions } from '../../utils/sortUtils';
 
@@ -286,6 +289,32 @@ function ImageOverviewTable({
                             });
                         }
 
+                        const labels: ReactNode[] = [];
+                        const verifiedSignatureResults = getVerifiedSignatureInResults(
+                            signatureVerificationData?.results
+                        );
+                        if (verifiedSignatureResults.length !== 0) {
+                            labels.push(
+                                <VerifiedSignatureLabel
+                                    verifiedSignatureResults={verifiedSignatureResults}
+                                    isCompact
+                                    variant="outline"
+                                />
+                            );
+                        }
+                        if (isWatchedImage) {
+                            labels.push(
+                                <Label isCompact variant="outline" color="grey" icon={<EyeIcon />}>
+                                    Watched image
+                                </Label>
+                            );
+                        }
+                        if (hasScanMessage) {
+                            labels.push(<ImageScanningIncompleteLabel scanMessage={scanMessage} />);
+                        }
+
+                        // Td style={{ paddingTop: 0 }} prop emulates vertical space when label was in cell instead of row
+                        // and assumes adjacent empty cell has no paddingTop.
                         return (
                             <Tbody
                                 key={id}
@@ -296,30 +325,7 @@ function ImageOverviewTable({
                                 <Tr>
                                     <Td className={getVisibilityClass('image')} dataLabel="Image">
                                         {name ? (
-                                            <ImageNameLink name={name} id={id}>
-                                                <VerifiedSignatureLabel
-                                                    results={signatureVerificationData?.results}
-                                                    className="pf-v5-u-mt-xs"
-                                                    isCompact
-                                                    variant="outline"
-                                                />
-                                                {isWatchedImage && (
-                                                    <Label
-                                                        isCompact
-                                                        variant="outline"
-                                                        color="grey"
-                                                        className="pf-v5-u-mt-xs"
-                                                        icon={<EyeIcon />}
-                                                    >
-                                                        Watched image
-                                                    </Label>
-                                                )}
-                                                {hasScanMessage && (
-                                                    <ImageScanningIncompleteLabel
-                                                        scanMessage={scanMessage}
-                                                    />
-                                                )}
-                                            </ImageNameLink>
+                                            <ImageNameLink name={name} id={id} />
                                         ) : (
                                             'Image name not available'
                                         )}
@@ -383,6 +389,15 @@ function ImageOverviewTable({
                                         />
                                     </Td>
                                 </Tr>
+                                {labels.length !== 0 && (
+                                    <Tr>
+                                        <Td colSpan={colSpan} style={{ paddingTop: 0 }}>
+                                            <LabelGroup numLabels={labels.length}>
+                                                {labels}
+                                            </LabelGroup>
+                                        </Td>
+                                    </Tr>
+                                )}
                             </Tbody>
                         );
                     })

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -5,7 +5,7 @@ import { gql } from '@apollo/client';
 import { getDistanceStrict, getDateTime } from 'utils/dateUtils';
 import { SignatureVerificationResult } from '../../types';
 import SignatureCountLabel from './SignatureCountLabel';
-import VerifiedSignatureLabel from './VerifiedSignatureLabel';
+import VerifiedSignatureLabel, { getVerifiedSignatureInResults } from './VerifiedSignatureLabel';
 
 export type ImageDetails = {
     deploymentCount: number;
@@ -69,11 +69,16 @@ function ImageDetailBadges({ imageData }: ImageDetailBadgesProps) {
     } = imageData;
     const created = metadata?.v1?.created;
     const isActive = deploymentCount > 0;
+    const verifiedSignatureResults = getVerifiedSignatureInResults(
+        signatureVerificationData?.results
+    );
 
     return (
         <LabelGroup numLabels={Infinity}>
             <Label color={isActive ? 'green' : 'gold'}>{isActive ? 'Active' : 'Inactive'}</Label>
-            <VerifiedSignatureLabel results={signatureVerificationData?.results} />
+            {verifiedSignatureResults.length !== 0 && (
+                <VerifiedSignatureLabel verifiedSignatureResults={verifiedSignatureResults} />
+            )}
             <SignatureCountLabel count={signatureCount} />
             {operatingSystem && <Label>OS: {operatingSystem}</Label>}
             {created && <Label>Age: {getDistanceStrict(created, new Date())}</Label>}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
@@ -15,10 +15,9 @@ export type ImageNameLinkProps = {
         tag: string;
     };
     id: string;
-    children?: React.ReactNode;
 };
 
-function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
+function ImageNameLink({ name, id }: ImageNameLinkProps) {
     const { urlBuilder } = useWorkloadCveViewContext();
     const vulnerabilityState = useVulnerabilityState();
     const [copyIconTooltip, setCopyIconTooltip] = useState('Copy image name');
@@ -45,7 +44,6 @@ function ImageNameLink({ name, id, children }: ImageNameLinkProps) {
                     <Truncate position="middle" content={baseName} />
                 </Link>{' '}
                 <span className="pf-v5-u-color-200 pf-v5-u-font-size-sm">in {registry}</span>
-                <div>{children}</div>
             </Flex>
             <FlexItem>
                 <Tooltip

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Flex, FlexItem, Label, Popover } from '@patternfly/react-core';
+import { Flex, FlexItem, Label, Popover } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
@@ -11,39 +11,37 @@ export type ImageScanningIncompleteLabelProps = {
 };
 
 function ImageScanningIncompleteLabel({ scanMessage }: ImageScanningIncompleteLabelProps) {
+    // TODO replace style={{ cursor: 'pointer' }} prop with isClickable prop in PatternFly 6?
     return (
-        <>
-            <Popover
-                aria-label="Image scanning incomplete label"
-                bodyContent={
-                    <PopoverBodyContent
-                        headerContent="CVE data may be inaccurate"
-                        bodyContent={
-                            <Flex
-                                direction={{ default: 'column' }}
-                                spaceItems={{ default: 'spaceItemsSm' }}
-                            >
-                                <FlexItem>{scanMessage.header}</FlexItem>
-                                <FlexItem>{scanMessage.body}</FlexItem>
-                            </Flex>
-                        }
-                    />
-                }
-                enableFlip
-                position="top"
+        <Popover
+            aria-label="Image scanning incomplete label"
+            bodyContent={
+                <PopoverBodyContent
+                    headerContent="CVE data may be inaccurate"
+                    bodyContent={
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsSm' }}
+                        >
+                            <FlexItem>{scanMessage.header}</FlexItem>
+                            <FlexItem>{scanMessage.body}</FlexItem>
+                        </Flex>
+                    }
+                />
+            }
+            enableFlip
+            position="top"
+        >
+            <Label
+                color="orange"
+                isCompact
+                icon={<ExclamationTriangleIcon />}
+                variant="outline"
+                style={{ cursor: 'pointer' }}
             >
-                <Button variant="plain" className="pf-v5-u-p-0">
-                    <Label
-                        color="orange"
-                        isCompact
-                        icon={<ExclamationTriangleIcon />}
-                        variant="outline"
-                    >
-                        Image scanning incomplete
-                    </Label>
-                </Button>
-            </Popover>
-        </>
+                Image scanning incomplete
+            </Label>
+        </Popover>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SignatureCountLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SignatureCountLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Flex, FlexItem, Label, Popover, Text } from '@patternfly/react-core';
+import { Flex, FlexItem, Label, Popover, Text } from '@patternfly/react-core';
 
 import useMetadata from 'hooks/useMetadata';
 import { getProductBranding } from 'constants/productBranding';
@@ -89,9 +89,9 @@ function SignatureCountLabel({ count }: SignatureCountLabelProps) {
             hasAutoWidth
             position="top"
         >
-            <Button variant="plain" className="pf-v5-u-p-0">
-                <Label color={getColor(count)}>{getMessage(count)}</Label>
-            </Button>
+            <Label color={getColor(count)} style={{ cursor: 'pointer' }}>
+                {getMessage(count)}
+            </Label>
         </Popover>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
@@ -5,8 +5,17 @@ import { CheckCircleIcon } from '@patternfly/react-icons';
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 import { SignatureVerificationResult } from '../../types';
 
+export function getVerifiedSignatureInResults(
+    results: SignatureVerificationResult[] | null | undefined
+): SignatureVerificationResult[] {
+    const verifiedSignatureResults = results?.filter((result) => result.status === 'VERIFIED');
+    return Array.isArray(verifiedSignatureResults) && verifiedSignatureResults.length !== 0
+        ? verifiedSignatureResults
+        : [];
+}
+
 export type VerifiedSignatureLabelProps = {
-    results?: SignatureVerificationResult[] | null;
+    verifiedSignatureResults: SignatureVerificationResult[];
     className?: string;
     isCompact?: boolean;
     variant?: 'outline' | 'filled';
@@ -18,57 +27,52 @@ const styleList = {
 } as CSSProperties;
 
 function VerifiedSignatureLabel({
-    results,
+    verifiedSignatureResults,
     className,
     isCompact,
     variant,
 }: VerifiedSignatureLabelProps) {
-    const verifiedSignatureResults = results?.filter((result) => result.status === 'VERIFIED');
-    const hasVerifiedSignature = !!verifiedSignatureResults?.length;
-
     return (
-        hasVerifiedSignature && (
-            <Popover
-                aria-label="Verified image references"
-                bodyContent={
-                    <PopoverBodyContent
-                        headerContent="Verified image references"
-                        bodyContent={
-                            <Flex
-                                direction={{ default: 'column' }}
-                                spaceItems={{ default: 'spaceItemsMd' }}
-                            >
-                                {verifiedSignatureResults?.map((result) => (
-                                    <FlexItem key={result.verifierId}>
-                                        <strong>{result.verifierId}</strong>
-                                        <List style={styleList}>
-                                            {result.verifiedImageReferences?.map((name) => (
-                                                <ListItem key={name}>{name}</ListItem>
-                                            ))}
-                                        </List>
-                                    </FlexItem>
-                                ))}
-                            </Flex>
-                        }
-                    />
-                }
-                enableFlip
-                hasAutoWidth
-                position="top"
-            >
-                <Button variant="plain" className="pf-v5-u-p-0">
-                    <Label
-                        isCompact={isCompact}
-                        variant={variant}
-                        color="green"
-                        className={className}
-                        icon={<CheckCircleIcon />}
-                    >
-                        Verified signature
-                    </Label>
-                </Button>
-            </Popover>
-        )
+        <Popover
+            aria-label="Verified image references"
+            bodyContent={
+                <PopoverBodyContent
+                    headerContent="Verified image references"
+                    bodyContent={
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsMd' }}
+                        >
+                            {verifiedSignatureResults?.map((result) => (
+                                <FlexItem key={result.verifierId}>
+                                    <strong>{result.verifierId}</strong>
+                                    <List style={styleList}>
+                                        {result.verifiedImageReferences?.map((name) => (
+                                            <ListItem key={name}>{name}</ListItem>
+                                        ))}
+                                    </List>
+                                </FlexItem>
+                            ))}
+                        </Flex>
+                    }
+                />
+            }
+            enableFlip
+            hasAutoWidth
+            position="top"
+        >
+            <Button variant="plain">
+                <Label
+                    isCompact={isCompact}
+                    variant={variant}
+                    color="green"
+                    className={className}
+                    icon={<CheckCircleIcon />}
+                >
+                    Verified signature
+                </Label>
+            </Button>
+        </Popover>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import { Button, Flex, FlexItem, Label, List, ListItem, Popover } from '@patternfly/react-core';
+import { Flex, FlexItem, Label, List, ListItem, Popover } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
@@ -32,6 +32,7 @@ function VerifiedSignatureLabel({
     isCompact,
     variant,
 }: VerifiedSignatureLabelProps) {
+    // TODO replace style={{ cursor: 'pointer' }} prop with isClickable prop in PatternFly 6?
     return (
         <Popover
             aria-label="Verified image references"
@@ -61,17 +62,16 @@ function VerifiedSignatureLabel({
             hasAutoWidth
             position="top"
         >
-            <Button variant="plain">
-                <Label
-                    isCompact={isCompact}
-                    variant={variant}
-                    color="green"
-                    className={className}
-                    icon={<CheckCircleIcon />}
-                >
-                    Verified signature
-                </Label>
-            </Button>
+            <Label
+                isCompact={isCompact}
+                variant={variant}
+                color="green"
+                className={className}
+                icon={<CheckCircleIcon />}
+                style={{ cursor: 'pointer' }}
+            >
+                Verified signature
+            </Label>
         </Popover>
     );
 }


### PR DESCRIPTION
## Description

Although for consistency with CISA KEV, omit from feature epic to prevent distraction.

### Problems

Manual testing of multiple labels for CISA KEV discovered a similar cell layout.

* Width of **Image** column determines whether layout of labels is horizontal, or vertical, or both.
* Although there has been a pattern for part-time contributors to follow, even better that labels row become a consistent pattern.
* `ImageNameLink` component has extra layout responsibility for layout.

### Analysis

1. Find in Files `<ImageNameLink` has 4 results in 4 files

    * 3 have no children
    * 1 has children: ImageOverviewTable.tsx file

2. Purpose of `Label` wrapped in `Button` wrapped in `Popover` element seems like indication that there is a click interaction.

3. `VerifiedSignatureLabel` encapsulates the condition whether or not to render a label and has implicit `undefined` return value.

    * IF a component encapsulates conditional rendering, usual convention is early return of explicit `null` value.
    * Refactored `if` pattern for zero or more labels requires explicit condition.

### Solution

Fix while it is fresh in our minds.

1. Instead of coupling cell content with layout:

    * Delete `children` prop of `ImageNameLink` component.
    * Conditionally render labels row.

2. Prevent `Button` wrapper of `Label` element.

    * Add lint rules.
    * Add explicit `style` for cursor:
        https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#keyword
    * Write comment about possible replacement with `isClickable prop in PatternFly 6` especially because the `style` work-around does not deal with accessibility of interaction.

3. Lift up conditional rendering of `VerifiedSignatureLabel` element.

    * Export pure `getVerifiedSignatureInResults` function.
    * Call function in `ImageOverTable` and `ImageDetailBadges` components.

4. Although no error from `react/jsx-key` nor warning from React in browser console, hypothesize for `if push` idiom that `key` prop might help React.

    * I did add `key` prop in #16641
    * I did add `key` prop in #16555

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/images-without-cves first page

    Before changes, see absence of space between labels
    <img width="1920" height="898" alt="ImageOverviewTable_1_without_space" src="https://github.com/user-attachments/assets/d90b1fe7-1cc3-4e7b-89a8-13c645c7f58b" />

    After changes, see presence of space between labels
    <img width="1919" height="898" alt="ImageOverviewTable_1_with_space" src="https://github.com/user-attachments/assets/59f23c1a-af34-4ef2-b7d4-02137efef5fa" />

2. Go to second page

    Before changes, see third label on separate line within cell
    <img width="1920" height="898" alt="ImageOverviewTable_2_within_cell" src="https://github.com/user-attachments/assets/803cb898-56cf-4ae5-9e30-eb815fb31500" />

    After changes, see labels in row
    <img width="1920" height="898" alt="ImageOverviewTable_1_with_space_Button_Popover" src="https://github.com/user-attachments/assets/3ff9d616-1032-4f05-b843-2a1a5aebc03a" />

    With `Button` element, see unmatched height of labels
    <img width="1920" height="898" alt="unmatched_height" src="https://github.com/user-attachments/assets/8b6abb2a-7a96-4e7b-ae65-7e6977075fa0" />

    Without `Button` element, see matched height of labels
    <img width="1920" height="898" alt="matched_height" src="https://github.com/user-attachments/assets/8b4f6a7d-f543-482c-ab54-b6bd859e4e0c" />