### PR TITLE
ROX-30875: Verify pod config-hash annotation in Operator Kuttl tests

### DIFF
--- a/operator/internal/common/confighash/pod_template_annotation.go
+++ b/operator/internal/common/confighash/pod_template_annotation.go
@@ -56,7 +56,6 @@ func applyPodTemplateAnnotationAndSerialize(rl kube.ResourceList, configHash str
 		switch obj := i.Object.(type) {
 		case *unstructuredapi.Unstructured:
 			kind := obj.GetKind()
-			// TODO(ROX-30875): Add a test to detect when new pod-creating resource types are introduced.
 			if kind == "Deployment" || kind == "DaemonSet" {
 				annotations, found, err := unstructuredapi.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
 				if err != nil {

--- a/operator/tests/common/config-hash-assert.yaml
+++ b/operator/tests/common/config-hash-assert.yaml
@@ -19,3 +19,13 @@ commands:
     # Run kuttl assert on the generated file
     ${KUTTL:-kubectl-kuttl} assert --namespace $NAMESPACE --timeout 30 $assert_file
     rm $assert_file
+    # Verify that each Stackrox pod has the expected config-hash annotation
+    mismatch_pods=$(retry-kubectl.sh get pods -n $NAMESPACE -o json | jq -r --arg hash "$config_hash" '[.items[]
+      | select(.metadata.labels["app.kubernetes.io/name"]=="stackrox")
+      | select(.metadata.annotations["app.stackrox.io/config-hash"] != $hash)
+      | .metadata.name] | @tsv')
+    if [ -n "$mismatch_pods" ]; then
+      echo "ERROR: Pods with missing or mismatched app.stackrox.io/config-hash:"
+      printf '%s\n' "$mismatch_pods"
+      exit 1
+    fi


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR checks that all the pods that belong to Stackrox have the correct config-hash annotation.
This makes sure that this test will fail if new workload types are added to ACS in the future, and we forget to add the config-hash to their pod template annotations.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI will test the happy flow.
Tested the error flow manually by executing the script with a wrong hash:
```
ERROR: Pods with missing or mismatched app.stackrox.io/config-hash:
admission-control-785d8f5f87-56n9k	admission-control-785d8f5f87-7vmx9	admission-control-785d8f5f87-9zhsw	central-55945d9fbd-j5sgw	central-db-76fcbf56b-f5fw4	collector-dj27m	collector-l6q4s	collector-mlm5j	collector-s4mbp	collector-sxhh5	collector-vzbds	config-controller-79cbbbf9b5-5tzhj	scanner-65f998b879-hnq2j	scanner-65f998b879-zwh6h	scanner-db-5f758b6668-pjsl2	scanner-v4-db-66654f8bf9-zm6px	scanner-v4-indexer-57b4b7b64-j26kn	scanner-v4-indexer-57b4b7b64-k8vmh	scanner-v4-matcher-7fc57bd46c-pdhfh	scanner-v4-matcher-7fc57bd46c-pqxgp	sensor-98c9947d5-r2rnp
```
