### PR TITLE
chore: Remove deprecated rand.Seed() calls

### DIFF
--- a/central/processindicator/pruner/pruner_test.go
+++ b/central/processindicator/pruner/pruner_test.go
@@ -64,7 +64,6 @@ func processToIDAndArgs(process *storage.ProcessIndicator) processindicator.IDAn
 }
 
 func TestRabbitMQPruning(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	var processes []processindicator.IDAndArgs
 	processes = append(processes, processToIDAndArgs(deterministicRabbitMQProcess))
 	for i := 0; i < 1000; i++ {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -2,7 +2,6 @@ package compliance
 
 import (
 	"context"
-	"math/rand"
 	"os"
 	"os/signal"
 	"syscall"
@@ -60,9 +59,6 @@ func NewComplianceApp(nnp node.NodeNameProvider, scanner node.NodeScanner, nodeI
 func (c *Compliance) Start() {
 	log.Infof("Running StackRox Version: %s", version.GetMainVersion())
 	clientconn.SetUserAgent(clientconn.Compliance)
-
-	// Set the random seed based on the current time.
-	rand.Seed(time.Now().UnixNano())
 
 	// Start the prometheus metrics server
 	metrics.NewServer(metrics.ComplianceSubsystem, metrics.NewTLSConfigurerFromEnv()).RunForever()

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -156,9 +156,9 @@ func doTestCloneMigrationFailureAndReentry(t *testing.T) {
 		},
 	}
 	// For the parameters that should not matter, run pseudo random to get coverage on different cases
-	rand.Seed(8181818)
+	r := rand.New(rand.NewSource(8181818))
 	for _, c := range testCases {
-		reboot := rand.Intn(2) == 1
+		reboot := r.Intn(2) == 1
 		if reboot {
 			c.description = c.description + " with reboot"
 		}
@@ -436,9 +436,9 @@ func doTestRollback(t *testing.T) {
 			breakPoint:  breakAfterGetClone,
 		},
 	}
-	rand.Seed(8056)
+	r := rand.New(rand.NewSource(8056))
 	for _, c := range testCases {
-		reboot := rand.Intn(2) == 1
+		reboot := r.Intn(2) == 1
 		if reboot {
 			c.description = c.description + " with reboot"
 		}

--- a/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/selector"
@@ -24,11 +23,6 @@ const charset = "abcdef0123456789"
 type namespaceAndSelector struct {
 	namespace string
 	selector  selector.Selector
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-
 }
 
 // BenchmarkBuildDeployments_NoChange uses one deployment and generates

--- a/sensor/tests/pipeline/bench_test.go
+++ b/sensor/tests/pipeline/bench_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -40,8 +39,6 @@ var (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
-
 	serviceAccounts = make([]string, 1000)
 	for i := 0; i < 1000; i++ {
 		serviceAccounts[i] = randString(5)


### PR DESCRIPTION
## Description

As of Go 1.20 rand.Seed() has been deprecated (see [Go docs](https://pkg.go.dev/math/rand@go1.25.1#Seed)), and linters point it out (e.g. those run by the pre-commit hook):


> Deprecated: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator.


This PR removes the Seed() calls with random values, and implements the recommended change where non-random seed values were used.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI