### PR TITLE
ROX-30724,ROX-30397: Don't set ROX_SCANNER_V4 in manifest bundle env

### DIFF
--- a/central/clusters/deployer.go
+++ b/central/clusters/deployer.go
@@ -142,7 +142,7 @@ func getBaseMetaValues(c *storage.Cluster, versions version.Versions, scannerSli
 		TolerationsEnabled: !c.GetTolerationsConfig().GetDisabled(),
 		CreateUpgraderSA:   opts.CreateUpgraderSA,
 
-		EnvVars: getFilteredFeatureFlags(),
+		EnvVars: getFeatureFlagsAsManifestBundleEnv(),
 
 		K8sCommand: command,
 
@@ -172,7 +172,7 @@ func getBaseMetaValues(c *storage.Cluster, versions version.Versions, scannerSli
 	}
 }
 
-func getFilteredFeatureFlags() map[string]string {
+func getFeatureFlagsAsManifestBundleEnv() map[string]string {
 	// For the environment variables we need to filter out ROX_SCANNER_V4, because it would
 	// wrongly enable Scanner V4 delegated scanning on secured clusters which are set up
 	// using manifest bundles. But delegated scanning is not supported for manifest bundle

--- a/central/clusters/deployer.go
+++ b/central/clusters/deployer.go
@@ -175,7 +175,8 @@ func getBaseMetaValues(c *storage.Cluster, versions version.Versions, scannerSli
 func getFilteredFeatureFlags() map[string]string {
 	// For the environment variables we need to filter out ROX_SCANNER_V4, because it would
 	// wrongly enable Scanner V4 delegated scanning on secured clusters which are set up
-	// using manifest bundles.
+	// using manifest bundles. But delegated scanning is not supported for manifest bundle
+	// installed secured clusters.
 	skipFeatureFlags := set.NewFrozenStringSet("ROX_SCANNER_V4")
 	featureFlagVals := make(map[string]string)
 	for _, feature := range features.Flags {

--- a/central/clusters/deployer.go
+++ b/central/clusters/deployer.go
@@ -123,11 +123,6 @@ func deriveImageWithNewName(baseImage *storage.ImageName, name string) *storage.
 }
 
 func getBaseMetaValues(c *storage.Cluster, versions version.Versions, scannerSlimImageRemote string, chartRepo defaults.ChartRepo, opts *RenderOptions) *charts.MetaValues {
-	envVars := make(map[string]string)
-	for _, feature := range features.Flags {
-		envVars[feature.EnvVar()] = strconv.FormatBool(feature.Enabled())
-	}
-
 	command := "kubectl"
 	if c.Type == storage.ClusterType_OPENSHIFT_CLUSTER || c.Type == storage.ClusterType_OPENSHIFT4_CLUSTER {
 		command = "oc"

--- a/central/clusters/deployer.go
+++ b/central/clusters/deployer.go
@@ -174,7 +174,7 @@ func getBaseMetaValues(c *storage.Cluster, versions version.Versions, scannerSli
 
 func getFilteredFeatureFlags() map[string]string {
 	// For the environment variables we need to filter out ROX_SCANNER_V4, because it would
-	// wrongly enable Scanner V4 delegeated scanning on secured clusters which are set up
+	// wrongly enable Scanner V4 delegated scanning on secured clusters which are set up
 	// using manifest bundles.
 	skipFeatureFlags := set.NewFrozenStringSet("ROX_SCANNER_V4")
 	featureFlagVals := make(map[string]string)

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -950,9 +950,7 @@ EOT
     verify_scannerV2_deployed
     verify_no_scannerV4_deployed
     run ! verify_deployment_scannerV4_env_var_set "stackrox" "central"
-    # Temporarily disabled, because 4.8.0 has been released with a bug where sensor has ROX_SCANNER_V4=true set.
-    # TODO(ROX-30062)
-    # run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor"
+    run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor"
 
     _begin "upgrade-stackrox"
 
@@ -964,9 +962,7 @@ EOT
     verify_scannerV2_deployed
     verify_scannerV4_deployed
     verify_deployment_scannerV4_env_var_set "stackrox" "central"
-    # Temporarily disabled, because 4.8.0 has been released with a bug where sensor has ROX_SCANNER_V4=true set.
-    # TODO(ROX-30062)
-    # run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor" # no Scanner V4 support in Sensor with roxctl
+    run ! verify_deployment_scannerV4_env_var_set "stackrox" "sensor" # no Scanner V4 support in Sensor with roxctl
 
     _end
 }


### PR DESCRIPTION
## Description

Make sure that we don't inject `ROX_SCANNER_V4=true` into sensor deployment bundles.

## User-facing documentation

No doc changes needed.

## Testing and quality

- [x] the change is production ready
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

Deploy Central.

```
roxctl -e $API_ENDPOINT--insecure-skip-tls-verify sensor generate k8s --name sc6
INFO:   Deployment bundle does not include PodSecurityPolicies (PSPs).
INFO:   This is incompatible with pre-v1.25 Kubernetes installations having the PodSecurityPolicy Admission Controller plugin enabled.
INFO:   Use --enable-pod-security-policies if PodSecurityPolicies are required for your Kubernetes environment.
INFO:   Successfully wrote sensor folder "sensor-sc6"
```

```
❯ cat sensor-sc6/sensor.yaml | yq e  '. | select(.metadata.name == "sensor" and .kind == "Deployment")' -o=json | jq -r '.spec.template.spec.containers[0].env[] | select(.name | startswith("ROX_")) | "\(.name)=\(.value)"' | sort |rg SCANNER
ROX_SCANNER_V4_MAVEN_SEARCH=false
ROX_SCANNER_V4_PARTIAL_NODE_JS_SUPPORT=false
ROX_SCANNER_V4_RED_HAT_CSAF=false
ROX_SCANNER_V4_RED_HAT_CVES=true
ROX_SCANNER_V4_RED_HAT_LAYERS_RED_HAT_VULNS_ONLY=false
ROX_SCANNER_V4_REINDEX=true
```

No `ROX_SCANNER_V4=true`!
