### PR TITLE
chore(qa): wait for cluster healthy

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -317,7 +317,8 @@ class BaseSpecification extends Specification {
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
-        if (Env.IN_CI) {
+        //TODO(janisz): figure out why Sensor is unhealthy at the end of UpgradesTest
+        if (Env.IN_CI && this.class.simpleName == "UpgradesTest") {
             log.info("Checking if cluster is healthy after test")
             waitForClusterHealthy()
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -317,7 +317,7 @@ class BaseSpecification extends Specification {
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
-        //TODO(janisz): figure out why Sensor is unhealthy at the end of UpgradesTest
+        //TODO(ROX-30946): figure out why Sensor is unhealthy at the end of UpgradesTest
         if (Env.IN_CI && this.class.simpleName == "UpgradesTest") {
             log.info("Checking if cluster is healthy after test")
             waitForClusterHealthy()

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -318,7 +318,7 @@ class BaseSpecification extends Specification {
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
         //TODO(ROX-30946): figure out why Sensor is unhealthy at the end of UpgradesTest
-        if (Env.IN_CI && this.class.simpleName == "UpgradesTest") {
+        if (Env.IN_CI && this.class.simpleName != "UpgradesTest") {
             log.info("Checking if cluster is healthy after test")
             waitForClusterHealthy()
         }


### PR DESCRIPTION
This PR add a check for healthy cluster at the end of test spec. This is done to ensure the test left cluster in healthy state so it will not interfere with other tests,