### PR TITLE
chore: Bump Renovate PR limits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,12 @@
     // This tells Renovate to combine all updates in one PR so that we have fewer PRs to deal with.
     "group:all",
   ],
+  // The number of PRs that can be open against the repo.
+  "prConcurrentLimit": 20,
+  // `null` means the branch limit should be the same as PR limit.
+  "branchConcurrentLimit": null,
+  // The number of PRs MintMaker can open in one hour, effectively in one run.
+  "prHourlyLimit": 4,
   "timezone": "Etc/UTC",
   "schedule": [
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule


### PR DESCRIPTION
## Description

As we [start seeing](https://redhat-internal.slack.com/archives/CELUQKESC/p1758093948724879?thread_ts=1758016415.279099&cid=CELUQKESC) MintMaker getting alive again in StackRox, I remembered about this docs page https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#how-to-limit-the-number-of-prsmrs

We want to see all PRs in the StackRox repo since we have no automerge here and so I decided to bump the limits.

You can find out defaults and descriptions in docs:
- https://docs.renovatebot.com/configuration-options/#prhourlylimit
- https://docs.renovatebot.com/configuration-options/#prconcurrentlimit
- https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit

Please also keep in mind the default from MintMaker config:
- https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json#L17

`prConcurrentLimit` was calculated as following.
We have four active branches, `master` and three release streams. We have four types of PRs: Konflux tasks, our custom tasks, Dockerfiles and RPMs. Security update RPMs aren't counted against this limit. 4*4 plus some buffer makes 20 :-)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Only ran config validator.
