### PR TITLE
chore(ci): skip compliance ns count test

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
@@ -14,7 +14,8 @@ import { selectors } from './Compliance.selectors';
 describe('Compliance entities list', () => {
     withAuth();
 
-    it('should filter namespaces table with passing controls', () => {
+    // TODO: ROX-30939: fix test for OCP4.20 "1 namespace" (openshift-cloud-credential-operator)
+    it.skip('should filter namespaces table with passing controls', () => {
         triggerScan(); // in case complianceDashboard.test.js is skipped
         visitComplianceEntities('namespaces');
 


### PR DESCRIPTION
This test fails in openshift-4.20 because there is "1 namespace" in the compliant results instead of "0 namespaces".

https://issues.redhat.com/browse/ROX-30939