### PR TITLE
ROX-30867: process indicator add performance

### DIFF
--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -55,17 +55,7 @@ func (ds *datastoreImpl) Search(ctx context.Context, q *v1.Query) ([]pkgSearch.R
 }
 
 func (ds *datastoreImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
-	var indicators []*storage.ProcessIndicator
-	// Using WalkByQuery as risk could potentially return a large amount of data
-	err := ds.storage.WalkByQuery(ctx, q, func(indicator *storage.ProcessIndicator) error {
-		indicators = append(indicators, indicator)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return indicators, nil
+	return ds.storage.GetByQuery(ctx, q)
 }
 
 func (ds *datastoreImpl) GetProcessIndicator(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error) {

--- a/central/processindicator/store/mocks/store.go
+++ b/central/processindicator/store/mocks/store.go
@@ -176,17 +176,3 @@ func (mr *MockStoreMockRecorder) Walk(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockStore)(nil).Walk), arg0, arg1)
 }
-
-// WalkByQuery mocks base method.
-func (m *MockStore) WalkByQuery(ctx context.Context, query *v1.Query, fn func(*storage.ProcessIndicator) error) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WalkByQuery", ctx, query, fn)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WalkByQuery indicates an expected call of WalkByQuery.
-func (mr *MockStoreMockRecorder) WalkByQuery(ctx, query, fn any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkByQuery", reflect.TypeOf((*MockStore)(nil).WalkByQuery), ctx, query, fn)
-}

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -17,13 +17,11 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
-	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(pi *storage.ProcessIndicator) error) error
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
 
 	UpsertMany(context.Context, []*storage.ProcessIndicator) error
 	DeleteMany(ctx context.Context, id []string) error
 
 	Walk(context.Context, func(pi *storage.ProcessIndicator) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(pi *storage.ProcessIndicator) error) error
 	DeleteByQuery(ctx context.Context, query *v1.Query) ([]string, error)
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

While investigating some customer cases I noticed at very large scale we would encounter some deadlocks of deletes on the process_indicators table.  These seemed to be occurring in the `copyFrom` method.  To use `copyFrom` we first have to delete the rows.  So there is a lot going on with large `copyFrom` operations.

1.  the code grabs a lock to try to alleviate deadlocks by preventing multiple updates.
2. This lock is held until all the data is copied.  This can be a significant amount of time causing things to stack up.
3. The database transaction is held until ALL the process indicators are written.  

So for large chunks of process indicators we can wind up holding a lock and transaction for a significant amount of time.  Which opens us up to deadlocks with deletes coming from pruning and pod removals.

copyFrom already batches the data WITHIN the lock and transaction boundaries, but that doesn't work so well for process indicators that are simply grouped by how many come in during the minute we are watching.  There isn't a logical grouping of process indicators just time.  So if part of a batch fails there is little reason to fail the whole thing.

So this change does an additional batching in the datastore outside the lock and transaction boundary.  In benchmark testing for small-ish batches the performance was very slightly degraded (as in within the same nanosecond).  But for large chunks of indicators this PR cut the time in half.  In fact there were limits on how many indicators we could process at a time the old way without running into the dev mutex lock of 10 seconds.  We could process many more indicators at a time batching outside the lock and transaction boundaries.

The benchmark data is below in the testing section.

I also added a benchmark for `SearchRawIndicators` because my initial plan was to replace the `GetByQuery` with `WalkByQuery`, but `WalkByQuery` was much slower.  As such I'm leaving that as is and didn't bother to record those numbers since I wasn't changing anything.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

benchmark tests.  Also running some scale tests just to make sure it lasts a day or so.

Existing, 100K for this run.  Once we hit about 400-500K this one starts hitting the dev mutex timeout of 10 seconds.  But that alone points to holding the lock and transaction a long time.
```
main branch
100000 -- fails much higher than that.
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	2658395916 ns/op	311739984 B/op	 7602645 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	15.217s
```

Here are the numbers for the branch off this PR.  I included various batch sizes so you can see how I settled on 5000, though I did make that configurable.  Notice while I find it unlikely we would have 1M indicators to process at once, we can.  Below are the results processing 100K so we are comparing same things as the one above
```
batch size 1000
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	1493210583 ns/op	320917440 B/op	 7619394 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	13.887s


batch size 5000
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	1212476667 ns/op	315088216 B/op	 7604961 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	14.053s


batch size 10000
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	1653545583 ns/op	315444320 B/op	 7602862 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	13.839s


batch size 15000
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	1928827500 ns/op	314188000 B/op	 7603367 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	14.427s

batch size 25000
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	2138675875 ns/op	312847680 B/op	 7603073 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	17.340s
```

For fun these are the numbers processing 1M
```
batch size 1000
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	119674805166 ns/op	3179871216 B/op	76184622 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	190.263s

batch size 5000
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	81561018625 ns/op	3146906240 B/op	76043417 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	144.621s


batch size 10000
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	82970643791 ns/op	3149431376 B/op	76022775 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	149.100s


batch size 15000
BenchmarkAddIndicator-12       	       1	81925414500 ns/op	3135125832 B/op	76027923 allocs/op
PASS
ok  	github.com/stackrox/rox/central/processindicator/datastore	145.036s

batch size 25000
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/central/processindicator/datastore
cpu: Apple M3 Pro
BenchmarkAddIndicator-12       	       1	81600232041 ns/op	3124274128 B/op	76024864 allocs/op
```