### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for central-db-4-8

### DIFF
--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -14,7 +14,8 @@ LABEL \
     io.k8s.display-name="central-db" \
     io.openshift.tags="rhacs,central-db,stackrox" \
     maintainer="Red Hat, Inc." \
-    name="rhacs-central-db-rhel8" \
+    name="advanced-cluster-security/rhacs-central-db-rhel8" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8" \
     # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
     source-location="https://github.com/stackrox/stackrox" \
     summary="Central DB for Red Hat Advanced Cluster Security for Kubernetes" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
