### PR TITLE
ROX-29681: Scanner V4 KEV support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ controller webhooks will now be configured to 1) always scan images inline 2) ei
 - ROX-28326: Custom Prometheus metrics exposed on the `/metrics` path of the central API endpoint. Configured via the `/v1/config` service.
   Disabled by default.
 - ROX-20262: Enable internal CA rotation for Operator-installed Centrals and Secured Clusters. Operator-installed Secured Clusters have full support, while Helm-installed Secured Clusters have partial support (can connect to Central with rotated CA but their certificates remain signed by the older CA).
+- ROX-29681: StackRox now supports CISA KEV data by default when using Scanner V4. To turn this off, set `ROX_CISA_KEV=false` in both Central and Scanner V4 Matcher.
 
 ### Removed Features
 

--- a/generated/internalapi/scanner/v4/vulnerability_report.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report.pb.go
@@ -182,7 +182,7 @@ func (VulnerabilityReport_Vulnerability_CVSS_Source) EnumDescriptor() ([]byte, [
 	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 0, 0}
 }
 
-// Next tag: 16
+// Next tag: 17
 type VulnerabilityReport struct {
 	state                  protoimpl.MessageState                        `protogen:"open.v1"`
 	HashId                 string                                        `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
@@ -371,9 +371,10 @@ type VulnerabilityReport_Vulnerability struct {
 	RepositoryId       string                                     `protobuf:"bytes,10,opt,name=repository_id,json=repositoryId,proto3" json:"repository_id,omitempty"`
 	FixedInVersion     string                                     `protobuf:"bytes,11,opt,name=fixed_in_version,json=fixedInVersion,proto3" json:"fixed_in_version,omitempty"`
 	// Deprecated: Marked as deprecated in internalapi/scanner/v4/vulnerability_report.proto.
-	Cvss          *VulnerabilityReport_Vulnerability_CVSS   `protobuf:"bytes,12,opt,name=cvss,proto3" json:"cvss,omitempty"` // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
-	CvssMetrics   []*VulnerabilityReport_Vulnerability_CVSS `protobuf:"bytes,13,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
-	EpssMetrics   *VulnerabilityReport_Vulnerability_EPSS   `protobuf:"bytes,14,opt,name=epss_metrics,json=epssMetrics,proto3" json:"epss_metrics,omitempty"`
+	Cvss          *VulnerabilityReport_Vulnerability_CVSS    `protobuf:"bytes,12,opt,name=cvss,proto3" json:"cvss,omitempty"` // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
+	CvssMetrics   []*VulnerabilityReport_Vulnerability_CVSS  `protobuf:"bytes,13,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
+	EpssMetrics   *VulnerabilityReport_Vulnerability_EPSS    `protobuf:"bytes,14,opt,name=epss_metrics,json=epssMetrics,proto3" json:"epss_metrics,omitempty"`
+	Exploit       *VulnerabilityReport_Vulnerability_Exploit `protobuf:"bytes,16,opt,name=exploit,proto3" json:"exploit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -515,6 +516,13 @@ func (x *VulnerabilityReport_Vulnerability) GetEpssMetrics() *VulnerabilityRepor
 	return nil
 }
 
