### PR TITLE
ROX-30701: Implement SecurityVulnerabilitiesPage

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import ComponentTestProvider from 'test-utils/ComponentTestProvider';
 import { graphqlUrl } from 'test-utils/apiEndpoints';
@@ -479,5 +479,49 @@ describe(Cypress.spec.relative, () => {
             category: 'Image',
             value: 'docker.io',
         });
+    });
+
+    it('should display the default entity and attribute when the selected entity and attribute are not in the config', () => {
+        const onSearch = cy.stub().as('onSearch');
+        const searchFilter = {};
+
+        function SetupWithConfigSwap() {
+            const [config, setConfig] = useState([
+                imageSearchFilterConfig,
+                clusterSearchFilterConfig,
+            ]);
+            return (
+                <ComponentTestProvider>
+                    <button type="button" onClick={() => setConfig([imageSearchFilterConfig])}>
+                        Trim config
+                    </button>
+                    <div className="pf-v5-u-p-md">
+                        <CompoundSearchFilter
+                            defaultEntity="Image"
+                            config={config}
+                            searchFilter={searchFilter}
+                            onSearch={onSearch}
+                        />
+                    </div>
+                </ComponentTestProvider>
+            );
+        }
+
+        cy.mount(<SetupWithConfigSwap />);
+
+        // should display the default entity and attribute
+        cy.get(selectors.entitySelectToggle).should('contain.text', 'Image');
+        cy.get(selectors.attributeSelectToggle).should('contain.text', 'Name');
+
+        // Change to Cluster entity
+        cy.get(selectors.entitySelectToggle).click();
+        cy.get(selectors.entitySelectItem('Cluster')).click();
+        cy.get(selectors.entitySelectToggle).should('contain.text', 'Cluster');
+        cy.get(selectors.attributeSelectToggle).should('contain.text', 'ID');
+
+        // Click swap config button and verify the default entity and attribute are displayed
+        cy.get('button:contains("Trim config")').click();
+        cy.get(selectors.entitySelectToggle).should('contain.text', 'Image');
+        cy.get(selectors.attributeSelectToggle).should('contain.text', 'Name');
     });
 });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -45,6 +45,16 @@ function CompoundSearchFilter({
         return getDefaultAttributeName(config, defaultEntityName);
     });
 
