### PR TITLE
ROX-30770: Fix bug in CA selection logic for Helm sensors

### DIFF
--- a/central/securedclustercertgen/certificates.go
+++ b/central/securedclustercertgen/certificates.go
@@ -73,16 +73,18 @@ func IssueSecuredClusterCertsWithCAs(
 		return nil, errors.New("primary CA is required")
 	}
 
-	// If CA rotation is enabled and both CAs are present, ensure the primary CA is the one that expires later.
-	if sensorSupportsCARotation && secondaryCA != nil {
-		primaryCACert := primaryCA.Certificate()
-		secondaryCACert := secondaryCA.Certificate()
-		if secondaryCACert.NotAfter.After(primaryCACert.NotAfter) {
+	if secondaryCA != nil {
+		if sensorSupportsCARotation {
+			// If CA rotation is enabled, ensure the signing CA is the one that expires later.
+			primaryCACert := primaryCA.Certificate()
+			secondaryCACert := secondaryCA.Certificate()
+			if secondaryCACert.NotAfter.After(primaryCACert.NotAfter) {
+				primaryCA, secondaryCA = secondaryCA, primaryCA
+			}
+		} else if sensorCAFingerprint != "" && sensorCAFingerprint == cryptoutils.CertFingerprint(secondaryCA.Certificate()) {
+			// If a CA fingerprint is provided, prefer the matching CA. Otherwise just use the primary CA.
 			primaryCA, secondaryCA = secondaryCA, primaryCA
 		}
-	} else if sensorCAFingerprint != "" && secondaryCA != nil && sensorCAFingerprint == cryptoutils.CertFingerprint(secondaryCA.Certificate()) {
-		// If a CA fingerprint is provided, prefer the matching CA. Otherwise just use the primary CA.
-		primaryCA, secondaryCA = secondaryCA, primaryCA
 	}
 
 	certIssuer := certIssuerImpl{


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Fixes a bug introduced in https://github.com/stackrox/stackrox/pull/16636

`IssueSecuredClusterCerts` should load the secondary CA even if Sensor does not support CA rotation, because the CA selection logic in `IssueSecuredClusterCertsWithCAs` might use the secondary CA in some cases (e.g. Secured Cluster that trusts "secondary CA" and does not support CA rotation).

Unit tests didn't catch this because they only cover `IssueSecuredClusterCertsWithCAs` (which allows providing the CAs as parameters), and `IssueSecuredClusterCerts` is not unit tested because it uses global state.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested manually in the https://github.com/stackrox/stackrox/pull/15349 branch.