### PR TITLE
ROX-30758: Retry on k8s assertions

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -314,7 +315,7 @@ func teardownDeploymentWithoutCheck(t *testing.T, deploymentName string) {
 	}
 }
 
-func getConfig(t *testing.T) *rest.Config {
+func getConfig(t testutils.T) *rest.Config {
 	config, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 	require.NoError(t, err, "could not load default Kubernetes client config")
 
@@ -324,11 +325,11 @@ func getConfig(t *testing.T) *rest.Config {
 	return restCfg
 }
 
-func createK8sClient(t *testing.T) kubernetes.Interface {
+func createK8sClient(t T) kubernetes.Interface {
 	return createK8sClientWithConfig(t, getConfig(t))
 }
 
-func createK8sClientWithConfig(t *testing.T, restCfg *rest.Config) kubernetes.Interface {
+func createK8sClientWithConfig(t T, restCfg *rest.Config) kubernetes.Interface {
 	// Configure retryable HTTP client for network resilience
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 3
@@ -356,8 +357,13 @@ func createK8sClientWithConfig(t *testing.T, restCfg *rest.Config) kubernetes.In
 	return k8sClient
 }
 
+type T interface {
+	testutils.T
+	Logf(string, ...interface{})
+}
+
 type logWrapper struct {
-	t *testing.T
+	t T
 }
 
 func (l logWrapper) Printf(format string, values ...interface{}) {
@@ -857,4 +863,40 @@ func getCluster(ctx context.Context, conn *grpc.ClientConn) (*storage.Cluster, e
 	}
 
 	return clusters.Clusters[0], nil
+}
+
+type collectT struct {
+	t *testing.T
+	c *assert.CollectT
+}
+
+func (c *collectT) Fatalf(format string, args ...interface{}) {
+	if c.t != nil {
+		c.t.Fatalf(format, args...)
+	}
+}
+
+func (c *collectT) Errorf(format string, args ...interface{}) {
+	if c.c != nil {
+		c.c.Errorf(format, args...)
+	}
+}
+
+func (c *collectT) FailNow() {
+	if c.c != nil {
+		c.c.FailNow()
+	}
+}
+
+func (c *collectT) Logf(format string, values ...interface{}) {
+	if c.t != nil {
+		c.t.Logf(format, values...)
+	}
+}
+
+func wrapCollectT(t *testing.T, c *assert.CollectT) *collectT {
+	return &collectT{
+		t: t,
+		c: c,
+	}
 }

--- a/tests/compliance_operator_test.go
+++ b/tests/compliance_operator_test.go
@@ -50,36 +50,6 @@ const defaultWaitTime = 600 * time.Second
 const defaultSleepTime = 10 * time.Second
 const defaultTickTime = 2 * time.Second
 
-type collectT struct {
-	t *testing.T
-	c *assert.CollectT
-}
-
-func (c *collectT) Fatalf(format string, args ...interface{}) {
-	if c.t != nil {
-		c.t.Fatalf(format, args...)
-	}
-}
-
-func (c *collectT) Errorf(format string, args ...interface{}) {
-	if c.c != nil {
-		c.c.Errorf(format, args...)
-	}
-}
-
-func (c *collectT) FailNow() {
-	if c.c != nil {
-		c.c.FailNow()
-	}
-}
-
-func wrapCollectT(t *testing.T, c *assert.CollectT) *collectT {
-	return &collectT{
-		t: t,
-		c: c,
-	}
-}
-
 func getCurrentComplianceResults(t testutils.T) (rhcos, ocp *storage.ComplianceRunResults) {
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	managementService := v1.NewComplianceManagementServiceClient(conn)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

If we retrieve the ScanSetting/Binding too soon, it won't be updated and the test will fail. This PR adds a retry logic to wait for the resource to be updated before failing.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] CI
