### PR TITLE
ROX-30390: Remove gauge metric for update types

### DIFF
--- a/sensor/common/networkflow/updatecomputer/metrics.go
+++ b/sensor/common/networkflow/updatecomputer/metrics.go
@@ -8,7 +8,6 @@ import (
 func init() {
 	prometheus.MustRegister(
 		UpdateEvents,
-		UpdateEventsGauge,
 		periodicCleanupDurationSeconds,
 	)
 }
@@ -20,14 +19,6 @@ var (
 		Name:      "update_computer_update_events_total",
 		Help: "Counts the internal update events for the categorizeUpdate method in TransitionBased updateComputer. " +
 			"The 'transition' allows counting the transitions of connections between states 'open' and 'closed'." +
-			"Action stores the decision whether a given update was sent to Central.",
-	}, []string{"transition", "entity", "action", "reason"})
-	UpdateEventsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.SensorSubsystem.String(),
-		Name:      "update_computer_update_events_current",
-		Help: "Counts the internal update events for the categorizeUpdate method in TransitionBased updateComputer in a single tick. " +
-			"The 'transition' allows counting the transitions of connections between states 'open' and 'closed'. in a given tick." +
 			"Action stores the decision whether a given update was sent to Central.",
 	}, []string{"transition", "entity", "action", "reason"})
 	periodicCleanupDurationSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{

--- a/sensor/common/networkflow/updatecomputer/transition_based.go
+++ b/sensor/common/networkflow/updatecomputer/transition_based.go
@@ -171,10 +171,6 @@ func NewTransitionBased() *TransitionBased {
 func (c *TransitionBased) ComputeUpdatedConns(current map[indicator.NetworkConn]timestamp.MicroTS) []*storage.NetworkFlow {
 	var updates []*storage.NetworkFlow
 	ee := ConnectionEnrichedEntity
-	// Reset the gauge metric only on the first call to the ComputeUpdated.
-	// The current state assumes that `ComputeUpdatedConns` is always called before other ComputeUpdated functions.
-	// Calling Reset in other ComputeUpdated functions would remove the data collected in the metric in this function.
-	UpdateEventsGauge.Reset()
 	if len(current) == 0 {
 		// Received an empty map with current state. This may happen because:
 		// - Some items were discarded during the enrichment process, so none made it through.
@@ -292,8 +288,6 @@ func updateMetrics(update bool, tt TransitionType, ee EnrichedEntity) {
 		}
 	}
 	UpdateEvents.WithLabelValues(tt.String(), string(ee), action, reason).Inc()
-	// This metric must be reset on each tick, otherwise it would behave as a counter.
-	UpdateEventsGauge.WithLabelValues(tt.String(), string(ee), action, reason).Inc()
 }
 
 // categorizeUpdateNoPast determines whether an update to Central should be sent for a given enrichment update.


### PR DESCRIPTION
## Description

It was difficult to capture the correct data for a gauge, as it was required to use `Reset()`. That made the metric values interrupted (for example: 60, nil, 70, nil, nil, 85). Recording it properly would require more changes and was not worth the effort.

The counter version of the same metric is still available. The same result can be achieved using the counter version with  `increase(the_counter_metric[30s])` in Prometheus or Grafana.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
    - Not needed, as the metric was added recently and has not been released yet. 
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

I haven't
