### PR TITLE
fix: data race in signature verification

### DIFF
--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -513,13 +513,12 @@ func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([
 	log.Debugf("Retrieving verified image references from the image names [%v] and signature identity %q",
 		image.GetNames(), signatureIdentity)
 	var verifiedImageReferences []string
-	// We must ensure here that `append` is not called on the result of `image.GetNames()`.
-	// Otherwise, we create a data race caused by concurrent writes when resizing the
-	// underlying data array of the slice.
-	imageNames := protoutils.SliceUnique(image.GetNames())
-	if !protoutils.SliceContains(image.GetName(), imageNames) {
-		imageNames = append(imageNames, image.GetName())
-	}
+	// We must ensure here that `append` is not called directly on the result of
+	// `image.GetNames()`. Otherwise, we create a data race caused by concurrent
+	// writes to the underlying data array of the slice.
+	imageNames := protoutils.SliceUnique(
+		append([]*storage.ImageName{image.GetName()}, image.GetNames()...),
+	)
 	for _, name := range imageNames {
 		ok, err := equalRegistryRepository(signatureIdentity, name.GetFullName())
 		if err != nil {

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -668,6 +668,32 @@ func TestCosignVerifier_VerifySignature_Certificate(t *testing.T) {
 	}
 }
 
+// TestCosignSignatureVerifier_VerifySignature_ConcurrentAccess tests that VerifySignature can safely handle
+// concurrent access to the same image object without data races, see https://github.com/stackrox/stackrox/pull/16671
+func TestCosignSignatureVerifier_VerifySignature_ConcurrentAccess(t *testing.T) {
+	verifier, err := newCosignSignatureVerifier(&storage.SignatureIntegration{
+		Cosign: &storage.CosignPublicKeyVerification{
+			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
+				{Name: "key1", PublicKeyPemEnc: pemPublicKey_1},
+				{Name: "key2", PublicKeyPemEnc: pemPublicKey_1},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	img, err := generateImageWithCosignSignature(imgName_1a, b64Signature_1a, b64SignaturePayload_1a, nil, nil, nil)
+	require.NoError(t, err)
+
+	// Force situation where the capacity of img.Names is larger than its length, which implies that append operations
+	// will not create a new underlying array. This ensures that (without the fix in
+	// https://github.com/stackrox/stackrox/pull/16671) a race condition happens when
+	// multiple goroutines call append on the same image.Names object simultaneously.
+	img.Names = append(make([]*storage.ImageName, 0, 1000), img.GetNames()...)
+
+	_, _, err = verifier.VerifySignature(context.Background(), img)
+	require.NoError(t, err)
+}
+
 func TestRetrieveVerificationDataFromImage_Success(t *testing.T) {
 	//#nosec G101 -- This is a false positive
 	const (


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The problem is that `image.GetNames()` returns `[]*ImageName`, and when this is passed to `append(image.GetNames(), image.GetName())`, if multiple goroutines are working with the same image object, they could be sharing the underlying slice backing array.

The fix is avoiding an `append` call to shared slices - instead, `append` is only called on the unique slice, which is a local copy.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
