### PR TITLE
refactor: remove useless metrics tracker category

### DIFF
--- a/central/metrics/custom/image_vulnerabilities/tracker.go
+++ b/central/metrics/custom/image_vulnerabilities/tracker.go
@@ -14,7 +14,6 @@ import (
 
 func New(ds deploymentDS.DataStore) *tracker.TrackerBase[*finding] {
 	return tracker.MakeTrackerBase(
-		"vulnerabilities",
 		"CVEs",
 		lazyLabels,
 		func(ctx context.Context, md tracker.MetricDescriptors) iter.Seq[*finding] {

--- a/central/metrics/custom/policy_violations/tracker.go
+++ b/central/metrics/custom/policy_violations/tracker.go
@@ -12,7 +12,6 @@ import (
 
 func New(ds alertDS.DataStore) *tracker.TrackerBase[*finding] {
 	return tracker.MakeTrackerBase(
-		"alerts",
 		"policy violations",
 		lazyLabels,
 		func(ctx context.Context, _ tracker.MetricDescriptors) iter.Seq[*finding] {

--- a/central/metrics/custom/tracker/tracker_base_test.go
+++ b/central/metrics/custom/tracker/tracker_base_test.go
@@ -51,7 +51,7 @@ func makeTestGatherFunc(data []map[Label]string) FindingGenerator[testFinding] {
 }
 
 func TestMakeTrackerBase(t *testing.T) {
-	tracker := MakeTrackerBase("test", "test", testLabelGetters, nilGatherFunc)
+	tracker := MakeTrackerBase("test", testLabelGetters, nilGatherFunc)
 	assert.NotNil(t, tracker)
 	assert.Nil(t, tracker.GetConfiguration())
 }
@@ -59,7 +59,7 @@ func TestMakeTrackerBase(t *testing.T) {
 func TestTrackerBase_Reconfigure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	t.Run("nil configuration", func(t *testing.T) {
-		tracker := MakeTrackerBase("test", "test", testLabelGetters, nilGatherFunc)
+		tracker := MakeTrackerBase("test", testLabelGetters, nilGatherFunc)
 
 		tracker.Reconfigure(nil)
 		config := tracker.GetConfiguration()
@@ -70,7 +70,7 @@ func TestTrackerBase_Reconfigure(t *testing.T) {
 	})
 
 	t.Run("test 0 period", func(t *testing.T) {
-		tracker := MakeTrackerBase("test", "test", testLabelGetters, nilGatherFunc)
+		tracker := MakeTrackerBase("test", testLabelGetters, nilGatherFunc)
 		cfg0 := &Configuration{}
 
 		tracker.Reconfigure(cfg0)
@@ -84,7 +84,7 @@ func TestTrackerBase_Reconfigure(t *testing.T) {
 	t.Run("test add -> delete -> stop", func(t *testing.T) {
 		trackedMetricNames := make([]MetricName, 0)
 
-		tracker := MakeTrackerBase("test", "test", testLabelGetters,
+		tracker := MakeTrackerBase("test", testLabelGetters,
 			makeTestGatherFunc(testData))
 
 		rf := mocks.NewMockCustomRegistry(ctrl)
@@ -176,7 +176,7 @@ func TestTrackerBase_Track(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rf := mocks.NewMockCustomRegistry(ctrl)
 
-	tracker := MakeTrackerBase("test", "test",
+	tracker := MakeTrackerBase("test",
 		testLabelGetters,
 		makeTestGatherFunc(testData))
 	tracker.registryFactory = func(string) metrics.CustomRegistry { return rf }
@@ -240,7 +240,7 @@ func TestTrackerBase_error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rf := mocks.NewMockCustomRegistry(ctrl)
 
-	tracker := MakeTrackerBase("test", "test",
+	tracker := MakeTrackerBase("test",
 		testLabelGetters,
 		func(context.Context, MetricDescriptors) iter.Seq[testFinding] {
 			return func(yield func(testFinding) bool) {
@@ -262,7 +262,7 @@ func TestTrackerBase_error(t *testing.T) {
 func TestTrackerBase_Gather(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rf := mocks.NewMockCustomRegistry(ctrl)
-	tracker := MakeTrackerBase("test", "test",
+	tracker := MakeTrackerBase("test",
 		testLabelGetters,
 		makeTestGatherFunc(testData),
 	)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The custom metrics tracker category was used only for logging. Let's just use the description instead.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI