### PR TITLE
ROX-30884: Fix bugs from bash of admission controller configuration

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
@@ -45,8 +45,12 @@ function DynamicConfigurationForm({
     // HelmValueWarning precedes FormHelperText element.
     return (
         <Form isWidthLimited>
-            <FormGroup label="Custom default image registry">
+            <FormGroup
+                fieldId="dynamicConfig.registryOverride"
+                label="Custom default image registry"
+            >
                 <TextInput
+                    id="dynamicConfig.registryOverride"
                     type="text"
                     value={dynamicConfig.registryOverride}
                     onChange={(_event, value) =>
@@ -158,7 +162,7 @@ function DynamicConfigurationForm({
             </FormGroup>
             <FormGroup label="Cluster audit logging">
                 <SelectSingle
-                    id="tolerationsConfig.disabled"
+                    id="dynamicConfig.disableAuditLogs"
                     value={dynamicConfig.disableAuditLogs ? 'disabled' : 'enabled'}
                     handleSelect={(id, value) => handleChange(id, value === 'disabled')}
                     isDisabled={isManagerTypeNonConfigurable || !isLoggingSupported}

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
@@ -53,8 +53,9 @@ function StaticConfigurationForm({
     // HelmValueWarning precedes FormHelperText element.
     return (
         <Form isWidthLimited>
-            <FormGroup label="Cluster name" isRequired>
+            <FormGroup fieldId="name" label="Cluster name" isRequired>
                 <TextInput
+                    id="name"
                     type="text"
                     value={selectedCluster.name}
                     onChange={(_event, value) => handleChange('name', value)}
@@ -80,8 +81,9 @@ function StaticConfigurationForm({
                     helmValue={selectedCluster?.helmConfig?.staticConfig?.type}
                 />
             </FormGroup>
-            <FormGroup label="Main image repository" isRequired>
+            <FormGroup fieldId="mainImage" label="Main image repository" isRequired>
                 <TextInput
+                    id="mainImage"
                     type="text"
                     value={selectedCluster.mainImage}
                     onChange={(_event, value) => handleChange('mainImage', value)}
@@ -93,8 +95,13 @@ function StaticConfigurationForm({
                     helmValue={selectedCluster?.helmConfig?.staticConfig?.mainImage}
                 />
             </FormGroup>
-            <FormGroup label="Central API endpoint (include port)" isRequired>
+            <FormGroup
+                fieldId="centralApiEndpoint"
+                label="Central API endpoint (include port)"
+                isRequired
+            >
                 <TextInput
+                    id="centralApiEndpoint"
                     type="text"
                     value={selectedCluster.centralApiEndpoint}
                     onChange={(_event, value) => handleChange('centralApiEndpoint', value)}
@@ -124,8 +131,12 @@ function StaticConfigurationForm({
                     helmValue={selectedCluster?.helmConfig?.staticConfig?.collectionMethod}
                 />
             </FormGroup>
-            <FormGroup label="Collector image repository (uses Main image repository by default)">
+            <FormGroup
+                fieldId="collectorImage"
+                label="Collector image repository (uses Main image repository by default)"
+            >
                 <TextInput
+                    id="collectorImage"
                     type="text"
                     value={selectedCluster.collectorImage}
                     onChange={(_event, value) => handleChange('collectorImage', value)}
@@ -186,7 +197,7 @@ function StaticConfigurationForm({
                     isDisabled={isManagerTypeNonConfigurable}
                 >
                     <SelectOption value="enabled">Enabled</SelectOption>
-                    <SelectOption value="eisabled">Disabled</SelectOption>
+                    <SelectOption value="disabled">Disabled</SelectOption>
                 </SelectSingle>
                 <HelmValueWarning
                     currentValue={selectedCluster?.tolerationsConfig?.disabled}


### PR DESCRIPTION
## Description

Thank you, **David Vail** for careful testing!

1. **Taint tolerations** selection

    * Problem: Selection does not change if you select **Disabled**.

    * Analysis: Typo `value="eisabled"`

    * Solution: Fix `value="disabled"`

2. **Cluster audit logging** selection

    * Problem: Selection does not change is you select **Enabled**.

    * Analysis: Copy-pasto `id="tolerationsConfig.disabled"` 

    * Solution: Fix `id="dynamicConfig.disableAuditLogs"`

3. Accessibility issues

    Problem: axe DevTools
    https://dequeuniversity.com/rules/axe/4.10/label
    > Ensure every form element has a label

    Solution: Add `fieldId` prop to `FieldGroup` element

    Problem: Console
    > Text input requires either an id or aria-label to be specified

    Solution: Add `id` prop to `TextInput` element

### Residue

1. Investigate lint rule in pluginPatternFly.js file.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder
2. `npm run lint` in ui/apps/platform folder
3. `npm run start` in ui/apps/platform folder with staging demo as central

#### Manual testing

1. Visit /main/clusters and click link to see form of secured cluster that has **manifest** installation method.
    That is, for which form elements are enabled.

    * After change, **Taint tolerations** does change if you select **Disabled**

    * After change, **Cluster audit logging** does change if you select **Enabled**

    * After changes, see absence of axe DevTools issues and Console warnings
