### PR TITLE
ROX-30390: Adjust grafana dashboards to recent changes

### DIFF
--- a/deploy/charts/monitoring/dashboards/enrichment-connections.json
+++ b/deploy/charts/monitoring/dashboards/enrichment-connections.json
@@ -219,12 +219,12 @@
           "editorMode": "code",
           "expr": "increase(rox_sensor_total_network_flows_sensor_received_counter[1m])",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "Updated connections",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total number of network flows received from Collector (per minute)",
+      "title": "Number of updated connections received from Collector (per minute)",
       "type": "timeseries"
     },
     {
@@ -572,7 +572,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{object}} closedTS={{closedTS}}",
+          "legendFormat": "{{object}} {{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false

--- a/deploy/charts/monitoring/dashboards/enrichment-endpoints.json
+++ b/deploy/charts/monitoring/dashboards/enrichment-endpoints.json
@@ -364,7 +364,7 @@
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "{{object}} closedTS={{closedTS}}",
+          "legendFormat": "{{object}} {{status}}",
           "range": true,
           "refId": "A",
           "useBackend": false


### PR DESCRIPTION
## Description

The diff should be readable. I mainly wanted to correct the legend that  shows now `open` and `closed` instead of `closedTS=true` - this was applied to few places.
<img width="560" height="303" alt="Screenshot 2025-09-12 at 10 15 21" src="https://github.com/user-attachments/assets/2e523e7f-adc8-4054-a35d-5ee7d8e5a69a" />


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Visually in grafana
