### PR TITLE
ROX-30705: Adds implementation of project security tab

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,7 +1,8 @@
 import navSelectors from '../selectors/navigation';
+import pf6 from '../selectors/pf6';
 
 import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
-import { visit, visitWithStaticResponseForPermissions } from './visit';
+import { visit, visitConsole, visitWithStaticResponseForPermissions } from './visit';
 
 /*
  * Import relevant alias constants in test files that call visitMainDashboard function
@@ -56,6 +57,8 @@ const routeMatcherMap = {
     ...routeMatcherMapForComplianceLevelsByStandard,
 };
 
+const routeMatcherMapForConsole = undefined;
+
 const basePath = '/main/dashboard';
 
 const title = 'Dashboard';
@@ -79,6 +82,16 @@ export function visitMainDashboard(staticResponseMap) {
 
     cy.get(`.pf-v5-c-nav__link.pf-m-current:contains("${title}")`);
     cy.get(`h1:contains("${title}")`);
+}
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitConsoleMainDashboard(staticResponseMap) {
+    visitConsole('/dashboards', routeMatcherMapForConsole, staticResponseMap);
+    cy.get(`${pf6.navExpandable} button:contains("Home")`).click();
+    cy.get(`${pf6.navExpandable} ${pf6.navItem} a.pf-m-current:contains("Overview")`);
+    cy.get(`h1:contains("Overview")`);
 }
 
 /**

--- a/ui/apps/platform/cypress/helpers/nav.ts
+++ b/ui/apps/platform/cypress/helpers/nav.ts
@@ -1,5 +1,6 @@
 import navSelectors from '../selectors/navigation';
-import { visitMainDashboard } from './main';
+import pf6 from '../selectors/pf6';
+import { visitConsoleMainDashboard, visitMainDashboard } from './main';
 import { interactAndWaitForResponses } from './request';
 
 /**
@@ -38,6 +39,26 @@ export function visitFromLeftNavExpandable(
             cy.get(`${navSelectors.navExpandable}:contains("${expandableTitle}")`).click();
             cy.get(
                 `${navSelectors.navExpandable}:contains("${expandableTitle}") + ${navSelectors.nestedNavLinks}:contains("${itemText}")`
+            ).click();
+        },
+        routeMatcherMap,
+        staticResponseMap
+    );
+}
+
+export function visitFromConsoleLeftNavExpandable(
+    expandableTitle: string,
+    itemText: string,
+    routeMatcherMap?: Record<string, { method: string; url: string }>,
+    staticResponseMap?: Record<string, { body: unknown } | { fixture: string }>
+) {
+    visitConsoleMainDashboard();
+
+    interactAndWaitForResponses(
+        () => {
+            cy.get(`${pf6.navExpandable}:contains("${expandableTitle}")`).click();
+            cy.get(
+                `${pf6.navExpandable}:contains("${expandableTitle}") ${pf6.navItem}:contains("${itemText}")`
             ).click();
         },
         routeMatcherMap,

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -1,15 +1,14 @@
 export function withOcpAuth() {
-    if (Cypress.env('OCP_BRIDGE_AUTH_DISABLED')) {
-        return;
-    }
-
     // Establish a cookie based session for the OCP web console
     cy.session('ocp-session-auth', () => {
         cy.visit('/');
-        cy.url().should('contain', '/login?');
-        cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
-        cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
-        cy.get('button[type="submit"]').click();
+
+        if (!Cypress.env('OCP_BRIDGE_AUTH_DISABLED')) {
+            cy.url().should('contain', '/login?');
+            cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
+            cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
+            cy.get('button[type="submit"]').click();
+        }
 
         // Wait for the page to load
         cy.url().should('contain', '/dashboards');

--- a/ui/apps/platform/cypress/helpers/ocpConsole.ts
+++ b/ui/apps/platform/cypress/helpers/ocpConsole.ts
@@ -1,0 +1,6 @@
+import pf6 from '../selectors/pf6';
+
+export function selectProject(project: string) {
+    cy.get(`.co-namespace-bar ${pf6.menuToggle}`).click();
+    cy.get(`.co-namespace-bar ${pf6.menuItem}:contains("${project}")`).click();
+}

--- a/ui/apps/platform/cypress/helpers/ocpConsole.ts
+++ b/ui/apps/platform/cypress/helpers/ocpConsole.ts
@@ -2,5 +2,7 @@ import pf6 from '../selectors/pf6';
 
 export function selectProject(project: string) {
     cy.get(`.co-namespace-bar ${pf6.menuToggle}`).click();
-    cy.get(`.co-namespace-bar ${pf6.menuItem}:contains("${project}")`).click();
+    cy.get(`.co-namespace-bar ${pf6.menuItem}`)
+        .contains(new RegExp(`^${project}$`, 'i'))
+        .click();
 }

--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -61,7 +61,7 @@ export function paginatePrevious() {
 
 export function assertOnEachRowForColumn(
     columnDataLabel: string,
-    // eslint-disable-next-line no-unused-vars
+
     assertion: (index: number, el: HTMLElement) => void
 ) {
     return cy
@@ -125,11 +125,8 @@ export function verifyColumnManagement({ tableSelector }: { tableSelector: strin
 }
 
 export function assertVisibleTableColumns(tableSelector: string, columns: string[]) {
-    cy.get(tableSelector)
-        .find('th')
-        .not('.pf-v5-u-display-none')
-        .should('have.length', columns.length);
+    cy.get(`${tableSelector} th:not(.pf-v5-u-display-none)`).should('have.length', columns.length);
     columns.forEach((column) => {
-        cy.get(tableSelector).find('th').should('contain.text', column);
+        cy.get(`${tableSelector} th:not(.pf-v5-u-display-none)`).should('contain.text', column);
     });
 }

--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -123,3 +123,13 @@ export function verifyColumnManagement({ tableSelector }: { tableSelector: strin
 
     resetManagedColumns();
 }
+
+export function assertVisibleTableColumns(tableSelector: string, columns: string[]) {
+    cy.get(tableSelector)
+        .find('th')
+        .not('.pf-v5-u-display-none')
+        .should('have.length', columns.length);
+    columns.forEach((column) => {
+        cy.get(tableSelector).find('th').should('contain.text', column);
+    });
+}

--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -61,7 +61,7 @@ export function paginatePrevious() {
 
 export function assertOnEachRowForColumn(
     columnDataLabel: string,
-
+    // eslint-disable-next-line no-unused-vars
     assertion: (index: number, el: HTMLElement) => void
 ) {
     return cy

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -79,6 +79,22 @@ export function visit(pageUrl, routeMatcherMap, staticResponseMap, waitOptions) 
 }
 
 /**
+ * @param {string} pageUrl
+ * @param {Record<string, RouteMatcherOptions>} [routeMatcherMap]
+ * @param {Record<string, RouteHandler>} [staticResponseMap]
+ * @param {WaitOptions} [waitOptions]
+ * @returns {Cypress.Chainable<Interception[] | Interception}
+ */
+export function visitConsole(pageUrl, routeMatcherMap, staticResponseMap, waitOptions) {
+    interceptRequests(undefined); // TODO Determine route matcher map for console
+    interceptRequests(routeMatcherMap, staticResponseMap);
+
+    cy.visit(pageUrl);
+
+    waitForResponses(undefined); // TODO Determine route matcher map for console
+    return waitForResponses(routeMatcherMap, waitOptions);
+}
+/**
  * Visit page to test conditional rendering for authentication status specified as response or fixture.
  *
  * { body: { resourceToAccess: { … } } }

--- a/ui/apps/platform/cypress/integration-ocp/security/vulnerabilities.test.ts
+++ b/ui/apps/platform/cypress/integration-ocp/security/vulnerabilities.test.ts
@@ -1,0 +1,81 @@
+import { visitFromConsoleLeftNavExpandable } from '../../helpers/nav';
+import { withOcpAuth } from '../../helpers/ocpAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { assertVisibleTableColumns } from '../../helpers/tableHelpers';
+import { selectors } from '../../integration/vulnerabilities/vulnerabilities.selectors';
+import { selectProject } from '../../helpers/ocpConsole';
+import { compoundFiltersSelectors } from '../../helpers/compoundFilters';
+
+describe('Security vulnerabilities page', () => {
+    it('should display only the expected table columns for each entity type', () => {
+        withOcpAuth();
+        visitFromConsoleLeftNavExpandable('Security', 'Vulnerabilities');
+
+        // Check CVE table columns
+        const expectedCveTableColumns = [
+            'Row expansion',
+            'CVE',
+            'Images by severity',
+            'Top CVSS',
+            hasFeatureFlag('ROX_SCANNER_V4') ? 'Top NVD CVSS' : null,
+            hasFeatureFlag('ROX_SCANNER_V4') ? 'EPSS probability' : null,
+            'First discovered',
+            'Published',
+        ].filter((column) => column !== null);
+        assertVisibleTableColumns('table', expectedCveTableColumns);
+
+        // Check Image table columns
+        const expectedImageTableColumns = [
+            'Image',
+            'CVEs by severity',
+            'Operating system',
+            'Deployments',
+            'Age',
+            'Scan time',
+        ];
+        cy.get(selectors.entityTypeToggleItem('Image')).click();
+        assertVisibleTableColumns('table', expectedImageTableColumns);
+
+        // Check Deployment table columns
+        const expectedDeploymentTableColumns = [
+            'Deployment',
+            'CVEs by severity',
+            'Namespace',
+            'Images',
+            'First discovered',
+        ];
+        cy.get(selectors.entityTypeToggleItem('Deployment')).click();
+        assertVisibleTableColumns('table', expectedDeploymentTableColumns);
+    });
+
+    it('should restrict the UI based on the status of the selected project', () => {
+        function assertSearchEntities(entities: string[]) {
+            cy.get(compoundFiltersSelectors.entityMenuToggle).click();
+            cy.get(compoundFiltersSelectors.entityMenuItem).should('have.length', entities.length);
+            entities.forEach((entity) => {
+                cy.get(compoundFiltersSelectors.entityMenuItem).contains(entity);
+            });
+        }
+
+        withOcpAuth();
+        visitFromConsoleLeftNavExpandable('Security', 'Vulnerabilities');
+
+        // Namespace is available by default when viewing "All projects"
+        assertSearchEntities(['CVE', 'Image', 'Image component', 'Deployment', 'Namespace']);
+
+        selectProject('stackrox');
+
+        // Namespace is not available when viewing a specific project
+        assertSearchEntities(['CVE', 'Image', 'Image component', 'Deployment']);
+
+        // Check Deployment table columns, expect `Namespace` to be missing
+        const expectedDeploymentTableColumns = [
+            'Deployment',
+            'CVEs by severity',
+            'Images',
+            'First discovered',
+        ];
+        cy.get(selectors.entityTypeToggleItem('Deployment')).click();
+        assertVisibleTableColumns('table', expectedDeploymentTableColumns);
+    });
+});

--- a/ui/apps/platform/cypress/selectors/pf6.ts
+++ b/ui/apps/platform/cypress/selectors/pf6.ts
@@ -1,0 +1,17 @@
+const navSelectors = {
+    nav: 'nav[data-ouia-component-type="PF6/Nav"]',
+    navExpandable: `li[data-ouia-component-type="PF6/NavExpandable"]`,
+    navItem: `li[data-ouia-component-type="PF6/NavItem"]`,
+} as const;
+
+const menu = 'div[data-ouia-component-type="PF6/Menu"]';
+const menuSelectors = {
+    menu,
+    menuToggle: `button[data-ouia-component-type="PF6/MenuToggle"]`,
+    menuItem: `${menu} *[role="menuitem"]`,
+} as const;
+
+export default {
+    ...navSelectors,
+    ...menuSelectors,
+};

--- a/ui/apps/platform/scripts/cypress-ocp.sh
+++ b/ui/apps/platform/scripts/cypress-ocp.sh
@@ -10,10 +10,10 @@ fi
 
 # Opens cypress with environment variables for feature flags and auth
 OPENSHIFT_CONSOLE_URL="${OPENSHIFT_CONSOLE_URL:-http://localhost:9000}"
-API_PROXY_BASE_URL="${OPENSHIFT_API_ENDPOINT}/api/proxy/plugin/advanced-cluster-security/api-service"
+API_PROXY_BASE_URL="${OPENSHIFT_CONSOLE_URL}/api/proxy/plugin/advanced-cluster-security/api-service"
 
-if [[ -z "$OPENSHIFT_CONSOLE_USERNAME" || -z "$OPENSHIFT_CONSOLE_PASSWORD" ]]; then
-    echo "OPENSHIFT_CONSOLE_USERNAME and OPENSHIFT_CONSOLE_PASSWORD must be set"
+if [[ -z "$OCP_BRIDGE_AUTH_DISABLED" && ( -z "$OPENSHIFT_CONSOLE_USERNAME" || -z "$OPENSHIFT_CONSOLE_PASSWORD" ) ]]; then
+    echo "OPENSHIFT_CONSOLE_USERNAME and OPENSHIFT_CONSOLE_PASSWORD must be set if OCP_BRIDGE_AUTH_DISABLED is not true"
     exit 1
 fi
 
@@ -21,7 +21,7 @@ curl_cfg() { # Use built-in echo to not expose $2 in the process list.
   echo -n "$1 = \"${2//[\"\\]/\\&}\""
 }
 
-if [[ -n "$OPENSHIFT_CONSOLE_PASSWORD" ]]; then
+if [[ -n "$OPENSHIFT_CONSOLE_PASSWORD" || "$OCP_BRIDGE_AUTH_DISABLED" == "true" ]]; then
   readarray -t arr < <(curl -sk --config <(curl_cfg user "$OPENSHIFT_CONSOLE_USERNAME:$OPENSHIFT_CONSOLE_PASSWORD") "${API_PROXY_BASE_URL}"/v1/featureflags | jq -cr '.featureFlags[] | {name: .envVar, enabled: .enabled}')
   for i in "${arr[@]}"; do
     name=$(echo "$i" | jq -rc .name)

--- a/ui/apps/platform/src/ConsolePlugin/Components/VulnerabilitiesOverviewContainer.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/Components/VulnerabilitiesOverviewContainer.tsx
@@ -115,7 +115,9 @@ export function VulnerabilitiesOverviewContainer() {
                 topNvdCvss: hideColumnIf(!isScannerV4Enabled),
                 epssProbability: hideColumnIf(!isScannerV4Enabled),
             }}
-            imageTableColumnOverrides={{}}
+            imageTableColumnOverrides={{
+                rowActions: hideColumnIf(true),
+            }}
             deploymentTableColumnOverrides={{
                 namespace: hideColumnIf(activeNamespace !== ALL_NAMESPACES_KEY),
                 cluster: hideColumnIf(true),

--- a/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
+import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
+
+import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';
+import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
 
 export function ProjectSecurityTab() {
-    return <div>Project Security Tab</div>;
+    const context = useDefaultWorkloadCveViewContext();
+
+    return (
+        <WorkloadCveViewContext.Provider value={context}>
+            <VulnerabilitiesOverviewContainer />
+        </WorkloadCveViewContext.Provider>
+    );
 }


### PR DESCRIPTION
## Description

Much like https://github.com/stackrox/stackrox/pull/16714, adds the Vuln Overview to the Home -> Projects -> Security tab.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Navigate to Home -> Projects -> Security and validate the correct data is shown:
<img width="1531" height="883" alt="image" src="https://github.com/user-attachments/assets/19d03daa-5e8a-45ff-ae6d-afd505b7b886" />
<img width="1531" height="883" alt="image" src="https://github.com/user-attachments/assets/6b6a1ba1-bada-4106-adc7-dca3a42e61dd" />
<img width="1531" height="883" alt="image" src="https://github.com/user-attachments/assets/ae32a1c9-0247-4141-a600-2ab2e66e9414" />
