### PR TITLE
ROX-30947: Distinguish warning from information for sensor upgrade

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
@@ -55,12 +55,14 @@ function SensorUpgradePanel({
                                 <SensorUpgrade upgradeStatus={upgradeStatus} />
                             </DescriptionListDescription>
                         </DescriptionListGroup>
-                        <DescriptionListGroup>
-                            <DescriptionListTerm>Status reasoning</DescriptionListTerm>
-                            <DescriptionListDescription>
-                                {statusReason || 'Unknown'}
-                            </DescriptionListDescription>
-                        </DescriptionListGroup>
+                        {statusReason && (
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Sensor information</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {statusReason}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        )}
                         {actionProps && (
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Available action</DescriptionListTerm>

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -340,7 +340,7 @@ describe('cluster helpers', () => {
             expect(received).toEqual(expected);
         });
 
-        it(`should return "Secured cluster version is not managed by ${getProductBranding().shortName}." if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
+        it(`should return "Sensor is not running the same version as Central" if upgradeStatus -> upgradability is MANUAL_UPGRADE_REQUIRED`, () => {
             const testUpgradeStatus = {
                 upgradability: 'MANUAL_UPGRADE_REQUIRED',
             };
@@ -348,7 +348,7 @@ describe('cluster helpers', () => {
             const received = findUpgradeState(testUpgradeStatus);
 
             const expected = {
-                displayValue: `Secured cluster version is not managed by ${getProductBranding().shortName}.`,
+                displayValue: 'Sensor is not running the same version as Central',
                 type: 'intervention',
             };
             expect(received).toEqual(expected);

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -1,5 +1,3 @@
-import { getProductBranding } from 'constants/productBranding';
-
 import {
     findUpgradeState,
     formatSensorVersion,

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -16,7 +16,6 @@ import {
 
 import { Cluster, ClusterHealthStatusLabel, ClusterProviderMetadata } from 'types/cluster.proto';
 import { getDate, getDistanceStrict } from 'utils/dateUtils';
-import { getProductBranding } from 'constants/productBranding';
 
 import { healthStatusLabels } from './cluster.constants';
 import { CertExpiryStatus } from './clusterTypes';
@@ -211,7 +210,7 @@ const upgradeStates: UpgradeStates = {
         type: 'current',
     },
     MANUAL_UPGRADE_REQUIRED: {
-        displayValue: `Secured cluster version is not managed by ${getProductBranding().shortName}.`,
+        displayValue: 'Sensor is not running the same version as Central',
         type: 'intervention',
     },
     UPGRADE_AVAILABLE: {


### PR DESCRIPTION
## Description

Over-communicate relationship between solution and problem to reduce the probability that we revisit this issue again within the next year.

### Problem

Slack comment in team public channel from **Michael Hess**:

> A colleague of ours recently tried out ACS CS with an older Secured Cluster to simulate a possible on-prem to cloud migration for their customer.

> While doing so, they noticed that the secured cluster page is giving them a warning.

> They raised the question why they were seeing a warning about the Operator controlling upgrades. I somewhat agree, as to the best of my understanding this setup is best practice (operator governs auto upgrades) so the warning is misleading.

> I am also wondering if the warning is actually triggered by secured cluster being Operator controlled, or if it is due to the version of the secured cluster being outdated. If it is the latter, can we maybe change so that the warning accordingly?

### Analysis

Secured cluster:
* **outdated** is cause for warning
* **Operator controlled** is supporting information

### History

Original problem:

> Customers see "Manual Upgrade Required" on their clusters page whenever Central and Secured Clusters versions mismatch. The word "Upgrade" is used, even if the Secured Cluster is on a **newer** version than Central.

> With ACS Cloud Service, Central is often on a point release that is behind the current available latest version. Customers using the Operator to auto-upgrade their Secured Clusters see that version advancing while ACS CS waits to adopt the new version.

Original changes to solve these problems:
* emphasizes that customers update sensor version via Helm or Operator, but because of warning style, this seems like a problem
* leaves implicit the contrast (with sentence for success style) that sensor and central do not have the same version

Observation:
* One side of coin: Perhaps for lack of a clear and concise alternative, changes did not include replacement of **upgrade** in the table column heading (even though for cloud service customers, the solution to version difference might be wait for central to catch up with sensor).
* Other side of coin: That has not (yet) been reported as a problem.

### Solution

Frontend changes only. No changes to backend code nor /v1/clusters responses.

1. Replace first text for `MANUAL_UPGRADE_REQUIRED` to be explicit.

    Sensor is not running the same version as Central

    By the way, only one letter longer than the replaced text.

2. Replace second label which originally implied that sentence is problem explanation to be more neutral because sentence has become supporting information.

    **Sensor information**

### Residue

1. Investigate with help of dog food cloud service instance scenario that sensor has newer version than central.

    I see a backend status that is converted by frontend in a way that might confuse.

2. Search whether or not upgrade states related to progress of manifest installations still exist.

    Maybe (above mentioned) conversion by frontend caused me to lose the trail.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Integration tests are already skipped pending rewrite for PatternFly

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

Thank you **Moritz** for out-of-date secured clusters left-over from admission controller configuration testing.

1. Visit /main/clusters and scroll to cluster for which sensor version is **up to date**.

    Collapsed row has same text before and after changes.
    <img width="1440" height="140" alt="UP_TO_DATE_collapsed" src="https://github.com/user-attachments/assets/e0cd80d6-1878-4dda-a02f-fe3aac8cb992" />

    Expanded row has **Status reasoning** label before changes.
    <img width="1440" height="610" alt="UP_TO_DATE_expanded_baseline" src="https://github.com/user-attachments/assets/87eece3d-a167-4e0c-9729-f978d44d7f44" />

    Expanded row has **Sensor information** label before changes.
    <img width="1439" height="594" alt="UP_TO_DATE_expanded_improved" src="https://github.com/user-attachments/assets/221d7f97-9b13-41ef-ba41-6c84a30277fa" />

2. Scroll to cluster that has **Helm** installation method for which sensor version is **out of date**.

    Collapsed row has text that is unexpected (from field viewpoint) before changes.
    <img width="1440" height="160" alt="MANUAL_UPGRADE_REQUIRED_Helm_collapsed_baseline" src="https://github.com/user-attachments/assets/4cefd271-3138-41fe-9795-34d0f2531067" />

    Collapsed row has text that describes reason for warning after changes.
    <img width="1440" height="140" alt="MANUAL_UPGRADE_REQUIRED_Helm_collapsed_improved" src="https://github.com/user-attachments/assets/77ca7632-6f95-4e20-8f8c-94ad9a170972" />

    Expanded row has **Status reasoning** label before changes.
    <img width="1439" height="616" alt="MANUAL_UPGRADE_REQUIRED_Helm_expanded_baseline" src="https://github.com/user-attachments/assets/b1869654-3d39-4d0f-9d94-afa6a2f70896" />

    Expanded row has **Sensor information** label before changes.
    <img width="1440" height="596" alt="MANUAL_UPGRADE_REQUIRED_Helm_expanded_improved" src="https://github.com/user-attachments/assets/f772179c-4987-46df-b8e6-33e848131fff" />

3. Scroll to cluster that has **Operator** installation method for which sensor version is **out of date**.

    Collapsed row has text that is unexpected (from field viewpoint) before changes.
    <img width="1440" height="149" alt="MANUAL_UPGRADE_REQUIRED_Operator_collapsed_baseline" src="https://github.com/user-attachments/assets/29bdaa2d-bbe3-4787-ba07-30abba613d52" />

    Collapsed row has text that describes reason for warning after changes.
    <img width="1440" height="140" alt="MANUAL_UPGRADE_REQUIRED_Operator_collapsed_improved" src="https://github.com/user-attachments/assets/66b21f22-97e7-4351-9bfe-bd683e2a8aa4" />

    Expanded row has **Status reasoning** label before changes.
    <img width="1440" height="616" alt="MANUAL_UPGRADE_REQUIRED_Operator_expanded_baseline" src="https://github.com/user-attachments/assets/c3d66d0a-fcbe-431d-8109-637306872dbc" />

    Expanded row has **Sensor information** label before changes.
    <img width="1440" height="583" alt="MANUAL_UPGRADE_REQUIRED_Operator_expanded_improved" src="https://github.com/user-attachments/assets/8dd65ba5-bd8a-43ce-bee2-fa4c2a5e1100" />