### PR TITLE
ROX-30968: Enforcement is disabled for audit log policies

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
@@ -50,13 +50,16 @@ function PolicyEnforcementForm() {
         );
     }
 
-    const responseMethodHelperText = showEnforcement
-        ? 'Inform and enforce will execute enforcement behavior at the stages you select.'
-        : 'Inform will always include violations for this policy in the violations list.';
-
     const hasBuild = values.lifecycleStages.includes('BUILD');
     const hasDeploy = values.lifecycleStages.includes('DEPLOY');
     const hasRuntime = values.lifecycleStages.includes('RUNTIME');
+    const hasAuditLog = values.eventSource === 'AUDIT_LOG_EVENT';
+
+    const responseMethodHelperText = showEnforcement
+        ? 'Inform and enforce will execute enforcement behavior at the stages you select.'
+        : hasRuntime && hasAuditLog
+          ? 'Inform will always include violations for this policy in the violations list. Enforcement is not available for audit log event sources.'
+          : 'Inform will always include violations for this policy in the violations list.';
 
     return (
         <Form>
@@ -67,6 +70,7 @@ function PolicyEnforcementForm() {
                         isChecked={!showEnforcement}
                         id="policy-response-inform"
                         name="inform"
+                        isDisabled={hasRuntime && hasAuditLog}
                         onChange={() => {
                             setShowEnforcement(false);
                             setFieldValue('enforcementActions', [], false); // do not validate, because code changes the value
@@ -77,6 +81,7 @@ function PolicyEnforcementForm() {
                         isChecked={showEnforcement}
                         id="policy-response-inform-enforce"
                         name="enforce"
+                        isDisabled={hasRuntime && hasAuditLog}
                         onChange={() => setShowEnforcement(true)}
                     />
                 </Flex>
@@ -159,7 +164,7 @@ function PolicyEnforcementForm() {
                                             'RUNTIME',
                                             values.enforcementActions
                                         )}
-                                        isDisabled={!hasRuntime}
+                                        isDisabled={!hasRuntime || hasAuditLog}
                                         onChange={(_event, isChecked) => {
                                             onChangeEnforcementActions('RUNTIME', isChecked);
                                         }}


### PR DESCRIPTION
## Description

Policy enforcement when using Runtime -> Audit Log is an invalid option, so we disable the ability to enable enforcement when this lifecycle/event source combination is selected.

Before this change:
<img width="1257" height="799" alt="image" src="https://github.com/user-attachments/assets/2f6a2bbc-17d9-4c89-8c1a-98b45eefe01c" />


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1257" height="799" alt="image" src="https://github.com/user-attachments/assets/99ad4a05-43ad-406c-b68c-62cc34b57943" />
<img width="1257" height="799" alt="image" src="https://github.com/user-attachments/assets/b1050715-c8a3-4f6f-b69a-c0e09e996c6e" />
