### PR TITLE
ROX-30738: Add prop for ransomware to KnownExploitLabel

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -349,7 +349,14 @@ function WorkloadCVEOverviewTable({
                             /*
                             // Ross CISA KEV
                             if (isFeatureFlagEnabled('ROX_SCANNER_V4') && isFeatureFlagEnabled('ROX_WHATEVER') && TODO) {
-                                labels.push(<KnownExploitLabel isCompact />);
+                                labels.push(
+                                    <KnownExploitLabel
+                                        isCompact
+                                        isKnownToBeUsedInRansomwareCampaigns={
+                                            isKnownToBeUsedInRansomwareCampaigns
+                                        }
+                                    />
+                                );
                             }
                             */
                             if (pendingExceptionCount > 0) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
@@ -7,13 +7,19 @@ const tooltip =
 
 export type KnownExploitLabelProps = {
     isCompact: boolean; // true for table and false for vulnerability page
+    isKnownToBeUsedInRansomwareCampaigns: boolean;
 };
 
-function KnownExploitLabel({ isCompact }: KnownExploitLabelProps) {
+function KnownExploitLabel({
+    isCompact,
+    isKnownToBeUsedInRansomwareCampaigns,
+}: KnownExploitLabelProps) {
     return (
         <Tooltip content={tooltip} position="top-start" isContentLeftAligned>
             <Label color="red" isCompact={isCompact}>
-                Known exploit
+                {isKnownToBeUsedInRansomwareCampaigns
+                    ? 'Known ransomware exploit'
+                    : 'Known exploit'}
             </Label>
         </Tooltip>
     );


### PR DESCRIPTION
## Description

Follow up question from **David Caravello** at sprint demos about plans for **Known To Be Used in Ransomware Campaigns** from CISA KEV.

Lean toward the future, although selection and implementation of visual presentation does not imply that ransomware has been added to MVP scope.

See pictures of alternative visual presentations below.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

Temporarily edit code to display possibilities.

1. Visit /main/vulnerabilities/all-images

    * No known exploit (no change from demo)
        <img width="1090" height="75" alt="No_known_exploit" src="https://github.com/user-attachments/assets/31e6f161-372e-44fc-ad29-fafd36e928f2" />

    * Has known exploit but not known to be used in ransomware campaigns (no change from demo)
        <img width="1100" height="115" alt="One_generic" src="https://github.com/user-attachments/assets/8598780a-34a6-432f-a39e-b1ffc735a22d" />

    * Has known exploit and known to be used in ransomware campaigns

        Most specific label (parallel wording)
        <img width="1100" height="115" alt="One_parallel" src="https://github.com/user-attachments/assets/860519cb-50e6-4a4e-b93a-9e3f7aed844c" />

        Both labels (parallel wording)
        <img width="1100" height="115" alt="Both_parallel" src="https://github.com/user-attachments/assets/5ba07f7a-9840-469d-beec-9a93bf490409" />

        Both labels (different wording)
        <img width="1099" height="115" alt="Both_different" src="https://github.com/user-attachments/assets/dc337efc-bbc3-40f7-8e00-2f10daaf923d" />
