### PR TITLE
chore: add lookup to LabelsWithLen

### DIFF
--- a/sensor/common/selector/selector.go
+++ b/sensor/common/selector/selector.go
@@ -6,8 +6,7 @@ import (
 
 // LabelsWithLen is label.Labels with added Len() function
 type LabelsWithLen interface {
-	Has(label string) (exists bool)
-	Get(label string) (value string)
+	labels.Labels
 	Len() uint
 }
 
@@ -29,6 +28,12 @@ func (l labelWithLenImpl) Has(label string) bool {
 // Get label
 func (l labelWithLenImpl) Get(label string) string {
 	return l.labels[label]
+}
+
+// Lookup returns the value for the provided label if it exists and whether the provided label exist
+func (l labelWithLenImpl) Lookup(label string) (value string, exists bool) {
+	value, exists = l.labels[label]
+	return value, exists
 }
 
 // Len returns length of labels


### PR DESCRIPTION
In https://github.com/kubernetes/apimachinery/commit/e172d59e75ed0ca47619a5d9ecae839ef4bfeda1 a new method was added to Labels interface. In order to bump api machinery to the latest version we need to reflect this change in our code