### PR TITLE
ROX-30727: Let roxctl ignore deprecated admission controller flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ since 4.7 and prior.
   - `--admission-controller-listen-on-updates`
   - `--admission-controller-listen-on-events`
   - `--admission-controller-timeout`
-
+  Using them has no effect.
 
 
 ### Technical Changes

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -169,6 +169,9 @@ func (s *sensorGenerateCommand) createCluster(ctx context.Context, svc v1.Cluste
 
 // Command defines the sensor generate command tree
 func Command(cliEnvironment environment.Environment) *cobra.Command {
+	var ignoredBoolFlag bool
+	var ignoredInt32Flag int32
+
 	generateCmd := &sensorGenerateCommand{env: cliEnvironment, cluster: defaultCluster()}
 	c := &cobra.Command{
 		Use:   "generate",
@@ -198,32 +201,26 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
 
 	// Note: If you need to change the default values for any of the flags below this comment, please change the defaults in the defaultCluster function above
-	var ignoreAdmissionControllerListenOnCreates bool
-	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerListenOnCreates, "admission-controller-listen-on-creates", true, "Whether or not to configure the admission controller webhook to listen on deployment creates.")
+	c.PersistentFlags().BoolVar(&ignoredBoolFlag, "admission-controller-listen-on-creates", true, "Whether or not to configure the admission controller webhook to listen on deployment creates.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-listen-on-creates", warningAdmissionControllerListenOnCreatesSet))
-	var ignoreAdmissionControllerListenOnUpdates bool
-	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerListenOnUpdates, "admission-controller-listen-on-updates", true, "Whether or not to configure the admission controller webhook to listen on deployment updates.")
+	c.PersistentFlags().BoolVar(&ignoredBoolFlag, "admission-controller-listen-on-updates", true, "Whether or not to configure the admission controller webhook to listen on deployment updates.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-listen-on-updates", warningAdmissionControllerListenOnUpdatesSet))
 
 	// Admission controller config
 	ac := generateCmd.cluster.DynamicConfig.AdmissionControllerConfig
 
-	var ignoreAdmissionControllerTimeout int32
-	c.PersistentFlags().Int32Var(&ignoreAdmissionControllerTimeout, "admission-controller-timeout", 0, "Timeout in seconds for the admission controller.")
+	c.PersistentFlags().Int32Var(&ignoredInt32Flag, "admission-controller-timeout", 0, "Timeout in seconds for the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-timeout", warningAdmissionControllerTimeoutSet))
 
-	var ignoreAdmissionControllerScanInline bool
-	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerScanInline, "admission-controller-scan-inline", true, "Get scans inline when using the admission controller.")
+	c.PersistentFlags().BoolVar(&ignoredBoolFlag, "admission-controller-scan-inline", true, "Get scans inline when using the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-scan-inline", warningAdmissionControllerScanInlineSet))
 
 	c.PersistentFlags().BoolVar(&ac.DisableBypass, "admission-controller-disable-bypass", false, "Disable the bypass annotations for the admission controller.")
 
-	var ignoreAdmissionControllerEnforceOnCreates bool
-	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerEnforceOnCreates, "admission-controller-enforce-on-creates", true, "Dynamic enable for enforcing on object creates in the admission controller.")
+	c.PersistentFlags().BoolVar(&ignoredBoolFlag, "admission-controller-enforce-on-creates", true, "Dynamic enable for enforcing on object creates in the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-enforce-on-creates", warningAdmissionControllerEnforceOnCreatesSet))
 
