### PR TITLE
ROX-29532: Known not affected enricher: Chunking records

### DIFF
--- a/scanner/enricher/notaffected/integration_test.go
+++ b/scanner/enricher/notaffected/integration_test.go
@@ -1,0 +1,212 @@
+//go:build scanner_db_integration
+
+package notaffected
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/datastore/postgres"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/zlog"
+	"github.com/stackrox/rox/pkg/scannerv4/enricher/notaffected"
+	roxpostgres "github.com/stackrox/rox/scanner/datastore/postgres"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testDB(t *testing.T, ctx context.Context, name string) *pgxpool.Pool {
+	t.Helper()
+
+	pgConn := "postgresql://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable"
+	pgPool, err := postgres.Connect(ctx, pgConn, name)
+	require.NoError(t, err)
+	createDatabase := `CREATE DATABASE ` + name
+	_, err = pgPool.Exec(ctx, createDatabase)
+	require.NoError(t, err)
+	t.Cleanup(pgPool.Close)
+
+	dbConn := fmt.Sprintf("postgresql://postgres:postgres@127.0.0.1:5432/%s?sslmode=disable", name)
+	dbPool, err := postgres.Connect(ctx, dbConn, name)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		dropDatabase := `DROP DATABASE IF EXISTS ` + name
+		_, _ = pgPool.Exec(ctx, dropDatabase)
+	})
+	t.Cleanup(dbPool.Close)
+
+	return dbPool
+}
+
+func TestNotAffectedIntegration(t *testing.T) {
+	ctx := zlog.Test(context.Background(), t)
+	pool := testDB(t, ctx, "notaffected_integration_test")
+
+	store, err := roxpostgres.InitPostgresMatcherStore(ctx, pool, true)
+	require.NoError(t, err)
+
+	serverURL, httpClient := ServeSecDB(t, "testdata/server.txtar")
+	enricher := &Enricher{}
+
+	err = enricher.Configure(ctx, func(v interface{}) error {
+		cfg := v.(*Config)
+		cfg.URL = serverURL + "/"
+		cfg.MaxCVEsPerRecord = 5
+		return nil
+	}, httpClient)
+	require.NoError(t, err)
+
+	data, fingerprint, err := enricher.FetchEnrichment(ctx, "")
+	require.NoError(t, err)
+	defer data.Close()
+	require.NotEmpty(t, fingerprint, "Fingerprint should not be empty")
+
+	records, err := enricher.ParseEnrichment(ctx, data)
+	require.NoError(t, err)
+	require.NotEmpty(t, records, "Should have parsed enrichment records")
+
+	_, err = store.UpdateEnrichments(ctx, enricher.Name(), fingerprint, records)
+	require.NoError(t, err, "Failed to store enrichments in database")
+
+	getter := &storeEnrichmentGetter{store: store, enricherName: enricher.Name()}
+
+	t.Run("Red Hat Image Gets Enrichments", func(t *testing.T) {
+		vr := createRedHatVulnReport()
+
+		enrichmentType, data, err := enricher.Enrich(ctx, getter, vr)
+		require.NoError(t, err)
+
+		assert.Equal(t, notaffected.Type, enrichmentType)
+		require.NotEmpty(t, data, "Should have enrichment data from database")
+
+		var enrichments map[string][]json.RawMessage
+		err = json.Unmarshal(data[0], &enrichments)
+		require.NoError(t, err)
+
+		var cveList []string
+
+		// Check all Red Hat products.
+		assert.Contains(t, enrichments, notaffected.RedHatProducts)
+		redHatEnrichments := enrichments[notaffected.RedHatProducts]
+		require.NotEmpty(t, redHatEnrichments, "Should have enrichments for red_hat_products")
+		err = json.Unmarshal(redHatEnrichments[0], &cveList)
+		require.NoError(t, err)
+		assert.Contains(t, cveList, "CVE-2024-21613", "Should contain CVE from fixture")
+
+		// Check specific not-affected for RHACS.
+		assert.Contains(t, enrichments, notaffected.RedHatProducts)
+		acsEnrichments := enrichments["advanced-cluster-security/rhacs-scanner-v4-rhel8"]
+		require.NotEmpty(t, acsEnrichments, "Should have enrichments for red_hat_products")
+		err = json.Unmarshal(acsEnrichments[0], &cveList)
+		require.NoError(t, err)
+		assert.Contains(t, cveList, "CVE-2025-7783", "Should contain CVE-2025-7783 for ACS roxctl product")
+
+	})
+
+	t.Run("Non Red Hat Image Gets No Enrichments", func(t *testing.T) {
+		vr := createUbuntuVulnReport()
+
+		enrichmentType, enrichments, err := enricher.Enrich(ctx, getter, vr)
+		require.NoError(t, err)
+		assert.Equal(t, notaffected.Type, enrichmentType)
+		assert.Empty(t, enrichments, "Non-Red Hat image should get no enrichments")
+	})
+
+	t.Run("Database Error Handling", func(t *testing.T) {
+		vr := createRedHatVulnReport()
+		brokenGetter := &errorEnrichmentGetter{}
+		enrichmentType, enrichments, err := enricher.Enrich(ctx, brokenGetter, vr)
+		require.Error(t, err, "Should propagate database errors")
+		assert.Equal(t, notaffected.Type, enrichmentType)
+		assert.Empty(t, enrichments)
+	})
+}
+
+type storeEnrichmentGetter struct {
+	store        roxpostgres.MatcherStore
+	enricherName string
+}
+
+func (g *storeEnrichmentGetter) GetEnrichment(ctx context.Context, tags []string) ([]driver.EnrichmentRecord, error) {
+	return g.store.GetEnrichment(ctx, g.enricherName, tags)
+}
+
+type errorEnrichmentGetter struct{}
+
+func (g *errorEnrichmentGetter) GetEnrichment(ctx context.Context, tags []string) ([]driver.EnrichmentRecord, error) {
+	return nil, assert.AnError
+}
+
+func createUbuntuVulnReport() *claircore.VulnerabilityReport {
+	ubuntuRepo := &claircore.Repository{
+		Name: "ubuntu",
+		Key:  "ubuntu-key",
+		URI:  "http://archive.ubuntu.com/ubuntu",
+	}
+	pkg := &claircore.Package{
+		ID:      "pkg1",
+		Name:    "libc6",
+		Version: "2.31-0ubuntu9.9",
+		Kind:    "binary",
+		Arch:    "amd64",
+	}
+	env := []*claircore.Environment{
+		{
+			PackageDB:     "var/lib/dpkg/status",
+			IntroducedIn:  claircore.MustParseDigest("sha256:fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"),
+			RepositoryIDs: []string{"repo1"},
+		},
+	}
+	return &claircore.VulnerabilityReport{
+		Packages: map[string]*claircore.Package{
+			"pkg1": pkg,
+		},
+		Repositories: map[string]*claircore.Repository{
+			"repo1": ubuntuRepo,
+		},
+		Environments: map[string][]*claircore.Environment{
+			"pkg1": env,
+		},
+		Vulnerabilities:        make(map[string]*claircore.Vulnerability),
+		PackageVulnerabilities: make(map[string][]string),
+	}
+}
+
+func createRedHatVulnReport() *claircore.VulnerabilityReport {
+	acsRepo := &claircore.Repository{
+		ID:   "1",
+		Name: "Red Hat Container Catalog",
+		URI:  "https://catalog.redhat.com/software/containers/explore",
+	}
+	pkg := &claircore.Package{
+		ID:      "1",
+		Name:    "advanced-cluster-security/rhacs-scanner-v4-rhel8",
+		Version: "4.8.0-5",
+		Kind:    "binary",
+		Arch:    "x86_64",
+	}
+	env := []*claircore.Environment{
+		{
+			PackageDB:     "root/buildinfo/Dockerfile-rhacs-scanner-v4-rhel8-4.8.0-5",
+			IntroducedIn:  claircore.MustParseDigest("sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456789a"),
+			RepositoryIDs: []string{"1"},
+		},
+	}
+	return &claircore.VulnerabilityReport{
+		Packages: map[string]*claircore.Package{
+			"1": pkg,
+		},
+		Repositories: map[string]*claircore.Repository{
+			"1": acsRepo,
+		},
+		Environments: map[string][]*claircore.Environment{
+			"1": env,
+		},
+		Vulnerabilities:        make(map[string]*claircore.Vulnerability),
+		PackageVulnerabilities: make(map[string][]string),
+	}
+}

--- a/scanner/enricher/notaffected/notaffected.go
+++ b/scanner/enricher/notaffected/notaffected.go
@@ -28,10 +28,11 @@ const (
 	// baseURL is the base url for the Red Hat VEX security data.
 	baseURL = "https://security.access.redhat.com/data/csaf/v2/vex/"
 
-	latestFile     = "archive_latest.txt"
-	changesFile    = "changes.csv"
-	lookBackToYear = 2014
-	updaterVersion = "4"
+	latestFile              = "archive_latest.txt"
+	changesFile             = "changes.csv"
+	lookBackToYear          = 2014
+	updaterVersion          = "4"
+	defaultMaxCVEsPerRecord = 1000
 )
 
 var (
@@ -48,6 +49,10 @@ type Enricher struct {
 	driver.NoopUpdater
 	c    *http.Client
 	base *url.URL
+
+	// maxCVEsPerRecord limits how many CVEs are encoded in a single enrichment
+	// record. A value of 0 uses the default.
+	maxCVEsPerRecord int
 }
 
 // NewFactory creates a Factory for the Not Affected enricher.
@@ -62,15 +67,20 @@ type Config struct {
 	// URL indicates the base URL for the VEX.
 	//
 	// Must include the trailing slash.
-	URL string `json:"url" yaml:"url"`
+	URL              string `json:"url" yaml:"url"`
+	MaxCVEsPerRecord int    `json:"max_cves_per_record" yaml:"max_cves_per_record"`
 }
 
 // Configure implements driver.Configurable.
 func (e *Enricher) Configure(_ context.Context, f driver.ConfigUnmarshaler, c *http.Client) error {
 	e.c = c
+	e.maxCVEsPerRecord = defaultMaxCVEsPerRecord
 	var cfg Config
 	if err := f(&cfg); err != nil {
 		return err
+	}
+	if cfg.MaxCVEsPerRecord > 0 {
+		e.maxCVEsPerRecord = cfg.MaxCVEsPerRecord
 	}
 	u := baseURL
 	if cfg.URL != "" {
@@ -98,7 +108,7 @@ func (*Enricher) Name() string {
 func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *claircore.VulnerabilityReport) (string, []json.RawMessage, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "enricher/notaffected/Enricher/Enrich")
 
-	// Fetch the repository ID which identifies this image as a (or based on a) Red Hat image.
+	// Find the repository ID which identifies this image as a (or based on a) Red Hat product.
 	var rhccID string
 	for id, repo := range r.Repositories {
 		if repo.Key == repositoryKey || repo.Name == legacyRHCCRepoName && repo.URI == legacyRHCCRepoURI {
@@ -107,16 +117,14 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 		}
 	}
 	if rhccID == "" {
-		// Not an official Red Hat image nor based on one.
+		// Not an official Red Hat product nor based on one.
 		return notaffected.Type, nil, nil
 	}
 
-	// Identify the name of each discovered Red Hat image.
-	// In the past, this would have identified not only the final
-	// Red Hat image, but also the images on which that final image
-	// was based.
-	// At this time, we expect to only find a single name here,
-	// which would be the final Red Hat image name.
+	// Identify the name of each discovered Red Hat image by the RHCC repository
+	// scanner. Notice that for older image RH builds this can identify not only the
+	// final Red Hat image, but also the images on which that final image was based.
+	// We don't expect this on current images.
 	pkgIDs := set.NewStringSet()
 	for pkgID, envs := range r.Environments {
 		for _, env := range envs {
@@ -137,13 +145,15 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 	}
 
 	m := make(map[string][]json.RawMessage)
+	// Include the special "red_hat_products" package (or product version in VEX
+	// terms), it's a wildcard for "all red hat products".
 	for _, pkgName := range append(pkgNames, notaffected.RedHatProducts) {
 		ts := []string{pkgName}
 		rec, err := g.GetEnrichment(ctx, ts)
 		if err != nil {
 			return notaffected.Type, nil, err
 		}
-
+		// We expect more than one record since we chunk them during parsing.
 		for _, r := range rec {
 			m[pkgName] = append(m[pkgName], r.Enrichment)
 		}

--- a/scanner/enricher/notaffected/parser.go
+++ b/scanner/enricher/notaffected/parser.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"iter"
 	"strings"
 
 	"github.com/klauspost/compress/snappy"
@@ -24,62 +25,110 @@ import (
 // TODO: This is defined in Claircore's rhcc package in versions post-v1.5.39.
 const repositoryKey = "rhcc-container-repository"
 
+// record represents enrichment data of a chunk of non-affected CVEs for a
+// given product.
+type record struct {
+	prod  string
+	chunk int
+	cves  []string
+}
+
+// EnrichmentRecord marshals a record into a driver.EnrichmentRecord
+func (r *record) EnrichmentRecord() (*driver.EnrichmentRecord, error) {
+	b, err := json.Marshal(r.cves)
+	if err != nil {
+		return nil, err
+	}
+	return &driver.EnrichmentRecord{
+		Tags: []string{
+			r.prod,
+			fmt.Sprintf("%s:%d", r.prod, r.chunk),
+		},
+		Enrichment: b,
+	}, nil
+}
+
+// parseRecords parses VEX data to yield records for each chunk of non-affected enrichment data (i.e., a record).
+func (e *Enricher) parseRecords(ctx context.Context, contents io.ReadCloser) iter.Seq2[*record, error] {
+	ctx = zlog.ContextWithValues(ctx, "component", "enricher/notaffected/Enricher/parseRecords")
+	return func(yield func(*record, error) bool) {
+		pc := newProductCache()
+		chunks := make(map[string]*record)
+
+		r := bufio.NewReader(snappy.NewReader(contents))
+		for b, err := r.ReadBytes('\n'); err == nil; b, err = r.ReadBytes('\n') {
+			c, err := csaf.Parse(bytes.NewReader(b))
+			if err != nil {
+				yield(nil, fmt.Errorf("error parsing CSAF: %w", err))
+				return
+			}
+			if c.Document.Tracking.Status == "deleted" {
+				continue
+			}
+			var selfLink string
+			for _, r := range c.Document.References {
+				if r.Category == "self" {
+					selfLink = r.URL
+				}
+			}
+			ctx = zlog.ContextWithValues(ctx, "link", selfLink)
+			creator := newCreator(c, pc)
+			for _, v := range c.Vulnerabilities {
+				prods, err := creator.knownNotAffectedVulnerabilities(ctx, v)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				for _, prod := range prods {
+					// Get or create current chunk for this product.
+					chunk := chunks[prod]
+					if chunk == nil {
+						chunk = &record{prod: prod, chunk: 0}
+						chunks[prod] = chunk
+					}
+					// Add CVE to current chunk.
+					chunk.cves = append(chunk.cves, v.CVE)
+					// If we've reached the chunk size, yield the record.
+					if len(chunk.cves) == e.maxCVEsPerRecord {
+						// Reset to new chunk for next batch.
+						chunks[prod] = &record{
+							prod:  prod,
+							chunk: chunk.chunk + 1,
+						}
+						if !yield(chunk, nil) {
+							return
+						}
+					}
+				}
+			}
+		}
+		// Yield any remaining data.
+		for _, chunk := range chunks {
+			if len(chunk.cves) > 0 {
+				if !yield(chunk, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
 // ParseEnrichment implements driver.EnrichmentUpdater.
 // The contents should be a line-delimited list of CSAF data, all of which is Snappy-compressed.
 // This method parses out the data the enricher cares about and marshals the result into JSON.
 func (e *Enricher) ParseEnrichment(ctx context.Context, contents io.ReadCloser) ([]driver.EnrichmentRecord, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "enricher/notaffected/Enricher/ParseEnrichment")
-
-	pc := newProductCache()
-
-	records := make(map[string][]string)
-
-	r := bufio.NewReader(snappy.NewReader(contents))
-	for b, err := r.ReadBytes('\n'); err == nil; b, err = r.ReadBytes('\n') {
-		c, err := csaf.Parse(bytes.NewReader(b))
-		if err != nil {
-			return nil, fmt.Errorf("error parsing CSAF: %w", err)
-		}
-		if c.Document.Tracking.Status == "deleted" {
-			continue
-		}
-
-		var selfLink string
-		for _, r := range c.Document.References {
-			if r.Category == "self" {
-				selfLink = r.URL
-			}
-		}
-		ctx = zlog.ContextWithValues(ctx, "link", selfLink)
-
-		creator := newCreator(c, pc)
-		for _, v := range c.Vulnerabilities {
-			prods, err := creator.knownNotAffectedVulnerabilities(ctx, v)
-			if err != nil {
-				return nil, err
-			}
-			for _, prod := range prods {
-				records[prod] = append(records[prod], v.CVE)
-			}
-		}
-	}
-
-	out := make([]driver.EnrichmentRecord, 0, len(records))
-	for name, record := range records {
-		// TODO: Figure out how to handle this
-		if name == notaffected.RedHatProducts {
-			continue
-		}
-		b, err := json.Marshal(record)
+	var out []driver.EnrichmentRecord
+	for r, err := range e.parseRecords(ctx, contents) {
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, driver.EnrichmentRecord{
-			Tags:       []string{name},
-			Enrichment: b,
-		})
+		er, err := r.EnrichmentRecord()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *er)
 	}
-
 	return out, nil
 }
 

--- a/scanner/enricher/notaffected/parser_test.go
+++ b/scanner/enricher/notaffected/parser_test.go
@@ -2,14 +2,19 @@ package notaffected
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/klauspost/compress/snappy"
 	"github.com/package-url/packageurl-go"
+	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/toolkit/types/csaf"
 )
 
@@ -339,4 +344,397 @@ func TestExtractPackageName(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_ParseEnrichment_SingleProduct tests chunking behavior for individual products with various chunk sizes.
+func Test_ParseEnrichment_SingleProduct(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		maxCVEsPerRecord int
+		productName      string
+		numCVEs          int
+	}{
+		{
+			name:             "single CVE per record",
+			maxCVEsPerRecord: 1,
+			productName:      "single-product",
+			numCVEs:          5,
+		},
+		{
+			name:             "multiple CVEs per record",
+			maxCVEsPerRecord: 3,
+			productName:      "multi-cve-product",
+			numCVEs:          7, // should create 3 records (3+3+1)
+		},
+		{
+			name:             "large chunk size",
+			maxCVEsPerRecord: 10,
+			productName:      "large-chunk-product",
+			numCVEs:          5, // should create 1 record
+		},
+		{
+			name:             "product with special chars",
+			maxCVEsPerRecord: 2,
+			productName:      "product-with-dashes/and-slashes",
+			numCVEs:          4, // should create 2 records (2+2)
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create enricher.
+			enricher := &Enricher{maxCVEsPerRecord: tc.maxCVEsPerRecord}
+			// Create CSAF structure.
+			testData := csafAdvisory(map[string]int{tc.productName: tc.numCVEs})
+			// Marshall into JSON.
+			var buf bytes.Buffer
+			sw := snappy.NewBufferedWriter(&buf)
+			_, err := sw.Write([]byte(testData))
+			if err != nil {
+				t.Fatalf("failed to write test data: %v", err)
+			}
+			if err = sw.Close(); err != nil {
+				t.Fatalf("failed to close test data writer: %v", err)
+			}
+			// Run.
+			records, err := enricher.ParseEnrichment(context.Background(), io.NopCloser(&buf))
+			if err != nil {
+				t.Fatalf("failed to parse enrichment: %v", err)
+			}
+
+			// Check expected number of chunks.
+			expectedChunks := (tc.numCVEs + tc.maxCVEsPerRecord - 1) / tc.maxCVEsPerRecord
+			if len(records) != expectedChunks {
+				t.Errorf("expected %d chunks, got %d", expectedChunks, len(records))
+			}
+			// Check product and chunk content.
+			uniqueProducts := make(map[string]bool)
+			totalCVEs := 0
+			for i, record := range records {
+				// Unmarshal CVEs from enrichment data.
+				var cves []string
+				if err := json.Unmarshal(record.Enrichment, &cves); err != nil {
+					t.Fatalf("failed to unmarshal enrichment: %v", err)
+				}
+				// Check tags.
+				if len(record.Tags) < 2 {
+					t.Errorf("record missing expected tags: %v", record.Tags)
+					continue
+				}
+				// Check product name.
+				productName := record.Tags[0]
+				if productName != tc.productName {
+					t.Errorf("expected product name %s, got %s", tc.productName, productName)
+				}
+				uniqueProducts[productName] = true
+				// Chunk chunk tag.
+				chunkTag := record.Tags[1]
+				expectedTag := tc.productName + ":" + strconv.Itoa(i)
+				if chunkTag != expectedTag {
+					t.Errorf("chunk %d: expected tag %s, got %s", i, expectedTag, chunkTag)
+				}
+				// Check chunk size, ensure last one is handled differently (it should have remaining CVEs).
+				if i == len(records)-1 {
+					expectedLastChunk := tc.numCVEs % tc.maxCVEsPerRecord
+					if expectedLastChunk == 0 {
+						expectedLastChunk = tc.maxCVEsPerRecord
+					}
+					if len(cves) != expectedLastChunk {
+						t.Errorf("last chunk: expected %d CVEs, got %d", expectedLastChunk, len(cves))
+					}
+				} else {
+					if len(cves) != tc.maxCVEsPerRecord {
+						t.Errorf("chunk %d: expected %d CVEs, got %d", i, tc.maxCVEsPerRecord, len(cves))
+					}
+				}
+				totalCVEs += len(cves)
+			}
+			// Validate total CVE count
+			if totalCVEs != tc.numCVEs {
+				t.Errorf("total CVEs mismatch: expected %d, got %d", tc.numCVEs, totalCVEs)
+			}
+			t.Logf("Processed %d records for product %s with %d total CVEs", len(records), tc.productName, totalCVEs)
+		})
+	}
+}
+
+// Test_ParseEnrichment_MultipleProducts tests chunking behavior when multiple products are processed together.
+func Test_ParseEnrichment_MultipleProducts(t *testing.T) {
+	enricher := &Enricher{maxCVEsPerRecord: 2}
+	testData := csafAdvisory(map[string]int{
+		"product-a": 5, // Should create 3 chunks: [2, 2, 1]
+		"product-b": 3, // Should create 2 chunks: [2, 1]
+		"product-c": 2, // Should create 1 chunk: [2]
+	})
+	var buf bytes.Buffer
+	sw := snappy.NewBufferedWriter(&buf)
+	_, err := sw.Write([]byte(testData))
+	if err != nil {
+		t.Fatalf("failed to write test data: %v", err)
+	}
+	if err = sw.Close(); err != nil {
+		t.Fatalf("failed to close snappy writer: %v", err)
+	}
+	records, err := enricher.ParseEnrichment(context.Background(), io.NopCloser(&buf))
+	if err != nil {
+		t.Fatalf("failed to parse enrichment: %v", err)
+	}
+	productRecords := make(map[string][]driver.EnrichmentRecord)
+	for _, record := range records {
+		if len(record.Tags) > 0 {
+			productName := strings.Split(record.Tags[0], ":")[0]
+			productRecords[productName] = append(productRecords[productName], record)
+		}
+	}
+	expectedChunks := map[string]int{
+		"product-a": 3, // 5 CVEs with chunk size 2 = 3 chunks
+		"product-b": 2, // 3 CVEs with chunk size 2 = 2 chunks
+		"product-c": 1, // 2 CVEs with chunk size 2 = 1 chunk
+	}
+	for product, expectedCount := range expectedChunks {
+		if got := len(productRecords[product]); got != expectedCount {
+			t.Errorf("product %s: expected %d chunks, got %d", product, expectedCount, got)
+		}
+		// Validate chunk tags are correct.
+		for i, record := range productRecords[product] {
+			expectedTag := product + ":" + string(rune('0'+i))
+			if len(record.Tags) < 2 || record.Tags[1] != expectedTag {
+				t.Errorf("product %s chunk %d: expected tag %s, got %v", product, i, expectedTag, record.Tags)
+			}
+		}
+	}
+}
+
+func Test_record_EnrichmentRecord(t *testing.T) {
+	rec := record{
+		prod:  "test-product",
+		chunk: 0,
+		cves:  []string{"CVE-2024-1", "CVE-2024-2"},
+	}
+
+	enrichmentRecord, err := rec.EnrichmentRecord()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if enrichmentRecord == nil {
+		t.Fatalf("expected non-nil enrichment record")
+	}
+
+	if len(enrichmentRecord.Tags) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(enrichmentRecord.Tags))
+	}
+
+	if enrichmentRecord.Tags[0] != "test-product" {
+		t.Errorf("expected first tag to be 'test-product', got %s", enrichmentRecord.Tags[0])
+	}
+
+	if enrichmentRecord.Tags[1] != "test-product:0" {
+		t.Errorf("expected second tag to be 'test-product:0', got %s", enrichmentRecord.Tags[1])
+	}
+}
+
+func Test_parseRecords(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		enricher := &Enricher{maxCVEsPerRecord: 10}
+		// Create invalid JSON that will definitely cause CSAF parsing to fail.
+		invalidCSAF := "this is not json!\n"
+		var buf bytes.Buffer
+		sw := snappy.NewBufferedWriter(&buf)
+		_, err := sw.Write([]byte(invalidCSAF))
+		if err != nil {
+			t.Fatalf("failed to write test data: %v", err)
+		}
+		if err = sw.Close(); err != nil {
+			t.Fatalf("failed to close snappy writer: %v", err)
+		}
+
+		errorFound := false
+		for record, err := range enricher.parseRecords(context.Background(), io.NopCloser(&buf)) {
+			if err != nil {
+				errorFound = true
+				if record != nil {
+					t.Error("expected nil record when error occurs")
+				}
+				if !strings.Contains(err.Error(), "error parsing CSAF") {
+					t.Errorf("expected CSAF parsing error, got: %v", err)
+				}
+				break
+			}
+			if record != nil {
+				t.Error("expected no records from invalid CSAF data")
+			}
+		}
+
+		if !errorFound {
+			t.Error("expected CSAF parsing error, but got none")
+		}
+	})
+	t.Run("iterator terminates early", func(t *testing.T) {
+		enricher := &Enricher{maxCVEsPerRecord: 1}
+		// Create test data with multiple CVEs.
+		testData := csafAdvisory(map[string]int{"test-product": 5})
+		var buf bytes.Buffer
+		sw := snappy.NewBufferedWriter(&buf)
+		_, err := sw.Write([]byte(testData))
+		if err != nil {
+			t.Fatalf("failed to write test data: %v", err)
+		}
+		if err = sw.Close(); err != nil {
+			t.Fatalf("failed to close snappy writer: %v", err)
+		}
+		// Parse but terminate early after first record.
+		recordCount := 0
+		for record, err := range enricher.parseRecords(context.Background(), io.NopCloser(&buf)) {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if record == nil {
+				t.Error("unexpected nil record")
+			}
+			recordCount++
+			if recordCount == 1 {
+				break // Early termination
+			}
+		}
+		if recordCount != 1 {
+			t.Errorf("expected to process exactly 1 record, got %d", recordCount)
+		}
+	})
+}
+
+// csafAdvisory creates test CSAF document with specified number of CVEs for multiple products.
+func csafAdvisory(productCVECounts map[string]int) string {
+	relationships, branches, vulnerabilities := csafComponents(productCVECounts)
+
+	csafData := map[string]any{
+		"document":        csafDocument(),
+		"product_tree":    csafProductTree(relationships, branches),
+		"vulnerabilities": vulnerabilities,
+	}
+
+	jsonData, _ := json.Marshal(csafData)
+	return string(jsonData) + "\n"
+}
+
+// csafDocument creates the standard document section for test CSAF data
+func csafDocument() map[string]any {
+	doc := map[string]any{
+		"category": "csaf_vex",
+		"title":    "Test VEX",
+		"tracking": map[string]any{
+			"status": "final",
+		},
+		"references": []map[string]any{
+			{
+				"category": "self",
+				"url":      "https://example.com/test.json",
+			},
+		},
+	}
+	validateCSAFDocument(doc)
+	return doc
+}
+
+// validateCSAFDocument weak validation of the CSAF structure.
+func validateCSAFDocument(doc map[string]any) {
+	// Required top-level fields
+	requiredFields := []string{"category", "title", "tracking", "references"}
+	for _, field := range requiredFields {
+		if _, exists := doc[field]; !exists {
+			panic(fmt.Sprintf("csafDocument() missing required field: %s", field))
+		}
+	}
+
+	// Validate category is correct
+	if doc["category"] != "csaf_vex" {
+		panic(fmt.Sprintf("csafDocument() invalid category: expected 'csaf_vex', got %v", doc["category"]))
+	}
+
+	// Validate tracking has status
+	tracking, ok := doc["tracking"].(map[string]any)
+	if !ok {
+		panic("csafDocument() tracking field is not a map")
+	}
+	if _, exists := tracking["status"]; !exists {
+		panic("csafDocument() tracking missing status field")
+	}
+
+	// Validate references is an array
+	references, ok := doc["references"].([]map[string]any)
+	if !ok {
+		panic("csafDocument() references field is not an array of maps")
+	}
+
+	// Validate self reference exists
+	hasSelfRef := false
+	for _, ref := range references {
+		if category, exists := ref["category"]; exists && category == "self" {
+			if _, hasURL := ref["url"]; hasURL {
+				hasSelfRef = true
+				break
+			}
+		}
+	}
+	if !hasSelfRef {
+		panic("csafDocument() missing self reference with URL")
+	}
+}
+
+// csafProductTree creates a product tree.
+func csafProductTree(relationships, branches []map[string]any) map[string]any {
+	return map[string]any{
+		"relationships": relationships,
+		"branches":      branches,
+	}
+}
+
+// csafComponents creates relationships, branches, and vulnerabilities for the given products.
+func csafComponents(productCVECounts map[string]int) ([]map[string]any, []map[string]any, []map[string]any) {
+	var relationships []map[string]any
+	var branches []map[string]any
+	var vulnerabilities []map[string]any
+
+	cveCounter := 1000
+	for product, cveCount := range productCVECounts {
+		rel := map[string]any{
+			"category": "default_component_of",
+			"full_product_name": map[string]any{
+				"name":       product + " as a component of Test Repository",
+				"product_id": "test-repo:" + product,
+			},
+			"product_reference":            product,
+			"relates_to_product_reference": "test-repo",
+		}
+		relationships = append(relationships, rel)
+		branch := map[string]any{
+			"name": product,
+			"product": map[string]any{
+				"name":       product,
+				"product_id": product,
+				"product_identification_helper": map[string]any{
+					"purl": "pkg:oci/" + product,
+				},
+			},
+		}
+		branches = append(branches, branch)
+		for i := 0; i < cveCount; i++ {
+			vuln := map[string]any{
+				"cve": cveName(cveCounter),
+				"product_status": map[string]any{
+					"known_not_affected": []string{"test-repo:" + product},
+				},
+			}
+			vulnerabilities = append(vulnerabilities, vuln)
+			cveCounter++
+		}
+	}
+	return relationships, branches, vulnerabilities
+}
+
+// cveName creates a CVE name from a number.
+func cveName(counter int) string {
+	return "CVE-2024-" +
+		string(rune('0'+(counter/1000))) +
+		string(rune('0'+((counter/100)%10))) +
+		string(rune('0'+((counter/10)%10))) +
+		string(rune('0'+(counter%10)))
 }

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stackrox/rox/scanner/datastore/postgres"
 	"github.com/stackrox/rox/scanner/enricher/csaf"
 	"github.com/stackrox/rox/scanner/enricher/fixedby"
+	"github.com/stackrox/rox/scanner/enricher/notaffected"
 	"github.com/stackrox/rox/scanner/enricher/nvd"
 	"github.com/stackrox/rox/scanner/internal/httputil"
 	"github.com/stackrox/rox/scanner/matcher/updater/vuln"
@@ -139,20 +140,23 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 		&fixedby.Enricher{},
 		&nvd.Enricher{},
 	}
-	var (
-		epssEnabled bool
-		csafEnabled bool
-	)
-	if features.EPSSScore.Enabled() {
-		epssEnabled = true
+
+	epssEnabled := features.EPSSScore.Enabled()
+	csafEnabled := features.ScannerV4RedHatCSAF.Enabled() && !features.ScannerV4RedHatCVEs.Enabled()
+	notAffectedEnabled := features.ScannerV4KnownNotAffected.Enabled()
+
+	if epssEnabled {
 		enrichers = append(enrichers, &epss.Enricher{})
 	}
-	if features.ScannerV4RedHatCSAF.Enabled() && !features.ScannerV4RedHatCVEs.Enabled() {
-		csafEnabled = true
+	if csafEnabled {
 		enrichers = append(enrichers, &csaf.Enricher{})
+	}
+	if notAffectedEnabled {
+		enrichers = append(enrichers, &notaffected.Enricher{})
 	}
 	zlog.Info(ctx).Bool("enabled", epssEnabled).Msg("EPSS enrichment")
 	zlog.Info(ctx).Bool("enabled", csafEnabled).Msg("CSAF enrichment")
+	zlog.Info(ctx).Bool("enabled", notAffectedEnabled).Msg("Known not affected enrichment")
 	libVuln, err := libvuln.New(ctx, &libvuln.Options{
 		Store:                    store,
 		Locker:                   locker,

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -187,6 +188,20 @@ func knownNotAffectedOpts() []updates.ManagerOption {
 		updates.WithEnabled([]string{}),
 		updates.WithFactories(map[string]driver.UpdaterSetFactory{
 			"stackrox.rhel-not-affected": notaffected.NewFactory(),
+		}),
+		updates.WithConfigs(map[string]driver.ConfigUnmarshaler{
+			"stackrox.rhel-not-affected": func(i interface{}) error {
+				cfg, ok := i.(*notaffected.Config)
+				if !ok {
+					return errors.New("internal error: config assertion failed")
+				}
+				if v := os.Getenv("STACKROX_SCANNER_V4_KNOWN_NOT_AFFECTED_MAX_CVES_PER_RECORD"); v != "" {
+					if n, err := strconv.Atoi(v); err == nil && n > 0 {
+						cfg.MaxCVEsPerRecord = n
+					}
+				}
+				return nil
+			},
 		}),
 	}
 }


### PR DESCRIPTION
## Description

Modify the enrichment records of the "not affected" enricher to chunk its data, to avoid problems with serialization.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- UTs
- Integration Tests over an actual DB.

Also:
```
⮩ make bin/scanner bin/updater
...
⮩ ./bin/updater export bundles
...
⮩  ls -l bundles                                                                               
total 127960
-rw-r--r--. 1 jvdm jvdm   994108 Sep 18 19:23 alpine.json.zst
-rw-r--r--. 1 jvdm jvdm  2485845 Sep 18 18:23 aws.json.zst
-rw-r--r--. 1 jvdm jvdm  8747878 Sep 18 18:45 debian.json.zst
-rw-r--r--. 1 jvdm jvdm  3564180 Sep 18 18:38 epss.json.zst
-rw-r--r--. 1 jvdm jvdm     1609 Sep 18 18:46 manual.json.zst
-rw-r--r--. 1 jvdm jvdm 28522135 Sep 18 19:11 nvd.json.zst
-rw-r--r--. 1 jvdm jvdm 10331383 Sep 18 18:46 oracle.json.zst
-rw-r--r--. 1 jvdm jvdm  9342713 Sep 18 18:46 osv.json.zst
-rw-r--r--. 1 jvdm jvdm  1029606 Sep 18 18:46 photon.json.zst
-rw-r--r--. 1 jvdm jvdm 28658038 Sep 18 18:38 rhel-vex.json.zst
-rw-r--r--. 1 jvdm jvdm   571600 Sep 18 19:23 stackrox-rhel-csaf.json.zst
-rw-r--r--. 1 jvdm jvdm   893710 Sep 18 23:40 stackrox-rhel-known-not-affected.json.zst
-rw-r--r--. 1 jvdm jvdm        0 Sep 18 18:38 suse.json.zst
-rw-r--r--. 1 jvdm jvdm 22060099 Sep 18 18:38 ubuntu.json.zst
⮩ 
⮩ zip server/vulnerabilities.zip bundles
...
⮩  cat config.yaml | grep vuln
  vulnerabilities_url: http://localhost:8080/vulnerabilities.zip
⮩  python -m http.server 8080 --directory server/
...
```

Then `bin/scanner --conf config.yaml`.

1. Observed logs with enrichments being updated.
2. Queried the database using the `%%` operator, [same operator used by the enrichments datastore](https://github.com/quay/claircore/blob/674d0f906034df4bec6196038aa00117a6a3f404/datastore/postgres/enrichment.go#L233), confirming per-product queries will return all enrichments:
   
   ```
   echo "select tags from enrichment where updater = 'stackrox.rhel-not-affected' and tags && '{"red_hat_products"}' limit 10;" | psql postgresql://scanner:scanner@localhost:5432/scanner 
                    tags                  
   ---------------------------------------
    {red_hat_products,red_hat_products:0}
    {red_hat_products,red_hat_products:1}
    {red_hat_products,red_hat_products:2}
    {red_hat_products,red_hat_products:3}
    {red_hat_products,red_hat_products:4}
    {red_hat_products,red_hat_products:5}
    {red_hat_products,red_hat_products:6}
    {red_hat_products,red_hat_products:7}
    {red_hat_products,red_hat_products:8}
    {red_hat_products,red_hat_products:9}
   (10 rows)
   ```

```