+func (x *VulnerabilityReport_Vulnerability) GetExploit() *VulnerabilityReport_Vulnerability_Exploit {
+	if x != nil {
+		return x.Exploit
+	}
+	return nil
+}
+
 type VulnerabilityReport_Vulnerability_CVSS struct {
 	state         protoimpl.MessageState                        `protogen:"open.v1"`
 	V2            *VulnerabilityReport_Vulnerability_CVSS_V2    `protobuf:"bytes,1,opt,name=v2,proto3" json:"v2,omitempty"`
@@ -651,6 +659,90 @@ func (x *VulnerabilityReport_Vulnerability_EPSS) GetPercentile() float32 {
 	return 0
 }
 
+type VulnerabilityReport_Vulnerability_Exploit struct {
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	CatalogVersion             string                 `protobuf:"bytes,1,opt,name=catalog_version,json=catalogVersion,proto3" json:"catalog_version,omitempty"`
+	DateAdded                  string                 `protobuf:"bytes,2,opt,name=date_added,json=dateAdded,proto3" json:"date_added,omitempty"`
+	ShortDescription           string                 `protobuf:"bytes,3,opt,name=short_description,json=shortDescription,proto3" json:"short_description,omitempty"`
+	RequiredAction             string                 `protobuf:"bytes,4,opt,name=required_action,json=requiredAction,proto3" json:"required_action,omitempty"`
+	DueDate                    string                 `protobuf:"bytes,5,opt,name=due_date,json=dueDate,proto3" json:"due_date,omitempty"`
+	KnownRansomwareCampaignUse string                 `protobuf:"bytes,6,opt,name=known_ransomware_campaign_use,json=knownRansomwareCampaignUse,proto3" json:"known_ransomware_campaign_use,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) Reset() {
+	*x = VulnerabilityReport_Vulnerability_Exploit{}
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VulnerabilityReport_Vulnerability_Exploit) ProtoMessage() {}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VulnerabilityReport_Vulnerability_Exploit.ProtoReflect.Descriptor instead.
+func (*VulnerabilityReport_Vulnerability_Exploit) Descriptor() ([]byte, []int) {
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 2}
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) GetCatalogVersion() string {
+	if x != nil {
+		return x.CatalogVersion
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) GetDateAdded() string {
+	if x != nil {
+		return x.DateAdded
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) GetShortDescription() string {
+	if x != nil {
+		return x.ShortDescription
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) GetRequiredAction() string {
+	if x != nil {
+		return x.RequiredAction
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) GetDueDate() string {
+	if x != nil {
+		return x.DueDate
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_Exploit) GetKnownRansomwareCampaignUse() string {
+	if x != nil {
+		return x.KnownRansomwareCampaignUse
+	}
+	return ""
+}
+
 type VulnerabilityReport_Vulnerability_CVSS_V2 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	BaseScore     float32                `protobuf:"fixed32,1,opt,name=base_score,json=baseScore,proto3" json:"base_score,omitempty"`
@@ -661,7 +753,7 @@ type VulnerabilityReport_Vulnerability_CVSS_V2 struct {
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V2) Reset() {
 	*x = VulnerabilityReport_Vulnerability_CVSS_V2{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -673,7 +765,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V2) String() string {
 func (*VulnerabilityReport_Vulnerability_CVSS_V2) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V2) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -713,7 +805,7 @@ type VulnerabilityReport_Vulnerability_CVSS_V3 struct {
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V3) Reset() {
 	*x = VulnerabilityReport_Vulnerability_CVSS_V3{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[9]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -725,7 +817,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V3) String() string {
 func (*VulnerabilityReport_Vulnerability_CVSS_V3) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V3) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[9]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -760,7 +852,7 @@ var File_internalapi_scanner_v4_vulnerability_report_proto protoreflect.FileDesc
 const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\n" +
 	"1internalapi/scanner/v4/vulnerability_report.proto\x12\n" +
-	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\x92\x11\n" +
+	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\xeb\x13\n" +
 	"\x13VulnerabilityReport\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12^\n" +
 	"\x0fvulnerabilities\x18\x02 \x03(\v24.scanner.v4.VulnerabilityReport.VulnerabilitiesEntryR\x0fvulnerabilities\x12t\n" +
@@ -769,7 +861,7 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\x05notes\x18\x05 \x03(\x0e2$.scanner.v4.VulnerabilityReport.NoteR\x05notes\x1a2\n" +
 	"\bAdvisory\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
-	"\x04link\x18\x02 \x01(\tR\x04link\x1a\xc7\v\n" +
+	"\x04link\x18\x02 \x01(\tR\x04link\x1a\xa0\x0e\n" +
 	"\rVulnerability\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12D\n" +
@@ -787,7 +879,8 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\x10fixed_in_version\x18\v \x01(\tR\x0efixedInVersion\x12J\n" +
 	"\x04cvss\x18\f \x01(\v22.scanner.v4.VulnerabilityReport.Vulnerability.CVSSB\x02\x18\x01R\x04cvss\x12U\n" +
 	"\fcvss_metrics\x18\r \x03(\v22.scanner.v4.VulnerabilityReport.Vulnerability.CVSSR\vcvssMetrics\x12U\n" +
-	"\fepss_metrics\x18\x0e \x01(\v22.scanner.v4.VulnerabilityReport.Vulnerability.EPSSR\vepssMetrics\x1a\xc5\x03\n" +
+	"\fepss_metrics\x18\x0e \x01(\v22.scanner.v4.VulnerabilityReport.Vulnerability.EPSSR\vepssMetrics\x12O\n" +
+	"\aexploit\x18\x10 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.ExploitR\aexploit\x1a\xc5\x03\n" +
 	"\x04CVSS\x12E\n" +
 	"\x02v2\x18\x01 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2R\x02v2\x12E\n" +
 	"\x02v3\x18\x02 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3R\x02v3\x12Q\n" +
@@ -814,7 +907,15 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\vprobability\x18\x03 \x01(\x02R\vprobability\x12\x1e\n" +
 	"\n" +
 	"percentile\x18\x04 \x01(\x02R\n" +
-	"percentile\"|\n" +
+	"percentile\x1a\x85\x02\n" +
+	"\aExploit\x12'\n" +
+	"\x0fcatalog_version\x18\x01 \x01(\tR\x0ecatalogVersion\x12\x1d\n" +
+	"\n" +
+	"date_added\x18\x02 \x01(\tR\tdateAdded\x12+\n" +
+	"\x11short_description\x18\x03 \x01(\tR\x10shortDescription\x12'\n" +
+	"\x0frequired_action\x18\x04 \x01(\tR\x0erequiredAction\x12\x19\n" +
+	"\bdue_date\x18\x05 \x01(\tR\adueDate\x12A\n" +
+	"\x1dknown_ransomware_campaign_use\x18\x06 \x01(\tR\x1aknownRansomwareCampaignUse\"|\n" +
 	"\bSeverity\x12\x18\n" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fSEVERITY_LOW\x10\x01\x12\x15\n" +
@@ -848,7 +949,7 @@ func file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP() []byte
 }
 
 var file_internalapi_scanner_v4_vulnerability_report_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_internalapi_scanner_v4_vulnerability_report_proto_goTypes = []any{
 	(VulnerabilityReport_Note)(0),                      // 0: scanner.v4.VulnerabilityReport.Note
 	(VulnerabilityReport_Vulnerability_Severity)(0),    // 1: scanner.v4.VulnerabilityReport.Vulnerability.Severity
@@ -861,32 +962,34 @@ var file_internalapi_scanner_v4_vulnerability_report_proto_goTypes = []any{
 	nil, // 8: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
 	(*VulnerabilityReport_Vulnerability_CVSS)(nil),    // 9: scanner.v4.VulnerabilityReport.Vulnerability.CVSS
 	(*VulnerabilityReport_Vulnerability_EPSS)(nil),    // 10: scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil), // 11: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
-	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil), // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
-	(*Contents)(nil),              // 13: scanner.v4.Contents
-	(*timestamppb.Timestamp)(nil), // 14: google.protobuf.Timestamp
+	(*VulnerabilityReport_Vulnerability_Exploit)(nil), // 11: scanner.v4.VulnerabilityReport.Vulnerability.Exploit
+	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil), // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
+	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil), // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
+	(*Contents)(nil),              // 14: scanner.v4.Contents
+	(*timestamppb.Timestamp)(nil), // 15: google.protobuf.Timestamp
 }
 var file_internalapi_scanner_v4_vulnerability_report_proto_depIdxs = []int32{
 	7,  // 0: scanner.v4.VulnerabilityReport.vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
 	8,  // 1: scanner.v4.VulnerabilityReport.package_vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
-	13, // 2: scanner.v4.VulnerabilityReport.contents:type_name -> scanner.v4.Contents
+	14, // 2: scanner.v4.VulnerabilityReport.contents:type_name -> scanner.v4.Contents
 	0,  // 3: scanner.v4.VulnerabilityReport.notes:type_name -> scanner.v4.VulnerabilityReport.Note
 	5,  // 4: scanner.v4.VulnerabilityReport.Vulnerability.advisory:type_name -> scanner.v4.VulnerabilityReport.Advisory
-	14, // 5: scanner.v4.VulnerabilityReport.Vulnerability.issued:type_name -> google.protobuf.Timestamp
+	15, // 5: scanner.v4.VulnerabilityReport.Vulnerability.issued:type_name -> google.protobuf.Timestamp
 	1,  // 6: scanner.v4.VulnerabilityReport.Vulnerability.normalized_severity:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.Severity
 	9,  // 7: scanner.v4.VulnerabilityReport.Vulnerability.cvss:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
 	9,  // 8: scanner.v4.VulnerabilityReport.Vulnerability.cvss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
 	10, // 9: scanner.v4.VulnerabilityReport.Vulnerability.epss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	6,  // 10: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry.value:type_name -> scanner.v4.VulnerabilityReport.Vulnerability
-	4,  // 11: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry.value:type_name -> scanner.v4.StringList
-	11, // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v2:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
-	12, // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v3:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
-	2,  // 14: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.source:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.Source
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	11, // 10: scanner.v4.VulnerabilityReport.Vulnerability.exploit:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.Exploit
+	6,  // 11: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry.value:type_name -> scanner.v4.VulnerabilityReport.Vulnerability
+	4,  // 12: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry.value:type_name -> scanner.v4.StringList
+	12, // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v2:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
+	13, // 14: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v3:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
+	2,  // 15: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.source:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.Source
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_scanner_v4_vulnerability_report_proto_init() }
@@ -901,7 +1004,7 @@ func file_internalapi_scanner_v4_vulnerability_report_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc), len(file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   10,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/internalapi/scanner/v4/vulnerability_report.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report.pb.go
@@ -371,10 +371,10 @@ type VulnerabilityReport_Vulnerability struct {
 	RepositoryId       string                                     `protobuf:"bytes,10,opt,name=repository_id,json=repositoryId,proto3" json:"repository_id,omitempty"`
 	FixedInVersion     string                                     `protobuf:"bytes,11,opt,name=fixed_in_version,json=fixedInVersion,proto3" json:"fixed_in_version,omitempty"`
 	// Deprecated: Marked as deprecated in internalapi/scanner/v4/vulnerability_report.proto.
-	Cvss          *VulnerabilityReport_Vulnerability_CVSS    `protobuf:"bytes,12,opt,name=cvss,proto3" json:"cvss,omitempty"` // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
-	CvssMetrics   []*VulnerabilityReport_Vulnerability_CVSS  `protobuf:"bytes,13,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
-	EpssMetrics   *VulnerabilityReport_Vulnerability_EPSS    `protobuf:"bytes,14,opt,name=epss_metrics,json=epssMetrics,proto3" json:"epss_metrics,omitempty"`
-	Exploit       *VulnerabilityReport_Vulnerability_Exploit `protobuf:"bytes,16,opt,name=exploit,proto3" json:"exploit,omitempty"`
+	Cvss          *VulnerabilityReport_Vulnerability_CVSS        `protobuf:"bytes,12,opt,name=cvss,proto3" json:"cvss,omitempty"` // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
+	CvssMetrics   []*VulnerabilityReport_Vulnerability_CVSS      `protobuf:"bytes,13,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
+	EpssMetrics   *VulnerabilityReport_Vulnerability_EPSS        `protobuf:"bytes,14,opt,name=epss_metrics,json=epssMetrics,proto3" json:"epss_metrics,omitempty"`
+	Exploit       *VulnerabilityReport_Vulnerability_CISAExploit `protobuf:"bytes,16,opt,name=exploit,proto3" json:"exploit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -516,7 +516,7 @@ func (x *VulnerabilityReport_Vulnerability) GetEpssMetrics() *VulnerabilityRepor
 	return nil
 }
 
-func (x *VulnerabilityReport_Vulnerability) GetExploit() *VulnerabilityReport_Vulnerability_Exploit {
+func (x *VulnerabilityReport_Vulnerability) GetExploit() *VulnerabilityReport_Vulnerability_CISAExploit {
 	if x != nil {
 		return x.Exploit
 	}
@@ -659,7 +659,7 @@ func (x *VulnerabilityReport_Vulnerability_EPSS) GetPercentile() float32 {
 	return 0
 }
 
-type VulnerabilityReport_Vulnerability_Exploit struct {
+type VulnerabilityReport_Vulnerability_CISAExploit struct {
 	state                      protoimpl.MessageState `protogen:"open.v1"`
 	CatalogVersion             string                 `protobuf:"bytes,1,opt,name=catalog_version,json=catalogVersion,proto3" json:"catalog_version,omitempty"`
 	DateAdded                  string                 `protobuf:"bytes,2,opt,name=date_added,json=dateAdded,proto3" json:"date_added,omitempty"`
@@ -671,20 +671,20 @@ type VulnerabilityReport_Vulnerability_Exploit struct {
 	sizeCache                  protoimpl.SizeCache
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) Reset() {
-	*x = VulnerabilityReport_Vulnerability_Exploit{}
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) Reset() {
+	*x = VulnerabilityReport_Vulnerability_CISAExploit{}
 	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) String() string {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*VulnerabilityReport_Vulnerability_Exploit) ProtoMessage() {}
+func (*VulnerabilityReport_Vulnerability_CISAExploit) ProtoMessage() {}
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) ProtoReflect() protoreflect.Message {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) ProtoReflect() protoreflect.Message {
 	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -696,47 +696,47 @@ func (x *VulnerabilityReport_Vulnerability_Exploit) ProtoReflect() protoreflect.
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use VulnerabilityReport_Vulnerability_Exploit.ProtoReflect.Descriptor instead.
-func (*VulnerabilityReport_Vulnerability_Exploit) Descriptor() ([]byte, []int) {
+// Deprecated: Use VulnerabilityReport_Vulnerability_CISAExploit.ProtoReflect.Descriptor instead.
+func (*VulnerabilityReport_Vulnerability_CISAExploit) Descriptor() ([]byte, []int) {
 	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 1, 2}
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) GetCatalogVersion() string {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetCatalogVersion() string {
 	if x != nil {
 		return x.CatalogVersion
 	}
 	return ""
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) GetDateAdded() string {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetDateAdded() string {
 	if x != nil {
 		return x.DateAdded
 	}
 	return ""
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) GetShortDescription() string {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetShortDescription() string {
 	if x != nil {
 		return x.ShortDescription
 	}
 	return ""
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) GetRequiredAction() string {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetRequiredAction() string {
 	if x != nil {
 		return x.RequiredAction
 	}
 	return ""
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) GetDueDate() string {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetDueDate() string {
 	if x != nil {
 		return x.DueDate
 	}
 	return ""
 }
 
-func (x *VulnerabilityReport_Vulnerability_Exploit) GetKnownRansomwareCampaignUse() string {
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetKnownRansomwareCampaignUse() string {
 	if x != nil {
 		return x.KnownRansomwareCampaignUse
 	}
@@ -852,7 +852,7 @@ var File_internalapi_scanner_v4_vulnerability_report_proto protoreflect.FileDesc
 const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\n" +
 	"1internalapi/scanner/v4/vulnerability_report.proto\x12\n" +
-	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\xeb\x13\n" +
+	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\xf3\x13\n" +
 	"\x13VulnerabilityReport\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12^\n" +
 	"\x0fvulnerabilities\x18\x02 \x03(\v24.scanner.v4.VulnerabilityReport.VulnerabilitiesEntryR\x0fvulnerabilities\x12t\n" +
@@ -861,7 +861,7 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\x05notes\x18\x05 \x03(\x0e2$.scanner.v4.VulnerabilityReport.NoteR\x05notes\x1a2\n" +
 	"\bAdvisory\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
-	"\x04link\x18\x02 \x01(\tR\x04link\x1a\xa0\x0e\n" +
+	"\x04link\x18\x02 \x01(\tR\x04link\x1a\xa8\x0e\n" +
 	"\rVulnerability\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12D\n" +
@@ -879,8 +879,8 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\x10fixed_in_version\x18\v \x01(\tR\x0efixedInVersion\x12J\n" +
 	"\x04cvss\x18\f \x01(\v22.scanner.v4.VulnerabilityReport.Vulnerability.CVSSB\x02\x18\x01R\x04cvss\x12U\n" +
 	"\fcvss_metrics\x18\r \x03(\v22.scanner.v4.VulnerabilityReport.Vulnerability.CVSSR\vcvssMetrics\x12U\n" +
-	"\fepss_metrics\x18\x0e \x01(\v22.scanner.v4.VulnerabilityReport.Vulnerability.EPSSR\vepssMetrics\x12O\n" +
-	"\aexploit\x18\x10 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.ExploitR\aexploit\x1a\xc5\x03\n" +
+	"\fepss_metrics\x18\x0e \x01(\v22.scanner.v4.VulnerabilityReport.Vulnerability.EPSSR\vepssMetrics\x12S\n" +
+	"\aexploit\x18\x10 \x01(\v29.scanner.v4.VulnerabilityReport.Vulnerability.CISAExploitR\aexploit\x1a\xc5\x03\n" +
 	"\x04CVSS\x12E\n" +
 	"\x02v2\x18\x01 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2R\x02v2\x12E\n" +
 	"\x02v3\x18\x02 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3R\x02v3\x12Q\n" +
@@ -907,8 +907,8 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\vprobability\x18\x03 \x01(\x02R\vprobability\x12\x1e\n" +
 	"\n" +
 	"percentile\x18\x04 \x01(\x02R\n" +
-	"percentile\x1a\x85\x02\n" +
-	"\aExploit\x12'\n" +
+	"percentile\x1a\x89\x02\n" +
+	"\vCISAExploit\x12'\n" +
 	"\x0fcatalog_version\x18\x01 \x01(\tR\x0ecatalogVersion\x12\x1d\n" +
 	"\n" +
 	"date_added\x18\x02 \x01(\tR\tdateAdded\x12+\n" +
@@ -960,11 +960,11 @@ var file_internalapi_scanner_v4_vulnerability_report_proto_goTypes = []any{
 	(*VulnerabilityReport_Vulnerability)(nil),          // 6: scanner.v4.VulnerabilityReport.Vulnerability
 	nil, // 7: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
 	nil, // 8: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
-	(*VulnerabilityReport_Vulnerability_CVSS)(nil),    // 9: scanner.v4.VulnerabilityReport.Vulnerability.CVSS
-	(*VulnerabilityReport_Vulnerability_EPSS)(nil),    // 10: scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	(*VulnerabilityReport_Vulnerability_Exploit)(nil), // 11: scanner.v4.VulnerabilityReport.Vulnerability.Exploit
-	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil), // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
-	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil), // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
+	(*VulnerabilityReport_Vulnerability_CVSS)(nil),        // 9: scanner.v4.VulnerabilityReport.Vulnerability.CVSS
+	(*VulnerabilityReport_Vulnerability_EPSS)(nil),        // 10: scanner.v4.VulnerabilityReport.Vulnerability.EPSS
+	(*VulnerabilityReport_Vulnerability_CISAExploit)(nil), // 11: scanner.v4.VulnerabilityReport.Vulnerability.CISAExploit
+	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil),     // 12: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
+	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil),     // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
 	(*Contents)(nil),              // 14: scanner.v4.Contents
 	(*timestamppb.Timestamp)(nil), // 15: google.protobuf.Timestamp
 }
@@ -979,7 +979,7 @@ var file_internalapi_scanner_v4_vulnerability_report_proto_depIdxs = []int32{
 	9,  // 7: scanner.v4.VulnerabilityReport.Vulnerability.cvss:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
 	9,  // 8: scanner.v4.VulnerabilityReport.Vulnerability.cvss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
 	10, // 9: scanner.v4.VulnerabilityReport.Vulnerability.epss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	11, // 10: scanner.v4.VulnerabilityReport.Vulnerability.exploit:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.Exploit
+	11, // 10: scanner.v4.VulnerabilityReport.Vulnerability.exploit:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CISAExploit
 	6,  // 11: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry.value:type_name -> scanner.v4.VulnerabilityReport.Vulnerability
 	4,  // 12: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry.value:type_name -> scanner.v4.StringList
 	12, // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v2:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2

--- a/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
@@ -118,11 +118,11 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) CloneMessageVT() proto.Message 
 	return m.CloneVT()
 }
 
-func (m *VulnerabilityReport_Vulnerability_Exploit) CloneVT() *VulnerabilityReport_Vulnerability_Exploit {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) CloneVT() *VulnerabilityReport_Vulnerability_CISAExploit {
 	if m == nil {
-		return (*VulnerabilityReport_Vulnerability_Exploit)(nil)
+		return (*VulnerabilityReport_Vulnerability_CISAExploit)(nil)
 	}
-	r := new(VulnerabilityReport_Vulnerability_Exploit)
+	r := new(VulnerabilityReport_Vulnerability_CISAExploit)
 	r.CatalogVersion = m.CatalogVersion
 	r.DateAdded = m.DateAdded
 	r.ShortDescription = m.ShortDescription
@@ -136,7 +136,7 @@ func (m *VulnerabilityReport_Vulnerability_Exploit) CloneVT() *VulnerabilityRepo
 	return r
 }
 
-func (m *VulnerabilityReport_Vulnerability_Exploit) CloneMessageVT() proto.Message {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -358,7 +358,7 @@ func (this *VulnerabilityReport_Vulnerability_EPSS) EqualMessageVT(thatMsg proto
 	}
 	return this.EqualVT(that)
 }
-func (this *VulnerabilityReport_Vulnerability_Exploit) EqualVT(that *VulnerabilityReport_Vulnerability_Exploit) bool {
+func (this *VulnerabilityReport_Vulnerability_CISAExploit) EqualVT(that *VulnerabilityReport_Vulnerability_CISAExploit) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
@@ -385,8 +385,8 @@ func (this *VulnerabilityReport_Vulnerability_Exploit) EqualVT(that *Vulnerabili
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *VulnerabilityReport_Vulnerability_Exploit) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*VulnerabilityReport_Vulnerability_Exploit)
+func (this *VulnerabilityReport_Vulnerability_CISAExploit) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*VulnerabilityReport_Vulnerability_CISAExploit)
 	if !ok {
 		return false
 	}
@@ -829,7 +829,7 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) MarshalToSizedBufferVT(dAtA []b
 	return len(dAtA) - i, nil
 }
 
-func (m *VulnerabilityReport_Vulnerability_Exploit) MarshalVT() (dAtA []byte, err error) {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -842,12 +842,12 @@ func (m *VulnerabilityReport_Vulnerability_Exploit) MarshalVT() (dAtA []byte, er
 	return dAtA[:n], nil
 }
 
-func (m *VulnerabilityReport_Vulnerability_Exploit) MarshalToVT(dAtA []byte) (int, error) {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *VulnerabilityReport_Vulnerability_Exploit) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -1327,7 +1327,7 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) SizeVT() (n int) {
 	return n
 }
 
-func (m *VulnerabilityReport_Vulnerability_Exploit) SizeVT() (n int) {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -2117,7 +2117,7 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) UnmarshalVT(dAtA []byte) error 
 	}
 	return nil
 }
-func (m *VulnerabilityReport_Vulnerability_Exploit) UnmarshalVT(dAtA []byte) error {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -2140,10 +2140,10 @@ func (m *VulnerabilityReport_Vulnerability_Exploit) UnmarshalVT(dAtA []byte) err
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: wiretype end group for non-group")
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -2904,7 +2904,7 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Exploit == nil {
-				m.Exploit = &VulnerabilityReport_Vulnerability_Exploit{}
+				m.Exploit = &VulnerabilityReport_Vulnerability_CISAExploit{}
 			}
 			if err := m.Exploit.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -4103,7 +4103,7 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) UnmarshalVTUnsafe(dAtA []byte) 
 	}
 	return nil
 }
-func (m *VulnerabilityReport_Vulnerability_Exploit) UnmarshalVTUnsafe(dAtA []byte) error {
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -4126,10 +4126,10 @@ func (m *VulnerabilityReport_Vulnerability_Exploit) UnmarshalVTUnsafe(dAtA []byt
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: wiretype end group for non-group")
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -4950,7 +4950,7 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVTUnsafe(dAtA []byte) error
 				return io.ErrUnexpectedEOF
 			}
 			if m.Exploit == nil {
-				m.Exploit = &VulnerabilityReport_Vulnerability_Exploit{}
+				m.Exploit = &VulnerabilityReport_Vulnerability_CISAExploit{}
 			}
 			if err := m.Exploit.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
@@ -118,6 +118,28 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) CloneMessageVT() proto.Message 
 	return m.CloneVT()
 }
 
+func (m *VulnerabilityReport_Vulnerability_Exploit) CloneVT() *VulnerabilityReport_Vulnerability_Exploit {
+	if m == nil {
+		return (*VulnerabilityReport_Vulnerability_Exploit)(nil)
+	}
+	r := new(VulnerabilityReport_Vulnerability_Exploit)
+	r.CatalogVersion = m.CatalogVersion
+	r.DateAdded = m.DateAdded
+	r.ShortDescription = m.ShortDescription
+	r.RequiredAction = m.RequiredAction
+	r.DueDate = m.DueDate
+	r.KnownRansomwareCampaignUse = m.KnownRansomwareCampaignUse
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *VulnerabilityReport_Vulnerability_Exploit) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *VulnerabilityReport_Vulnerability) CloneVT() *VulnerabilityReport_Vulnerability {
 	if m == nil {
 		return (*VulnerabilityReport_Vulnerability)(nil)
@@ -137,6 +159,7 @@ func (m *VulnerabilityReport_Vulnerability) CloneVT() *VulnerabilityReport_Vulne
 	r.FixedInVersion = m.FixedInVersion
 	r.Cvss = m.Cvss.CloneVT()
 	r.EpssMetrics = m.EpssMetrics.CloneVT()
+	r.Exploit = m.Exploit.CloneVT()
 	if rhs := m.CvssMetrics; rhs != nil {
 		tmpContainer := make([]*VulnerabilityReport_Vulnerability_CVSS, len(rhs))
 		for k, v := range rhs {
@@ -335,6 +358,40 @@ func (this *VulnerabilityReport_Vulnerability_EPSS) EqualMessageVT(thatMsg proto
 	}
 	return this.EqualVT(that)
 }
+func (this *VulnerabilityReport_Vulnerability_Exploit) EqualVT(that *VulnerabilityReport_Vulnerability_Exploit) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.CatalogVersion != that.CatalogVersion {
+		return false
+	}
+	if this.DateAdded != that.DateAdded {
+		return false
+	}
+	if this.ShortDescription != that.ShortDescription {
+		return false
+	}
+	if this.RequiredAction != that.RequiredAction {
+		return false
+	}
+	if this.DueDate != that.DueDate {
+		return false
+	}
+	if this.KnownRansomwareCampaignUse != that.KnownRansomwareCampaignUse {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *VulnerabilityReport_Vulnerability_Exploit) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*VulnerabilityReport_Vulnerability_Exploit)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *VulnerabilityReport_Vulnerability) EqualVT(that *VulnerabilityReport_Vulnerability) bool {
 	if this == that {
 		return true
@@ -398,6 +455,9 @@ func (this *VulnerabilityReport_Vulnerability) EqualVT(that *VulnerabilityReport
 		return false
 	}
 	if !this.Advisory.EqualVT(that.Advisory) {
+		return false
+	}
+	if !this.Exploit.EqualVT(that.Exploit) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -769,6 +829,81 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) MarshalToSizedBufferVT(dAtA []b
 	return len(dAtA) - i, nil
 }
 
+func (m *VulnerabilityReport_Vulnerability_Exploit) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VulnerabilityReport_Vulnerability_Exploit) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *VulnerabilityReport_Vulnerability_Exploit) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.KnownRansomwareCampaignUse) > 0 {
+		i -= len(m.KnownRansomwareCampaignUse)
+		copy(dAtA[i:], m.KnownRansomwareCampaignUse)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.KnownRansomwareCampaignUse)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.DueDate) > 0 {
+		i -= len(m.DueDate)
+		copy(dAtA[i:], m.DueDate)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DueDate)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.RequiredAction) > 0 {
+		i -= len(m.RequiredAction)
+		copy(dAtA[i:], m.RequiredAction)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RequiredAction)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.ShortDescription) > 0 {
+		i -= len(m.ShortDescription)
+		copy(dAtA[i:], m.ShortDescription)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ShortDescription)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.DateAdded) > 0 {
+		i -= len(m.DateAdded)
+		copy(dAtA[i:], m.DateAdded)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DateAdded)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.CatalogVersion) > 0 {
+		i -= len(m.CatalogVersion)
+		copy(dAtA[i:], m.CatalogVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CatalogVersion)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *VulnerabilityReport_Vulnerability) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -798,6 +933,18 @@ func (m *VulnerabilityReport_Vulnerability) MarshalToSizedBufferVT(dAtA []byte) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Exploit != nil {
+		size, err := m.Exploit.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
 	}
 	if m.Advisory != nil {
 		size, err := m.Advisory.MarshalToSizedBufferVT(dAtA[:i])
@@ -1180,6 +1327,40 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) SizeVT() (n int) {
 	return n
 }
 
