### PR TITLE
chore(perf): Add new metrics for CPU in mCores

### DIFF
--- a/tests/performance/scale/config/metrics-acs-base.yml
+++ b/tests/performance/scale/config/metrics-acs-base.yml
@@ -3,6 +3,10 @@
 - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace="stackrox"}[2m]) * 100) by (container, pod, namespace))
   metricName: stackrox_container_cpu
 
+# Replacement for "stackrox_container_cpu".
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace="stackrox"}[2m]) * 1000) by (container, pod, namespace))
+  metricName: stackrox_container_cpu_mcores
+
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace="stackrox"}) by (container, pod, namespace))
   metricName: stackrox_container_memory
 

--- a/tests/performance/scale/config/metrics-acs.yml
+++ b/tests/performance/scale/config/metrics-acs.yml
@@ -6,6 +6,10 @@
 - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace="stackrox"}[2m]) * 100) by (container, pod, namespace))
   metricName: stackrox_container_cpu
 
+# Replacement for "stackrox_container_cpu".
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace="stackrox"}[2m]) * 1000) by (container, pod, namespace))
+  metricName: stackrox_container_cpu_mcores
+
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace="stackrox"}) by (container, pod, namespace))
   metricName: stackrox_container_memory
 

--- a/tests/performance/scale/config/metrics-full.yml
+++ b/tests/performance/scale/config/metrics-full.yml
@@ -142,30 +142,37 @@
 - query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Workers
   instant: true
+  captureStart: true
 
 - query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Masters
   instant: true
+  captureStart: true
 
 - query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
   metricName: nodeCPUSeconds-Infra
   instant: true
+  captureStart: true
 
 - query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{ role = "worker",role != "infra" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Workers
   instant: true
+  captureStart: true
 
 - query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "master" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Masters
   instant: true
+  captureStart: true
 
 - query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "infra" } )  by   (   id  )
   metricName: cgroupCPUSeconds-Infra
   instant: true
+  captureStart: true
 
 - query: sum( container_cpu_usage_seconds_total{container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
   metricName: cgroupCPUSeconds-namespaces
   instant: true
+  captureStart: true
 
 # File: metrics-acs-base.yml
 
@@ -173,6 +180,10 @@
 
 - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace="stackrox"}[2m]) * 100) by (container, pod, namespace))
   metricName: stackrox_container_cpu
+
+# Replacement for "stackrox_container_cpu".
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace="stackrox"}[2m]) * 1000) by (container, pod, namespace))
+  metricName: stackrox_container_cpu_mcores
 
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace="stackrox"}) by (container, pod, namespace))
   metricName: stackrox_container_memory


### PR DESCRIPTION
## Description

The current CPU metric is using the formula: `cores * 100` - which is wrong and misleading.

This PR is adding new metrics to collect mili-cores.

Plan for switching is:
1. add new metric
2. wait for a reasonable time to collect data (1-2 months)
3. switch to new metric in dashboards/scripts
4. fix the old metric to represent mCores
5. wait for a reasonable time to collect data (1-2 months)
6. switch to the old fixed metric in dashboards/scripts
7. remove the new metric

**Note:**
Changes related to `captureStart: true` and introduced in another PR, but not all files have been fixed. Since I'm using a script to merge files, this is a product of that.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests (scale tests will collect more data)

### How I validated my change

I didn't test changes.
