### PR TITLE
fix: Fix YAML path of new enforce field in Helm config-shape

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -101,7 +101,7 @@ admissionControl:
     disableBypass: null # bool
     timeout: null # natural number
     enforceOnUpdates: null # bool
-    enforce: null # bool
+  enforce: null # bool
   imagePullPolicy: null # string
   replicas: null # int
   affinity: null # dict


### PR DESCRIPTION
## Description

I accidentally added the new `enforce` field in `admissionControl.dynamic`, but it should actually be in `admissionControl`.