+func (m *VulnerabilityReport_Vulnerability_Exploit) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.CatalogVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.DateAdded)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ShortDescription)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.RequiredAction)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.DueDate)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.KnownRansomwareCampaignUse)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *VulnerabilityReport_Vulnerability) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1246,6 +1427,10 @@ func (m *VulnerabilityReport_Vulnerability) SizeVT() (n int) {
 	if m.Advisory != nil {
 		l = m.Advisory.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Exploit != nil {
+		l = m.Exploit.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1932,6 +2117,249 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) UnmarshalVT(dAtA []byte) error 
 	}
 	return nil
 }
+func (m *VulnerabilityReport_Vulnerability_Exploit) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CatalogVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CatalogVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DateAdded", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DateAdded = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ShortDescription", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ShortDescription = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequiredAction", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RequiredAction = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DueDate", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DueDate = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownRansomwareCampaignUse", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KnownRansomwareCampaignUse = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *VulnerabilityReport_Vulnerability) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2443,6 +2871,42 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVT(dAtA []byte) error {
 				m.Advisory = &VulnerabilityReport_Advisory{}
 			}
 			if err := m.Advisory.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &VulnerabilityReport_Vulnerability_Exploit{}
+			}
+			if err := m.Exploit.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -3639,6 +4103,273 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) UnmarshalVTUnsafe(dAtA []byte) 
 	}
 	return nil
 }
