### PR TITLE
ROX-30937: Configure process baseline auto locking via roxctl

### DIFF
--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -230,7 +230,7 @@ func (m *managerImpl) isAutoLockEnabledForCluster(clusterId string) bool {
 		return false
 	}
 
-	if cluster.GetManagedBy() == storage.ManagerType_MANAGER_TYPE_MANUAL {
+	if cluster.GetManagedBy() == storage.ManagerType_MANAGER_TYPE_MANUAL || cluster.GetManagedBy() == storage.ManagerType_MANAGER_TYPE_UNKNOWN {
 		return cluster.GetDynamicConfig().GetAutoLockProcessBaselinesConfig().GetEnabled()
 	}
 

--- a/central/detection/lifecycle/manager_impl_test.go
+++ b/central/detection/lifecycle/manager_impl_test.go
@@ -56,6 +56,15 @@ var (
 			},
 		},
 	}
+
+	clusterAutolockUnknownEnabled = &storage.Cluster{
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_UNKNOWN,
+		DynamicConfig: &storage.DynamicClusterConfig{
+			AutoLockProcessBaselinesConfig: &storage.AutoLockProcessBaselinesConfig{
+				Enabled: true,
+			},
+		},
+	}
 )
 
 func TestManager(t *testing.T) {
@@ -287,6 +296,15 @@ func (suite *ManagerTestSuite) TestAutoLockProcessBaselinesManual() {
 
 	suite.T().Setenv(features.AutoLockProcessBaselines.EnvVar(), "true")
 	suite.cluster.EXPECT().GetCluster(gomock.Any(), clusterId).Return(clusterAutolockManualEnabled, true, nil)
+	enabled := suite.manager.isAutoLockEnabledForCluster(clusterId)
+	suite.True(enabled)
+}
+
+func (suite *ManagerTestSuite) TestAutoLockProcessBaselinesUnknown() {
+	clusterId := fixtureconsts.Cluster1
+
+	suite.T().Setenv(features.AutoLockProcessBaselines.EnvVar(), "true")
+	suite.cluster.EXPECT().GetCluster(gomock.Any(), clusterId).Return(clusterAutolockUnknownEnabled, true, nil)
 	enabled := suite.manager.isAutoLockEnabledForCluster(clusterId)
 	suite.True(enabled)
 }

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -652,6 +652,7 @@ function launch_sensor {
     fi
 
     if [[ "${SECURED_CLUSTER_AUTO_LOCK_PROCESS_BASELINES:-}" == "true" ]]; then
+        extra_config+=("--auto-lock-process-baselines=true")
         extra_helm_config+=(--set "autoLockProcessBaselines.enabled=true")
     fi
 

--- a/roxctl/maincommand/command_tree_debug.yaml
+++ b/roxctl/maincommand/command_tree_debug.yaml
@@ -2030,6 +2030,7 @@ sensor:
       - admission-controller-listen-on-updates
       - admission-controller-scan-inline
       - admission-controller-timeout
+      - auto-lock-process-baselines
       - central
       - collection-method
       - collector-image-repository
@@ -2070,6 +2071,7 @@ sensor:
         - admission-controller-listen-on-updates
         - admission-controller-scan-inline
         - admission-controller-timeout
+        - auto-lock-process-baselines
         - ca
         - central
         - collection-method
@@ -2111,6 +2113,7 @@ sensor:
         - admission-controller-listen-on-updates
         - admission-controller-scan-inline
         - admission-controller-timeout
+        - auto-lock-process-baselines
         - ca
         - central
         - collection-method

--- a/roxctl/maincommand/command_tree_release.yaml
+++ b/roxctl/maincommand/command_tree_release.yaml
@@ -1991,6 +1991,7 @@ sensor:
       - admission-controller-listen-on-updates
       - admission-controller-scan-inline
       - admission-controller-timeout
+      - auto-lock-process-baselines
       - central
       - collection-method
       - collector-image-repository
@@ -2031,6 +2032,7 @@ sensor:
         - admission-controller-listen-on-updates
         - admission-controller-scan-inline
         - admission-controller-timeout
+        - auto-lock-process-baselines
         - ca
         - central
         - collection-method
@@ -2072,6 +2074,7 @@ sensor:
         - admission-controller-listen-on-updates
         - admission-controller-scan-inline
         - admission-controller-timeout
+        - auto-lock-process-baselines
         - ca
         - central
         - collection-method

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -70,7 +70,7 @@ func defaultCluster() *storage.Cluster {
 				TimeoutSeconds:   0,
 			},
 			AutoLockProcessBaselinesConfig: &storage.AutoLockProcessBaselinesConfig{
-				Enabled:	false,
+				Enabled: false,
 			},
 		},
 	}

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -69,6 +69,9 @@ func defaultCluster() *storage.Cluster {
 				EnforceOnUpdates: true,
 				TimeoutSeconds:   0,
 			},