+    // If the selected entity/attribute is not in the config, use the default entity. This handles the case where the search config
+    // changes at runtime while the removed entity is still selected.
+    const entityConfig = config.find((entity) => entity.displayName === selectedEntity);
+    const currentEntity = entityConfig ? selectedEntity : getDefaultEntityName(config);
+    const currentAttribute = entityConfig?.attributes.find(
+        ({ displayName }) => displayName === selectedAttribute
+    )
+        ? selectedAttribute
+        : getDefaultAttributeName(config, currentEntity ?? '');
+
     const [inputValue, setInputValue] = useState<InputFieldValue>('');
 
     useEffect(() => {
@@ -68,7 +78,7 @@ function CompoundSearchFilter({
         >
             <EntitySelector
                 menuToggleClassName="pf-v5-u-flex-shrink-0"
-                selectedEntity={selectedEntity}
+                selectedEntity={currentEntity}
                 onChange={(value) => {
                     const entityName = ensureString(value);
                     const defaultAttributeName = getDefaultAttributeName(config, entityName);
@@ -80,8 +90,8 @@ function CompoundSearchFilter({
             />
             <AttributeSelector
                 menuToggleClassName="pf-v5-u-flex-shrink-0"
-                selectedEntity={selectedEntity}
-                selectedAttribute={selectedAttribute}
+                selectedEntity={currentEntity}
+                selectedAttribute={currentAttribute}
                 onChange={(value) => {
                     setSelectedAttribute(ensureString(value));
                     setInputValue('');
@@ -89,8 +99,8 @@ function CompoundSearchFilter({
                 config={config}
             />
             <CompoundSearchFilterInputField
-                selectedEntity={selectedEntity}
-                selectedAttribute={selectedAttribute}
+                selectedEntity={currentEntity}
+                selectedAttribute={currentAttribute}
                 value={inputValue}
                 onChange={(value) => {
                     setInputValue(value);

--- a/ui/apps/platform/src/ConsolePlugin/Components/VulnerabilitiesOverviewContainer.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/Components/VulnerabilitiesOverviewContainer.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import noop from 'lodash/noop';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
+import { DEFAULT_VM_PAGE_SIZE } from 'Containers/Vulnerabilities/constants';
+import { workloadEntityTabValues } from 'Containers/Vulnerabilities/types';
+import type { DefaultFilters, WorkloadEntityTab } from 'Containers/Vulnerabilities/types';
+import {
+    parseQuerySearchFilter,
+    getVulnStateScopedQueryString,
+} from 'Containers/Vulnerabilities/utils/searchUtils';
+import {
+    getWorkloadCveOverviewSortFields,
+    getWorkloadCveOverviewDefaultSortOption,
+} from 'Containers/Vulnerabilities/utils/sortUtils';
+import useWorkloadCveViewContext from 'Containers/Vulnerabilities/WorkloadCves/hooks/useWorkloadCveViewContext';
+import VulnerabilitiesOverview from 'Containers/Vulnerabilities/WorkloadCves/Overview/VulnerabilitiesOverview';
+import {
+    imageSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+} from 'Containers/Vulnerabilities/searchFilterConfig';
+
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import { hideColumnIf } from 'hooks/useManagedColumns';
+import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+
+import { ALL_NAMESPACES_KEY } from '../constants';
+
+const emptyDefaultFilters: DefaultFilters = {
+    SEVERITY: [],
+    FIXABLE: [],
+};
+
+export function VulnerabilitiesOverviewContainer() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isScannerV4Enabled = useIsScannerV4Enabled();
+    const [activeNamespace] = useActiveNamespace();
+    const { baseSearchFilter } = useWorkloadCveViewContext();
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
+    const workloadCvesScopedQueryString = getVulnStateScopedQueryString(
+        {
+            ...baseSearchFilter,
+            ...querySearchFilter,
+            // If "All Projects" is selected, use the query search filter's Namespace, otherwise override with the active namespace
+            Namespace:
+                activeNamespace === ALL_NAMESPACES_KEY
+                    ? querySearchFilter.Namespace
+                    : [activeNamespace],
+        },
+        'OBSERVED'
+    );
+
+    const [activeEntityTabKey] = useURLStringUnion('entityTab', workloadEntityTabValues);
+
+    const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+
+    const sort = useURLSort({
+        sortFields: getWorkloadCveOverviewSortFields(activeEntityTabKey),
+        defaultSortOption: getWorkloadCveOverviewDefaultSortOption(
+            activeEntityTabKey,
+            searchFilter
+        ),
+        onSort: () => pagination.setPage(1),
+    });
+
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        [
+            imageSearchFilterConfig,
+            imageCVESearchFilterConfig,
+            imageComponentSearchFilterConfig,
+            deploymentSearchFilterConfig,
+            ...(activeNamespace === ALL_NAMESPACES_KEY ? [namespaceSearchFilterConfig] : []),
+        ]
+    );
+
+    function onEntityTabChange(entityTab: WorkloadEntityTab) {
+        pagination.setPage(1);
+        sort.setSortOption(getWorkloadCveOverviewDefaultSortOption(entityTab, searchFilter));
+    }
+
+    return (
+        <VulnerabilitiesOverview
+            defaultFilters={emptyDefaultFilters}
+            searchFilter={searchFilter}
+            setSearchFilter={setSearchFilter}
+            querySearchFilter={querySearchFilter}
+            workloadCvesScopedQueryString={workloadCvesScopedQueryString}
+            searchFilterConfig={searchFilterConfig}
+            pagination={pagination}
+            sort={sort}
+            currentVulnerabilityState={'OBSERVED'}
+            isViewingWithCves
+            onWatchImage={noop}
+            onUnwatchImage={noop}
+            activeEntityTabKey={activeEntityTabKey}
+            onEntityTabChange={onEntityTabChange}
+            additionalToolbarItems={undefined}
+            additionalHeaderItems={undefined}
+            showDeferralUI={false}
+            cveTableColumnOverrides={{
+                cveSelection: hideColumnIf(true),
+                rowActions: hideColumnIf(true),
+                requestDetails: hideColumnIf(true),
+                affectedImages: hideColumnIf(true),
+                topNvdCvss: hideColumnIf(!isScannerV4Enabled),
+                epssProbability: hideColumnIf(!isScannerV4Enabled),
+            }}
+            imageTableColumnOverrides={{}}
+            deploymentTableColumnOverrides={{
+                namespace: hideColumnIf(activeNamespace !== ALL_NAMESPACES_KEY),
+                cluster: hideColumnIf(true),
+            }}
+        />
+    );
+}

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -6,6 +6,7 @@ import axios from 'services/instance';
 import { UserPermissionProvider } from 'providers/UserPermissionProvider';
 import { FeatureFlagsProvider } from 'providers/FeatureFlagProvider';
 import { MetadataProvider } from 'providers/MetadataProvider';
+import { PublicConfigProvider } from 'providers/PublicConfigProvider';
 
 import configureApolloClient from '../init/configureApolloClient';
 import consoleFetchAxiosAdapter from './consoleFetchAxiosAdapter';
@@ -25,7 +26,9 @@ export function PluginProvider({ children }: { children: ReactNode }) {
             <UserPermissionProvider>
                 <FeatureFlagsProvider>
                     <MetadataProvider>
-                        <PluginContent>{children}</PluginContent>
+                        <PublicConfigProvider>
+                            <PluginContent>{children}</PluginContent>
+                        </PublicConfigProvider>
                     </MetadataProvider>
                 </FeatureFlagsProvider>
             </UserPermissionProvider>

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
@@ -5,7 +5,7 @@ import { DocumentTitle, NamespaceBar } from '@openshift-console/dynamic-plugin-s
 import { namespaceSearchFilterConfig } from 'Containers/Vulnerabilities/searchFilterConfig';
 import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
 import useURLSearch from 'hooks/useURLSearch';
-import { deleteKeysFromSearchFilter } from 'utils/searchUtils';
+import { deleteKeysCaseInsensitive } from 'utils/searchUtils';
 
 import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';
 import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
@@ -22,7 +22,7 @@ export function SecurityVulnerabilitiesPage() {
                 onNamespaceChange={() => {
                     const namespaceAttributes = namespaceSearchFilterConfig.attributes;
                     const keysToDelete = namespaceAttributes.map(({ searchTerm }) => searchTerm);
-                    const result = deleteKeysFromSearchFilter(searchFilter, keysToDelete);
+                    const result = deleteKeysCaseInsensitive(searchFilter, keysToDelete);
                     setSearchFilter(result);
                 }}
             />

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
@@ -1,44 +1,30 @@
 import React from 'react';
 import { PageSection, Title } from '@patternfly/react-core';
-import { CheckCircleIcon } from '@patternfly/react-icons';
-import usePermissions from 'hooks/usePermissions';
+import { DocumentTitle, NamespaceBar } from '@openshift-console/dynamic-plugin-sdk';
 
-import SummaryCounts from 'Containers/Dashboard/SummaryCounts';
-import ViolationsByPolicyCategory from 'Containers/Dashboard/Widgets/ViolationsByPolicyCategory';
+import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
+import useURLSearch from 'hooks/useURLSearch';
+
+import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';
+import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
 
 export function SecurityVulnerabilitiesPage() {
-    const { hasReadAccess } = usePermissions();
-    const hasReadAccessForAlert = hasReadAccess('Alert');
-    const hasReadAccessForCluster = hasReadAccess('Cluster');
-    const hasReadAccessForDeployment = hasReadAccess('Deployment');
-    const hasReadAccessForImage = hasReadAccess('Image');
-    const hasReadAccessForNode = hasReadAccess('Node');
-    const hasReadAccessForSecret = hasReadAccess('Secret');
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const context = useDefaultWorkloadCveViewContext();
 
     return (
-        <>
-            <PageSection>
-                <Title headingLevel="h1">{'Hello, Plugin!'}</Title>
-                <SummaryCounts
-                    hasReadAccessForResource={{
-                        Cluster: hasReadAccessForCluster,
-                        Node: hasReadAccessForNode,
-                        Alert: hasReadAccessForAlert,
-                        Deployment: hasReadAccessForDeployment,
-                        Image: hasReadAccessForImage,
-                        Secret: hasReadAccessForSecret,
-                    }}
-                />
-                <ViolationsByPolicyCategory />
+        <WorkloadCveViewContext.Provider value={context}>
+            <DocumentTitle>Workload vulnerabilities</DocumentTitle>
+            <NamespaceBar
+                // Force clear Namespace filter when the user changes the namespace via the NamespaceBar
+                onNamespaceChange={() => setSearchFilter({ ...searchFilter, Namespace: [] })}
+            />
+            <PageSection variant="light">
+                <Title headingLevel="h1">Workload vulnerabilities</Title>
             </PageSection>
-            <PageSection>
-                <p>
-                    <span className="console-plugin-template__nice">
-                        <CheckCircleIcon /> {'Success!'}
-                    </span>{' '}
-                    {'Your plugin is working.'}
-                </p>
+            <PageSection variant="light">
+                <VulnerabilitiesOverviewContainer />
             </PageSection>
-        </>
+        </WorkloadCveViewContext.Provider>
     );
 }

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { PageSection, Title } from '@patternfly/react-core';
 import { DocumentTitle, NamespaceBar } from '@openshift-console/dynamic-plugin-sdk';
 
+import { namespaceSearchFilterConfig } from 'Containers/Vulnerabilities/searchFilterConfig';
 import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
 import useURLSearch from 'hooks/useURLSearch';
+import { deleteKeysFromSearchFilter } from 'utils/searchUtils';
 
 import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';
 import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
@@ -17,7 +19,12 @@ export function SecurityVulnerabilitiesPage() {
             <DocumentTitle>Workload vulnerabilities</DocumentTitle>
             <NamespaceBar
                 // Force clear Namespace filter when the user changes the namespace via the NamespaceBar
-                onNamespaceChange={() => setSearchFilter({ ...searchFilter, Namespace: [] })}
+                onNamespaceChange={() => {
+                    const namespaceAttributes = namespaceSearchFilterConfig.attributes;
+                    const keysToDelete = namespaceAttributes.map(({ searchTerm }) => searchTerm);
+                    const result = deleteKeysFromSearchFilter(searchFilter, keysToDelete);
+                    setSearchFilter(result);
+                }}
             />
             <PageSection variant="light">
                 <Title headingLevel="h1">Workload vulnerabilities</Title>

--- a/ui/apps/platform/src/ConsolePlugin/constants.ts
+++ b/ui/apps/platform/src/ConsolePlugin/constants.ts
@@ -1,0 +1,2 @@
+// TODO - This constant will be properly exported in a future version of the OpenShift Console SDK
+export const ALL_NAMESPACES_KEY = '#ALL_NS#';

--- a/ui/apps/platform/src/ConsolePlugin/hooks/useDefaultWorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/ConsolePlugin/hooks/useDefaultWorkloadCveViewContext.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+
+import type { VulnerabilityState } from 'types/cve.proto';
+import {
+    getOverviewPagePath,
+    getWorkloadEntityPagePath,
+} from 'Containers/Vulnerabilities/utils/searchUtils';
+import type { WorkloadCveView } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
+
+const acsSecurityVulnerabilitiesBase = '/acs/security/vulnerabilities';
+
+export function useDefaultWorkloadCveViewContext(): WorkloadCveView {
+    return useMemo(
+        () => ({
+            baseSearchFilter: {
+                'Image CVE Count': ['>0'],
+            },
+            pageTitle: '',
+            overviewEntityTabs: ['CVE', 'Image', 'Deployment'],
+            viewContext: '',
+            urlBuilder: {
+                vulnMgmtBase: (subPath: string) => `${acsSecurityVulnerabilitiesBase}/${subPath}`,
+                cveList: (vulnerabilityState: VulnerabilityState) =>
+                    `${acsSecurityVulnerabilitiesBase}/${getOverviewPagePath('Workload', {
+                        vulnerabilityState,
+                        entityTab: 'CVE',
+                    })}`,
+                cveDetails: (cve: string, vulnerabilityState: VulnerabilityState) =>
+                    `${acsSecurityVulnerabilitiesBase}/${getWorkloadEntityPagePath('CVE', cve, vulnerabilityState)}`,
+                imageList: (vulnerabilityState: VulnerabilityState) =>
+                    `${acsSecurityVulnerabilitiesBase}/${getOverviewPagePath('Workload', {
+                        vulnerabilityState,
+                        entityTab: 'Image',
+                    })}`,
+                imageDetails: (id: string, vulnerabilityState: VulnerabilityState) =>
+                    `${acsSecurityVulnerabilitiesBase}/${getWorkloadEntityPagePath('Image', id, vulnerabilityState)}`,
+                workloadList: (vulnerabilityState: VulnerabilityState) =>
+                    `${acsSecurityVulnerabilitiesBase}/${getOverviewPagePath('Workload', {
+                        vulnerabilityState,
+                        entityTab: 'Deployment',
+                    })}`,
+                workloadDetails: (workload: {
+                    id: string;
+                    name: string;
+                    namespace: string;
+                    type: string;
+                }) =>
+                    `/k8s/ns/${workload.namespace}/${workload.type.toLowerCase()}s/${workload.name}/security`,
+            },
+        }),
+        []
+    );
+}

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -9,7 +9,7 @@ import {
     convertToExactMatch,
     hasSearchKeyValue,
     getSearchFilterFromSearchString,
-    deleteKeysFromSearchFilter,
+    deleteKeysCaseInsensitive,
 } from './searchUtils';
 
 describe('searchUtils', () => {
@@ -417,14 +417,14 @@ describe('searchUtils', () => {
         it('deletes the keys from the search filter regardless of case', () => {
             const searchFilter = { Namespace: 'test', Cluster: 'test', cluster: 'test' };
             const keysToDelete = ['Namespace', 'cluster'];
-            const result = deleteKeysFromSearchFilter(searchFilter, keysToDelete);
+            const result = deleteKeysCaseInsensitive(searchFilter, keysToDelete);
             expect(result).toEqual({});
         });
 
         it('does not delete the keys that are not in the search filter', () => {
             const searchFilter = { Namespace: 'test', Cluster: 'test' };
             const keysToDelete = ['Deployment'];
-            const result = deleteKeysFromSearchFilter(searchFilter, keysToDelete);
+            const result = deleteKeysCaseInsensitive(searchFilter, keysToDelete);
             expect(result).toEqual({ Namespace: 'test', Cluster: 'test' });
         });
     });

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -9,6 +9,7 @@ import {
     convertToExactMatch,
     hasSearchKeyValue,
     getSearchFilterFromSearchString,
+    deleteKeysFromSearchFilter,
 } from './searchUtils';
 
 describe('searchUtils', () => {
@@ -409,6 +410,22 @@ describe('searchUtils', () => {
                 'Severity:Critical+:BadValue+NoColon+Key:'
             );
             expect(result).toEqual({ Severity: 'Critical' });
+        });
+    });
+
+    describe('deleteKeysFromSearchFilter', () => {
+        it('deletes the keys from the search filter regardless of case', () => {
+            const searchFilter = { Namespace: 'test', Cluster: 'test', cluster: 'test' };
+            const keysToDelete = ['Namespace', 'cluster'];
+            const result = deleteKeysFromSearchFilter(searchFilter, keysToDelete);
+            expect(result).toEqual({});
+        });
+
+        it('does not delete the keys that are not in the search filter', () => {
+            const searchFilter = { Namespace: 'test', Cluster: 'test' };
+            const keysToDelete = ['Deployment'];
+            const result = deleteKeysFromSearchFilter(searchFilter, keysToDelete);
+            expect(result).toEqual({ Namespace: 'test', Cluster: 'test' });
         });
     });
 });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -349,3 +349,21 @@ export function hasSearchKeyValue(search: string, key: string, value: string | n
 
     return urlSearchParams.get(key) === value || urlSearchParams.get(key) === encodedValue;
 }
+
+/**
+ * Deletes the keys from the `SearchFilter` regardless of case
+ *
+ * @param searchFilter The `SearchFilter` to delete the keys from
+ * @param keysToDelete The keys to delete from the `SearchFilter`
+ * @returns A new `SearchFilter` with the keys deleted
+ */
+export function deleteKeysFromSearchFilter(searchFilter: SearchFilter, keysToDelete: string[]) {
+    const keysCaseInsensitive = keysToDelete.map((key) => key.toLowerCase());
+    const nextFilter = structuredClone(searchFilter);
+    Object.keys(nextFilter).forEach((key) => {
+        if (keysCaseInsensitive.includes(key.toLowerCase())) {
+            delete nextFilter[key];
+        }
+    });
+    return nextFilter;
+}

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -351,13 +351,15 @@ export function hasSearchKeyValue(search: string, key: string, value: string | n
 }
 
 /**
- * Deletes the keys from the `SearchFilter` regardless of case
+ * Deletes the keys from the `SearchFilter` regardless of case. The backend search
+ * API is case-insensitive, so we need to ensure that any keys we delete are also
+ * deleted regardless of case.
  *
  * @param searchFilter The `SearchFilter` to delete the keys from
  * @param keysToDelete The keys to delete from the `SearchFilter`
  * @returns A new `SearchFilter` with the keys deleted
  */
-export function deleteKeysFromSearchFilter(searchFilter: SearchFilter, keysToDelete: string[]) {
+export function deleteKeysCaseInsensitive(searchFilter: SearchFilter, keysToDelete: string[]) {
     const keysCaseInsensitive = keysToDelete.map((key) => key.toLowerCase());
     const nextFilter = structuredClone(searchFilter);
     Object.keys(nextFilter).forEach((key) => {

--- a/ui/apps/platform/webpack.ocp-plugin.config.js
+++ b/ui/apps/platform/webpack.ocp-plugin.config.js
@@ -238,13 +238,14 @@ const config = {
             ],
         }),
         new DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
             'process.env.ACS_CONSOLE_DEV_TOKEN': JSON.stringify(
                 // Do not inject the token when building for production
                 process.env.NODE_ENV === 'development'
                     ? process.env.ACS_CONSOLE_DEV_TOKEN
                     : undefined
             ),
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+            'process.env.ROX_PRODUCT_BRANDING': JSON.stringify(process.env.ROX_PRODUCT_BRANDING),
         }),
     ],
     devtool: isProd ? false : 'source-map',


### PR DESCRIPTION
## Description

Implements the main Security->Vulnerabilities page in the console for the OCP plugin.

Since this main dashboard view will be used in multiple locations, this change also adds:

1. A default Workload CVE context to be used throughout plugin pages
2. A wrapper component for the main vulnerabilities view that handles common dependencies across all of these pages e.g. pagination hooks, callbacks

## Notes

1. e2e tests will follow in a separate PR to keep the size of this one manageable.

2. Visually, there is clearly too much space between the header components:
<img width="540" height="237" alt="image" src="https://github.com/user-attachments/assets/8871ddb2-d69c-4666-9b7d-741e343ba0c5" />

This will not be address at this point, as PatternFly 6 reduces the default padding of these components. Any attempt to achieve identical spacing to other console pages may be counter-productive before we upgrade to PF6.

3. This PR also includes a fix for `CompoundSearchFilter.tsx`. The OCP plugin needs to support changing search filter config dynamically due to the Project switcher at the top of the page. In the case where "All projects" was selected and the current filter was `Namespace` related, switching to a singular project would cause the filter component to not render. The fix uses the fallback selected entity/attribute to prevent this case.


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Open the OCP console and visit Security->Vulnerabilities from the left nav. The table sorting, filtering, and pagination should be identical to what is present in the standalone app. **Note that the data itself differs in this view, because the OCP console does not split the data into "User Workloads" and "Platform".**
<img width="1535" height="897" alt="image" src="https://github.com/user-attachments/assets/5c1a717e-6fb0-4048-94a5-eb43108dce71" />

Note that when "All projects" is selected, the Namespace filter and Namespace column in the deployment table are visible.
<img width="1535" height="897" alt="image" src="https://github.com/user-attachments/assets/2a14f6b3-3b52-4e73-b55e-d31cb3f7d19c" />

Changing to a single namespace removes the above items, and correctly filters the data.
<img width="1535" height="897" alt="image" src="https://github.com/user-attachments/assets/8b65901e-109e-4fe4-808f-eb77313ef01c" />

Verification of a single CVE to ensure derived fields match what is expected. Here is a single CVE that is present in 3 deployments across namespaces.
<img width="1535" height="979" alt="image" src="https://github.com/user-attachments/assets/697345b2-9920-474b-897d-0cbafdd91a07" />

When isolated to a single namespace view, notice the image counts and deployments:
<img width="1535" height="908" alt="image" src="https://github.com/user-attachments/assets/565e3180-9042-436c-906f-847e1ef6901f" />
<img width="1535" height="908" alt="image" src="https://github.com/user-attachments/assets/a9d2f1aa-c7e6-4993-b722-74bc1f226fe9" />
Switching to "All projects" correctly updates the data to include impact across all namespaces:
<img width="1535" height="908" alt="image" src="https://github.com/user-attachments/assets/55d341b0-55fe-4ac0-80cf-210e68678693" />
<img width="1535" height="908" alt="image" src="https://github.com/user-attachments/assets/3361d8c8-b68b-4174-8b71-06a9e908b482" />

Light theme:
<img width="1535" height="1006" alt="image" src="https://github.com/user-attachments/assets/95d2a2dd-c623-4e1e-aa05-6aa8864cf536" />