+func (m *VulnerabilityReport_Vulnerability_Exploit) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_Exploit: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CatalogVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CatalogVersion = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DateAdded", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DateAdded = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ShortDescription", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ShortDescription = stringValue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequiredAction", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.RequiredAction = stringValue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DueDate", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DueDate = stringValue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownRansomwareCampaignUse", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.KnownRansomwareCampaignUse = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *VulnerabilityReport_Vulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4186,6 +4917,42 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVTUnsafe(dAtA []byte) error
 				m.Advisory = &VulnerabilityReport_Advisory{}
 			}
 			if err := m.Advisory.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &VulnerabilityReport_Vulnerability_Exploit{}
+			}
+			if err := m.Exploit.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -140,7 +140,7 @@ var (
 	// CISAKEV enables support for CISA Known Exploited Vulnerabilities (KEV) data.
 	//
 	// This must be enabled in Central and Scanner V4 Matcher to have any effect.
-	CISAKEV = registerFeature("Display CISA Known Exploited Vulnerabilities (KEV) data", "ROX_CISA_KEV", enabled)
+	CISAKEV = registerFeature("Display CISA Known Exploited Vulnerabilities (KEV) data", "ROX_CISA_KEV")
 )
 
 // The following feature flags are related to Scanner V4.

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -134,6 +134,13 @@ var (
 
 	// SFA enables monitoring of sensitive files.
 	SensitiveFileActivity = registerFeature("Enable sensitive file monitoring", "ROX_SENSITIVE_FILE_ACTIVITY")
+
+	VirtualMachines = registerFeature("Enables virtual machine management", "ROX_VIRTUAL_MACHINES")
+
+	// CISAKEV enables support for CISA Known Exploited Vulnerabilities (KEV) data.
+	//
+	// This must be enabled in Central and Scanner V4 Matcher to have any effect.
+	CISAKEV = registerFeature("Display CISA Known Exploited Vulnerabilities (KEV) data", "ROX_CISA_KEV", enabled)
 )
 
 // The following feature flags are related to Scanner V4.
