### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-bundle-4-8

### DIFF
--- a/operator/konflux.bundle.Dockerfile
+++ b/operator/konflux.bundle.Dockerfile
@@ -85,7 +85,8 @@ LABEL io.k8s.description="Operator Bundle Image for Red Hat Advanced Cluster Sec
 LABEL io.k8s.display-name="operator-bundle"
 LABEL io.openshift.tags="rhacs,operator-bundle,stackrox"
 LABEL maintainer="Red Hat, Inc."
-LABEL name="rhacs-operator-bundle"
+LABEL name="advanced-cluster-security/rhacs-operator-bundle"
+LABEL cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8"
 # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
 LABEL source-location="https://github.com/stackrox/stackrox"
 LABEL summary="Operator Bundle Image for Red Hat Advanced Cluster Security for Kubernetes"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
