### PR TITLE
ROX-30702: Adds implementation for plugin CVE detail page

### DIFF
--- a/ui/apps/platform/cypress/helpers/tableHelpers.ts
+++ b/ui/apps/platform/cypress/helpers/tableHelpers.ts
@@ -125,8 +125,14 @@ export function verifyColumnManagement({ tableSelector }: { tableSelector: strin
 }
 
 export function assertVisibleTableColumns(tableSelector: string, columns: string[]) {
-    cy.get(`${tableSelector} th:not(.pf-v5-u-display-none)`).should('have.length', columns.length);
+    cy.get(`${tableSelector} > thead th:not(.pf-v5-u-display-none)`).should(
+        'have.length',
+        columns.length
+    );
     columns.forEach((column) => {
-        cy.get(`${tableSelector} th:not(.pf-v5-u-display-none)`).should('contain.text', column);
+        cy.get(`${tableSelector} > thead th:not(.pf-v5-u-display-none)`).should(
+            'contain.text',
+            column
+        );
     });
 }

--- a/ui/apps/platform/cypress/integration-ocp/security/cveDetail.test.ts
+++ b/ui/apps/platform/cypress/integration-ocp/security/cveDetail.test.ts
@@ -1,0 +1,59 @@
+import { visitFromConsoleLeftNavExpandable } from '../../helpers/nav';
+import { withOcpAuth } from '../../helpers/ocpAuth';
+import { assertVisibleTableColumns } from '../../helpers/tableHelpers';
+import { selectProject } from '../../helpers/ocpConsole';
+import { assertSearchEntities } from '../../integration/vulnerabilities/workloadCves/WorkloadCves.helpers';
+import { selectors } from '../../integration/vulnerabilities/workloadCves/WorkloadCves.selectors';
+import { selectors as vulnerabilitiesSelectors } from '../../integration/vulnerabilities/vulnerabilities.selectors';
+import pf6 from '../../selectors/pf6';
+
+describe('Security vulnerabilities - CVE Detail page', () => {
+    it('should navigate to the CVE Detail page and account for the project filter', () => {
+        withOcpAuth();
+        visitFromConsoleLeftNavExpandable('Security', 'Vulnerabilities');
+
+        // Visit a CVE page via link in the CVE table
+        cy.get(`${selectors.firstTableRow} td[data-label="CVE"]`)
+            .click()
+            .invoke('text')
+            .then((cveName) => {
+                cy.get('h1').contains(new RegExp(`^${cveName}$`));
+
+                // Verify that "All projects" is selected
+                cy.get(`.co-namespace-bar ${pf6.menuToggle}`).contains('All Projects');
+
+                // Click the deployment entity toggle
+                cy.get(vulnerabilitiesSelectors.entityTypeToggleItem('Deployment')).click();
+
+                // Columns that are always present in the table
+                const baseColumns = [
+                    'Row expansion',
+                    'Deployment',
+                    'Images by severity',
+                    'Images',
+                    'First discovered',
+                ];
+
+                const topLevelTableSelector = 'table:first-of-type';
+
+                // Verify that the "Namespace" column is present
+                assertVisibleTableColumns(topLevelTableSelector, [...baseColumns, 'Namespace']);
+
+                // Verify that Namespace is present in the search entities
+                assertSearchEntities(['Image', 'Image component', 'Deployment', 'Namespace']);
+
+                // Change to the 'stackrox' project
+                selectProject('stackrox');
+
+                // Wait for the table data to update
+                cy.get(selectors.loadingSpinner).should('exist');
+                cy.get(selectors.loadingSpinner).should('not.exist');
+
+                // Verify that the "Namespace" column is not present
+                assertVisibleTableColumns(topLevelTableSelector, [...baseColumns]);
+
+                // Verify that Namespace is not present in the search entities
+                assertSearchEntities(['Image', 'Image component', 'Deployment']);
+            });
+    });
+});

--- a/ui/apps/platform/cypress/integration-ocp/security/vulnerabilities.test.ts
+++ b/ui/apps/platform/cypress/integration-ocp/security/vulnerabilities.test.ts
@@ -4,7 +4,7 @@ import { hasFeatureFlag } from '../../helpers/features';
 import { assertVisibleTableColumns } from '../../helpers/tableHelpers';
 import { selectors } from '../../integration/vulnerabilities/vulnerabilities.selectors';
 import { selectProject } from '../../helpers/ocpConsole';
-import { compoundFiltersSelectors } from '../../helpers/compoundFilters';
+import { assertSearchEntities } from '../../integration/vulnerabilities/workloadCves/WorkloadCves.helpers';
 
 describe('Security vulnerabilities page', () => {
     it('should display only the expected table columns for each entity type', () => {
@@ -49,14 +49,6 @@ describe('Security vulnerabilities page', () => {
     });
 
     it('should restrict the UI based on the status of the selected project', () => {
-        function assertSearchEntities(entities: string[]) {
-            cy.get(compoundFiltersSelectors.entityMenuToggle).click();
-            cy.get(compoundFiltersSelectors.entityMenuItem).should('have.length', entities.length);
-            entities.forEach((entity) => {
-                cy.get(compoundFiltersSelectors.entityMenuItem).contains(entity);
-            });
-        }
-
         withOcpAuth();
         visitFromConsoleLeftNavExpandable('Security', 'Vulnerabilities');
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -7,6 +7,7 @@ import {
 import { visit } from '../../../helpers/visit';
 import { selectors } from './WorkloadCves.selectors';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
+import { compoundFiltersSelectors } from '../../../helpers/compoundFilters';
 
 export function getDateString(date) {
     return format(date, 'MMM DD, YYYY');
@@ -483,4 +484,12 @@ export function visitNamespaceView() {
 
 export function viewCvesByObservationState(observationState) {
     cy.get('button[role="tab"]').contains(observationState).click();
+}
+
+export function assertSearchEntities(entities) {
+    cy.get(compoundFiltersSelectors.entityMenuToggle).click();
+    cy.get(compoundFiltersSelectors.entityMenuItem).should('have.length', entities.length);
+    entities.forEach((entity) => {
+        cy.get(compoundFiltersSelectors.entityMenuItem).contains(entity);
+    });
 }

--- a/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
@@ -1,15 +1,46 @@
 import React from 'react';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
-import { useParams } from 'react-router-dom-v5-compat';
+import { NamespaceBar, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+
+import useURLSearch from 'hooks/useURLSearch';
+import { hideColumnIf } from 'hooks/useManagedColumns';
+import { ALL_NAMESPACES_KEY } from 'ConsolePlugin/constants';
+import { useDefaultWorkloadCveViewContext } from 'ConsolePlugin/hooks/useDefaultWorkloadCveViewContext';
+import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
+import {
+    imageSearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+} from 'Containers/Vulnerabilities/searchFilterConfig';
+import ImageCvePage from 'Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage';
 
 export function CveDetailPage() {
-    const { cveId } = useParams();
-    const [namespace] = useActiveNamespace();
+    const [activeNamespace] = useActiveNamespace();
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const context = useDefaultWorkloadCveViewContext();
+    const searchFilterConfig = [
+        imageSearchFilterConfig,
+        imageComponentSearchFilterConfig,
+        deploymentSearchFilterConfig,
+        ...(activeNamespace === ALL_NAMESPACES_KEY ? [namespaceSearchFilterConfig] : []),
+    ];
+
     return (
-        <>
-            <div>CVE Detail Page</div>
-            <div>Namespace: {namespace}</div>
-            <div>CVE ID: {cveId}</div>
-        </>
+        <WorkloadCveViewContext.Provider value={context}>
+            <NamespaceBar
+                // Force clear Namespace filter when the user changes the namespace via the NamespaceBar
+                onNamespaceChange={() => setSearchFilter({ ...searchFilter, Namespace: [] })}
+            />
+            <ImageCvePage
+                searchFilterConfig={searchFilterConfig}
+                showVulnerabilityStateTabs={false}
+                vulnerabilityState="OBSERVED"
+                imageTableColumnOverrides={{}}
+                deploymentTableColumnOverrides={{
+                    cluster: hideColumnIf(true),
+                    namespace: hideColumnIf(activeNamespace !== ALL_NAMESPACES_KEY),
+                }}
+            />
+        </WorkloadCveViewContext.Provider>
     );
 }


### PR DESCRIPTION
## Description

Adds the CVE detail page in the console plugin.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the security overview and click a CVE link in the table while viewing "All projects".
<img width="1531" height="995" alt="image" src="https://github.com/user-attachments/assets/ee463ed8-38bb-4893-b14e-bf047a25ec4a" />
<img width="1531" height="995" alt="image" src="https://github.com/user-attachments/assets/9070ab64-775a-48bb-a2af-68a4453e250e" />

Update the project selector to choose an individual project. The entity tables should update to contain only entities in scope, and the "Namespace" column should disappear. Namespace filters should not be available via the dropdown.
<img width="1531" height="995" alt="image" src="https://github.com/user-attachments/assets/35b8f966-9e62-4ad8-83a5-59908e5102e6" />


