### PR TITLE
refactor(ui): Allow customization of CVE page table column config

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -17,7 +17,6 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
@@ -38,7 +37,8 @@ import {
 } from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import { getTableUIState } from 'utils/getTableUIState';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
-import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
+import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import { HistoryAction } from 'hooks/useURLParameter';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
@@ -177,15 +177,19 @@ export type ImageCvePageProps = {
     searchFilterConfig: CompoundSearchFilterEntity[];
     vulnerabilityState: VulnerabilityState;
     showVulnerabilityStateTabs: boolean;
+    imageTableColumnOverrides: ColumnConfigOverrides<keyof typeof affectedImagesDefaultColumns>;
+    deploymentTableColumnOverrides: ColumnConfigOverrides<
+        keyof typeof affectedDeploymentsDefaultColumns
+    >;
 };
 
 function ImageCvePage({
     searchFilterConfig,
     vulnerabilityState,
     showVulnerabilityStateTabs,
+    imageTableColumnOverrides,
+    deploymentTableColumnOverrides,
 }: ImageCvePageProps) {
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
@@ -287,22 +291,25 @@ function ImageCvePage({
         skip: entityTab !== 'Deployment',
     });
 
-    const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const imageTableManagedState = useManagedColumns(
         affectedImagesTableId,
         affectedImagesDefaultColumns
     );
 
-    const imageTableColumnConfig = overrideManagedColumns(imageTableManagedState.columns, {
-        nvdCvss: hideColumnIf(!isNvdCvssColumnEnabled),
-    });
+    const imageTableColumnConfig = overrideManagedColumns(
+        imageTableManagedState.columns,
+        imageTableColumnOverrides
+    );
 
     const deploymentTableManagedState = useManagedColumns(
         affectedDeploymentsTableId,
         affectedDeploymentsDefaultColumns
     );
 
-    const deploymentTableColumnConfig = deploymentTableManagedState.columns;
+    const deploymentTableColumnConfig = overrideManagedColumns(
+        deploymentTableManagedState.columns,
+        deploymentTableColumnOverrides
+    );
 
     const imageCount = summaryRequest.data?.imageCount ?? 0;
     const deploymentCount = summaryRequest.data?.deploymentCount ?? 0;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageRoute.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageRoute.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
+import { hideColumnIf } from 'hooks/useManagedColumns';
+import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
+
 import {
     imageSearchFilterConfig,
     imageComponentSearchFilterConfig,
     deploymentSearchFilterConfig,
     namespaceSearchFilterConfig,
     clusterSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
+} from '../../searchFilterConfig';
 import ImageCvePage from './ImageCvePage';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
@@ -20,11 +23,20 @@ function ImageCvePageRoute() {
     ];
 
     const vulnerabilityState = useVulnerabilityState();
+    const isScannerV4Enabled = useIsScannerV4Enabled();
+
+    const imageTableColumnOverrides = {
+        nvdCvss: hideColumnIf(!isScannerV4Enabled),
+    };
+    const deploymentTableColumnOverrides = {};
+
     return (
         <ImageCvePage
             searchFilterConfig={searchFilterConfig}
             showVulnerabilityStateTabs
             vulnerabilityState={vulnerabilityState}
+            imageTableColumnOverrides={imageTableColumnOverrides}
+            deploymentTableColumnOverrides={deploymentTableColumnOverrides}
         />
     );
 }


### PR DESCRIPTION
## Description

As titled, moves the customization of table columns on the Image CVE page to a higher level to allow different values in the OCP plugin.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

With Scanner V4, see the inclusion of NVD CVSS:
<img width="1535" height="897" alt="image" src="https://github.com/user-attachments/assets/c3526f89-31b3-4f27-93f2-52ba7d0856b2" />

Without Scanner V4:

<img width="1535" height="897" alt="image" src="https://github.com/user-attachments/assets/81ed1384-07b5-471d-89ec-e871cdc2f240" />