### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for roxctl-4-8

### DIFF
--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -46,7 +46,8 @@ LABEL \
     io.k8s.display-name="roxctl" \
     io.openshift.tags="rhacs,roxctl,stackrox" \
     maintainer="Red Hat, Inc." \
-    name="rhacs-roxctl-rhel8" \
+    name="advanced-cluster-security/rhacs-roxctl-rhel8" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8" \
     # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
     source-location="https://github.com/stackrox/stackrox" \
     summary="The CLI for Red Hat Advanced Cluster Security for Kubernetes" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