@@ -173,8 +180,6 @@ var (
 	//
 	// This must be set in Scanner V4 Indexer to have any effect.
 	ScannerV4MavenSearch = registerFeature("Enables Scanner V4 to reach out to ROX_SCANNER_V4_MAVEN_SEARCH_URL for additional information about Java packages", "ROX_SCANNER_V4_MAVEN_SEARCH")
-
-	VirtualMachines = registerFeature("Enables virtual machine management", "ROX_VIRTUAL_MACHINES")
 
 	// ScannerV4StoreExternalIndexReports enables storing index reports from delegated scans to Central's Scanner V4 Indexer.
 	// Both ScannerV4StoreExternalIndexReports and SBOMGeneration features must be enabled to store the index reports.

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -711,7 +711,7 @@ func toProtoV4VulnerabilitiesMap(
 			}
 		}
 		if exploit != nil {
-			vulnerabilities[k].Exploit = &v4.VulnerabilityReport_Vulnerability_Exploit{
+			vulnerabilities[k].Exploit = &v4.VulnerabilityReport_Vulnerability_CISAExploit{
 				CatalogVersion:             exploit.CatalogVersion,
 				DateAdded:                  exploit.DateAdded,
 				ShortDescription:           exploit.ShortDescription,

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/facebookincubator/nvdtools/cvss3"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/enricher/kev"
 	"github.com/quay/claircore/rhel/rhcc"
 	"github.com/quay/claircore/rhel/vex"
 	"github.com/quay/claircore/toolkit/types/cpe"
@@ -133,7 +134,11 @@ func ToProtoV4VulnerabilityReport(ctx context.Context, r *claircore.Vulnerabilit
 	if err != nil {
 		return nil, fmt.Errorf("internal error: parsing Red Hat CSAF advisories: %w", err)
 	}
-	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, nvdVulns, epssItems, csafAdvisories)
+	kevExploits, err := kevExploits(ctx, r.Enrichments)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: parsing CISA KEV exploits: %w", err)
+	}
+	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, nvdVulns, epssItems, csafAdvisories, kevExploits)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %w", err)
 	}
