### PR TITLE
ROX-30899: Rename `rpm` -> `rpm-lockfile` manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,9 @@
 {
-  // This configures Konflux Renovate bot, the thing that keeps our pipelines use up-to-date tasks.
+  // This configures Konflux Renovate bot a.k.a. MintMaker, the thing that keeps our pipelines use up-to-date tasks.
 
   // After making changes to this file, you can validate it by running something like this in the root of the repo:
   // $ docker run --rm -it --entrypoint=renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict
-  // Note: ignore errors about the config for `rpm`. This is to be addressed with https://issues.redhat.com/browse/CWFHEALTH-4117
+  // Note: ignore errors about the config for `rpm-lockfile`. This is to be addressed with https://issues.redhat.com/browse/CWFHEALTH-4117
   // There are more validation options, see https://docs.renovatebot.com/config-validation/
 
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
@@ -59,9 +59,10 @@
       ],
     },
   },
-  "rpm": {
+  "rpm-lockfile": {
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
+      // Note that MintMaker will create security updates outside of schedule.
       "after 3am and before 7am",
     ],
   },
@@ -69,6 +70,6 @@
     // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
     "tekton",
     "dockerfile",
-    "rpm",
+    "rpm-lockfile",
   ],
 }


### PR DESCRIPTION
## Description

Same as https://github.com/stackrox/scanner/pull/2201 but for the StackRox repo.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Checked `renovate-config-validator`.