### PR TITLE
ROX-30860: Limit parallel port use by processes 

### DIFF
--- a/scale/workloads/10-sensors.yaml
+++ b/scale/workloads/10-sensors.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 5000
   flowInterval: 30s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/active-vulnmgmt.yaml
+++ b/scale/workloads/active-vulnmgmt.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 1s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 500
 rbacWorkload:

--- a/scale/workloads/default.yaml
+++ b/scale/workloads/default.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 1s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/high-alert.yaml
+++ b/scale/workloads/high-alert.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 1s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/long-running.yaml
+++ b/scale/workloads/long-running.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 1s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/np-load.yaml
+++ b/scale/workloads/np-load.yaml
@@ -41,6 +41,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 1s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/okr-single-load.yaml
+++ b/scale/workloads/okr-single-load.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 500
   flowInterval: 24h
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/rbac.yaml
+++ b/scale/workloads/rbac.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 30s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 100
 rbacWorkload:

--- a/scale/workloads/sample.yaml
+++ b/scale/workloads/sample.yaml
@@ -58,4 +58,7 @@ networkWorkload:
   batchSize: 500
   # whether to generate endpoints that will never be marked as closed
   generateUnclosedEndpoints: true
+  # a probability of reusing an existing open endpoint by a different process without closing the endpoint
+  # i.e., multiple processes listening on the same port.
+  openPortReuseProbability: 0.05
 

--- a/scale/workloads/scale-test.yaml
+++ b/scale/workloads/scale-test.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 1s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/small.yaml
+++ b/scale/workloads/small.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 30s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 100
 rbacWorkload:

--- a/scale/workloads/vulnmgmt.yaml
+++ b/scale/workloads/vulnmgmt.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 100
   flowInterval: 0
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/scale/workloads/xlarge.yaml
+++ b/scale/workloads/xlarge.yaml
@@ -17,6 +17,7 @@ networkWorkload:
   batchSize: 500
   flowInterval: 1s
   generateUnclosedEndpoints: true
+  openPortReuseProbability: 0.05
 nodeWorkload:
   numNodes: 1000
 rbacWorkload:

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -224,10 +225,22 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 	}
 	mgr.initializePreexistingResources()
 
+	if warn := validateWorkload(workload); warn != nil {
+		log.Warnf("Validaing workload: %s", warn)
+	}
+
 	log.Info("Created Workload manager for workload")
 	log.Infof("Workload: %s", string(data))
 	log.Infof("Rendered workload: %+v", workload)
 	return mgr