-	var ignoreAdmissionControllerEnforceOnUpdates bool
-	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerEnforceOnUpdates, "admission-controller-enforce-on-updates", true, "Dynamic enable for enforcing on object updates in the admission controller.")
+	c.PersistentFlags().BoolVar(&ignoredBoolFlag, "admission-controller-enforce-on-updates", true, "Dynamic enable for enforcing on object updates in the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-enforce-on-updates", warningAdmissionControllerEnforceOnUpdatesSet))
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerFailOnError, "admission-controller-fail-on-error", false, "Fail the admission review request in case of errors or timeouts in request evaluation.")

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -160,10 +160,6 @@ func (s *sensorGenerateCommand) fullClusterCreation() error {
 }
 
 func (s *sensorGenerateCommand) createCluster(ctx context.Context, svc v1.ClustersServiceClient) (string, error) {
-	if !s.cluster.GetAdmissionController() && s.cluster.GetDynamicConfig().GetAdmissionControllerConfig() != nil {
-		s.cluster.DynamicConfig.AdmissionControllerConfig = nil
-	}
-
 	response, err := svc.PostCluster(ctx, s.cluster)
 	if err != nil {
 		return "", errors.Wrap(err, "error creating cluster")
@@ -202,26 +198,32 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
 
 	// Note: If you need to change the default values for any of the flags below this comment, please change the defaults in the defaultCluster function above
-	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionController, "admission-controller-listen-on-creates", true, "Whether or not to configure the admission controller webhook to listen on deployment creates.")
+	var ignoreAdmissionControllerListenOnCreates bool
+	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerListenOnCreates, "admission-controller-listen-on-creates", true, "Whether or not to configure the admission controller webhook to listen on deployment creates.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-listen-on-creates", warningAdmissionControllerListenOnCreatesSet))
-	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerUpdates, "admission-controller-listen-on-updates", true, "Whether or not to configure the admission controller webhook to listen on deployment updates.")
+	var ignoreAdmissionControllerListenOnUpdates bool
+	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerListenOnUpdates, "admission-controller-listen-on-updates", true, "Whether or not to configure the admission controller webhook to listen on deployment updates.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-listen-on-updates", warningAdmissionControllerListenOnUpdatesSet))
 
 	// Admission controller config
 	ac := generateCmd.cluster.DynamicConfig.AdmissionControllerConfig
 
-	c.PersistentFlags().Int32Var(&ac.TimeoutSeconds, "admission-controller-timeout", 0, "Timeout in seconds for the admission controller.")
+	var ignoreAdmissionControllerTimeout int32
+	c.PersistentFlags().Int32Var(&ignoreAdmissionControllerTimeout, "admission-controller-timeout", 0, "Timeout in seconds for the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-timeout", warningAdmissionControllerTimeoutSet))
 
-	c.PersistentFlags().BoolVar(&ac.ScanInline, "admission-controller-scan-inline", true, "Get scans inline when using the admission controller.")
+	var ignoreAdmissionControllerScanInline bool
+	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerScanInline, "admission-controller-scan-inline", true, "Get scans inline when using the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-scan-inline", warningAdmissionControllerScanInlineSet))
 
 	c.PersistentFlags().BoolVar(&ac.DisableBypass, "admission-controller-disable-bypass", false, "Disable the bypass annotations for the admission controller.")
 
-	c.PersistentFlags().BoolVar(&ac.Enabled, "admission-controller-enforce-on-creates", true, "Dynamic enable for enforcing on object creates in the admission controller.")
+	var ignoreAdmissionControllerEnforceOnCreates bool
+	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerEnforceOnCreates, "admission-controller-enforce-on-creates", true, "Dynamic enable for enforcing on object creates in the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-enforce-on-creates", warningAdmissionControllerEnforceOnCreatesSet))
 
