### PR TITLE
test(ui): Add UI script changes to allow plugin e2e tests

### DIFF
--- a/ui/Makefile
+++ b/ui/Makefile
@@ -47,6 +47,8 @@ test-component: deps $(SOURCES)
 test-e2e: deps $(SOURCES)
 	@echo "+ $@"
 	npm run test-e2e
+# Uncomment this once the plugin is installed via the operator in CI
+# npm run test-e2e:ocp
 
 .PHONY: clean
 clean:

--- a/ui/apps/platform/README.md
+++ b/ui/apps/platform/README.md
@@ -142,6 +142,36 @@ run all end-to-end tests in a headless mode use `npm run test-e2e-local`. To run
 one test suite specifically in headless mode, use
 `npm run cypress-spec <spec-file>`.
 
+#### End-to-end Tests (Cypress targeting console plugin)
+
+To run Cypress against the OCP console for dynamic plugin tests, there are two scenarios that are supported.
+
+1. Running against a locally deployed version of the development console with bridge authentication off
+
+```sh
+# If necessary, export the target URL
+export OPENSHIFT_CONSOLE_URL=<url-to-web-console-ui>
+# Set ORCHESTRATOR_FLAVOR, which is typically only available in CI
+export ORCHESTRATOR_FLAVOR='openshift'
+# Runs Cypress OCP tests ignoring authentication
+OCP_BRIDGE_AUTH_DISABLED=true npm run cypress-open:ocp
+```
+
+2. Running against a deployed version of the console with username/password credentials
+
+```sh
+# If necessary, export the target URL
+export OPENSHIFT_CONSOLE_URL=<url-to-web-console-ui>
+# Set ORCHESTRATOR_FLAVOR, which is typically only available in CI
+export ORCHESTRATOR_FLAVOR='openshift'
+# export credentials
+export OPENSHIFT_CONSOLE_USERNAME='kubeadmin'
+export OPENSHIFT_CONSOLE_PASSWORD=<password>
+
+# Runs Cypress OCP tests with a session initialization step
+npm run cypress-open:ocp
+```
+
 ### Feature flags
 
 #### Add a feature flag to frontend code

