### PR TITLE
ROX-30733: Omit include in optional columns and add CISA KEV comments

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/components/ReportParametersDetails.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     DescriptionList,
     DescriptionListDescription,
@@ -7,7 +9,6 @@ import {
     FlexItem,
     Title,
 } from '@patternfly/react-core';
-import React, { ReactElement } from 'react';
 
 import { ReportFormValues } from 'Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues';
 import { fixabilityLabels } from 'constants/reportConstants';
@@ -29,14 +30,43 @@ function ReportParametersDetails({
     formValues,
 }: ReportParametersDetailsProps): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isIncludeAdvisoryEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const hasIncludeAdvisory =
-        isIncludeAdvisoryEnabled && formValues.reportParameters.includeAdvisory;
-    const isIncludeEpssProbabilityEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const hasIncludeEpssProbability =
-        isIncludeEpssProbabilityEnabled && formValues.reportParameters.includeEpssProbability;
-    const isIncludeNvdCvssEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const hasIncludeNvdCvss = isIncludeNvdCvssEnabled && formValues.reportParameters.includeNvdCvss;
+    const optionalColumnsDescriptions: ReactElement[] = [];
+    if (isFeatureFlagEnabled('ROX_SCANNER_V4') && formValues.reportParameters.includeNvdCvss) {
+        optionalColumnsDescriptions.push(
+            <DescriptionListDescription key="includeNvdCvss">NVDCVSS</DescriptionListDescription>
+        );
+    }
+    if (
+        isFeatureFlagEnabled('ROX_SCANNER_V4') &&
+        formValues.reportParameters.includeEpssProbability
+    ) {
+        optionalColumnsDescriptions.push(
+            <DescriptionListDescription key="includeEpssProbability">
+                EPSS Probability Percentage
+            </DescriptionListDescription>
+        );
+    }
+    if (isFeatureFlagEnabled('ROX_SCANNER_V4') && formValues.reportParameters.includeAdvisory) {
+        optionalColumnsDescriptions.push(
+            <DescriptionListDescription key="includeAdvisory">
+                Advisory Name and Advisory Link
+            </DescriptionListDescription>
+        );
+    }
+    /*
+    // Ross CISA KEV includeKnownExploit?
+    if (
+        isFeatureFlagEnabled('ROX_SCANNER_V4') &&
+        isFeatureFlagEnabled('ROX_WHATEVER') &&
+        formValues.reportParameters.includeKnownExploit
+    ) {
+        optionalColumnsDescriptions.push(
+            <DescriptionListDescription key="includeKnownExploit">
+                Known exploit
+            </DescriptionListDescription>
+        );
+    }
+    */
 
     const cveSeverities =
         formValues.reportParameters.cveSeverities.length !== 0 ? (
@@ -136,22 +166,10 @@ function ReportParametersDetails({
                         <DescriptionListDescription>Discovered At</DescriptionListDescription>
                         <DescriptionListDescription>Reference</DescriptionListDescription>
                     </DescriptionListGroup>
-                    {(hasIncludeNvdCvss || hasIncludeEpssProbability || hasIncludeAdvisory) && (
+                    {optionalColumnsDescriptions.length !== 0 && (
                         <DescriptionListGroup>
                             <DescriptionListTerm>Optional columns</DescriptionListTerm>
-                            {hasIncludeNvdCvss && (
-                                <DescriptionListDescription>NVDCVSS</DescriptionListDescription>
-                            )}
-                            {hasIncludeEpssProbability && (
-                                <DescriptionListDescription>
-                                    EPSS Probability Percentage
-                                </DescriptionListDescription>
-                            )}
-                            {hasIncludeAdvisory && (
-                                <DescriptionListDescription>
-                                    Advisory Name and Advisory Link
-                                </DescriptionListDescription>
-                            )}
+                            {optionalColumnsDescriptions}
                         </DescriptionListGroup>
                     )}
                 </DescriptionList>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -1,4 +1,5 @@
-import React, { ChangeEvent, FormEvent, ReactElement } from 'react';
+import React from 'react';
+import type { ChangeEvent, FormEvent, ReactElement } from 'react';
 import {
     Checkbox,
     DatePicker,
@@ -13,7 +14,7 @@ import {
     TextInput,
     Title,
 } from '@patternfly/react-core';
-import { FormikProps } from 'formik';
+import type { FormikProps } from 'formik';
 import { cloneDeep } from 'lodash';
 
 import {
@@ -31,8 +32,8 @@ import SelectSingle from 'Components/SelectSingle/SelectSingle';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { CollectionSlim } from 'services/CollectionsService';
-import { NotifierConfiguration } from 'services/ReportsService.types';
+import type { CollectionSlim } from 'services/CollectionsService';
+import type { NotifierConfiguration } from 'services/ReportsService.types';
 import CollectionSelection from './CollectionSelection';
 
 export type ReportParametersFormProps = {
@@ -42,9 +43,54 @@ export type ReportParametersFormProps = {
 
 function ReportParametersForm({ title, formik }: ReportParametersFormProps): ReactElement {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isIncludeAdvisoryEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isIncludeEpssProbabilityEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isIncludeNvdCvssEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const optionalColumnsCheckboxes: ReactElement[] = [];
+    if (isFeatureFlagEnabled('ROX_SCANNER_V4')) {
+        optionalColumnsCheckboxes.push(
+            <Checkbox
+                key="includeNvdCvss"
+                label="NVD CVSS"
+                id="reportParameters.includeNvdCvss"
+                isChecked={formik.values.reportParameters.includeNvdCvss}
+                onChange={onChange}
+            />
+        );
+    }
+    if (isFeatureFlagEnabled('ROX_SCANNER_V4')) {
+        optionalColumnsCheckboxes.push(
+            <Checkbox
+                key="includeEpssProbability"
+                label="EPSS probability"
+                id="reportParameters.includeEpssProbability"
+                isChecked={formik.values.reportParameters.includeEpssProbability}
+                onChange={onChange}
+            />
+        );
+    }
+    if (isFeatureFlagEnabled('ROX_SCANNER_V4')) {
+        optionalColumnsCheckboxes.push(
+            <Checkbox
+                key="includeAdvisory"
+                label="advisory name and link"
+                id="reportParameters.includeAdvisory"
+                isChecked={formik.values.reportParameters.includeAdvisory}
+                onChange={onChange}
+            />
+        );
+    }
+    /*
+    // Ross CISA KEV includeKnownExploit?
+    if (isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_WHATEVER')) {
+        optionalColumnsCheckboxes.push(
+            <Checkbox
+                key="includeKnownExploit"
+                label="known exploit"
+                id="reportParameters.includeKnownExploit"
+                isChecked={formik.values.reportParameters.includeKnownExploit}
+                onChange={onChange}
+            />
+        );
+    }
+    */
 
     const handleTextChange =
         (fieldName: string) =>
@@ -291,34 +337,9 @@ function ReportParametersForm({ title, formik }: ReportParametersFormProps): Rea
                         />
                     </FormLabelGroup>
                 )}
-                {(isIncludeNvdCvssEnabled ||
-                    isIncludeEpssProbabilityEnabled ||
-                    isIncludeAdvisoryEnabled) && (
+                {optionalColumnsCheckboxes.length !== 0 && (
                     <FormGroup label="Optional columns" isInline isStack>
-                        {isIncludeNvdCvssEnabled && (
-                            <Checkbox
-                                label="Include NVD CVSS"
-                                id="reportParameters.includeNvdCvss"
-                                isChecked={formik.values.reportParameters.includeNvdCvss}
-                                onChange={onChange}
-                            />
-                        )}
-                        {isIncludeEpssProbabilityEnabled && (
-                            <Checkbox
-                                label="Include EPSS probability"
-                                id="reportParameters.includeEpssProbability"
-                                isChecked={formik.values.reportParameters.includeEpssProbability}
-                                onChange={onChange}
-                            />
-                        )}
-                        {isIncludeAdvisoryEnabled && (
-                            <Checkbox
-                                label="Include advisory name and link"
-                                id="reportParameters.includeAdvisory"
-                                isChecked={formik.values.reportParameters.includeAdvisory}
-                                onChange={onChange}
-                            />
-                        )}
+                        {optionalColumnsCheckboxes}
                     </FormGroup>
                 )}
                 <FormLabelGroup

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -70,7 +70,7 @@ function ReportParametersForm({ title, formik }: ReportParametersFormProps): Rea
         optionalColumnsCheckboxes.push(
             <Checkbox
                 key="includeAdvisory"
-                label="advisory name and link"
+                label="Advisory Name and Advisory Link"
                 id="reportParameters.includeAdvisory"
                 isChecked={formik.values.reportParameters.includeAdvisory}
                 onChange={onChange}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/useReportFormValues.tsx
@@ -51,6 +51,7 @@ export type ReportParametersFormValues = {
     cvesDiscoveredStartDate: CVESDiscoveredStartDate;
     includeAdvisory: boolean;
     includeEpssProbability: boolean;
+    // Ross CISA KEV includeKnownExploit?
     includeNvdCvss: boolean;
     reportScope: ReportScope | null;
 };
@@ -82,6 +83,7 @@ export const defaultReportFormValues: ReportFormValues = {
         cvesDiscoveredStartDate: undefined,
         includeAdvisory: false,
         includeEpssProbability: false,
+        // Ross CISA KEV includeKnownExploit?
         includeNvdCvss: false,
         reportScope: null,
     },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.test.ts
@@ -83,6 +83,7 @@ describe('utils', () => {
                 imageType: [],
                 includeAdvisory: false,
                 includeEpssProbability: false,
+                // Ross CISA KEV includeKnownExploit?
                 includeNvdCvss: false,
                 cvesDiscoveredSince: 'ALL_VULN',
                 cvesDiscoveredStartDate: undefined,
@@ -103,6 +104,7 @@ describe('utils', () => {
                 imageType: [],
                 includeAdvisory: false,
                 includeEpssProbability: false,
+                // Ross CISA KEV includeKnownExploit?
                 includeNvdCvss: false,
                 cvesDiscoveredSince: 'SINCE_LAST_REPORT',
                 cvesDiscoveredStartDate: undefined,
@@ -123,6 +125,7 @@ describe('utils', () => {
                 imageType: [],
                 includeAdvisory: false,
                 includeEpssProbability: false,
+                // Ross CISA KEV includeKnownExploit?
                 includeNvdCvss: false,
                 cvesDiscoveredSince: 'START_DATE',
                 cvesDiscoveredStartDate: '2023-10-02',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/utils.ts
@@ -60,6 +60,7 @@ export function getReportConfigurationFromFormValues(
         imageTypes: reportParameters.imageType,
         includeAdvisory: reportParameters.includeAdvisory,
         includeEpssProbability: reportParameters.includeEpssProbability,
+        // Ross CISA KEV includeKnownExploit?
         includeNvdCvss: reportParameters.includeNvdCvss,
     };
     let vulnReportFilters: VulnerabilityReportFilters;
@@ -191,6 +192,7 @@ export function getReportFormValuesFromConfiguration(
             cvesDiscoveredStartDate,
             includeAdvisory: vulnReportFilters.includeAdvisory,
             includeEpssProbability: vulnReportFilters.includeEpssProbability,
+            // Ross CISA KEV includeKnownExploit?
             includeNvdCvss: vulnReportFilters.includeNvdCvss,
             reportScope: {
                 id: resourceScope.collectionScope.collectionId,


### PR DESCRIPTION
## Description

Prerequisite for Ross to add optional column for CISA KEV.

1. Follow up on suggestion during sneak peek at sprint demos to simplify checkbox text.
    The less the delta to add an optional column, the better.
    I had already omitted **Include** from `ReportParameterDetails` in #15467
2. Add `// Ross CISA KEV` comments because several files need consistent changes.

### Residue

1. Inform docs team about change, because it affects:
    https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.8/html/operating/managing-vulnerabilities#vulnerability-management20-creating-report_vulnerability-reporting
2. Ask team about apparent inconsistency between optional columns for view-based and existing vulnerability reports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR not needed and informed docs team

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration?action=create

    Before changes, see presence of **Include**
    <img width="1440" height="536" alt="ReportParametersForm_presence" src="https://github.com/user-attachments/assets/eb400684-46a4-477c-8ece-55a6962a0b10" />

    After changes, see absence of **Include**
    Also **Advisory Name and Advisory Link** for consistency with column headings in CSV file
    <img width="1440" height="538" alt="Advisory_Name_and_Advisory_Link" src="https://github.com/user-attachments/assets/e4c3b4ed-0638-4cb4-bf99-b559b64df048" />
