### PR TITLE
ROX-30685: Update vulnerability schema version for 4.8.3

### DIFF
--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -6,4 +6,4 @@
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
 v1 4.5.2
-v2 4.8.0
+v2 4.8.3


### PR DESCRIPTION
## Description

Per [Update Scanner's vulnerability schema version](https://spaces.redhat.com/spaces/StackRox/pages/284431271/Upstream+Release+Automation#UpstreamReleaseAutomation-scanner-updater-configurationUpdateScanner'svulnerabilityschemaversion) instructions, item (3).

Must be merged only after https://github.com/stackrox/stackrox/pull/16574.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

I did not.