--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -7,7 +7,6 @@
  */
 
 module.exports = {
-    blockHosts: ['*.*'], // Browser options
     chromeWebSecurity: false, // Browser options
     defaultCommandTimeout: 8000, // Timeouts options
     numTestsKeptInMemory: 0, // Global options
@@ -25,7 +24,6 @@ module.exports = {
 
     e2e: {
         baseUrl: 'https://localhost:3000',
-        specPattern: 'cypress/integration/**/*.test.{js,ts}',
         viewportHeight: 850, // Viewport options
         viewportWidth: 1440, // Viewport options
         setupNodeEvents: (on) => {

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -1,0 +1,21 @@
+export function withOcpAuth() {
+    if (Cypress.env('OCP_BRIDGE_AUTH_DISABLED')) {
+        return;
+    }
+
+    // Establish a cookie based session for the OCP web console
+    cy.session('ocp-session-auth', () => {
+        cy.visit('/');
+        cy.url().should('contain', '/login?');
+        cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
+        cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
+        cy.get('button[type="submit"]').click();
+
+        // Wait for the page to load
+        cy.url().should('contain', '/dashboards');
+        cy.get('h1:contains("Overview")');
+
+        // Pressing Escape closes the welcome modal if it exists, and silently does nothing if it doesn't
+        cy.get('body').type('{esc}');
+    });
+}

--- a/ui/apps/platform/cypress/integration-ocp/smoke.test.ts
+++ b/ui/apps/platform/cypress/integration-ocp/smoke.test.ts
@@ -1,0 +1,11 @@
+import { withOcpAuth } from '../helpers/ocpAuth';
+
+describe('Basic connectivity to the OCP plugin', () => {
+    it('should open the OCP web console', () => {
+        withOcpAuth();
+
+        cy.visit('/');
+
+        cy.get('h1:contains("Overview")');
+    });
+});

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -107,10 +107,13 @@
         "lint:fix": "eslint --fix --quiet",
         "tsc": "tsc",
         "cypress-open": "./scripts/cypress.sh open --e2e --config defaultBrowser=chrome",
+        "cypress-open:ocp": "./scripts/cypress-ocp.sh open --e2e --config defaultBrowser=chrome",
         "cypress-spec": "./scripts/cypress.sh run --spec",
         "cypress-component": "CYPRESS_COMPONENT_TEST=true ./scripts/cypress-component.sh open --component",
         "test-e2e": "TZ=UTC ./scripts/cypress.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js",
         "test-e2e-local": "TZ=UTC ./scripts/cypress.sh run",
+        "test-e2e:ocp": "TZ=UTC ./scripts/cypress-ocp.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js",
+        "test-e2e-local:ocp": "TZ=UTC ./scripts/cypress-ocp.sh run",
         "test-component": "TZ=UTC CYPRESS_COMPONENT_TEST=true ./scripts/cypress-component.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js --component",
         "generate-graphql-possible-types": "ROX_AUTH_TOKEN=$(./scripts/get-auth-token.sh) node scripts/generate-graphql-possible-types.js",
         "postinstall": "node scripts/check-optional-dependency-versions.js"

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
+# exit if ORCHESTRATOR_FLAVOR is not 'openshift' - these tests are only relevant for openshift
+if [ "${ORCHESTRATOR_FLAVOR}" != "openshift" ]; then
+    echo "ORCHESTRATOR_FLAVOR is not 'openshift', skipping cypress-ocp"
+    exit 0
+fi
+
+
+# Opens cypress with environment variables for feature flags and auth
+OPENSHIFT_CONSOLE_URL="${OPENSHIFT_CONSOLE_URL:-http://localhost:9000}"
+API_PROXY_BASE_URL="${OPENSHIFT_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"
+
+if [[ -z "$OPENSHIFT_CONSOLE_USERNAME" || -z "$OPENSHIFT_CONSOLE_PASSWORD" ]]; then
+    echo "OPENSHIFT_CONSOLE_USERNAME and OPENSHIFT_CONSOLE_PASSWORD must be set"
+    exit 1
+fi
+
+curl_cfg() { # Use built-in echo to not expose $2 in the process list.
+  echo -n "$1 = \"${2//[\"\\]/\\&}\""
+}
+
+if [[ -n "$OPENSHIFT_CONSOLE_PASSWORD" ]]; then
+  readarray -t arr < <(curl -sk --config <(curl_cfg user "$OPENSHIFT_CONSOLE_USERNAME:$OPENSHIFT_CONSOLE_PASSWORD") "${API_PROXY_BASE_URL}"/v1/featureflags | jq -cr '.featureFlags[] | {name: .envVar, enabled: .enabled}')
+  for i in "${arr[@]}"; do
+    name=$(echo "$i" | jq -rc .name)
+    val=$(echo "$i" | jq -rc .enabled)
+    export CYPRESS_"${name}"="${val}"
+  done
+fi
+
+# eventually it should be in cypress.config.js: https://github.com/cypress-io/cypress/issues/5218
+artifacts_dir="${TEST_RESULTS_OUTPUT_DIR:-cypress/test-results}/artifacts/ocp-console-plugin"
+export CYPRESS_VIDEOS_FOLDER="${artifacts_dir}/videos"
+export CYPRESS_SCREENSHOTS_FOLDER="${artifacts_dir}/screenshots"
+if [[ -n "${OPENSHIFT_CONSOLE_URL}" ]]; then
+  export CYPRESS_BASE_URL="${OPENSHIFT_CONSOLE_URL}"
+fi
+
+export CYPRESS_SPEC_PATTERN='cypress/integration-ocp/**/*.test.{js,ts}'
+
+
+export CYPRESS_OCP_BRIDGE_AUTH_DISABLED="${OCP_BRIDGE_AUTH_DISABLED}"
+export CYPRESS_OPENSHIFT_CONSOLE_USERNAME="${OPENSHIFT_CONSOLE_USERNAME}"
+export CYPRESS_OPENSHIFT_CONSOLE_PASSWORD="${OPENSHIFT_CONSOLE_PASSWORD}"
+
+if [ "$2" == "--spec" ]; then
+    if [ $# -ne 3 ]; then
+        echo "usage: npm run cypress-spec <spec-file>"
+        exit 1
+    fi
+    cypress run --spec "cypress/integration-ocp/$3"
+else
+    DEBUG="cypress*" NO_COLOR=1 cypress "$@" 2> /dev/null
+fi

--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -14,11 +14,11 @@ curl_cfg() { # Use built-in echo to not expose $2 in the process list.
 }
 
 if [[ -n "$ROX_ADMIN_PASSWORD" ]]; then
-  readarray -t arr < <(curl -sk --config <(curl_cfg user "admin:$ROX_ADMIN_PASSWORD") ${api_endpoint}/v1/featureflags | jq -cr '.featureFlags[] | {name: .envVar, enabled: .enabled}')
+  readarray -t arr < <(curl -sk --config <(curl_cfg user "admin:$ROX_ADMIN_PASSWORD") "${api_endpoint}"/v1/featureflags | jq -cr '.featureFlags[] | {name: .envVar, enabled: .enabled}')
   for i in "${arr[@]}"; do
-    name=$(echo $i | jq -rc .name)
-    val=$(echo $i | jq -rc .enabled)
-    export CYPRESS_${name}=${val}
+    name=$(echo "$i" | jq -rc .name)
+    val=$(echo "$i" | jq -rc .enabled)
+    export CYPRESS_"${name}"="${val}"
   done
 fi
 export CYPRESS_ROX_AUTH_TOKEN=$(./scripts/get-auth-token.sh)
@@ -31,10 +31,12 @@ if [[ -n "${UI_BASE_URL}" ]]; then
   export CYPRESS_BASE_URL="${UI_BASE_URL}"
 fi
 
+export CYPRESS_SPEC_PATTERN='cypress/integration/**/*.test.{js,ts}'
+
 # be able to skip tests that are not relevant, for example: openshift
 export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
 
-if [ $2 == "--spec" ]; then
+if [ "$2" == "--spec" ]; then
     if [ $# -ne 3 ]; then
         echo "usage: npm run cypress-spec <spec-file>"
         exit 1

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
         "lint": "npm --prefix apps/platform run lint",
         "test": "CI=true npm --prefix apps/platform run test",
         "test-e2e": "TEST_RESULTS_OUTPUT_DIR=../../test-results npm --prefix apps/platform run test-e2e",
+        "test-e2e:ocp": "TEST_RESULTS_OUTPUT_DIR=../../test-results npm --prefix apps/platform run test-e2e:ocp",
         "test-component": "npm --prefix apps/platform run test-component",
         "posttest-e2e:coverage": "mv apps/platform/coverage/ ./test-results/artifacts/",
         "prebuild": "npm run clean",


### PR DESCRIPTION
## Description

This is a re-commit of *only the UI changes* that were reverted in https://github.com/stackrox/stackrox/pull/16698.

The original full change set in the PR breaks `ocp-qa-e2e-tests` test runs due to the CI changes causing an cluster name change. More context here: https://redhat-internal.slack.com/archives/CELUQKESC/p1757098564825109

Since the plugin e2e test already are unable to run in CI, this re-adds the UI only changes so that tests can continue to be developed and run *locally* until we are ready to re-implement the changes in CI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manually run `/test ocp-4-19-qa-e2e-tests` on this PR and ensure the job succeeds.