+}
+
+func validateWorkload(workload Workload) error {
+	if workload.NetworkWorkload.OpenPortReuseProbability < 0.0 || workload.NetworkWorkload.OpenPortReuseProbability > 1.0 {
+		return fmt.Errorf("incorrect probability value %.2f for 'openPortReuseProbability', "+
+			"rounding to the nearest value from range <0.0, 1.0>", workload.NetworkWorkload.OpenPortReuseProbability)
+	}
+	return nil
 }
 
 // SetSignalHandlers sets the handlers that will accept runtime data to be mocked from collector

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -101,6 +101,7 @@ type WorkloadManager struct {
 	containerPool             *pool
 	registeredHostConnections []manager.HostNetworkInfo
 	workload                  *Workload
+	originatorCache           *OriginatorCache
 
 	// signals services
 	servicesInitialized concurrency.Signal
@@ -212,12 +213,13 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 	mgr := &WorkloadManager{
 		db:                  db,
 		workload:            &workload,
-		processPool:         config.processPool,
+		originatorCache:     NewOriginatorCache(), // Dependency injection
 		labelsPool:          config.labelsPool,
 		endpointPool:        config.endpointPool,
 		ipPool:              config.ipPool,
 		externalIpPool:      config.externalIpPool,
 		containerPool:       config.containerPool,
+		processPool:         config.processPool,
 		servicesInitialized: concurrency.NewSignal(),
 	}
 	mgr.initializePreexistingResources()

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -213,7 +213,7 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 	mgr := &WorkloadManager{
 		db:                  db,
 		workload:            &workload,
-		originatorCache:     NewOriginatorCache(), // Dependency injection
+		originatorCache:     NewOriginatorCache(),
 		labelsPool:          config.labelsPool,
 		endpointPool:        config.endpointPool,
 		ipPool:              config.ipPool,
@@ -336,5 +336,5 @@ func (w *WorkloadManager) initializePreexistingResources() {
 		go w.manageNetworkPolicy(context.Background(), resource)
 	}
 
-	go w.manageFlows(context.Background(), w.workload.NetworkWorkload)
+	go w.manageFlows(context.Background())
 }

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -56,14 +56,10 @@ func NewOriginatorCache() *OriginatorCache {
 // Note that if Sensor sees an open endpoint for <container1, 1.1.1.1:80, nginx> and then another open endpoint for
 // <container1, 1.1.1.1:80, apache2>, then Sensor will keep the nginx-entry forever, as there was no 'close' message in between.
 //
-// The probability logic is explicit and configurable for differ{ent testing scenarios.
+// The probability logic is explicit and configurable for different testing scenarios.
 func (oc *OriginatorCache) GetOrSetOriginator(endpointKey string, containerID string, openPortReuseProbability float64, processPool *ProcessPool) *storage.NetworkProcessUniqueKey {
-	// Ensure that the probability is between 0.0 and 1.0.
+	// Ensure that the probability is between 0.0 and 1.0. Warning log has been produced in `validateWorkload`.
 	prob := math.Min(1.0, math.Max(0.0, openPortReuseProbability))
-	if openPortReuseProbability < 0.0 || openPortReuseProbability > 1.0 {
-		log.Warnf("Incorrect probability value %.2f for 'openPortReuseProbability', "+
-			"rounding to: %.2f.", openPortReuseProbability, prob)
-	}
 
 	originator, exists := concurrency.WithRLock2(&oc.lock, func() (*storage.NetworkProcessUniqueKey, bool) {
 		originator, exists := oc.cache[endpointKey]

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -3,7 +3,6 @@ package fake
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/rand"
 	"time"
 
@@ -58,15 +57,12 @@ func NewOriginatorCache() *OriginatorCache {
 //
 // The probability logic is explicit and configurable for different testing scenarios.
 func (oc *OriginatorCache) GetOrSetOriginator(endpointKey string, containerID string, openPortReuseProbability float64, processPool *ProcessPool) *storage.NetworkProcessUniqueKey {
-	// Ensure that the probability is between 0.0 and 1.0. Warning log has been produced in `validateWorkload`.
-	prob := math.Min(1.0, math.Max(0.0, openPortReuseProbability))
-
 	originator, exists := concurrency.WithRLock2(&oc.lock, func() (*storage.NetworkProcessUniqueKey, bool) {
 		originator, exists := oc.cache[endpointKey]
 		return originator, exists
 	})
 
-	if exists && rand.Float64() > prob {
+	if exists && rand.Float64() > openPortReuseProbability {
 		// Use the previously-known process for the same endpoint.
 		return originator
 	}

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -3,6 +3,7 @@ package fake
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"time"
 
@@ -55,15 +56,21 @@ func NewOriginatorCache() *OriginatorCache {
 // Note that if Sensor sees an open endpoint for <container1, 1.1.1.1:80, nginx> and then another open endpoint for
 // <container1, 1.1.1.1:80, apache2>, then Sensor will keep the nginx-entry forever, as there was no 'close' message in between.
 //
-// The probability logic is explicit and configurable for different testing scenarios.
-func (oc *OriginatorCache) GetOrSetOriginator(endpointKey string, containerID string, openPortReuseProbability float32, processPool *ProcessPool) *storage.NetworkProcessUniqueKey {
-	// Use panic-safe read lock to check cache
+// The probability logic is explicit and configurable for differ{ent testing scenarios.
+func (oc *OriginatorCache) GetOrSetOriginator(endpointKey string, containerID string, openPortReuseProbability float64, processPool *ProcessPool) *storage.NetworkProcessUniqueKey {
+	// Ensure that the probability is between 0.0 and 1.0.
+	prob := math.Min(1.0, math.Max(0.0, openPortReuseProbability))
+	if openPortReuseProbability < 0.0 || openPortReuseProbability > 1.0 {
+		log.Warnf("Incorrect probability value %.2f for 'openPortReuseProbability', "+
+			"rounding to: %.2f.", openPortReuseProbability, prob)
+	}
+
 	originator, exists := concurrency.WithRLock2(&oc.lock, func() (*storage.NetworkProcessUniqueKey, bool) {
 		originator, exists := oc.cache[endpointKey]
 		return originator, exists
 	})
 
-	if exists && rand.Float32() > openPortReuseProbability {
+	if exists && rand.Float64() > prob {
 		// Use the previously-known process for the same endpoint.
 		return originator
 	}

--- a/sensor/kubernetes/fake/flows_test.go
+++ b/sensor/kubernetes/fake/flows_test.go
@@ -3,22 +3,36 @@ package fake
 import (
 	"testing"
 
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stretchr/testify/suite"
 )
 
 type flowsSuite struct {
 	suite.Suite
+	containerID string
+	endpointKey string
+	processPool *ProcessPool
 }
 
 func TestFlowsSuite(t *testing.T) {
 	suite.Run(t, new(flowsSuite))
 }
 
+func (s *flowsSuite) SetupSuite() {
+	// containerID must be 12 chars due to impl details of `getActiveProcesses`.
+	s.containerID = "container123"
+	s.endpointKey = "10.0.0.1:8080"
+	s.processPool = newProcessPool()
+	for _, process := range getActiveProcesses(s.containerID) {
+		s.processPool.add(process)
+	}
+}
+
 func (s *flowsSuite) TestGetRandomInternalExternalIP() {
 	w := &WorkloadManager{
 		endpointPool:   newEndpointPool(),
-		processPool:    newProcessPool(),
+		processPool:    s.processPool,
 		ipPool:         newPool(),
 		externalIpPool: newPool(),
 		containerPool:  newPool(),
@@ -45,4 +59,51 @@ func (s *flowsSuite) TestGetRandomInternalExternalIP() {
 		s.True(!net.ParseIP(src).IsPublic() || !net.ParseIP(dst).IsPublic())
 		s.True(ok)
 	}
+}
+
+func (s *flowsSuite) TestOriginatorCache_BasicCaching() {
+	cache := NewOriginatorCache()
+
+	// Manually seed the cache with a known originator
+	seedOriginator := &storage.NetworkProcessUniqueKey{
+		ProcessName:         "cached-process",
+		ProcessExecFilePath: "/usr/bin/cached-process",
+		ProcessArgs:         "cached args",
+	}
+	cache.cache[s.endpointKey] = seedOriginator
+
+	// With 0.0 probability, it should return the cached originator
+	for range 10 {
+		originator := cache.GetOrSetOriginator(s.endpointKey, s.containerID, 0.0, s.processPool)
+		s.NotNil(originator)
+		s.Equal("cached-process", originator.ProcessName)
+		s.Equal("/usr/bin/cached-process", originator.ProcessExecFilePath)
+		s.Equal("cached args", originator.ProcessArgs)
+	}
+}
+
+func (s *flowsSuite) TestOriginatorCache_ProbabilityCaching() {
+	cache := NewOriginatorCache()
+
+	seedOriginator := &storage.NetworkProcessUniqueKey{
+		ProcessName:         "cached-process",
+		ProcessExecFilePath: "/usr/bin/cached-process",
+		ProcessArgs:         "cached args",
+	}
+	cache.cache[s.endpointKey] = seedOriginator
+	numCacheMisses := 0
+
+	s.T().Logf("Testing with endpoint key: %s, number of processes in pool: %d", s.endpointKey, len(s.processPool.Processes[s.containerID]))
+
+	for range 100_000 {
+		originator := cache.GetOrSetOriginator(s.endpointKey, s.containerID, 0.05, s.processPool)
+		s.Require().NotNil(originator)
+		if originator != seedOriginator {
+			numCacheMisses++
+		}
+	}
+	s.Len(cache.cache, 1, "Cache should have 1 entry")
+	got := float64(numCacheMisses) / 100_000
+	s.T().Logf("Observed probability of reusing port: %f", got)
+	s.InDelta(0.05, got, 0.02, "Cache miss rate should be close to 0.05 (range <0.03,0.07>)")
 }

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -47,7 +47,7 @@ type NetworkWorkload struct {
 	GenerateUnclosedEndpoints bool          `yaml:"generateUnclosedEndpoints"`
 	// OpenPortReuseProbability is the probability of reusing an existing open endpoint
 	// by a different process without closing the endpoint.
-	// In releases 4.8 and older, this was not configurable and was always set to1.0.
+	// In releases 4.8 and older, this was not configurable and was always set to 1.0.
 	OpenPortReuseProbability float64 `yaml:"openPortReuseProbability"`
 }
 

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -48,7 +48,7 @@ type NetworkWorkload struct {
 	// OpenPortReuseProbability is the probability of reusing an existing open endpoint
 	// by a different process without closing the endpoint.
 	// In releases 4.8 and older, this was not configurable and was always set to1.0.
-	OpenPortReuseProbability float32 `yaml:"openPortReuseProbability"`
+	OpenPortReuseProbability float64 `yaml:"openPortReuseProbability"`
 }
 
 // PodWorkload defines the workload and lifecycle of the pods within a deployment

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -45,6 +45,10 @@ type NetworkWorkload struct {
 	FlowInterval              time.Duration `yaml:"flowInterval"`
 	BatchSize                 int           `yaml:"batchSize"`
 	GenerateUnclosedEndpoints bool          `yaml:"generateUnclosedEndpoints"`
+	// OpenPortReuseProbability is the probability of reusing an existing open endpoint
+	// by a different process without closing the endpoint.
+	// In releases 4.8 and older, this was not configurable and was always set to1.0.
+	OpenPortReuseProbability float32 `yaml:"openPortReuseProbability"`
 }
 
 // PodWorkload defines the workload and lifecycle of the pods within a deployment


### PR DESCRIPTION
## Description


Introduced configurable port reuse probability to limit unrealistic endpoint sharing behavior in fake workload generation.

**Key Changes:**
- **Added `OriginatorCache`**: Implements probabilistic endpoint-to-originator caching with configurable reuse probability
- **Added `openPortReuseProbability` field**: Configurable parameter (default 0.05) controlling how often different processes reuse the same IP:port without closing endpoints
- **Updated all workload configurations**: Set realistic 5% port reuse probability across all test scenarios
- **Enhanced network endpoint generation**: Uses consistent originator caching instead of random assignment

**Why**: Previous behavior (100% port reuse in releases ≤4.8) was unrealistic and caused memory pressure in Sensor's enrichment pipeline. Multiple processes listening on the same IP:port without proper endpoint closure created excessive deduplication overhead, as Sensor would retain stale entries indefinitely when no close messages were sent between different originators on the same endpoint.

The new approach simulates realistic container behavior where processes typically bind consistently to endpoints (95% default) while allowing occasional port reuse scenarios (5% for restarts/takeovers).

**Impact**: 
- Reduces memory pressure in test environments while maintaining test coverage for edge cases.
- Long running cluster measurements for 4.9 cannot be directly compared against versions ≤4.8 as the workload profile has changed.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] CI and added unit tests
- [x] Manual run on the long-running cluster

The workload runs fine on the long running cluster. 
Sensor is crashing every 12 hours on 8GB of memory (due to OOMKill), which is a known pattern, but that is not caused by this PR, but by the: (1) bug in the memory management that is currently on master, (2) giving Sensor only 8GB of memory for the experiment.

The following chart confirms the rates of objects being generated by fake workflows
<img width="1135" height="451" alt="Screenshot 2025-09-23 at 10 39 33" src="https://github.com/user-attachments/assets/83c1894d-6d1a-427b-96a4-786546ccfbe0" />

This chart shows that the processesListening are being processed and sent to Central
<img width="1324" height="835" alt="Screenshot 2025-09-23 at 10 46 02" src="https://github.com/user-attachments/assets/2c66001a-768b-414f-9326-17f6bbf3a000" />