@@ -567,6 +572,7 @@ func toProtoV4VulnerabilitiesMap(
 	nvdVulns map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem,
 	epssItems map[string]map[string]*epss.EPSSItem,
 	csafAdvisories map[string]csaf.Advisory,
+	kevExploits map[string]map[string]*kev.Entry,
 ) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {
 	if vulns == nil {
 		return nil, nil
@@ -670,6 +676,12 @@ func toProtoV4VulnerabilitiesMap(
 		if rhelEPSS, ok := rhelEPSSDetails[name]; ok {
 			vulnEPSS = &rhelEPSS
 		}
+		var exploit *kev.Entry
+		if exploitItem, ok := kevExploits[v.ID]; ok {
+			if e, ok := exploitItem[cve]; foundCVE && ok {
+				exploit = e
+			}
+		}
 
 		if vulnerabilities == nil {
 			vulnerabilities = make(map[string]*v4.VulnerabilityReport_Vulnerability, len(vulns))
@@ -696,6 +708,16 @@ func toProtoV4VulnerabilitiesMap(
 				Date:         vulnEPSS.Date,
 				Probability:  float32(vulnEPSS.EPSS),
 				Percentile:   float32(vulnEPSS.Percentile),
+			}
+		}
+		if exploit != nil {
+			vulnerabilities[k].Exploit = &v4.VulnerabilityReport_Vulnerability_Exploit{
+				CatalogVersion:             exploit.CatalogVersion,
+				DateAdded:                  exploit.DateAdded,
+				ShortDescription:           exploit.ShortDescription,
+				RequiredAction:             exploit.RequiredAction,
+				DueDate:                    exploit.DueDate,
+				KnownRansomwareCampaignUse: exploit.KnownRansomwareCampaignUse,
 			}
 		}
 	}
@@ -1005,6 +1027,38 @@ func redhatCSAFAdvisories(ctx context.Context, enrichments map[string][]json.Raw
 			continue
 		}
 		ret[id] = records[0]
+	}
+	return ret, nil
+}
+
+func kevExploits(_ context.Context, enrichments map[string][]json.RawMessage) (map[string]map[string]*kev.Entry, error) {
+	enrichmentsList := enrichments[kev.Type]
+	if len(enrichmentsList) == 0 {
+		return nil, nil
+	}
+	var items map[string][]kev.Entry
+	// The CISA KEV enrichment always contains only one element.
+	err := json.Unmarshal(enrichmentsList[0], &items)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	// Returns a map of maps keyed by CVE ID due to enrichment matching on multiple
+	// vulnerability fields, potentially including unrelated records--we assume the
+	// caller will know how to filter what is relevant.
+	ret := make(map[string]map[string]*kev.Entry)
+	for ccVulnID, list := range items {
+		if len(list) == 0 {
+			continue
+		}
+		m := make(map[string]*kev.Entry)
+		for idx := range list {
+			vulnData := list[idx]
+			m[vulnData.CVE] = &vulnData
+		}
+		ret[ccVulnID] = m
 	}
 	return ret, nil
 }

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -10,6 +10,7 @@ import (
 	nvdschema "github.com/facebookincubator/nvdtools/cveapi/nvd/schema"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/enricher/kev"
 	"github.com/quay/claircore/toolkit/types/cpe"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/features"
@@ -1560,7 +1561,78 @@ func Test_toProtoV4VulnerabilitiesMapWithEPSS(t *testing.T) {
 			t.Setenv(features.ScannerV4RedHatCVEs.EnvVar(), enableRedHatCVEs)
 			enableEPSS := "true"
 			t.Setenv(features.EPSSScore.EnvVar(), enableEPSS)
-			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, tt.epssItems, nil)
+			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, tt.epssItems, nil, nil)
+			assert.NoError(t, err)
+			protoassert.MapEqual(t, tt.want, got)
+		})
+	}
+}
+
+func Test_toProtoV4VulnerabilitiesMapWithExploit(t *testing.T) {
+	now := time.Now()
+	protoNow, err := protocompat.ConvertTimeToTimestampOrError(now)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		ccVulnerabilities map[string]*claircore.Vulnerability
+		exploits          map[string]map[string]*kev.Entry
+		want              map[string]*v4.VulnerabilityReport_Vulnerability
+	}{
+		"basic": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					ID:     "foo",
+					Name:   "CVE-1234-567",
+					Issued: now,
+				},
+				"bar": {
+					ID:     "bar",
+					Name:   "CVE-1234-568",
+					Issued: now,
+				},
+			},
+			exploits: map[string]map[string]*kev.Entry{
+				"foo": {
+					"CVE-1234-567": &kev.Entry{
+						CVE:                        "CVE-1234-567",
+						VulnerabilityName:          "bad news",
+						CatalogVersion:             "2025.10.01",
+						DateAdded:                  "2025-09-20",
+						ShortDescription:           "This is a bad vulnerability",
+						RequiredAction:             "hide",
+						DueDate:                    "2025-10-12",
+						KnownRansomwareCampaignUse: "Known",
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Id:     "foo",
+					Issued: protoNow,
+					Name:   "CVE-1234-567",
+					Exploit: &v4.VulnerabilityReport_Vulnerability_Exploit{
+						CatalogVersion:             "2025.10.01",
+						DateAdded:                  "2025-09-20",
+						ShortDescription:           "This is a bad vulnerability",
+						RequiredAction:             "hide",
+						DueDate:                    "2025-10-12",
+						KnownRansomwareCampaignUse: "Known",
+					},
+				},
+				"bar": {
+					Id:     "bar",
+					Issued: protoNow,
+					Name:   "CVE-1234-568",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.CISAKEV.EnvVar(), "true")
+			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, nil, nil, nil, tt.exploits)
 			assert.NoError(t, err)
 			protoassert.MapEqual(t, tt.want, got)
 		})
