### PR TITLE
ROX-30827: Add conditional rendering for status in ClusterSummaryGrid

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
@@ -25,29 +25,37 @@ export function ClusterSummaryGrid({
 }: ClusterSummaryGridProps) {
     return (
         <Grid hasGutter>
-            <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
-                <ClusterHealthPanel header="Cluster metadata">
-                    <ClusterMetadata status={clusterInfo.status} />
-                </ClusterHealthPanel>
-            </GridItem>
-            <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
-                <SensorUpgradePanel
-                    centralVersion={centralVersion}
-                    sensorVersion={clusterInfo.status?.sensorVersion}
-                    upgradeStatus={clusterInfo.status?.upgradeStatus}
-                />
-            </GridItem>
-            <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
-                <ClusterHealthPanel header="Credential expiration">
-                    <CredentialExpiration
-                        certExpiryStatus={clusterInfo.status?.certExpiryStatus as CertExpiryStatus}
-                        autoRefreshEnabled={clusterInfo.sensorCapabilities?.includes(
-                            'SecuredClusterCertificatesRefresh'
-                        )}
-                        isList
+            {clusterInfo.status && (
+                <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
+                    <ClusterHealthPanel header="Cluster metadata">
+                        <ClusterMetadata status={clusterInfo.status} />
+                    </ClusterHealthPanel>
+                </GridItem>
+            )}
+            {clusterInfo.status && (
+                <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
+                    <SensorUpgradePanel
+                        centralVersion={centralVersion}
+                        sensorVersion={clusterInfo.status?.sensorVersion}
+                        upgradeStatus={clusterInfo.status?.upgradeStatus}
                     />
-                </ClusterHealthPanel>
-            </GridItem>
+                </GridItem>
+            )}
+            {clusterInfo.status && (
+                <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
+                    <ClusterHealthPanel header="Credential expiration">
+                        <CredentialExpiration
+                            certExpiryStatus={
+                                clusterInfo.status?.certExpiryStatus as CertExpiryStatus
+                            }
+                            autoRefreshEnabled={clusterInfo.sensorCapabilities?.includes(
+                                'SecuredClusterCertificatesRefresh'
+                            )}
+                            isList
+                        />
+                    </ClusterHealthPanel>
+                </GridItem>
+            )}
             <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
                 <ClusterHealthPanel header="Cluster deletion">
                     <ClusterDeletion clusterRetentionInfo={clusterRetentionInfo} />

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterMetadata.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterMetadata.tsx
@@ -18,7 +18,7 @@ function ClusterMetadata({ status }: ClusterMetadataProps) {
     return (
         <DescriptionList>
             <DescriptionListGroup>
-                <DescriptionListTerm>ClusterStatus</DescriptionListTerm>
+                <DescriptionListTerm>Kubernetes version</DescriptionListTerm>
                 <DescriptionListDescription>
                     {formatKubernetesVersion(status?.orchestratorMetadata)}
                 </DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
@@ -23,7 +23,7 @@ export type DynamicConfigurationFormProps = {
     dynamicConfig: DynamicClusterConfig;
     handleChange: (path: string, value: boolean | string) => void;
     handleChangeAdmissionControllerEnforcementBehavior: (value: boolean) => void;
-    helmConfig: CompleteClusterConfig;
+    helmConfig: CompleteClusterConfig | null;
     isManagerTypeNonConfigurable: boolean;
 };
 


### PR DESCRIPTION
## Description

Hide space (because of indentation changes) for review.

### Problems

1. Thank you, **Khushboo** for finding lack of conditional rendering for `status: null` property in clusters response.

2. Investigation of conditional rendering also found copy-pasto of **ClusterSummary** instead of **Kubernetes version** in `ClusterMetadata` element.

### Analysis

How did I forget to study and conditional rendering in `ClusterTable` component?

### Solution

1. Study conditional rendering in `ClusterTable` component, and then apply it in `ClusterSummaryGrid` component.

2. Fix copy-pasto.

3. Add `| null` to prop declaration of `DynamicConfigurationForm` component.
    See absence of errors, because already had optional chaining.
    Although it would be parallel to do similarly in `StaticConfigurationForm` element, to make sure we do not miss optional chaining, it has longer chain. Too bad, so sad.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder
2. `npm run lint` in ui/apps/platform folder
3. `npm run start` in ui/apps/platform folder with staging demo as central

#### Manual testing

1. Visit /main/clusters and click **test-unhealthy** link to visit its cluster page, and then scroll down to cluster summary grid.

    Before changes, with unconditional rendering, see error boundary page:
    <img width="1919" height="897" alt="status_null_unconditional" src="https://github.com/user-attachments/assets/cdf9874a-632a-4b86-bbd4-ec758155d7b8" />

    After changes, with conditional rendering, see:
    * absence of **Cluster metadata**
    * absence of **Sensor upgrade**
    * absence of **Credential expiration**
    * presence of **Cluster deletion**
    <img width="1920" height="898" alt="status_null_conditional" src="https://github.com/user-attachments/assets/d993e9e5-7046-4740-be30-6bb90ebe2c8d" />

2. Go back, visit other cluster pages, and then scroll down.

    After changes, see **Kubernetes version** as description list term.
