### PR TITLE
ROX-30748: full identity singletons

### DIFF
--- a/pkg/postgres/schema/configs.go
+++ b/pkg/postgres/schema/configs.go
@@ -16,6 +16,9 @@ var (
 	CreateTableConfigsStmt = &postgres.CreateStmts{
 		GormModel: (*Configs)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE configs REPLICA IDENTITY FULL",
+		},
 	}
 
 	// ConfigsSchema is the go schema for table `configs`.

--- a/pkg/postgres/schema/delegated_registry_configs.go
+++ b/pkg/postgres/schema/delegated_registry_configs.go
@@ -16,6 +16,9 @@ var (
 	CreateTableDelegatedRegistryConfigsStmt = &postgres.CreateStmts{
 		GormModel: (*DelegatedRegistryConfigs)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE delegated_registry_configs REPLICA IDENTITY FULL",
+		},
 	}
 
 	// DelegatedRegistryConfigsSchema is the go schema for table `delegated_registry_configs`.

--- a/pkg/postgres/schema/installation_infos.go
+++ b/pkg/postgres/schema/installation_infos.go
@@ -16,6 +16,9 @@ var (
 	CreateTableInstallationInfosStmt = &postgres.CreateStmts{
 		GormModel: (*InstallationInfos)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE installation_infos REPLICA IDENTITY FULL",
+		},
 	}
 
 	// InstallationInfosSchema is the go schema for table `installation_infos`.

--- a/pkg/postgres/schema/notification_schedules.go
+++ b/pkg/postgres/schema/notification_schedules.go
@@ -16,6 +16,9 @@ var (
 	CreateTableNotificationSchedulesStmt = &postgres.CreateStmts{
 		GormModel: (*NotificationSchedules)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE notification_schedules REPLICA IDENTITY FULL",
+		},
 	}
 
 	// NotificationSchedulesSchema is the go schema for table `notification_schedules`.

--- a/pkg/postgres/schema/notifier_enc_configs.go
+++ b/pkg/postgres/schema/notifier_enc_configs.go
@@ -16,6 +16,9 @@ var (
 	CreateTableNotifierEncConfigsStmt = &postgres.CreateStmts{
 		GormModel: (*NotifierEncConfigs)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE notifier_enc_configs REPLICA IDENTITY FULL",
+		},
 	}
 
 	// NotifierEncConfigsSchema is the go schema for table `notifier_enc_configs`.

--- a/pkg/postgres/schema/sensor_upgrade_configs.go
+++ b/pkg/postgres/schema/sensor_upgrade_configs.go
@@ -16,6 +16,9 @@ var (
 	CreateTableSensorUpgradeConfigsStmt = &postgres.CreateStmts{
 		GormModel: (*SensorUpgradeConfigs)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE sensor_upgrade_configs REPLICA IDENTITY FULL",
+		},
 	}
 
 	// SensorUpgradeConfigsSchema is the go schema for table `sensor_upgrade_configs`.

--- a/pkg/postgres/schema/system_infos.go
+++ b/pkg/postgres/schema/system_infos.go
@@ -16,6 +16,9 @@ var (
 	CreateTableSystemInfosStmt = &postgres.CreateStmts{
 		GormModel: (*SystemInfos)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE system_infos REPLICA IDENTITY FULL",
+		},
 	}
 
 	// SystemInfosSchema is the go schema for table `system_infos`.

