### PR TITLE
ROX-30567: Add non-checkbox select for known exploit search filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -24,4 +24,28 @@ export const CVSS: CompoundSearchFilterAttribute = {
     inputType: 'condition-number',
 };
 
+/*
+// Ross CISA KEV
+export const KnownExploit: CompoundSearchFilterAttribute = {
+    displayName: 'Known exploit',
+    filterChipLabel: 'Known exploit',
+    searchTerm: 'Known Exploit',
+    inputType: 'select',
+    inputProps: {
+        hasCheckbox: false,
+        options: [
+            { label: 'Has a known expoit', value: 'HAS_KNOWN_EXPLOIT' },
+            // {
+            //     label: 'Used in ransomware campaigns',
+            //     value: 'USED_IN_RANSOMWARE',
+            // },
+            { label: 'No known exploit', value: 'NO_KNOWN_EXPLOIT' },
+        ],
+    },
+    // featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_KEV_EXPLOIT'],
+    featureFlagDependency: ['ROX_SCANNER_V4'],
+};
+
+export const imageCVEAttributes = [Name, DiscoveredTime, CVSS, EPSSProbability, KnownExploit];
+*/
 export const imageCVEAttributes = [Name, DiscoveredTime, CVSS, EPSSProbability];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -113,7 +113,10 @@ function CompoundSearchFilter({
                         (action === 'ADD' &&
                             value !== '' &&
                             !searchFilter?.[category]?.includes(value)) ||
-                        (action === 'REMOVE' && value !== '');
+                        (action === 'REMOVE' && value !== '') ||
+                        (action === 'REPLACE' &&
+                            (searchFilter?.[category]?.length !== 1 ||
+                                searchFilter?.[category]?.[0] !== value));
 
                     if (shouldSearch) {
                         onSearch(payload);

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -9,6 +9,7 @@ import {
 
 import { SearchFilter } from 'types/search';
 import CheckboxSelect from 'Components/CheckboxSelect';
+import SelectSingle from 'Components/SelectSingle';
 import { ensureString, ensureStringArray } from 'utils/ensure';
 import { SelectedEntity } from './EntitySelector';
 import { SelectedAttribute } from './AttributeSelector';
@@ -171,9 +172,44 @@ function CompoundSearchFilterInputField({
         );
     }
     if (isSelectType(attribute)) {
+        const hasCheckbox = !!attribute.inputProps.hasCheckbox; // default is true
         const attributeLabel = attribute.displayName;
         const { searchTerm } = attribute;
         const selection = ensureStringArray(searchFilter?.[searchTerm]);
+
+        if (
+            !hasCheckbox &&
+            !hasGroupedSelectOptions(attribute.inputProps) &&
+            hasSelectOptions(attribute.inputProps) &&
+            attribute.inputProps.options.length !== 0
+        ) {
+            return (
+                <SelectSingle
+                    id={attribute.searchTerm}
+                    isFullWidth={false}
+                    placeholderText={`Filter by ${attributeLabel}`}
+                    value={selection.length === 0 ? '' : selection[0]}
+                    handleSelect={(_name, value: string) => {
+                        // onChange(value);
+                        onSearch({
+                            action: 'REPLACE',
+                            category: attribute.searchTerm,
+                            value,
+                        });
+                    }}
+                >
+                    {attribute.inputProps.options.map((option) => (
+                        <SelectOption
+                            key={option.value}
+                            hasCheckbox={hasCheckbox}
+                            value={option.value}
+                        >
+                            {option.label}
+                        </SelectOption>
+                    ))}
+                </SelectSingle>
+            );
+        }
 
         let content: JSX.Element | JSX.Element[] = (
             <SelectList>
@@ -193,7 +229,6 @@ function CompoundSearchFilterInputField({
                                 {options.map((option) => (
                                     <SelectOption
                                         key={option.value}
-                                        hasCheckbox
                                         value={option.value}
                                         isSelected={selection.includes(option.value)}
                                     >
@@ -215,7 +250,7 @@ function CompoundSearchFilterInputField({
                     {attribute.inputProps.options.map((option) => (
                         <SelectOption
                             key={option.value}
-                            hasCheckbox
+                            hasCheckbox={hasCheckbox}
                             value={option.value}
                             isSelected={selection.includes(option.value)}
                         >

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -172,16 +172,15 @@ function CompoundSearchFilterInputField({
         );
     }
     if (isSelectType(attribute)) {
-        const hasCheckbox = !!attribute.inputProps.hasCheckbox; // default is true
         const attributeLabel = attribute.displayName;
         const { searchTerm } = attribute;
         const selection = ensureStringArray(searchFilter?.[searchTerm]);
 
         if (
-            !hasCheckbox &&
             !hasGroupedSelectOptions(attribute.inputProps) &&
             hasSelectOptions(attribute.inputProps) &&
-            attribute.inputProps.options.length !== 0
+            attribute.inputProps.options.length !== 0 &&
+            !!attribute.inputProps.hasCheckbox
         ) {
             return (
                 <SelectSingle
@@ -199,11 +198,7 @@ function CompoundSearchFilterInputField({
                     }}
                 >
                     {attribute.inputProps.options.map((option) => (
-                        <SelectOption
-                            key={option.value}
-                            hasCheckbox={hasCheckbox}
-                            value={option.value}
-                        >
+                        <SelectOption key={option.value} value={option.value}>
                             {option.label}
                         </SelectOption>
                     ))}
@@ -250,7 +245,7 @@ function CompoundSearchFilterInputField({
                     {attribute.inputProps.options.map((option) => (
                         <SelectOption
                             key={option.value}
-                            hasCheckbox={hasCheckbox}
+                            hasCheckbox
                             value={option.value}
                             isSelected={selection.includes(option.value)}
                         >

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -7,9 +7,11 @@ import { ConditionTextInputProps } from './components/ConditionText';
 export type BaseInputType = 'autocomplete' | 'text' | 'date-picker' | 'condition-number';
 export type InputType = BaseInputType | 'condition-text' | 'select';
 export type SelectSearchFilterOptions = {
+    hasCheckbox?: boolean;
     options: { label: string; value: string }[];
 };
 export type SelectSearchFilterGroupedOptions = {
+    hasCheckbox?: boolean;
     groupOptions: { name: string; options: { label: string; value: string }[] }[];
 };
 
@@ -53,7 +55,7 @@ export type CompoundSearchFilterConfig = CompoundSearchFilterEntity[];
 export type OnSearchCallback = (payload: OnSearchPayload) => void;
 
 export type OnSearchPayload = {
-    action: 'ADD' | 'REMOVE';
+    action: 'ADD' | 'REMOVE' | 'REPLACE';
     category: string;
     value: string;
 };

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -11,7 +11,6 @@ export type SelectSearchFilterOptions = {
     options: { label: string; value: string }[];
 };
 export type SelectSearchFilterGroupedOptions = {
-    hasCheckbox?: boolean;
     groupOptions: { name: string; options: { label: string; value: string }[] }[];
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -101,7 +101,9 @@ function AdvancedFiltersToolbar({
             [category]:
                 action === 'ADD'
                     ? uniq([...selectedSearchFilter, value])
-                    : selectedSearchFilter.filter((oldValue) => value !== oldValue),
+                    : action === 'REMOVE'
+                      ? selectedSearchFilter.filter((oldValue) => value !== oldValue)
+                      : [value],
         };
         onFilterChange(newFilter, { category, value, action });
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
@@ -18,7 +18,7 @@ function KnownExploitLabel({
         <Tooltip content={tooltip} position="top-start" isContentLeftAligned>
             <Label color="red" isCompact={isCompact}>
                 {isKnownToBeUsedInRansomwareCampaigns
-                    ? 'Known to be used in ransomware campaigns'
+                    ? 'Used in ransomware campaigns'
                     : 'Known exploit'}
             </Label>
         </Tooltip>


### PR DESCRIPTION
## Description

Prerequisite for **Ross** to add search filter for CISA KEV.

### Analysis of code

1. Tables that will conditionally render `KnownExploitLabel` element:
    * DeploymentVulnerabilitiesTable
    * ImageVulnerabilitiesTable
    * WorkloadVulnerabilitiesTable

2. Pages that render the tables also import `imageCVESearchFilterConfig` which has `imageCVEAttributes`
    * DeploymentPageVulnerabilities
    * ImagePageVulnerabilities
    * WorkloadCvesOverviewPage

### Analysis of search filter

### Pair of checkboxes

Red Hat Insights search filter has 2 checkboxes:
* Has a known exploit (column 1a)
* No known exploit (column 1b)

Parallel with **CVE status** which has 2 checkboxes:
* Fixable (column 1a)
* Not fixable (column 1b)

2 checkboxes have 2 × 2 = 4 combinations:

| | 1a | 1b | Analysis | Description |
| ---: | ---: | ---: | ---: | :--- |
| 0 | | | unfiltered | no search filter |
| 1 | ✓ | | filtered | Has a known exploit |
| 2 | | ✓ | filtered | No known exploit |
| | ✓ | ✓ | redundant | equivalent to 0 |

Although 2 checkboxes implies 4 possibilities:
* mutually exclusive alternatives have 3 possibilities
* because no search filter corresponds to neither option selected, an alternative search filter has 2 mutually exclusive **non-checkbox** selection options

#### Pair of pair of checkboxes

Consider **Known To Be Used in Ransomware Campaigns?**
* `"knownRansomwareCampaignUse": "Known"` (column 2a)
* `"knownRansomwareCampaignUse": "Unknown"` (column 2b)

Its alternatives are subcategories of **Has a known exploit**

4 checkboxes have 2 × 2 × 2 × 2 = 16 combinations:

| | 1a | 1b | 2a | 2b | Analysis | Description |
| ---: | ---: | ---: | ---: | ---: | ---: | :--- |
| 0 | | | | | unfiltered | no search filter |
| | | | | ✓ | ambiguous | equivalent to either 0 or C |
| | | | ✓ | | redundant | equivalent to 2 |
| | | | ✓ | ✓ | redundant | equivalent to 1 |
| 3 | | ✓ | | | filtered | No known exploit |
| | | ✓ | | ✓ | redundant | equivalent to 0 |
| | | ✓ | ✓ | | impossible | false negative |
| | | ✓ | ✓ | ✓ | redundant | equivalent to 3 |
| 1 | ✓ | | | | filtered | Has a known exploit |
| C | ✓ | | | ✓ | confusing | Has a known exploit **but is not known** to be used in ransomware campaigns |
| 2 | ✓ | | ✓ | | filtered | Used in ransomware campaigns |
| | ✓ | | ✓ | ✓ | redundant | equivalent to 1 |
| | ✓ | ✓ | | | redundant| equivalent to 0 |
| | ✓ | ✓ | | ✓ | ambiguous | equivalent to either 0 or C |
| | ✓ | ✓ | ✓ | | redundant | equivalent to 2 |
| | ✓ | ✓ | ✓ | ✓ | redundant | equivalent to 0 |

Although 4 checkboxes implies 16 possibilities:
* mutually exclusive alternatives that are possible have 5 possibilities (pardon pun)
* thread in team Slack channel gave strong feedback that **but is not known** possibility is confusing and unlikely to be useful
* because no search filter corresponds to neither option selected, an alternative search filter has 3 mutually exclusive **non-checkbox** selection options:
    * Has a known exploit
    * Has a known exploit and is known to be used in ransomware campaigns
    * No known exploit

#### CompoundSearchFilterInputField

For `inputType: 'select'` component assumes:
* `hasCheckbox` prop for `SelectOption` element
* `CheckboxSelect` element

#### PatternFly Select

https://www.patternfly.org/components/menus/select/#single-select

The `value` argument implies selected, because there is no unselect.

Implication for search filter: delete search filter chip to unselect.

For compatibility with search filter convention that options are an array, callback function will be a hybrid of this and the following, because it pushes the selected option onto the **emptied** array.

```ts
  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
    // eslint-disable-next-line no-console
    console.log('selected', value);

    setSelected(value as string);
    setIsOpen(false);
  };
```

https://www.patternfly.org/components/menus/select/#checkbox-select

The `value` argument implies clicked, therefore current state determines whether select or unselect.

Implication for search filter: either click to clear checkbox or delete search filter chip to unselect.

```ts
  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
    // eslint-disable-next-line no-console
    console.log('selected', value);

    if (selectedItems.includes(value as number)) {
      setSelectedItems(selectedItems.filter((id) => id !== value));
    } else {
      setSelectedItems([...selectedItems, value as number]);
    }
  };
```

### Solution

1. Add `hasCheckbox` prop to `inputProps` object.
    For now to minimize changes, optional with `true` as default value.
2. Add conditional rendering in `CompoundSearchFilterInputField` component:
    * `hasCheckbox` prop for `SelectOption` element and `CheckboxSelect` element
    * `hasCheckbox={false}` prop for `SelectOption` element and `SelectSingle` element

### Residue

1. Make `hasCheckbox` prop required?

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

With temporary uncomment **Known exploit** search filter.

1. Visit /main/vulnerabilities/user-workloads and with **CVE** selected, select **Known exploit** to see options.
    <img width="1440" height="370" alt="WorkloadCvesOverviewPage_KnownExploit_2" src="https://github.com/user-attachments/assets/31b158cc-193f-401e-ade0-759c7fb79349" />

2. Select **Has a known exploit**
    See **Known exploit: Has a known exploit** in search filter chips
    See `s[Known%20Exploit][0]=HAS_KNOWN_EXPLOIT` in query string of page address
    See `Known Exploit:HAS_KNOWN_EXPLOIT` in `query` string of `variables` object in payload of `getImageCVEList` query
    <img width="1920" height="368" alt="WorkloadCvesOverviewPage_Has_a_known_expoit" src="https://github.com/user-attachments/assets/aa941585-c9ee-488e-bc58-ad14c9788a87" />

3. Select **Has a known exploit** again
    See no change in search filter chips
    See no change in query string of page address
    See no change in `query` string and so on

4. Select **No known exploit**
    See **Known exploit: No known exploit** in search filter chips
    See `s[Known%20Exploit][0]=NO_KNOWN_EXPLOIT` in query string of page address
    See `Known Exploit:NO_KNOWN_EXPLOIT` in `query` string of `variables` object in payload of `getImageCVEList` query
    <img width="1920" height="370" alt="WorkloadCvesOverviewPage_No_known_exploit" src="https://github.com/user-attachments/assets/83c00d13-9108-4f3a-a7ad-77fe3a3e75bb" />

5. Select **No known exploit** again
    See no change in search filter chips
    See no change in query string of page address
    See no change in `query` string and so on

6. Delete **Known exploit** filter chip.
    See absence of search filter chip.
    See absence of `s[Known%20Exploit][0]` in query string of page address
    See absence of `Known Exploit` in `query` string of `variables` object in payload of `getImageCVEList` query
    <img width="1920" height="374" alt="WorkloadCvesOverviewPage_Known_Exploit_unfiltered" src="https://github.com/user-attachments/assets/021e21d7-39ff-4330-b934-1ea30158ae2b" />

7. Select **Used in ransomware campaigns** (future)
    See **Known exploit: Used in ransomware campaigns** in search filter chips
    See `s[Known%20Exploit][0]=USED_IN_RANSOMWARE` in query string of page address
    See `Known Exploit:USED_IN_RANSOMWARE` in `query` string of `variables` object in payload of `getImageCVEList` query
<img width="1440" height="370" alt="WorkloadCvesOverviewPage_KnownExploit_3" src="https://github.com/user-attachments/assets/106e1672-48d0-46c7-92b2-236c24214a77" />
<img width="1920" height="421" alt="WorkloadCvesOverviewPage_Used_in_ransomware_campaigns" src="https://github.com/user-attachments/assets/0c75c979-c592-4eb7-96c3-a73cc42f6fce" />

8. Click **Images**, click a link, and then ditto.

9. Go back, click **Deployments**, click a link, and then ditto.

10. Comment out code and see absense of **Known exploit** search filter.