-	c.PersistentFlags().BoolVar(&ac.EnforceOnUpdates, "admission-controller-enforce-on-updates", true, "Dynamic enable for enforcing on object updates in the admission controller.")
+	var ignoreAdmissionControllerEnforceOnUpdates bool
+	c.PersistentFlags().BoolVar(&ignoreAdmissionControllerEnforceOnUpdates, "admission-controller-enforce-on-updates", true, "Dynamic enable for enforcing on object updates in the admission controller.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-enforce-on-updates", warningAdmissionControllerEnforceOnUpdatesSet))
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerFailOnError, "admission-controller-fail-on-error", false, "Fail the admission review request in case of errors or timeouts in request evaluation.")

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -116,8 +116,6 @@ func (s *sensorGenerateCommand) fullClusterCreation() error {
 		// enforcement "on" for both operations, or "off" for both, in line with the new design based on
 		// customer expectations.
 		acc.Enabled = acc.EnforceOnUpdates
-		// We set the timeout to 0 so that the Helm rendering takes care of setting the default value for timeout
-		acc.TimeoutSeconds = 0
 	}
 
 	id, err := s.createCluster(ctx, service)

--- a/roxctl/sensor/generate/k8s.go
+++ b/roxctl/sensor/generate/k8s.go
@@ -37,7 +37,8 @@ func k8s(generateCmd *sensorGenerateCommand) *cobra.Command {
 		}),
 	}
 
-	c.PersistentFlags().BoolVar(&k8sCommand.cluster.AdmissionControllerEvents, "admission-controller-listen-on-events", true, "Enable admission controller webhook to listen on Kubernetes events.")
+	var ignoredBoolFlag bool
+	c.PersistentFlags().BoolVar(&ignoredBoolFlag, "admission-controller-listen-on-events", true, "Enable admission controller webhook to listen on Kubernetes events.")
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-listen-on-events", WarningAdmissionControllerListenOnEventsSet))
 
 	return c


### PR DESCRIPTION
## Description

According to the design doc the now-deprecated admission controller flags shall not only be deprecated, but they shall also be without any effect, to ensure a good admission controller configuration.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] documentation PR is tracked in a dedicated ticket (ROX-30434).

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No automated tests added or modified.

### How I validated my change

Manual testing:

```
$ roxctl -e $API_ENDPOINT sensor generate k8s --name sensor-a --admission-controller-enforce-on-creates=false --admission-controller-enforce-on-updates=false --admission-controller-listen-on-creates=false --admission-controller-listen-on-updates=false --admission-controller-listen-on-events=false --admission-controller-timeout=5
Flag --admission-controller-enforce-on-creates has been deprecated, The --admission-controller-enforce-on-creates flag will be removed in future versions of roxctl. It will be ignored from version 4.9 onwards.
Flag --admission-controller-enforce-on-updates has been deprecated, The --admission-controller-enforce-on-updates flag will be removed in future versions of roxctl. It will be ignored from version 4.9 onwards.
Flag --admission-controller-listen-on-creates has been deprecated, The --admission-controller-listen-on-creates will be removed in future versions of roxctl. It will be ignored from version 4.9 onwards.
Flag --admission-controller-listen-on-updates has been deprecated, The --admission-controller-listen-on-updates will be removed in future versions of roxctl. It will be ignored from version 4.9 onwards.
Flag --admission-controller-listen-on-events has been deprecated, The --admission-controller-listen-on-events flag has been deprecated and will be removed in future versions of roxctl. It will be ignored from version 4.9 onwards.
Flag --admission-controller-timeout has been deprecated, The --admission-controller-timeout flag will be removed in future versions of roxctl. It will be ignored from version 4.9 onwards.
INFO:   Deployment bundle does not include PodSecurityPolicies (PSPs).
INFO:   This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.
INFO:   Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.
INFO:   Successfully wrote sensor folder "sensor-sensor-a"
```

Verify admission controller configuration of cluster in central DB:
```
$ roxcurl /v1/clusters | jq '.clusters[] | select(.name == "sensor-a") | {admissionController, admissionControllerUpdates, admissionControllerEvents, dynamicConfig: .dynamicConfig.admissionControllerConfig | {enabled, timeoutSeconds, enforceOnUpdates}}'
{
  "admissionController": true,
  "admissionControllerUpdates": true,
  "admissionControllerEvents": true,
  "dynamicConfig": {
    "enabled": true,
    "timeoutSeconds": 10,
    "enforceOnUpdates": true
  }
}
```