--- a/pkg/postgres/schema/versions.go
+++ b/pkg/postgres/schema/versions.go
@@ -17,6 +17,9 @@ var (
 	CreateTableVersionsStmt = &postgres.CreateStmts{
 		GormModel: (*Versions)(nil),
 		Children:  []*postgres.CreateStmts{},
+		PostStmts: []string{
+			"ALTER TABLE versions REPLICA IDENTITY FULL",
+		},
 	}
 
 	// VersionsSchema is the go schema for table `versions`.

--- a/tools/generate-helpers/pg-table-bindings/main.go
+++ b/tools/generate-helpers/pg-table-bindings/main.go
@@ -224,6 +224,7 @@ func main() {
 			"ReverseDefaultSort":   props.ReverseDefaultSort,
 			"TransformSortOptions": props.TransformSortOptions,
 			"DefaultTransform":     props.TransformSortOptions != "",
+			"Singleton":            props.SingletonStore,
 		}
 
 		if err := common.RenderFile(templateMap, schemaTemplate, getSchemaFileName(props.SchemaDirectory, schema.Table)); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -24,20 +24,26 @@ import (
 )
 
 {{- define "createTableStmt" }}
-{{- $schema := . }}
+{{- $singleton := .Singleton }}
+{{- $schema := .Schema }}
 &postgres.CreateStmts{
     GormModel: (*{{$schema.Table|upperCamelCase}})(nil),
     Children: []*postgres.CreateStmts{
      {{- range $index, $child := $schema.Children }}
-        {{- template "createTableStmt" $child }},
+        {{- template "createTableStmt" dict "Schema" $child "Singleton" $singleton }},
     {{- end }}
     },
+    {{- if $singleton }}
+    PostStmts: []string{
+        "ALTER TABLE {{$schema.Table|lowerCase}} REPLICA IDENTITY FULL",
+    },
+    {{- end }}
 }
 {{- end}}
 
 var (
     // {{template "createTableStmtVar" .Schema }} holds the create statement for table `{{.Schema.Table|lowerCase}}`.
-    {{template "createTableStmtVar" .Schema }} = {{template "createTableStmt" .Schema }}
+    {{template "createTableStmtVar" .Schema }} = {{template "createTableStmt" dict "Schema" .Schema "Singleton" .Singleton }}
 
     // {{template "schemaVar" .Schema.Table}} is the go schema for table `{{.Schema.Table|lowerCase}}`.
     {{template "schemaVar" .Schema.Table}} = func() *walker.Schema {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The cloud service when trying to use logical replication discovered that we have 8 tables with no replication identity and thus they cannot be replicated.  
```
| configs
| delegated_registry_configs
| installation_infos
| notification_schedules
| notifier_enc_configs
| sensor_upgrade_configs
| system_infos
| versions
```
Since these tables do not have a primary key they have no replication identity and thus cannot be replicated.  All these tables are `singletons` which in our data framework lingo means they only ever have at most 1 row.  So changing the replication identity of these tables to be `FULL` should resolve this issue.  Any further singletons created will automatically gather this as long as the code gen tools are utilized correctly.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
Before:
```
stackrox=> SELECT
    relname,
    CASE relreplident
        WHEN 'd' THEN 'DEFAULT'
        WHEN 'n' THEN 'NOTHING'
        WHEN 'f' THEN 'FULL'
        WHEN 'i' THEN 'INDEX'
    END AS replica_identity_setting
FROM
    pg_class
WHERE
    relname in ('versions', 'configs', 'delegated_registry_configs', 'installation_infos', 'notification_schedules', 'notifier_enc_configs', 'sensor_upgrade_configs', 'system_infos');
          relname           | replica_identity_setting 
----------------------------+--------------------------
 versions                   | DEFAULT
 configs                    | DEFAULT
 delegated_registry_configs | DEFAULT
 installation_infos         | DEFAULT
 notification_schedules     | DEFAULT
 notifier_enc_configs       | DEFAULT
 sensor_upgrade_configs     | DEFAULT
 system_infos               | DEFAULT
(8 rows)
```

After:
```
stackrox=> SELECT
    relname,
    CASE relreplident
        WHEN 'd' THEN 'DEFAULT'
        WHEN 'n' THEN 'NOTHING'
        WHEN 'f' THEN 'FULL'
        WHEN 'i' THEN 'INDEX'
    END AS replica_identity_setting
FROM
    pg_class
WHERE
    relname in ('versions', 'configs', 'delegated_registry_configs', 'installation_infos', 'notification_schedules', 'notifier_enc_configs', 'sensor_upgrade_configs', 'system_infos');
          relname           | replica_identity_setting 
----------------------------+--------------------------
 versions                   | FULL
 delegated_registry_configs | FULL
 configs                    | FULL
 installation_infos         | FULL
 notifier_enc_configs       | FULL
 notification_schedules     | FULL
 system_infos               | FULL
 sensor_upgrade_configs     | FULL
(8 rows)
```