### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-4-8

### DIFF
--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -24,12 +24,13 @@ ARG BUILD_TAG
 LABEL \
     com.redhat.component="rhacs-operator-container" \
     com.redhat.license_terms="https://www.redhat.com/agreements" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8" \
     description="Operator for Red Hat Advanced Cluster Security for Kubernetes" \
     io.k8s.description="Operator for Red Hat Advanced Cluster Security for Kubernetes" \
     io.k8s.display-name="operator" \
     io.openshift.tags="rhacs,operator,stackrox" \
     maintainer="Red Hat, Inc." \
-    name="rhacs-rhel8-operator" \
+    name="advanced-cluster-security/rhacs-rhel8-operator" \
     # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
     source-location="https://github.com/stackrox/stackrox" \
     summary="Operator for Red Hat Advanced Cluster Security for Kubernetes" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
