### PR TITLE
build: Speed up `main` Konflux builds on arm64

### DIFF
--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -390,7 +390,7 @@ spec:
   - name: build-container-arm64
     params:
     - name: PLATFORM
-      value: linux/arm64
+      value: linux-c2xlarge/arm64
     - name: IMAGE
       value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-arm64
     - name: DOCKERFILE

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -390,7 +390,7 @@ spec:
   - name: build-container-arm64
     params:
     - name: PLATFORM
-      value: linux-cxlarge/arm64
+      value: linux-c2xlarge/arm64
     - name: IMAGE
       value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-arm64
     - name: DOCKERFILE

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -390,7 +390,7 @@ spec:
   - name: build-container-arm64
     params:
     - name: PLATFORM
-      value: linux-c2xlarge/arm64
+      value: linux-cxlarge/arm64
     - name: IMAGE
       value: $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-arm64
     - name: DOCKERFILE


### PR DESCRIPTION
## Description

I spotted that `arm64` builds of `main` run for about an hour as opposed to 30-40 minutes for all other arches (examples: [one](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-4-8/pipelineruns/main-on-push-m92nd), [two](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs-4-8/pipelineruns/main-on-push-z4859), [three](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/main-on-push-ffbs6)).

This isn't due to queuing because the queue is in front of the PipelineRun, not in front of buildah* tasks.

Knowing from [docs](https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html#cpu-optimized) we can select different sizes of ARM VMs, I decided to give it a try and allocate more ARM CPU cores.

* `linux-c2xlarge/arm64` ->
  * 29m40s https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/main-on-push-mgqlm
  * 29m18s https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/main-on-push-f4cq8
* `linux-cxlarge/arm64` ->
  * 39m40s https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/main-on-push-lsr2l
  * more than 32m (I canceled it) https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/main-on-push-h7cb8

I tested mostly during quieter times and so the behavior may be different when Konflux is busy. However, the time decrease from using the bigger VMs is clear so I suggest to go ahead and apply this change.

Note that `linux-c2xlarge/arm64` costs ~4x more than `linux/arm64` but we aren't charged for that anyway and engineer's time is quite more costly.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

CI is green, ARM buildah task runs aren't much slower than for other arches.