### PR TITLE
ROX-30690: configure junit output for compliance tests

### DIFF
--- a/tests/e2e/run-compliance-e2e.sh
+++ b/tests/e2e/run-compliance-e2e.sh
@@ -44,7 +44,7 @@ run_compliance_e2e_tests() {
     rm -f FAIL
     make -C tests compliance-v2-tests || touch FAIL
 
-    store_test_results "compliance/test-results/reports" "reports"
+    store_test_results "tests/compliance-v2-tests-results" "compliance-v2-tests-results"
 
     if is_OPENSHIFT_CI; then
         cp -a compliance/test-results/artifacts/* "${ARTIFACT_DIR}/" || true

--- a/tests/e2e/run-compliance-e2e.sh
+++ b/tests/e2e/run-compliance-e2e.sh
@@ -46,10 +46,6 @@ run_compliance_e2e_tests() {
 
     store_test_results "tests/compliance-v2-tests-results" "compliance-v2-tests-results"
 
-    if is_OPENSHIFT_CI; then
-        cp -a compliance/test-results/artifacts/* "${ARTIFACT_DIR}/" || true
-    fi
-
     [[ ! -f FAIL ]] || die "Compliance e2e tests failed"
 }
 


### PR DESCRIPTION
## Description

This PR aims to fix wrong junit reports paths resulting in not applying junit2jira nor prow UI to compliance test results.
- https://github.com/stackrox/stackrox/pull/6829 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI

Log from junit2jira
```
INFO: Fri Aug 29 10:35:59 UTC 2025: Will use junit2jira to create CSV for BigQuery input
warning: tag '4.9' is externally known as '4.9.x'
time="Aug 29 10:36:00" level=info msg="Found 3 failed tests"
time="Aug 29 10:36:00" level=info msg="Issue not found. Creating new issue..." ID="?" summary="github.com/stackrox/rox/tests / TestComplianceV2UpdateScanConfigurations FAILED"
time="Aug 29 10:36:00" level=info msg="Issue not found. Creating new issue..." ID="?" summary="github.com/stackrox/rox/tests / TestComplianceV2ComplianceObjectMetadata FAILED"
time="Aug 29 10:36:00" level=info msg="Issue not found. Creating new issue..." ID="?" summary="github.com/stackrox/rox/tests / TestComplianceV2ScheduleRescan FAILED"
```
<img width="667" height="1205" alt="prow ci openshift org_view_gs_test-platform-results_pr-logs_pull_stackrox_stackrox_16600_pull-ci-stackrox-stackrox-master-ocp-4-19-compliance-e2e-tests_1961348644456108032" src="https://github.com/user-attachments/assets/34be8f7f-6d21-4dfb-8f74-43163ab65f6b" />

