### PR TITLE
ROX-30883: Limit width of Select elements in cluster form

### DIFF
--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -18,6 +18,7 @@ export type SelectSingleProps = {
     value: string;
     handleSelect: (name: string, value: string) => void;
     isDisabled?: boolean;
+    isFullWidth?: boolean;
     children: ReactElement<SelectOptionProps>[];
     direction?: 'up' | 'down';
     placeholderText?: string;
@@ -37,6 +38,7 @@ function SelectSingle({
     value,
     handleSelect,
     isDisabled = false,
+    isFullWidth = true,
     children,
     direction = 'down',
     placeholderText = '',
@@ -71,10 +73,10 @@ function SelectSingle({
             onClick={onToggle}
             isExpanded={isOpen}
             isDisabled={isDisabled}
+            isFullWidth={isFullWidth}
             aria-label={toggleAriaLabel}
             id={id}
             variant={variant}
-            className="pf-v5-u-w-100"
         >
             <span className="pf-v5-u-display-flex pf-v5-u-align-items-center">
                 {toggleIcon && <span className="pf-v5-u-mr-sm">{toggleIcon}</span>}

--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -18,7 +18,7 @@ export type SelectSingleProps = {
     value: string;
     handleSelect: (name: string, value: string) => void;
     isDisabled?: boolean;
-    isFullWidth?: boolean;
+    isFullWidth?: boolean; // TODO make prop required
     children: ReactElement<SelectOptionProps>[];
     direction?: 'up' | 'down';
     placeholderText?: string;
@@ -38,7 +38,7 @@ function SelectSingle({
     value,
     handleSelect,
     isDisabled = false,
-    isFullWidth = true,
+    isFullWidth = true, // TODO make prop required
     children,
     direction = 'down',
     placeholderText = '',

--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
@@ -75,6 +75,7 @@ function DynamicConfigurationForm({
                         handleChangeAdmissionControllerEnforcementBehavior(value === 'enabled')
                     }
                     isDisabled={isManagerTypeNonConfigurable}
+                    isFullWidth={false}
                 >
                     <SelectOption value="enabled">Enforce policies</SelectOption>
                     <SelectOption value="disabled">No enforcement</SelectOption>
@@ -124,6 +125,7 @@ function DynamicConfigurationForm({
                     }
                     handleSelect={(id, value) => handleChange(id, value === 'disabled')}
                     isDisabled={isManagerTypeNonConfigurable}
+                    isFullWidth={false}
                 >
                     <SelectOption value="enabled">Enabled</SelectOption>
                     <SelectOption value="disabled">Disabled</SelectOption>
@@ -162,6 +164,7 @@ function DynamicConfigurationForm({
                     value={dynamicConfig.disableAuditLogs ? 'disabled' : 'enabled'}
                     handleSelect={(id, value) => handleChange(id, value === 'disabled')}
                     isDisabled={isManagerTypeNonConfigurable || !isLoggingSupported}
+                    isFullWidth={false}
                 >
                     <SelectOption value="enabled">Enabled</SelectOption>
                     <SelectOption value="disabled">Disabled</SelectOption>

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
@@ -68,6 +68,7 @@ function StaticConfigurationForm({
                     value={selectedCluster.type}
                     handleSelect={handleChange}
                     isDisabled={isManagerTypeNonConfigurable}
+                    isFullWidth={false}
                 >
                     {filteredClusterTypeOptions.map(({ label, value }) => (
                         <SelectOption key={value} value={value}>
@@ -112,6 +113,7 @@ function StaticConfigurationForm({
                     value={selectedCluster.collectionMethod}
                     handleSelect={handleChange}
                     isDisabled={isManagerTypeNonConfigurable}
+                    isFullWidth={false}
                 >
                     {filteredRuntimeOptions.map(({ label, value }) => (
                         <SelectOption key={value} value={value}>
@@ -144,6 +146,7 @@ function StaticConfigurationForm({
                     }
                     handleSelect={(id, value) => handleChange(id, value === 'failClosed')}
                     isDisabled={isManagerTypeNonConfigurable}
+                    isFullWidth={false}
                 >
                     <SelectOption value="failOpen">Fail open</SelectOption>
                     <SelectOption value="failClosed">Fail closed</SelectOption>
@@ -184,6 +187,7 @@ function StaticConfigurationForm({
                     value={selectedCluster.tolerationsConfig?.disabled ? 'disabled' : 'enabled'}
                     handleSelect={(id, value) => handleChange(id, value === 'disabled')}
                     isDisabled={isManagerTypeNonConfigurable}
+                    isFullWidth={false}
                 >
                     <SelectOption value="enabled">Enabled</SelectOption>
                     <SelectOption value="eisabled">Disabled</SelectOption>


### PR DESCRIPTION
## Description

Thank you, **David Vail** for careful testing!

### Problem

1. Clickable area in `SelectOption` has less than width of option.
2. Width of `Select` is too wide.

### Analysis

Find in Files `<SelectSingle` has 33 results in 24 files including:
* 3 in DynamicConfigurationForm.tsx file
* 4 in StaticConfigurationForm.tsx file

We limited width of `TextInput` via `isWidthLimited` prop of `Form` element in #16501

In SelectSingle.tsx file, `MenuToggle` has `className="pf-v5-u-w-100"` prop.

### Solution

1. As discussed with team in Slack thread, replace `className` with `isFullWidth` prop of `MenuToggle` element add it to `SelectSingle` component.
    https://www.patternfly.org/components/menus/select#menutoggle

2. To unblock the solution for this feature, `isFullWidth` prop is optional with `true` as default value to preserve existing behavior, pending investigation of other occurrences.

3. Add `isFullWidth={false}` prop to `SelectSingle` elements:
    * `DynamicConfigurationForm` component
    * `StaticConfigurationForm` component

### Residue

1. Investigate remaining occurrences of `SelectSingle` element to confirm:
    * If full width works well, add explicit `isFullWidth` prop.
    * If full width does not work well, add explicit `isFullWidth={false}` prop.

2. Make `isFullWidth` prop of `SelectSingle` component required and delete default `true` value.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder
2. `npm run lint:fast-dev` in ui/apps/platform folder
3. `npm run start` in ui/apps/platform folder with staging demo as central

#### Manual testing

1. Visit /main/clusters and click link to see form of secured cluster that has **manifest** installation method.
    That is, for which form elements are enabled.

    Before changes, with implicit `className="pf-v5-u-w-100"` prop:
    * clickable area has less than width of option
    * width of select is same as imput elements
    <img width="1439" height="898" alt="enabled_without_isFullWidth" src="https://github.com/user-attachments/assets/86bfc95e-10ef-45b1-8afe-cb197839731e" />

    After changes, with explicit `isFullWidth={false}` prop:
    * clickable area has less than width of option
    * width of select is width of content
    <img width="1440" height="898" alt="enabled_with_isFullWidth" src="https://github.com/user-attachments/assets/6fbb2db6-ecdf-4ebc-a598-a4601afd2e63" />

2. Go back and click another link to see form of secured cluster that has **Operator** installation method.
    That is, for which form elements are disabled.

    After changes, with explicit `isFullWidth={false}` prop:
    * width of select is width of content
    <img width="1440" height="898" alt="disabled_with_isFullWidth" src="https://github.com/user-attachments/assets/4f5602e0-eb4f-46d4-b962-c2547525fda3" />