@@ -2355,7 +2427,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			}
 			t.Setenv(features.ScannerV4RedHatCVEs.EnvVar(), enableRedHatCVEs)
 			// EPSS scores are intentionally not covered here
-			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, nil, tt.advisories)
+			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, nil, tt.advisories, nil)
 			assert.NoError(t, err)
 			protoassert.MapEqual(t, tt.want, got)
 		})

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -1610,7 +1610,7 @@ func Test_toProtoV4VulnerabilitiesMapWithExploit(t *testing.T) {
 					Id:     "foo",
 					Issued: protoNow,
 					Name:   "CVE-1234-567",
-					Exploit: &v4.VulnerabilityReport_Vulnerability_Exploit{
+					Exploit: &v4.VulnerabilityReport_Vulnerability_CISAExploit{
 						CatalogVersion:             "2025.10.01",
 						DateAdded:                  "2025-09-20",
 						ShortDescription:           "This is a bad vulnerability",

--- a/proto/internalapi/scanner/v4/vulnerability_report.proto
+++ b/proto/internalapi/scanner/v4/vulnerability_report.proto
@@ -51,7 +51,7 @@ message VulnerabilityReport {
       float probability = 3;
       float percentile = 4;
     }
-    message Exploit {
+    message CISAExploit {
       string catalog_version = 1;
       string date_added = 2;
       string short_description = 3;
@@ -74,7 +74,7 @@ message VulnerabilityReport {
     CVSS cvss = 12 [deprecated = true]; // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
     repeated CVSS cvss_metrics = 13;
     EPSS epss_metrics = 14;
-    Exploit exploit = 16;
+    CISAExploit exploit = 16;
   }
   enum Note {
     NOTE_UNSPECIFIED = 0;

--- a/proto/internalapi/scanner/v4/vulnerability_report.proto
+++ b/proto/internalapi/scanner/v4/vulnerability_report.proto
@@ -11,7 +11,7 @@ import "internalapi/scanner/v4/common.proto";
 
 option go_package = "./internalapi/scanner/v4;v4";
 
-// Next tag: 16
+// Next tag: 17
 message VulnerabilityReport {
   message Advisory {
     string name = 1;
@@ -51,6 +51,14 @@ message VulnerabilityReport {
       float probability = 3;
       float percentile = 4;
     }
+    message Exploit {
+      string catalog_version = 1;
+      string date_added = 2;
+      string short_description = 3;
+      string required_action = 4;
+      string due_date = 5;
+      string known_ransomware_campaign_use = 6;
+    }
     string id = 1;
     string name = 2;
     Advisory advisory = 15;
@@ -66,6 +74,7 @@ message VulnerabilityReport {
     CVSS cvss = 12 [deprecated = true]; // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
     repeated CVSS cvss_metrics = 13;
     EPSS epss_metrics = 14;
+    Exploit exploit = 16;
   }
   enum Note {
     NOTE_UNSPECIFIED = 0;

--- a/scanner/enricher/fixedby/fixedby_test.go
+++ b/scanner/enricher/fixedby/fixedby_test.go
@@ -1226,6 +1226,7 @@ func TestEnrich_RHCC(t *testing.T) {
 						Name: "Red Hat Container Catalog",
 						Key:  "rhcc-container-repository",
 						URI:  "https://catalog.redhat.com/software/containers/explore",
+						Key:  "rhcc-container-repository",
 					},
 				},
 				Environments: map[string][]*claircore.Environment{
@@ -1268,6 +1269,7 @@ func TestEnrich_RHCC(t *testing.T) {
 						Name: "Red Hat Container Catalog",
 						Key:  "rhcc-container-repository",
 						URI:  "https://catalog.redhat.com/software/containers/explore",
+						Key:  "rhcc-container-repository",
 					},
 				},
 				Environments: map[string][]*claircore.Environment{

--- a/scanner/enricher/fixedby/fixedby_test.go
+++ b/scanner/enricher/fixedby/fixedby_test.go
@@ -1226,7 +1226,6 @@ func TestEnrich_RHCC(t *testing.T) {
 						Name: "Red Hat Container Catalog",
 						Key:  "rhcc-container-repository",
 						URI:  "https://catalog.redhat.com/software/containers/explore",
-						Key:  "rhcc-container-repository",
 					},
 				},
 				Environments: map[string][]*claircore.Environment{
@@ -1269,7 +1268,6 @@ func TestEnrich_RHCC(t *testing.T) {
 						Name: "Red Hat Container Catalog",
 						Key:  "rhcc-container-repository",
 						URI:  "https://catalog.redhat.com/software/containers/explore",
-						Key:  "rhcc-container-repository",
 					},
 				},
 				Environments: map[string][]*claircore.Environment{

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -18,6 +18,7 @@ import (
 	"github.com/quay/claircore/libvuln/jsonblob"
 	"github.com/quay/claircore/libvuln/updates"
 	"github.com/quay/zlog"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/scanner/enricher/csaf"
 	"github.com/stackrox/rox/scanner/enricher/nvd"
 	"github.com/stackrox/rox/scanner/updater/manual"
@@ -51,7 +52,9 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 	bundles["nvd"] = nvdOpts()
 	bundles["epss"] = epssOpts()
 	bundles["stackrox-rhel-csaf"] = redhatCSAFOpts()
-	bundles["cisa-kev"] = kevOpts()
+	if features.CISAKEV.Enabled() {
+		bundles["cisa-kev"] = kevOpts()
+	}
 
 	// ClairCore updaters.
 	for _, uSet := range []string{

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/enricher/kev"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/libvuln/jsonblob"
 	"github.com/quay/claircore/libvuln/updates"
@@ -50,6 +51,7 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 	bundles["nvd"] = nvdOpts()
 	bundles["epss"] = epssOpts()
 	bundles["stackrox-rhel-csaf"] = redhatCSAFOpts()
+	bundles["cisa-kev"] = kevOpts()
 
 	// ClairCore updaters.
 	for _, uSet := range []string{
@@ -172,6 +174,16 @@ func redhatCSAFOpts() []updates.ManagerOption {
 		updates.WithEnabled([]string{}),
 		updates.WithFactories(map[string]driver.UpdaterSetFactory{
 			"stackrox.rhel-csaf": csaf.NewFactory(),
+		}),
+	}
+}
+
+func kevOpts() []updates.ManagerOption {
+	return []updates.ManagerOption{
+		// This is required to prevent default updaters from running.
+		updates.WithEnabled([]string{}),
+		updates.WithFactories(map[string]driver.UpdaterSetFactory{
+			"clair.kev": kev.NewFactory(),
 		}),
 	}
 }


### PR DESCRIPTION
## Description

Scanner V4-side implementation of CISA KEV support. This PR updates the Claircore version to one which includes CISA KEV enrichment support and updates Scanner V4 Matcher to ingest and output the enrichment data. It is currently unused by Central/Sensor, but it will be in a followup.

See https://github.com/quay/claircore/pull/1563 for the Claircore-side.

This also introduces a feature flag: `ROX_CISA_KEV`.

~This is currently failing E2E tests due to some Claircore regressions:~

* https://github.com/quay/claircore/pull/1640
* https://github.com/quay/claircore/pull/1641

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

CI is sufficient to test Scanner V4 Matcher utilizing the enricher. As for ensuring the enrichment data is created: I added the `pr-update-scanner-vulns` label. You can find the data generated for this PR [here](https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/ROX-29681-scanner/vulnerabilities.zip). There you will find `cisa-kev.json.zst`. There are currently 1414 entries there, which matches the number of exploits [here](https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json).

When testing https://github.com/stackrox/stackrox/pull/16886 live, I was also able to see this log message (originating from this PR):

```
{"level":"info","host":"scanner-v4-matcher-85f5ff6fbb-rvrsw","component":"scanner/backend/matcher.NewMatcher","enabled":true,"time":"2025-09-18T22:09:17Z","message":"fixedby enricher"}
{"level":"info","host":"scanner-v4-matcher-85f5ff6fbb-rvrsw","component":"scanner/backend/matcher.NewMatcher","enabled":true,"time":"2025-09-18T22:09:17Z","message":"nvd enricher"}
{"level":"info","host":"scanner-v4-matcher-85f5ff6fbb-rvrsw","component":"scanner/backend/matcher.NewMatcher","enabled":true,"time":"2025-09-18T22:09:17Z","message":"epss enricher"}
{"level":"info","host":"scanner-v4-matcher-85f5ff6fbb-rvrsw","component":"scanner/backend/matcher.NewMatcher","enabled":false,"time":"2025-09-18T22:09:17Z","message":"csaf enricher"}
{"level":"info","host":"scanner-v4-matcher-85f5ff6fbb-rvrsw","component":"scanner/backend/matcher.NewMatcher","enabled":true,"time":"2025-09-18T22:09:17Z","message":"kev enricher"}
```
