### PR TITLE
ROX-30460: Add warning about not-default admission controller options

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Flex, FlexItem, Title } from '@patternfly/react-core';
 
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import type { Cluster, ClusterManagerType } from 'types/cluster.proto';
+import type { Cluster, ClusterManagerType, CompleteClusterConfig } from 'types/cluster.proto';
 import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 
 import ClusterLabelsTable from './ClusterLabelsTable';
@@ -12,6 +13,18 @@ import ClusterSummaryGrid from './ClusterSummaryGrid';
 import ClusterSummaryLegacy from './Components/ClusterSummaryLegacy';
 import DynamicConfigurationForm from './DynamicConfigurationForm';
 import StaticConfigurationForm from './StaticConfigurationForm';
+
+// Delete whenever deprecated properties are deleted.
+function getClusterHasDefaultsForAdmissionController(helmConfig: CompleteClusterConfig) {
+    return (
+        helmConfig.staticConfig.admissionController &&
+        helmConfig.staticConfig.admissionControllerUpdates &&
+        helmConfig.staticConfig.admissionControllerEvents &&
+        helmConfig.dynamicConfig?.admissionControllerConfig?.scanInline &&
+        helmConfig.dynamicConfig?.admissionControllerConfig?.enabled &&
+        helmConfig.dynamicConfig?.admissionControllerConfig?.enforceOnUpdates
+    );
+}
 
 type ClusterLabelsConfigurationStatusSummaryProps = {
     centralVersion: string;
@@ -92,6 +105,32 @@ function ClusterLabelsConfigurationStatusSummary({
                     />
                 </Flex>
             )}
+            {isManagerTypeNonConfigurable &&
+                selectedCluster.helmConfig &&
+                !getClusterHasDefaultsForAdmissionController(selectedCluster.helmConfig) && (
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                        <Alert
+                            variant="warning"
+                            isInline
+                            title="Admission controller configuration of this secured cluster differs from default configuration"
+                            component="p"
+                        >
+                            For more information, see{' '}
+                            <ExternalLink>
+                                <a
+                                    href="https://access.redhat.com/solutions/7130669"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Knowledge Centered Support solution
+                                </a>
+                            </ExternalLink>
+                        </Alert>
+                    </Flex>
+                )}
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
                 <Title headingLevel="h2">Static configuration (requires deployment)</Title>
                 <StaticConfigurationForm


### PR DESCRIPTION
## Description

In case the picture is hard to read:
Admission controller configuration of this secured cluster differs from default configuration
For more information, see Knowledge Centered Support solution

### Problem

Unlike **new** secured clusters which have better default properties starting with 4.9 release, **existing** secured clusters might still have worser properties.

### Analysis

1. Khushboo confirmed for which properties to compare actual and default properties.

    Static configuration:

    ```ts
    admissionControllerEvents: true,
    admissionController: true, // default changed in 4.9
    admissionControllerUpdates: true, // default changed in 4.9
    ```

    Dynamic configuration:

    ```ts
    enabled: true, // default changed in 4.9
    enforceOnUpdates: true, // default changed in 4.9
    scanInline: true, // default changed in 4.9
    ```

2. Khushboo and Moritz confirmed that the comparison is relevant **only** for when secured cluster is managed by Helm chart or Operator (that is, almost all customer installations).

### Solution

1. Add `getClusterHasDefaultsForAdmissionController` function.

2. Add conditional rendering of warning alert with link to solutions article if:
    * `isManagerTypeNonConfigurable`
    * `selectedCluster.helmConfig` (theoretically redundant with preceding)
    * negation of comparison function call

    RHACS KCS 101

    > KCS refers to **Knowledge Centered Support** or Knowledge Centered Service
    > KCS can be either an article (the focus is more general) or a **solution** (the focus is very specific).

### Residue

1. Double-check what is source of truth for dynamic and static configuration in form:
    * properties of `selectedCluster` object
    * properties of its `helmConfig` object

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder
2. `npm run lint` in ui/apps/platform folder
3. `npm run start` in ui/apps/platform folder with staging demo as central

#### Manual testing

1. Visit /main/clusters and then click **test_external_ips** link to visit cluster page

    Before changes, absence of warning alert preceding **Static configuration**
    <img width="1920" height="898" alt="absence" src="https://github.com/user-attachments/assets/dbc20283-7345-4699-9101-e14216d14526" />

    After changes, see presence of warning alert preceding **Static configuration**
    <img width="1920" height="898" alt="presence" src="https://github.com/user-attachments/assets/23517432-4a28-45cc-8c46-49938f95583c" />

2. Go back, and then click **staging-central-cluster** or **staging-secured-cluster** link

    Before and after changes, see absence of warning alert (at time of testing)