+			AutoLockProcessBaselinesConfig: &storage.AutoLockProcessBaselinesConfig{
+				Enabled:	false,
+			},
 		},
 	}
 }
@@ -222,6 +225,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-enforce-on-updates", warningAdmissionControllerEnforceOnUpdatesSet))
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerFailOnError, "admission-controller-fail-on-error", false, "Fail the admission review request in case of errors or timeouts in request evaluation.")
+	c.PersistentFlags().BoolVar(&generateCmd.cluster.DynamicConfig.AutoLockProcessBaselinesConfig.Enabled, "auto-lock-process-baselines", false, "Locks process baselines when their deployments leave the observation period")
 	c.PersistentFlags().BoolVar(&ac.EnforceOnUpdates, "admission-controller-enforcement", true, "Enforce security policies on the admission review request.")
 
 	c.MarkFlagsMutuallyExclusive("admission-controller-enforce-on-creates", "admission-controller-enforcement")

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -225,7 +225,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	utils.Must(c.PersistentFlags().MarkDeprecated("admission-controller-enforce-on-updates", warningAdmissionControllerEnforceOnUpdatesSet))
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerFailOnError, "admission-controller-fail-on-error", false, "Fail the admission review request in case of errors or timeouts in request evaluation.")
-	c.PersistentFlags().BoolVar(&generateCmd.cluster.DynamicConfig.AutoLockProcessBaselinesConfig.Enabled, "auto-lock-process-baselines", false, "Locks process baselines when their deployments leave the observation period")
+	c.PersistentFlags().BoolVar(&generateCmd.cluster.DynamicConfig.AutoLockProcessBaselinesConfig.Enabled, "auto-lock-process-baselines", false, "Locks process baselines when their deployments leave the observation period.")
 	c.PersistentFlags().BoolVar(&ac.EnforceOnUpdates, "admission-controller-enforcement", true, "Enforce security policies on the admission review request.")
 
 	c.MarkFlagsMutuallyExclusive("admission-controller-enforce-on-creates", "admission-controller-enforcement")


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds the ability to configure process baseline auto-locking via roxct.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Set the following environment variables

```
export SENSOR_HELM_DEPLOY=false
export SECURED_CLUSTER_AUTO_LOCK_PROCESS_BASELINES=true
export ROX_BASELINE_GENERATION_DURATION=3m
export ROX_AUTO_LOCK_PROCESS_BASELINES=true
```

Deployed ACS using the `deploy/deploy-local.sh`.

Got the cluster config using the following script

```
#!/usr/bin/env bash
set -eou pipefail

ROX_ENDPOINT=${1:-https://localhost:8000}

json_clusters="$(curl --location --silent --request GET "${ROX_ENDPOINT}/v1/clusters" -k -H "Authorization: Bearer $ROX_API_TOKEN")"

echo "$json_clusters" | jq
```

The results was the following
```
{
  "clusters": [
    {
      "id": "165e6d5e-10f6-4bf4-90e0-4804ebccedb6",
      "name": "remote",
      "type": "KUBERNETES_CLUSTER",
      "labels": {},
      "mainImage": "quay.io/rhacs-eng/main",
      "collectorImage": "",
      "centralApiEndpoint": "central.stackrox:443",
      "runtimeSupport": true,
      "collectionMethod": "CORE_BPF",
      "admissionController": true,
      "admissionControllerUpdates": true,
      "admissionControllerEvents": true,

...

      "dynamicConfig": {
        "admissionControllerConfig": {
          "enabled": true,
          "timeoutSeconds": 10,
          "scanInline": true,
          "disableBypass": false,
          "enforceOnUpdates": true
        },
        "registryOverride": "",
        "disableAuditLogs": true,
        "autoLockProcessBaselinesConfig": {
          "enabled": true
        }
      },

...

      "helmConfig": null,

...

      "managedBy": "MANAGER_TYPE_UNKNOWN",
      "sensorCapabilities": [
        "AuditLogEvents",
        "CancelTelemetryPull",
        "ComplianceInNodes",
        "ComplianceV2ScanConfigSync",
        "HealthMonitoring",
        "NetworkGraphExternalSrcs",
        "PullMetrics",
        "PullTelemetryData",
        "SendDeduperStateOnReconnect",
        "SensorDetection",
        "SensorEnhancedDeploymentCheck"
      ],
      "admissionControllerFailOnError": false
    }
  ],
  "clusterIdToRetentionInfo": {}
}
```

The process baseline auto-locking feature is enabled in the dynamic config section. The helm config section is null. The manager type is `MANAGER_TYPE_UNKNOWN`.

Created a deployment

```
kubectl run ubuntu-pod --image=ubuntu --restart=Never --command -- sleep infinity
```

<img width="1917" height="923" alt="image" src="https://github.com/user-attachments/assets/5af8d178-8573-4f6b-9efe-2cc72828e636" />

The process baseline was locked after three minutes.