### PR TITLE
ROX-30770: CA rotation fallback for Helm-installed Sensors

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -401,8 +401,9 @@ func (c *sensorConnection) processIssueSecuredClusterCertsRequest(ctx context.Co
 		err = errors.New("requestID is required to issue the certificates for a Secured Cluster")
 	} else {
 		var certificates *storage.TypedServiceCertificateSet
-		certificates, err = securedclustercertgen.IssueSecuredClusterCerts(namespace, clusterID,
-			c.capabilities.Contains(centralsensor.SensorCARotationSupported))
+		sensorSupportsRotation := c.capabilities.Contains(centralsensor.SensorCARotationSupported)
+		caFingerprint := request.GetCaFingerprint()
+		certificates, err = securedclustercertgen.IssueSecuredClusterCerts(namespace, clusterID, sensorSupportsRotation, caFingerprint)
 		response = &central.IssueSecuredClusterCertsResponse{
 			RequestId: requestID,
 			Response: &central.IssueSecuredClusterCertsResponse_Certificates{

--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -155,7 +155,7 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 		if err := safe.RunE(func() error {
 			sensorNamespace := sensorHello.GetDeploymentIdentification().GetAppNamespace()
 			certificateSet, err := securedclustercertgen.IssueSecuredClusterCerts(
-				sensorNamespace, clusterID, isCARotationSupported(sensorHello))
+				sensorNamespace, clusterID, isCARotationSupported(sensorHello), "")
 			if err != nil {
 				return errors.Wrapf(err, "issuing a certificate bundle for cluster %s", cluster.GetName())
 			}

--- a/generated/internalapi/central/secured_cluster_cert_refresh.pb.go
+++ b/generated/internalapi/central/secured_cluster_cert_refresh.pb.go
@@ -67,8 +67,10 @@ func (x *SecuredClusterCertsIssueError) GetMessage() string {
 }
 
 type IssueSecuredClusterCertsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	RequestId string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	// Optional: hex-encoded fingerprint of the Sensor's currently trusted CA
+	CaFingerprint string `protobuf:"bytes,2,opt,name=ca_fingerprint,json=caFingerprint,proto3" json:"ca_fingerprint,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -106,6 +108,13 @@ func (*IssueSecuredClusterCertsRequest) Descriptor() ([]byte, []int) {
 func (x *IssueSecuredClusterCertsRequest) GetRequestId() string {
 	if x != nil {
 		return x.RequestId
+	}
+	return ""
+}
+
+func (x *IssueSecuredClusterCertsRequest) GetCaFingerprint() string {
+	if x != nil {
+		return x.CaFingerprint
 	}
 	return ""
 }
@@ -206,10 +215,11 @@ const file_internalapi_central_secured_cluster_cert_refresh_proto_rawDesc = "" +
 	"\n" +
 	"6internalapi/central/secured_cluster_cert_refresh.proto\x12\acentral\x1a\x1estorage/service_identity.proto\"9\n" +
 	"\x1dSecuredClusterCertsIssueError\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"@\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"g\n" +
 	"\x1fIssueSecuredClusterCertsRequest\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x01 \x01(\tR\trequestId\"\xd8\x01\n" +
+	"request_id\x18\x01 \x01(\tR\trequestId\x12%\n" +
+	"\x0eca_fingerprint\x18\x02 \x01(\tR\rcaFingerprint\"\xd8\x01\n" +
 	" IssueSecuredClusterCertsResponse\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12I\n" +

--- a/generated/internalapi/central/secured_cluster_cert_refresh.pb.go
+++ b/generated/internalapi/central/secured_cluster_cert_refresh.pb.go
@@ -69,7 +69,7 @@ func (x *SecuredClusterCertsIssueError) GetMessage() string {
 type IssueSecuredClusterCertsRequest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	RequestId string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	// Optional: hex-encoded fingerprint of the Sensor's currently trusted CA
+	// Optional: hex-encoded SHA-512_256 fingerprint of the Sensor's currently trusted CA
 	CaFingerprint string `protobuf:"bytes,2,opt,name=ca_fingerprint,json=caFingerprint,proto3" json:"ca_fingerprint,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/generated/internalapi/central/secured_cluster_cert_refresh_vtproto.pb.go
+++ b/generated/internalapi/central/secured_cluster_cert_refresh_vtproto.pb.go
@@ -44,6 +44,7 @@ func (m *IssueSecuredClusterCertsRequest) CloneVT() *IssueSecuredClusterCertsReq
 	}
 	r := new(IssueSecuredClusterCertsRequest)
 	r.RequestId = m.RequestId
+	r.CaFingerprint = m.CaFingerprint
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -129,6 +130,9 @@ func (this *IssueSecuredClusterCertsRequest) EqualVT(that *IssueSecuredClusterCe
 		return false
 	}
 	if this.RequestId != that.RequestId {
+		return false
+	}
+	if this.CaFingerprint != that.CaFingerprint {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -298,6 +302,13 @@ func (m *IssueSecuredClusterCertsRequest) MarshalToSizedBufferVT(dAtA []byte) (i
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.CaFingerprint) > 0 {
+		i -= len(m.CaFingerprint)
+		copy(dAtA[i:], m.CaFingerprint)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CaFingerprint)))
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.RequestId) > 0 {
 		i -= len(m.RequestId)
 		copy(dAtA[i:], m.RequestId)
@@ -436,6 +447,10 @@ func (m *IssueSecuredClusterCertsRequest) SizeVT() (n int) {
 	var l int
 	_ = l
 	l = len(m.RequestId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.CaFingerprint)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -637,6 +652,38 @@ func (m *IssueSecuredClusterCertsRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.RequestId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CaFingerprint", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CaFingerprint = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -992,6 +1039,42 @@ func (m *IssueSecuredClusterCertsRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.RequestId = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CaFingerprint", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CaFingerprint = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/proto/internalapi/central/secured_cluster_cert_refresh.proto
+++ b/proto/internalapi/central/secured_cluster_cert_refresh.proto
@@ -12,6 +12,8 @@ message SecuredClusterCertsIssueError {
 
 message IssueSecuredClusterCertsRequest {
   string request_id = 1;
+  // Optional: hex-encoded fingerprint of the Sensor's currently trusted CA
+  string ca_fingerprint = 2;
 }
 
 message IssueSecuredClusterCertsResponse {

--- a/proto/internalapi/central/secured_cluster_cert_refresh.proto
+++ b/proto/internalapi/central/secured_cluster_cert_refresh.proto
@@ -12,7 +12,7 @@ message SecuredClusterCertsIssueError {
 
 message IssueSecuredClusterCertsRequest {
   string request_id = 1;
-  // Optional: hex-encoded fingerprint of the Sensor's currently trusted CA
+  // Optional: hex-encoded SHA-512_256 fingerprint of the Sensor's currently trusted CA
   string ca_fingerprint = 2;
 }
 

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/cryptoutils"
 	pkgKubernetes "github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/mtls"
 	testutilsMTLS "github.com/stackrox/rox/pkg/mtls/testutils"
@@ -128,8 +129,15 @@ func (f *securedClusterTLSIssuerFixture) respondRequest(
 	select {
 	case <-ctx.Done():
 	case request := <-f.tlsIssuer.msgToCentralC:
-		interceptedRequestID := request.GetIssueSecuredClusterCertsRequest().GetRequestId()
+		certRequest := request.GetIssueSecuredClusterCertsRequest()
+		interceptedRequestID := certRequest.GetRequestId()
 		assert.NotEmpty(t, interceptedRequestID)
+
+		cert, _, err := mtls.CACert()
+		assert.NoError(t, err)
+		assert.NotNil(t, cert)
+		assert.Equal(t, cryptoutils.CertFingerprint(cert), certRequest.GetCaFingerprint())
+
 		var response *central.IssueSecuredClusterCertsResponse
 		if responseOverwrite != nil {
 			response = responseOverwrite


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->
### Context
CA rotation will initially be fully supported only by Operator-based installations. This is a recent development, due to difficulties with updating the `ca_bundle` of the `ValidatingWebhookConfiguration` when using Helm (we'd need an equivalent of https://github.com/stackrox/stackrox/pull/15706 for Helm). 

Helm-installed Secured Clusters will have partial support, in the sense that they will be able to connect to a Central that uses a new CA (as long as the one trusted by Sensor is still valid), but won't be able to automatically switch to it.

Because of the above, we need to change the certificate issuing logic, which currently is the following:
* if Sensor supports CA rotation, issue certificates signed by the latest CA
* otherwise issue certificates signed by the primary CA

This does not work well in some cases, e.g. Helm-based Secured Cluster uses CA_Old, connects to Central that uses CA_New as primary, a cert refresh request will return leaf certs based on CA_New - breaks the Secured Cluster (more specifically admission-controller), even though it could still work for as long as CA_Old is still valid. 

In practice this means that without the changes in this PR, Helm-based Secured Clusters will now stop working sooner (after about 4 years) instead of 5 years originally (the total lifetime of the Stackrox internal CA), if we enable CA rotation in the Operator.

### Proposed solution
Update the cert refresh API to allow Sensor to send a fingerprint of its own CA.
Central then has the following logic:
- if Sensor supports CA rotation (advertised via sensor capability), use newer CA to issue certs
- otherwise, if Sensor sent CA hash, prefer the CA that Sensor knows
- otherwise, fallback to primary CA

### Related PRs
* https://github.com/stackrox/stackrox/pull/15312
* https://github.com/stackrox/stackrox/pull/16304
* https://github.com/stackrox/stackrox/pull/15074
* https://github.com/stackrox/stackrox/pull/15706

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Using https://github.com/stackrox/stackrox/pull/15349 for manual testing, which rotates the CA after 10 minutes. Forcing a cert refresh by deleting one of the `tl-cert-*` Secrets in Sensor, and checking the ca.pem field in the returned certificates.