### PR TITLE
ROX-29388: Fix indefinite deferrals getting expired when storing them in db

### DIFF
--- a/central/convert/storagetov2/vuln_exception_service_test.go
+++ b/central/convert/storagetov2/vuln_exception_service_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/central/convert/testutils"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoassert"
 )
 
@@ -36,5 +38,25 @@ func TestVulnerabilityException(t *testing.T) {
 		t,
 		testutils.GetTestVulnExceptionWithUpdate(t),
 		VulnerabilityException(testutils.GetTestVulnRequestWithUpdate(t)),
+	)
+
+	protoassert.Equal(
+		t,
+		func() *v2.VulnerabilityException {
+			req := testutils.GetTestVulnExceptionWithUpdate(t)
+			req.GetDeferralRequest().Expiry = &v2.ExceptionExpiry{
+				ExpiryType: v2.ExceptionExpiry_TIME,
+				ExpiresOn:  nil,
+			}
+			return req
+		}(),
+		func() *v2.VulnerabilityException {
+			req := testutils.GetTestVulnRequestWithUpdate(t)
+			req.GetDeferralReq().Expiry = &storage.RequestExpiry{
+				ExpiryType: storage.RequestExpiry_TIME,
+				Expiry:     nil,
+			}
+			return VulnerabilityException(req)
+		}(),
 	)
 }

--- a/central/convert/v2tostorage/vuln_exception_service.go
+++ b/central/convert/v2tostorage/vuln_exception_service.go
@@ -219,8 +219,10 @@ func requestExpiry(expiry *v2.ExceptionExpiry) *storage.RequestExpiry {
 	}
 	switch expiry.GetExpiryType() {
 	case v2.ExceptionExpiry_TIME:
-		ret.Expiry = &storage.RequestExpiry_ExpiresOn{
-			ExpiresOn: expiry.GetExpiresOn(),
+		if expiry.GetExpiresOn() != nil {
+			ret.Expiry = &storage.RequestExpiry_ExpiresOn{
+				ExpiresOn: expiry.GetExpiresOn(),
+			}
 		}
 	case v2.ExceptionExpiry_ANY_CVE_FIXABLE:
 		// Set the legacy field for backward compatibility.

--- a/central/convert/v2tostorage/vuln_exception_service_test.go
+++ b/central/convert/v2tostorage/vuln_exception_service_test.go
@@ -85,6 +85,26 @@ func TestVulnerabilityRequest(t *testing.T) {
 		}(),
 	)
 
+	protoassert.Equal(
+		t,
+		func() *storage.VulnerabilityRequest {
+			req := testutils.GetTestVulnRequestWithUpdate(t)
+			req.GetDeferralReq().Expiry = &storage.RequestExpiry{
+				ExpiryType: storage.RequestExpiry_TIME,
+				Expiry:     nil,
+			}
+			return req
+		}(),
+		func() *storage.VulnerabilityRequest {
+			req := testutils.GetTestVulnExceptionWithUpdate(t)
+			req.GetDeferralRequest().Expiry = &v2.ExceptionExpiry{
+				ExpiryType: v2.ExceptionExpiry_TIME,
+				ExpiresOn:  nil,
+			}
+			return VulnerabilityRequest(req)
+		}(),
+	)
+
 	id := mockIdentity.NewMockIdentity(gomock.NewController(t))
 	id.EXPECT().UID().Return("userID").AnyTimes()
 	id.EXPECT().FullName().Return("userName").AnyTimes()

--- a/central/vulnmgmt/vulnerabilityrequest/utils/util.go
+++ b/central/vulnmgmt/vulnerabilityrequest/utils/util.go
@@ -28,8 +28,9 @@ func V1DeferVulnRequestToVulnReq(ctx context.Context, req *v1.DeferVulnRequest) 
 			Expiry: &storage.RequestExpiry_ExpiresWhenFixed{ExpiresWhenFixed: true},
 		}
 	} else {
-		ret.GetDeferralReq().Expiry = &storage.RequestExpiry{
-			Expiry: &storage.RequestExpiry_ExpiresOn{ExpiresOn: req.GetExpiresOn()},
+		ret.GetDeferralReq().Expiry = &storage.RequestExpiry{}
+		if req.GetExpiresOn() != nil {
+			ret.GetDeferralReq().GetExpiry().Expiry = &storage.RequestExpiry_ExpiresOn{ExpiresOn: req.GetExpiresOn()}
 		}
 	}
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The indefinite deferrals used to rely on `ExpiresOn` timestamp in storage.VulnerabilityRequest being set to nil. This `ExpiresOn` field is a part of one of field in proto.
```
oneof expiry {
    // Indicates that this request expires when the associated vulnerability is fixed.
    bool expires_when_fixed = 1; // @gotags: search:"Request Expires When Fixed"
    // Indicates the timestamp when this request expires.
    google.protobuf.Timestamp expires_on = 2; // @gotags: search:"Request Expiry Time"
  }
```
We upgraded the tool used to generate marshalling and unmarshalling code sometime in 4.7. Because of this change, if the value of a field inside one of wrapper is nil, then the marshaller defaults its value to the type's zero value. In this case, if `ExpiresOn` is nil, then marshaller will set it to zero time - which is `01/01/1970` on Unix. Thus, the requests get stored as already expired in the db and defeats the purpose of indefinite deferrals. The workaround is to set the `oneof` wrapper itself to nil, which the marshaller allows and writes as nil. This PR implements this workaround for indefinite deferrals. 

Due to separation between API and storage, there is no need to make any API changes.
 
## User-facing documentation

- [X] CHANGELOF update is not needed
- [X] documentation is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [X] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit tests and manual tests by creating indefinite deferrals.
