### PR TITLE
fix(scanner): use map instead of slice for vuln report api

### DIFF
--- a/compliance/collection/metrics/metrics.go
+++ b/compliance/collection/metrics/metrics.go
@@ -255,12 +255,16 @@ func ObserveNodeIndexReport(report *v4.IndexReport, nodeName string) {
 
 	if contents.GetPackages() != nil {
 		rhelPackageCount = len(contents.GetPackages())
+	} else if contents.GetPackagesDEPRECATED() != nil {
+		rhelPackageCount = len(contents.GetPackagesDEPRECATED())
 	}
 	observePackages(nodeName, "", ScannerVersionV4, rhelPackageCount)
 
 	rhelContentSets := 0
 	if contents.GetRepositories() != nil {
 		rhelContentSets = len(contents.GetRepositories())
+	} else if contents.GetRepositoriesDEPRECATED() != nil {
+		rhelContentSets = len(contents.GetRepositoriesDEPRECATED())
 	}
 	observeContentSets(nodeName, "", ScannerVersionV4, rhelContentSets)
 }

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -1876,24 +1876,42 @@
     "v4Contents": {
       "type": "object",
       "properties": {
-        "packages": {
+        "packagesDEPRECATED": {
           "type": "array",
           "items": {
             "type": "object",
             "$ref": "#/definitions/v4Package"
           }
         },
-        "distributions": {
+        "packages": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v4Package"
+          }
+        },
+        "distributionsDEPRECATED": {
           "type": "array",
           "items": {
             "type": "object",
             "$ref": "#/definitions/v4Distribution"
           }
         },
-        "repositories": {
+        "distributions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v4Distribution"
+          }
+        },
+        "repositoriesDEPRECATED": {
           "type": "array",
           "items": {
             "type": "object",
+            "$ref": "#/definitions/v4Repository"
+          }
+        },
+        "repositories": {
+          "type": "object",
+          "additionalProperties": {
             "$ref": "#/definitions/v4Repository"
           }
         },

--- a/generated/internalapi/scanner/v4/common.pb.go
+++ b/generated/internalapi/scanner/v4/common.pb.go
@@ -26,13 +26,19 @@ const (
 )
 
 type Contents struct {
-	state         protoimpl.MessageState       `protogen:"open.v1"`
-	Packages      []*Package                   `protobuf:"bytes,1,rep,name=packages,proto3" json:"packages,omitempty"`
-	Distributions []*Distribution              `protobuf:"bytes,2,rep,name=distributions,proto3" json:"distributions,omitempty"`
-	Repositories  []*Repository                `protobuf:"bytes,3,rep,name=repositories,proto3" json:"repositories,omitempty"`
-	Environments  map[string]*Environment_List `protobuf:"bytes,4,rep,name=environments,proto3" json:"environments,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Deprecated: Marked as deprecated in internalapi/scanner/v4/common.proto.
+	PackagesDEPRECATED []*Package          `protobuf:"bytes,1,rep,name=packagesDEPRECATED,proto3" json:"packagesDEPRECATED,omitempty"`
+	Packages           map[string]*Package `protobuf:"bytes,5,rep,name=packages,proto3" json:"packages,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Deprecated: Marked as deprecated in internalapi/scanner/v4/common.proto.
+	DistributionsDEPRECATED []*Distribution          `protobuf:"bytes,2,rep,name=distributionsDEPRECATED,proto3" json:"distributionsDEPRECATED,omitempty"`
+	Distributions           map[string]*Distribution `protobuf:"bytes,6,rep,name=distributions,proto3" json:"distributions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Deprecated: Marked as deprecated in internalapi/scanner/v4/common.proto.
+	RepositoriesDEPRECATED []*Repository                `protobuf:"bytes,3,rep,name=repositoriesDEPRECATED,proto3" json:"repositoriesDEPRECATED,omitempty"`
+	Repositories           map[string]*Repository       `protobuf:"bytes,7,rep,name=repositories,proto3" json:"repositories,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Environments           map[string]*Environment_List `protobuf:"bytes,4,rep,name=environments,proto3" json:"environments,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *Contents) Reset() {
@@ -65,21 +71,45 @@ func (*Contents) Descriptor() ([]byte, []int) {
 	return file_internalapi_scanner_v4_common_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *Contents) GetPackages() []*Package {
+// Deprecated: Marked as deprecated in internalapi/scanner/v4/common.proto.
+func (x *Contents) GetPackagesDEPRECATED() []*Package {
+	if x != nil {
+		return x.PackagesDEPRECATED
+	}
+	return nil
+}
+
+func (x *Contents) GetPackages() map[string]*Package {
 	if x != nil {
 		return x.Packages
 	}
 	return nil
 }
 
-func (x *Contents) GetDistributions() []*Distribution {
+// Deprecated: Marked as deprecated in internalapi/scanner/v4/common.proto.
+func (x *Contents) GetDistributionsDEPRECATED() []*Distribution {
+	if x != nil {
+		return x.DistributionsDEPRECATED
+	}
+	return nil
+}
+
+func (x *Contents) GetDistributions() map[string]*Distribution {
 	if x != nil {
 		return x.Distributions
 	}
 	return nil
 }
 
-func (x *Contents) GetRepositories() []*Repository {
+// Deprecated: Marked as deprecated in internalapi/scanner/v4/common.proto.
+func (x *Contents) GetRepositoriesDEPRECATED() []*Repository {
+	if x != nil {
+		return x.RepositoriesDEPRECATED
+	}
+	return nil
+}
+
+func (x *Contents) GetRepositories() map[string]*Repository {
 	if x != nil {
 		return x.Repositories
 	}
@@ -540,7 +570,7 @@ type Environment_List struct {
 
 func (x *Environment_List) Reset() {
 	*x = Environment_List{}
-	mi := &file_internalapi_scanner_v4_common_proto_msgTypes[7]
+	mi := &file_internalapi_scanner_v4_common_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -552,7 +582,7 @@ func (x *Environment_List) String() string {
 func (*Environment_List) ProtoMessage() {}
 
 func (x *Environment_List) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_common_proto_msgTypes[7]
+	mi := &file_internalapi_scanner_v4_common_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -580,12 +610,24 @@ var File_internalapi_scanner_v4_common_proto protoreflect.FileDescriptor
 const file_internalapi_scanner_v4_common_proto_rawDesc = "" +
 	"\n" +
 	"#internalapi/scanner/v4/common.proto\x12\n" +
-	"scanner.v4\"\xe2\x02\n" +
-	"\bContents\x12/\n" +
-	"\bpackages\x18\x01 \x03(\v2\x13.scanner.v4.PackageR\bpackages\x12>\n" +
-	"\rdistributions\x18\x02 \x03(\v2\x18.scanner.v4.DistributionR\rdistributions\x12:\n" +
-	"\frepositories\x18\x03 \x03(\v2\x16.scanner.v4.RepositoryR\frepositories\x12J\n" +
-	"\fenvironments\x18\x04 \x03(\v2&.scanner.v4.Contents.EnvironmentsEntryR\fenvironments\x1a]\n" +
+	"scanner.v4\"\x8c\a\n" +
+	"\bContents\x12G\n" +
+	"\x12packagesDEPRECATED\x18\x01 \x03(\v2\x13.scanner.v4.PackageB\x02\x18\x01R\x12packagesDEPRECATED\x12>\n" +
+	"\bpackages\x18\x05 \x03(\v2\".scanner.v4.Contents.PackagesEntryR\bpackages\x12V\n" +
+	"\x17distributionsDEPRECATED\x18\x02 \x03(\v2\x18.scanner.v4.DistributionB\x02\x18\x01R\x17distributionsDEPRECATED\x12M\n" +
+	"\rdistributions\x18\x06 \x03(\v2'.scanner.v4.Contents.DistributionsEntryR\rdistributions\x12R\n" +
+	"\x16repositoriesDEPRECATED\x18\x03 \x03(\v2\x16.scanner.v4.RepositoryB\x02\x18\x01R\x16repositoriesDEPRECATED\x12J\n" +
+	"\frepositories\x18\a \x03(\v2&.scanner.v4.Contents.RepositoriesEntryR\frepositories\x12J\n" +
+	"\fenvironments\x18\x04 \x03(\v2&.scanner.v4.Contents.EnvironmentsEntryR\fenvironments\x1aP\n" +
+	"\rPackagesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.scanner.v4.PackageR\x05value:\x028\x01\x1aZ\n" +
+	"\x12DistributionsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12.\n" +
+	"\x05value\x18\x02 \x01(\v2\x18.scanner.v4.DistributionR\x05value:\x028\x01\x1aW\n" +
+	"\x11RepositoriesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.scanner.v4.RepositoryR\x05value:\x028\x01\x1a]\n" +
 	"\x11EnvironmentsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x122\n" +
 	"\x05value\x18\x02 \x01(\v2\x1c.scanner.v4.Environment.ListR\x05value:\x028\x01\"\x86\x03\n" +
@@ -647,7 +689,7 @@ func file_internalapi_scanner_v4_common_proto_rawDescGZIP() []byte {
 	return file_internalapi_scanner_v4_common_proto_rawDescData
 }
 
-var file_internalapi_scanner_v4_common_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_internalapi_scanner_v4_common_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_internalapi_scanner_v4_common_proto_goTypes = []any{
 	(*Contents)(nil),          // 0: scanner.v4.Contents
 	(*Package)(nil),           // 1: scanner.v4.Package
@@ -655,23 +697,32 @@ var file_internalapi_scanner_v4_common_proto_goTypes = []any{
 	(*Distribution)(nil),      // 3: scanner.v4.Distribution
 	(*Repository)(nil),        // 4: scanner.v4.Repository
 	(*Environment)(nil),       // 5: scanner.v4.Environment
-	nil,                       // 6: scanner.v4.Contents.EnvironmentsEntry
-	(*Environment_List)(nil),  // 7: scanner.v4.Environment.List
+	nil,                       // 6: scanner.v4.Contents.PackagesEntry
+	nil,                       // 7: scanner.v4.Contents.DistributionsEntry
+	nil,                       // 8: scanner.v4.Contents.RepositoriesEntry
+	nil,                       // 9: scanner.v4.Contents.EnvironmentsEntry
+	(*Environment_List)(nil),  // 10: scanner.v4.Environment.List
 }
 var file_internalapi_scanner_v4_common_proto_depIdxs = []int32{
-	1, // 0: scanner.v4.Contents.packages:type_name -> scanner.v4.Package
-	3, // 1: scanner.v4.Contents.distributions:type_name -> scanner.v4.Distribution
-	4, // 2: scanner.v4.Contents.repositories:type_name -> scanner.v4.Repository
-	6, // 3: scanner.v4.Contents.environments:type_name -> scanner.v4.Contents.EnvironmentsEntry
-	2, // 4: scanner.v4.Package.normalized_version:type_name -> scanner.v4.NormalizedVersion
-	1, // 5: scanner.v4.Package.source:type_name -> scanner.v4.Package
-	7, // 6: scanner.v4.Contents.EnvironmentsEntry.value:type_name -> scanner.v4.Environment.List
-	5, // 7: scanner.v4.Environment.List.environments:type_name -> scanner.v4.Environment
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	1,  // 0: scanner.v4.Contents.packagesDEPRECATED:type_name -> scanner.v4.Package
+	6,  // 1: scanner.v4.Contents.packages:type_name -> scanner.v4.Contents.PackagesEntry
+	3,  // 2: scanner.v4.Contents.distributionsDEPRECATED:type_name -> scanner.v4.Distribution
+	7,  // 3: scanner.v4.Contents.distributions:type_name -> scanner.v4.Contents.DistributionsEntry
+	4,  // 4: scanner.v4.Contents.repositoriesDEPRECATED:type_name -> scanner.v4.Repository
+	8,  // 5: scanner.v4.Contents.repositories:type_name -> scanner.v4.Contents.RepositoriesEntry
+	9,  // 6: scanner.v4.Contents.environments:type_name -> scanner.v4.Contents.EnvironmentsEntry
+	2,  // 7: scanner.v4.Package.normalized_version:type_name -> scanner.v4.NormalizedVersion
+	1,  // 8: scanner.v4.Package.source:type_name -> scanner.v4.Package
+	1,  // 9: scanner.v4.Contents.PackagesEntry.value:type_name -> scanner.v4.Package
+	3,  // 10: scanner.v4.Contents.DistributionsEntry.value:type_name -> scanner.v4.Distribution
+	4,  // 11: scanner.v4.Contents.RepositoriesEntry.value:type_name -> scanner.v4.Repository
+	10, // 12: scanner.v4.Contents.EnvironmentsEntry.value:type_name -> scanner.v4.Environment.List
+	5,  // 13: scanner.v4.Environment.List.environments:type_name -> scanner.v4.Environment
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_scanner_v4_common_proto_init() }
@@ -685,7 +736,7 @@ func file_internalapi_scanner_v4_common_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_scanner_v4_common_proto_rawDesc), len(file_internalapi_scanner_v4_common_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/internalapi/scanner/v4/common_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/common_vtproto.pb.go
@@ -25,22 +25,43 @@ func (m *Contents) CloneVT() *Contents {
 		return (*Contents)(nil)
 	}
 	r := new(Contents)
-	if rhs := m.Packages; rhs != nil {
+	if rhs := m.PackagesDEPRECATED; rhs != nil {
 		tmpContainer := make([]*Package, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.PackagesDEPRECATED = tmpContainer
+	}
+	if rhs := m.Packages; rhs != nil {
+		tmpContainer := make(map[string]*Package, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.Packages = tmpContainer
 	}
-	if rhs := m.Distributions; rhs != nil {
+	if rhs := m.DistributionsDEPRECATED; rhs != nil {
 		tmpContainer := make([]*Distribution, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.DistributionsDEPRECATED = tmpContainer
+	}
+	if rhs := m.Distributions; rhs != nil {
+		tmpContainer := make(map[string]*Distribution, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.Distributions = tmpContainer
 	}
-	if rhs := m.Repositories; rhs != nil {
+	if rhs := m.RepositoriesDEPRECATED; rhs != nil {
 		tmpContainer := make([]*Repository, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.RepositoriesDEPRECATED = tmpContainer
+	}
+	if rhs := m.Repositories; rhs != nil {
+		tmpContainer := make(map[string]*Repository, len(rhs))
 		for k, v := range rhs {
 			tmpContainer[k] = v.CloneVT()
 		}
@@ -213,11 +234,11 @@ func (this *Contents) EqualVT(that *Contents) bool {
 	} else if this == nil || that == nil {
 		return false
 	}
-	if len(this.Packages) != len(that.Packages) {
+	if len(this.PackagesDEPRECATED) != len(that.PackagesDEPRECATED) {
 		return false
 	}
-	for i, vx := range this.Packages {
-		vy := that.Packages[i]
+	for i, vx := range this.PackagesDEPRECATED {
+		vy := that.PackagesDEPRECATED[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
 				p = &Package{}
@@ -230,11 +251,11 @@ func (this *Contents) EqualVT(that *Contents) bool {
 			}
 		}
 	}
-	if len(this.Distributions) != len(that.Distributions) {
+	if len(this.DistributionsDEPRECATED) != len(that.DistributionsDEPRECATED) {
 		return false
 	}
-	for i, vx := range this.Distributions {
-		vy := that.Distributions[i]
+	for i, vx := range this.DistributionsDEPRECATED {
+		vy := that.DistributionsDEPRECATED[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
 				p = &Distribution{}
@@ -247,11 +268,11 @@ func (this *Contents) EqualVT(that *Contents) bool {
 			}
 		}
 	}
-	if len(this.Repositories) != len(that.Repositories) {
+	if len(this.RepositoriesDEPRECATED) != len(that.RepositoriesDEPRECATED) {
 		return false
 	}
-	for i, vx := range this.Repositories {
-		vy := that.Repositories[i]
+	for i, vx := range this.RepositoriesDEPRECATED {
+		vy := that.RepositoriesDEPRECATED[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
 				p = &Repository{}
@@ -278,6 +299,66 @@ func (this *Contents) EqualVT(that *Contents) bool {
 			}
 			if q == nil {
 				q = &Environment_List{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.Packages) != len(that.Packages) {
+		return false
+	}
+	for i, vx := range this.Packages {
+		vy, ok := that.Packages[i]
+		if !ok {
+			return false
+		}
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Package{}
+			}
+			if q == nil {
+				q = &Package{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.Distributions) != len(that.Distributions) {
+		return false
+	}
+	for i, vx := range this.Distributions {
+		vy, ok := that.Distributions[i]
+		if !ok {
+			return false
+		}
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Distribution{}
+			}
+			if q == nil {
+				q = &Distribution{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.Repositories) != len(that.Repositories) {
+		return false
+	}
+	for i, vx := range this.Repositories {
+		vy, ok := that.Repositories[i]
+		if !ok {
+			return false
+		}
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Repository{}
+			}
+			if q == nil {
+				q = &Repository{}
 			}
 			if !p.EqualVT(q) {
 				return false
@@ -545,6 +626,72 @@ func (m *Contents) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Repositories) > 0 {
+		for k := range m.Repositories {
+			v := m.Repositories[k]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3a
+		}
+	}
+	if len(m.Distributions) > 0 {
+		for k := range m.Distributions {
+			v := m.Distributions[k]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
+	if len(m.Packages) > 0 {
+		for k := range m.Packages {
+			v := m.Packages[k]
+			baseI := i
+			size, err := v.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
 	if len(m.Environments) > 0 {
 		for k := range m.Environments {
 			v := m.Environments[k]
@@ -567,9 +714,9 @@ func (m *Contents) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			dAtA[i] = 0x22
 		}
 	}
-	if len(m.Repositories) > 0 {
-		for iNdEx := len(m.Repositories) - 1; iNdEx >= 0; iNdEx-- {
-			size, err := m.Repositories[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+	if len(m.RepositoriesDEPRECATED) > 0 {
+		for iNdEx := len(m.RepositoriesDEPRECATED) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.RepositoriesDEPRECATED[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
@@ -579,9 +726,9 @@ func (m *Contents) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			dAtA[i] = 0x1a
 		}
 	}
-	if len(m.Distributions) > 0 {
-		for iNdEx := len(m.Distributions) - 1; iNdEx >= 0; iNdEx-- {
-			size, err := m.Distributions[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+	if len(m.DistributionsDEPRECATED) > 0 {
+		for iNdEx := len(m.DistributionsDEPRECATED) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.DistributionsDEPRECATED[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
@@ -591,9 +738,9 @@ func (m *Contents) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			dAtA[i] = 0x12
 		}
 	}
-	if len(m.Packages) > 0 {
-		for iNdEx := len(m.Packages) - 1; iNdEx >= 0; iNdEx-- {
-			size, err := m.Packages[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+	if len(m.PackagesDEPRECATED) > 0 {
+		for iNdEx := len(m.PackagesDEPRECATED) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.PackagesDEPRECATED[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
@@ -1068,26 +1215,65 @@ func (m *Contents) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	if len(m.Packages) > 0 {
-		for _, e := range m.Packages {
+	if len(m.PackagesDEPRECATED) > 0 {
+		for _, e := range m.PackagesDEPRECATED {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
-	if len(m.Distributions) > 0 {
-		for _, e := range m.Distributions {
+	if len(m.DistributionsDEPRECATED) > 0 {
+		for _, e := range m.DistributionsDEPRECATED {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
-	if len(m.Repositories) > 0 {
-		for _, e := range m.Repositories {
+	if len(m.RepositoriesDEPRECATED) > 0 {
+		for _, e := range m.RepositoriesDEPRECATED {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
 	if len(m.Environments) > 0 {
 		for k, v := range m.Environments {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.SizeVT()
+			}
+			l += 1 + protohelpers.SizeOfVarint(uint64(l))
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.Packages) > 0 {
+		for k, v := range m.Packages {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.SizeVT()
+			}
+			l += 1 + protohelpers.SizeOfVarint(uint64(l))
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.Distributions) > 0 {
+		for k, v := range m.Distributions {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.SizeVT()
+			}
+			l += 1 + protohelpers.SizeOfVarint(uint64(l))
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.Repositories) > 0 {
+		for k, v := range m.Repositories {
 			_ = k
 			_ = v
 			l = 0
@@ -1333,7 +1519,7 @@ func (m *Contents) UnmarshalVT(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Packages", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field PackagesDEPRECATED", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1360,14 +1546,14 @@ func (m *Contents) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Packages = append(m.Packages, &Package{})
-			if err := m.Packages[len(m.Packages)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+			m.PackagesDEPRECATED = append(m.PackagesDEPRECATED, &Package{})
+			if err := m.PackagesDEPRECATED[len(m.PackagesDEPRECATED)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Distributions", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionsDEPRECATED", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1394,14 +1580,14 @@ func (m *Contents) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Distributions = append(m.Distributions, &Distribution{})
-			if err := m.Distributions[len(m.Distributions)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+			m.DistributionsDEPRECATED = append(m.DistributionsDEPRECATED, &Distribution{})
+			if err := m.DistributionsDEPRECATED[len(m.DistributionsDEPRECATED)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Repositories", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RepositoriesDEPRECATED", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -1428,8 +1614,8 @@ func (m *Contents) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Repositories = append(m.Repositories, &Repository{})
-			if err := m.Repositories[len(m.Repositories)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+			m.RepositoriesDEPRECATED = append(m.RepositoriesDEPRECATED, &Repository{})
+			if err := m.RepositoriesDEPRECATED[len(m.RepositoriesDEPRECATED)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -1561,6 +1747,393 @@ func (m *Contents) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Environments[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Packages", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Packages == nil {
+				m.Packages = make(map[string]*Package)
+			}
+			var mapkey string
+			var mapvalue *Package
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &Package{}
+					if err := mapvalue.UnmarshalVT(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Packages[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Distributions", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Distributions == nil {
+				m.Distributions = make(map[string]*Distribution)
+			}
+			var mapkey string
+			var mapvalue *Distribution
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &Distribution{}
+					if err := mapvalue.UnmarshalVT(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Distributions[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Repositories", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Repositories == nil {
+				m.Repositories = make(map[string]*Repository)
+			}
+			var mapkey string
+			var mapvalue *Repository
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &Repository{}
+					if err := mapvalue.UnmarshalVT(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Repositories[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3031,7 +3604,7 @@ func (m *Contents) UnmarshalVTUnsafe(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Packages", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field PackagesDEPRECATED", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3058,14 +3631,14 @@ func (m *Contents) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Packages = append(m.Packages, &Package{})
-			if err := m.Packages[len(m.Packages)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+			m.PackagesDEPRECATED = append(m.PackagesDEPRECATED, &Package{})
+			if err := m.PackagesDEPRECATED[len(m.PackagesDEPRECATED)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Distributions", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field DistributionsDEPRECATED", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3092,14 +3665,14 @@ func (m *Contents) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Distributions = append(m.Distributions, &Distribution{})
-			if err := m.Distributions[len(m.Distributions)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+			m.DistributionsDEPRECATED = append(m.DistributionsDEPRECATED, &Distribution{})
+			if err := m.DistributionsDEPRECATED[len(m.DistributionsDEPRECATED)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Repositories", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field RepositoriesDEPRECATED", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -3126,8 +3699,8 @@ func (m *Contents) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Repositories = append(m.Repositories, &Repository{})
-			if err := m.Repositories[len(m.Repositories)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+			m.RepositoriesDEPRECATED = append(m.RepositoriesDEPRECATED, &Repository{})
+			if err := m.RepositoriesDEPRECATED[len(m.RepositoriesDEPRECATED)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -3263,6 +3836,405 @@ func (m *Contents) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.Environments[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Packages", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Packages == nil {
+				m.Packages = make(map[string]*Package)
+			}
+			var mapkey string
+			var mapvalue *Package
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &Package{}
+					if err := mapvalue.UnmarshalVTUnsafe(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Packages[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Distributions", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Distributions == nil {
+				m.Distributions = make(map[string]*Distribution)
+			}
+			var mapkey string
+			var mapvalue *Distribution
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &Distribution{}
+					if err := mapvalue.UnmarshalVTUnsafe(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Distributions[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Repositories", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Repositories == nil {
+				m.Repositories = make(map[string]*Repository)
+			}
+			var mapkey string
+			var mapvalue *Repository
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &Repository{}
+					if err := mapvalue.UnmarshalVTUnsafe(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Repositories[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -33,9 +33,14 @@ func components(metadata *storage.ImageMetadata, report *v4.VulnerabilityReport)
 	layerSHAToIndex := clair.BuildSHAToIndexMap(metadata)
 
 	pkgs := report.GetContents().GetPackages()
+	if len(pkgs) == 0 {
+		// Fallback to the deprecated slice, if needed.
+		for _, pkg := range report.GetContents().GetPackagesDEPRECATED() {
+			pkgs[pkg.GetId()] = pkg
+		}
+	}
 	components := make([]*storage.EmbeddedImageScanComponent, 0, len(pkgs))
-	for _, pkg := range pkgs {
-		id := pkg.GetId()
+	for id, pkg := range pkgs {
 		vulnIDs := report.GetPackageVulnerabilities()[id].GetValues()
 
 		var (
@@ -354,11 +359,21 @@ func normalizedSeverity(severity v4.VulnerabilityReport_Vulnerability_Severity) 
 // return "unknown", as StackRox only supports a single base-OS at this time.
 func os(report *v4.VulnerabilityReport) string {
 	dists := report.GetContents().GetDistributions()
+	if len(dists) == 0 {
+		// Fallback to the deprecated slice, if needed.
+		for _, dist := range report.GetContents().GetDistributionsDEPRECATED() {
+			dists[dist.GetId()] = dist
+		}
+	}
 	if len(dists) != 1 {
 		return "unknown"
 	}
 
-	dist := dists[0]
+	var dist *v4.Distribution
+	for _, d := range dists {
+		dist = d
+		break
+	}
 	return dist.GetDid() + ":" + dist.GetVersionId()
 }
 

--- a/pkg/scanners/scannerv4/nodescan_convert.go
+++ b/pkg/scanners/scannerv4/nodescan_convert.go
@@ -48,6 +48,12 @@ func toOperatingSystem(ref string) string {
 
 func toStorageComponents(r *v4.VulnerabilityReport) []*storage.EmbeddedNodeScanComponent {
 	packages := r.GetContents().GetPackages()
+	if len(packages) == 0 {
+		// Fallback to the deprecated slice, if needed.
+		for _, pkg := range r.GetContents().GetPackagesDEPRECATED() {
+			packages[pkg.GetId()] = pkg
+		}
+	}
 	result := make([]*storage.EmbeddedNodeScanComponent, 0, len(packages))
 
 	for _, pkg := range packages {

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -155,36 +155,27 @@ func ToClairCoreIndexReport(contents *v4.Contents) (*claircore.IndexReport, erro
 	if contents == nil {
 		return nil, errors.New("internal error: empty contents")
 	}
-	pkgs, err := convertSliceToMap(contents.GetPackages(), toClairCorePackage)
+	pkgs, err := ccPackages(contents)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %w", err)
 	}
-	dists, err := convertSliceToMap(contents.GetDistributions(), toClairCoreDistribution)
+	dists, err := ccDistributions(contents)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %w", err)
 	}
-	repos, err := convertSliceToMap(contents.GetRepositories(), toClairCoreRepository)
+	repos, err := ccRepositories(contents)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %w", err)
 	}
-	var environments map[string][]*claircore.Environment
-	if envs := contents.GetEnvironments(); envs != nil {
-		environments = make(map[string][]*claircore.Environment, len(envs))
-		for k, v := range envs {
-			for _, env := range v.GetEnvironments() {
-				ccEnv, err := toClairCoreEnvironment(env)
-				if err != nil {
-					return nil, err
-				}
-				environments[k] = append(environments[k], ccEnv)
-			}
-		}
+	envs, err := ccEnvironments(contents)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: %w", err)
 	}
 	return &claircore.IndexReport{
 		Packages:      pkgs,
 		Distributions: dists,
 		Repositories:  repos,
-		Environments:  environments,
+		Environments:  envs,
 	}, nil
 }
 
@@ -195,38 +186,43 @@ func toProtoV4Contents(
 	envs map[string][]*claircore.Environment,
 	pkgFixedBy map[string]string,
 ) (*v4.Contents, error) {
-	var environments map[string]*v4.Environment_List
-	if len(envs) > 0 {
-		environments = make(map[string]*v4.Environment_List, len(envs))
+	packages, deprecatedPackages, err := v4Packages(pkgs, pkgFixedBy)
+	if err != nil {
+		return nil, err
 	}
-	for k, v := range envs {
-		l, ok := environments[k]
-		if !ok {
-			l = &v4.Environment_List{}
-			environments[k] = l
-		}
-		for _, e := range v {
-			l.Environments = append(l.Environments, toProtoV4Environment(e))
-		}
-	}
-	var packages []*v4.Package
-	for _, ccP := range pkgs {
-		pkg, err := toProtoV4Package(ccP)
-		if err != nil {
-			return nil, err
-		}
-		pkg.FixedInVersion = pkgFixedBy[pkg.GetId()]
-		packages = append(packages, pkg)
-	}
+	distributions, deprecatedDistributions := v4Distributions(dists)
+	repositories, deprecatedRepositories := v4Repositories(repos)
+	environments := v4Environments(envs)
 	return &v4.Contents{
-		Packages:      packages,
-		Distributions: convertMapToSlice(toProtoV4Distribution, dists),
-		Repositories:  convertMapToSlice(toProtoV4Repository, repos),
-		Environments:  environments,
+		Packages:                packages,
+		PackagesDEPRECATED:      deprecatedPackages,
+		Distributions:           distributions,
+		DistributionsDEPRECATED: deprecatedDistributions,
+		Repositories:            repositories,
+		RepositoriesDEPRECATED:  deprecatedRepositories,
+		Environments:            environments,
 	}, nil
 }
 
-func toProtoV4Package(p *claircore.Package) (*v4.Package, error) {
+func v4Packages(ccPkgs map[string]*claircore.Package, pkgFixedBy map[string]string) (map[string]*v4.Package, []*v4.Package, error) {
+	if len(ccPkgs) == 0 {
+		return nil, nil, nil
+	}
+	packages := make(map[string]*v4.Package, len(ccPkgs))
+	deprecatedPackages := make([]*v4.Package, 0, len(ccPkgs))
+	for id, ccPkg := range ccPkgs {
+		v4Pkg, err := v4Package(ccPkg)
+		if err != nil {
+			return nil, nil, err
+		}
+		v4Pkg.FixedInVersion = pkgFixedBy[id]
+		packages[id] = v4Pkg
+		deprecatedPackages = append(deprecatedPackages, v4Pkg)
+	}
+	return packages, deprecatedPackages, nil
+}
+
+func v4Package(p *claircore.Package) (*v4.Package, error) {
 	if p == nil {
 		return nil, nil
 	}
@@ -241,7 +237,7 @@ func toProtoV4Package(p *claircore.Package) (*v4.Package, error) {
 			V:    version.V[:],
 		}
 	}
-	srcPkg, err := toProtoV4Package(p.Source)
+	srcPkg, err := v4Package(p.Source)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +272,21 @@ func VersionID(d *claircore.Distribution) string {
 	return vID
 }
 
-func toProtoV4Distribution(d *claircore.Distribution) *v4.Distribution {
+func v4Distributions(ccDists map[string]*claircore.Distribution,) (map[string]*v4.Distribution, []*v4.Distribution) {
+	if len(ccDists) == 0 {
+		return nil, nil
+	}
+	distributions := make(map[string]*v4.Distribution, len(ccDists))
+	deprecatedDistributions := make([]*v4.Distribution, 0, len(ccDists))
+	for id, ccDist := range ccDists {
+		v4Dist := v4Distribution(ccDist)
+		distributions[id] = v4Dist
+		deprecatedDistributions = append(deprecatedDistributions, v4Dist)
+	}
+	return distributions, deprecatedDistributions
+}
+
+func v4Distribution(d *claircore.Distribution) *v4.Distribution {
 	if d == nil {
 		return nil
 	}
@@ -293,7 +303,21 @@ func toProtoV4Distribution(d *claircore.Distribution) *v4.Distribution {
 	}
 }
 
-func toProtoV4Repository(r *claircore.Repository) *v4.Repository {
+func v4Repositories(ccRepos map[string]*claircore.Repository) (map[string]*v4.Repository, []*v4.Repository) {
+	if len(ccRepos) == 0 {
+		return nil, nil
+	}
+	repositories := make(map[string]*v4.Repository, len(ccRepos))
+	deprecatedRepositories := make([]*v4.Repository, 0, len(ccRepos))
+	for id, ccRepo := range ccRepos {
+		v4Repo := v4Repository(ccRepo)
+		repositories[id] = v4Repo
+		deprecatedRepositories = append(deprecatedRepositories, v4Repo)
+	}
+	return repositories, deprecatedRepositories
+}
+
+func v4Repository(r *claircore.Repository) *v4.Repository {
 	if r == nil {
 		return nil
 	}
@@ -306,7 +330,25 @@ func toProtoV4Repository(r *claircore.Repository) *v4.Repository {
 	}
 }
 
-func toProtoV4Environment(e *claircore.Environment) *v4.Environment {
+func v4Environments(ccEnvs map[string][]*claircore.Environment) map[string]*v4.Environment_List {
+	if len(ccEnvs) == 0 {
+		return nil
+	}
+	environments := make(map[string]*v4.Environment_List, len(ccEnvs))
+	for id, envs := range ccEnvs {
+		l, ok := environments[id]
+		if !ok {
+			l = &v4.Environment_List{}
+			environments[id] = l
+		}
+		for _, env := range envs {
+			l.Environments = append(l.Environments, v4Environment(env))
+		}
+	}
+	return environments
+}
+
+func v4Environment(e *claircore.Environment) *v4.Environment {
 	if e == nil {
 		return nil
 	}
@@ -688,7 +730,25 @@ func toClairCoreCPE(s string) (cpe.WFN, error) {
 	return c, nil
 }
 
-func toClairCorePackage(p *v4.Package) (string, *claircore.Package, error) {
+func ccPackages(contents *v4.Contents) (map[string]*claircore.Package, error) {
+	if pkgs := contents.GetPackages(); len(pkgs) > 0 {
+		packages := make(map[string]*claircore.Package)
+		for id, pkg := range pkgs {
+			_, ccPkg, err := ccPackage(pkg)
+			if err != nil {
+				return nil, err
+			}
+			packages[id] = ccPkg
+		}
+		return packages, nil
+	}
+	// Fallback to the deprecated slice, if necessary.
+	return convertSliceToMap(contents.GetPackagesDEPRECATED(), ccPackage)
+}
+
+// ccPackage converts the given package into its Claircore equivalent.
+// The first return is the package's ID.
+func ccPackage(p *v4.Package) (string, *claircore.Package, error) {
 	if p == nil {
 		return "", nil, nil
 	}
@@ -707,7 +767,7 @@ func toClairCorePackage(p *v4.Package) (string, *claircore.Package, error) {
 		return "", nil, fmt.Errorf("package %q: invalid source package %q: source specifies source",
 			p.GetId(), p.GetSource().GetId())
 	}
-	_, src, err := toClairCorePackage(p.GetSource())
+	_, src, err := ccPackage(p.GetSource())
 	if err != nil {
 		return "", nil, err
 	}
@@ -726,7 +786,23 @@ func toClairCorePackage(p *v4.Package) (string, *claircore.Package, error) {
 	}, nil
 }
 
-func toClairCoreDistribution(d *v4.Distribution) (string, *claircore.Distribution, error) {
+func ccDistributions(contents *v4.Contents) (map[string]*claircore.Distribution, error) {
+	if dists := contents.GetDistributions(); len(dists) > 0 {
+		distributions := make(map[string]*claircore.Distribution)
+		for id, dist := range dists {
+			_, ccDist, err := ccDistribution(dist)
+			if err != nil {
+				return nil, err
+			}
+			distributions[id] = ccDist
+		}
+		return distributions, nil
+	}
+	// Fallback to the deprecated slice, if necessary.
+	return convertSliceToMap(contents.GetDistributionsDEPRECATED(), ccDistribution)
+}
+
+func ccDistribution(d *v4.Distribution) (string, *claircore.Distribution, error) {
 	if d == nil {
 		return "", nil, nil
 	}
@@ -747,7 +823,23 @@ func toClairCoreDistribution(d *v4.Distribution) (string, *claircore.Distributio
 	}, nil
 }
 
-func toClairCoreRepository(r *v4.Repository) (string, *claircore.Repository, error) {
+func ccRepositories(contents *v4.Contents) (map[string]*claircore.Repository, error) {
+	if repos := contents.GetRepositories(); len(repos) > 0 {
+		repositories := make(map[string]*claircore.Repository)
+		for id, repo := range repos {
+			_, ccRepo, err := ccRepository(repo)
+			if err != nil {
+				return nil, err
+			}
+			repositories[id] = ccRepo
+		}
+		return repositories, nil
+	}
+	// Fallback to the deprecated slice, if necessary.
+	return convertSliceToMap(contents.GetRepositoriesDEPRECATED(), ccRepository)
+}
+
+func ccRepository(r *v4.Repository) (string, *claircore.Repository, error) {
 	if r == nil {
 		return "", nil, nil
 	}
@@ -764,7 +856,25 @@ func toClairCoreRepository(r *v4.Repository) (string, *claircore.Repository, err
 	}, nil
 }
 
-func toClairCoreEnvironment(env *v4.Environment) (*claircore.Environment, error) {
+func ccEnvironments(contents *v4.Contents) (map[string][]*claircore.Environment, error) {
+	if len(contents.GetEnvironments()) == 0 {
+		return nil, nil
+	}
+	environments := make(map[string][]*claircore.Environment, len(contents.GetEnvironments()))
+	for id, envs := range contents.GetEnvironments() {
+		environments[id] = make([]*claircore.Environment, 0, len(envs.GetEnvironments()))
+		for _, env := range envs.GetEnvironments() {
+			ccEnv, err := ccEnvironment(env)
+			if err != nil {
+				return nil, err
+			}
+			environments[id] = append(environments[id], ccEnv)
+		}
+	}
+	return environments, nil
+}
+
+func ccEnvironment(env *v4.Environment) (*claircore.Environment, error) {
 	introducedIn, err := claircore.ParseDigest(env.GetIntroducedIn())
 	if err != nil {
 		return nil, err

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -402,8 +402,19 @@ func Test_ToProtoV4VulnerabilityReport_FilterNodeJS(t *testing.T) {
 					},
 				},
 				Contents: &v4.Contents{
-					Packages: []*v4.Package{
+					PackagesDEPRECATED: []*v4.Package{
 						{
+							Id:      "1",
+							Name:    "nodejs1",
+							Version: "1",
+							NormalizedVersion: &v4.NormalizedVersion{
+								V: []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							},
+							Cpe: emptyCPE,
+						},
+					},
+					Packages: map[string]*v4.Package{
+						"1": {
 							Id:      "1",
 							Name:    "nodejs1",
 							Version: "1",
@@ -577,7 +588,45 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 					},
 				},
 				Contents: &v4.Contents{
-					Packages: []*v4.Package{
+					Packages: map[string]*v4.Package{
+						"0": {
+							Id:      "0",
+							Name:    "my go binary",
+							Version: "0",
+							NormalizedVersion: &v4.NormalizedVersion{
+								V: []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							},
+							Cpe: emptyCPE,
+						},
+						"1": {
+							Id:      "1",
+							Name:    "my java jar",
+							Version: "1",
+							NormalizedVersion: &v4.NormalizedVersion{
+								V: []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							},
+							Cpe: emptyCPE,
+						},
+						"2": {
+							Id:      "2",
+							Name:    "my python egg",
+							Version: "2",
+							NormalizedVersion: &v4.NormalizedVersion{
+								V: []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							},
+							Cpe: emptyCPE,
+						},
+						"3": {
+							Id:      "3",
+							Name:    "my ruby gem",
+							Version: "3",
+							NormalizedVersion: &v4.NormalizedVersion{
+								V: []int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							},
+							Cpe: emptyCPE,
+						},
+					},
+					PackagesDEPRECATED: []*v4.Package{
 						{
 							Id:      "0",
 							Name:    "my go binary",
@@ -615,7 +664,21 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 							Cpe: emptyCPE,
 						},
 					},
-					Repositories: []*v4.Repository{
+					Repositories: map[string]*v4.Repository{
+						"0": {
+							Id:   "0",
+							Name: "Red Hat Container Catalog",
+							Uri:  `https://catalog.redhat.com/software/containers/explore`,
+							Cpe:  emptyCPE,
+						},
+						"1": {
+							Id:   "1",
+							Name: "something else",
+							Uri:  "somethingelse.com",
+							Cpe:  emptyCPE,
+						},
+					},
+					RepositoriesDEPRECATED: []*v4.Repository{
 						{
 							Id:   "0",
 							Name: "Red Hat Container Catalog",
@@ -683,10 +746,10 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 			for _, pkgVulns := range got.GetPackageVulnerabilities() {
 				slices.Sort(pkgVulns.GetValues())
 			}
-			slices.SortFunc(got.GetContents().GetPackages(), func(a, b *v4.Package) int {
+			slices.SortFunc(got.GetContents().GetPackagesDEPRECATED(), func(a, b *v4.Package) int {
 				return strings.Compare(a.GetId(), b.GetId())
 			})
-			slices.SortFunc(got.GetContents().GetRepositories(), func(a, b *v4.Repository) int {
+			slices.SortFunc(got.GetContents().GetRepositoriesDEPRECATED(), func(a, b *v4.Repository) int {
 				return strings.Compare(a.GetId(), b.GetId())
 			})
 
@@ -710,7 +773,7 @@ func Test_ToClairCoreIndexReport(t *testing.T) {
 		},
 		"when content package has source with source then error": {
 			arg: &v4.Contents{
-				Packages: []*v4.Package{
+				PackagesDEPRECATED: []*v4.Package{
 					{
 						Id:  "sample package",
 						Cpe: "cpe:2.3:a:redhat:scanner:4:*:el9:*:*:*:*:*",
@@ -726,7 +789,7 @@ func Test_ToClairCoreIndexReport(t *testing.T) {
 		},
 		"when content package has invalid CPE then error": {
 			arg: &v4.Contents{
-				Packages: []*v4.Package{
+				PackagesDEPRECATED: []*v4.Package{
 					{
 						Id:  "sample package",
 						Cpe: "something that is not a cpe",
@@ -737,7 +800,7 @@ func Test_ToClairCoreIndexReport(t *testing.T) {
 		},
 		"when distribution contains invalid cpe then error": {
 			arg: &v4.Contents{
-				Distributions: []*v4.Distribution{
+				DistributionsDEPRECATED: []*v4.Distribution{
 					{
 						Cpe: "something that is not a cpe",
 					},
@@ -747,7 +810,7 @@ func Test_ToClairCoreIndexReport(t *testing.T) {
 		},
 		"when repository contains invalid cpe then error": {
 			arg: &v4.Contents{
-				Repositories: []*v4.Repository{
+				RepositoriesDEPRECATED: []*v4.Repository{
 					{
 						Cpe: "something that is not a cpe",
 					},
@@ -758,7 +821,29 @@ func Test_ToClairCoreIndexReport(t *testing.T) {
 
 		"when all fields are valid then return success": {
 			arg: &v4.Contents{
-				Packages: []*v4.Package{
+				Packages: map[string]*v4.Package{
+					"sample pkg id": {
+						Id:      "sample pkg id",
+						Name:    "sample pkg name",
+						Version: "sample pkg version",
+						NormalizedVersion: &v4.NormalizedVersion{
+							Kind: "test",
+							V:    []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+						},
+						Kind: "sample pkg kind",
+						Source: &v4.Package{
+							Id:   "sample source id",
+							Name: "sample source name",
+							Cpe:  "cpe:2.3:a:redhat:scanner:4:*:el9:*:*:*:*:*",
+						},
+						PackageDb:      "sample pkg db",
+						RepositoryHint: "sample pkg repo hint",
+						Module:         "sample pkg module",
+						Arch:           "sample pkg arch",
+						Cpe:            "cpe:2.3:a:redhat:scanner:4:*:el9:*:*:*:*:*",
+					},
+				},
+				PackagesDEPRECATED: []*v4.Package{
 					{
 						Id:      "sample pkg id",
 						Name:    "sample pkg name",
@@ -780,7 +865,20 @@ func Test_ToClairCoreIndexReport(t *testing.T) {
 						Cpe:            "cpe:2.3:a:redhat:scanner:4:*:el9:*:*:*:*:*",
 					},
 				},
-				Distributions: []*v4.Distribution{
+				Distributions: map[string]*v4.Distribution{
+					"sample dist id": {
+						Id:              "sample dist id",
+						Did:             "sample dist did",
+						Name:            "sample dist name",
+						Version:         "sample dist version",
+						VersionCodeName: "sample dist version codename",
+						VersionId:       "sample dist version id",
+						Arch:            "sample dist arch",
+						Cpe:             "cpe:2.3:a:redhat:scanner:4:*:el9:*:*:*:*:*",
+						PrettyName:      "sample dist pretty",
+					},
+				},
+				DistributionsDEPRECATED: []*v4.Distribution{
 					{
 						Id:              "sample dist id",
 						Did:             "sample dist did",
@@ -793,7 +891,16 @@ func Test_ToClairCoreIndexReport(t *testing.T) {
 						PrettyName:      "sample dist pretty",
 					},
 				},
-				Repositories: []*v4.Repository{
+				Repositories: map[string]*v4.Repository{
+					"sample id": {
+						Id:   "sample id",
+						Name: "sample name",
+						Key:  "sample key",
+						Uri:  "sample URI",
+						Cpe:  "cpe:2.3:a:redhat:scanner:4:*:el9:*:*:*:*:*",
+					},
+				},
+				RepositoriesDEPRECATED: []*v4.Repository{
 					{
 						Id:   "sample id",
 						Name: "sample name",
@@ -950,7 +1057,7 @@ func Test_toProtoV4Package(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := toProtoV4Package(tt.arg)
+			got, err := v4Package(tt.arg)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				assert.Nil(t, tt.want)
@@ -971,7 +1078,7 @@ func Test_toProtoV4Package(t *testing.T) {
 				},
 			},
 		}
-		got, err := toProtoV4Package(arg)
+		got, err := v4Package(arg)
 		assert.Nil(t, got)
 		assert.ErrorContains(t, err, "source specifies source")
 	})
@@ -1020,7 +1127,7 @@ func Test_toProtoV4Distribution(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toProtoV4Distribution(tt.arg)
+			got := v4Distribution(tt.arg)
 			protoassert.Equal(t, tt.want, got)
 		})
 	}
@@ -1055,7 +1162,7 @@ func Test_toProtoV4Repository(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toProtoV4Repository(tt.arg)
+			got := v4Repository(tt.arg)
 			protoassert.Equal(t, tt.want, got)
 		})
 	}
@@ -1093,7 +1200,7 @@ func Test_toProtoV4Environment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toProtoV4Environment(tt.arg)
+			got := v4Environment(tt.arg)
 			protoassert.Equal(t, tt.want, got)
 			if tt.want != nil && tt.want.RepositoryIds != nil {
 				assert.NotEqual(t, &tt.want.RepositoryIds, &got.RepositoryIds)
@@ -1124,17 +1231,32 @@ func Test_toProtoV4Contents(t *testing.T) {
 				},
 			},
 			want: &v4.Contents{
-				Packages: []*v4.Package{{
+				Packages: map[string]*v4.Package{
+					"sample pkg": {
+						Cpe: emptyCPE,
+						NormalizedVersion: &v4.NormalizedVersion{
+							Kind: "",
+							V:    make([]int32, 10),
+						},
+					},
+				},
+				PackagesDEPRECATED: []*v4.Package{{
 					Cpe: emptyCPE,
 					NormalizedVersion: &v4.NormalizedVersion{
 						Kind: "",
 						V:    make([]int32, 10),
 					},
 				}},
-				Distributions: []*v4.Distribution{{
+				Distributions: map[string]*v4.Distribution{
+					"sample dist": {Cpe: emptyCPE},
+				},
+				DistributionsDEPRECATED: []*v4.Distribution{{
 					Cpe: emptyCPE,
 				}},
-				Repositories: []*v4.Repository{{
+				Repositories: map[string]*v4.Repository{
+					"sample repo": {Cpe: emptyCPE},
+				},
+				RepositoriesDEPRECATED: []*v4.Repository{{
 					Cpe: emptyCPE,
 				}},
 				Environments: map[string]*v4.Environment_List{

--- a/proto/internalapi/scanner/v4/common.proto
+++ b/proto/internalapi/scanner/v4/common.proto
@@ -9,9 +9,12 @@ package scanner.v4;
 option go_package = "./internalapi/scanner/v4;v4";
 
 message Contents {
-  repeated Package packages = 1;
-  repeated Distribution distributions = 2;
-  repeated Repository repositories = 3;
+  repeated Package packagesDEPRECATED = 1 [deprecated = true];
+  map<string, Package> packages = 5;
+  repeated Distribution distributionsDEPRECATED = 2 [deprecated = true];
+  map<string, Distribution> distributions = 6;
+  repeated Repository repositoriesDEPRECATED = 3 [deprecated = true];
+  map<string, Repository> repositories = 7;
   map<string, Environment.List> environments = 4;
 }
 

--- a/scanner/services/validators/validators.go
+++ b/scanner/services/validators/validators.go
@@ -98,13 +98,22 @@ func validateContents(contents *v4.Contents) error {
 	if contents == nil {
 		return nil
 	}
-	if err := validateList(contents.GetPackages(), "Contents.Packages", validatePackage); err != nil {
+	if err := validateMap(contents.GetPackages(), "Contents.Packages", validatePackage); err != nil {
 		return err
 	}
-	if err := validateList(contents.GetDistributions(), "Contents.Distributions", validateDistribution); err != nil {
+	if err := validateList(contents.GetPackagesDEPRECATED(), "Contents.PackagesDEPRECATED", validatePackage); err != nil {
 		return err
 	}
-	if err := validateList(contents.GetRepositories(), "Contents.Repositories", validateRepository); err != nil {
+	if err := validateMap(contents.GetDistributions(), "Contents.Distributions", validateDistribution); err != nil {
+		return err
+	}
+	if err := validateList(contents.GetDistributionsDEPRECATED(), "Contents.DistributionsDEPRECATED", validateDistribution); err != nil {
+		return err
+	}
+	if err := validateMap(contents.GetRepositories(), "Contents.Repositories", validateRepository); err != nil {
+		return err
+	}
+	if err := validateList(contents.GetRepositoriesDEPRECATED(), "Contents.RepositoriesDEPRECATED", validateRepository); err != nil {
 		return err
 	}
 	for k, envs := range contents.GetEnvironments() {
@@ -112,6 +121,27 @@ func validateContents(contents *v4.Contents) error {
 			if env == nil {
 				return fmt.Errorf("Contents.Environments[%q] element #%d is empty", k, idx+1)
 			}
+		}
+	}
+	return nil
+}
+
+func validateMap[T hasIDAndCPE](l map[string]T, fieldName string, validateF func(T) error) error {
+	var n int
+	for _, o := range l {
+		n++
+		if reflect.ValueOf(o).IsZero() {
+			return fmt.Errorf("%s element #%d is empty", fieldName, n)
+		}
+		if o.GetId() == "" {
+			return fmt.Errorf("%s element #%d: Id is empty", fieldName, n)
+		}
+		_, err := cpe.Unbind(o.GetCpe())
+		if err != nil {
+			return fmt.Errorf("%s element #%d (id: %q): invalid CPE: %w", fieldName, n, o.GetId(), err)
+		}
+		if err := validateF(o); err != nil {
+			return fmt.Errorf("%s element #%d (id: %q): %w", fieldName, n, o.GetId(), err)
 		}
 	}
 	return nil

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -393,8 +393,14 @@ func attachRPMtoRHCOS(version, arch string, rpm *v4.IndexReport) *v4.IndexReport
 	}
 	strID := strconv.Itoa(idCandidate)
 	oci := buildRHCOSIndexReport(strID, version, arch)
-	oci.Contents.Packages = append(oci.Contents.Packages, rpm.GetContents().GetPackages()...)
-	oci.Contents.Repositories = append(oci.Contents.Repositories, rpm.GetContents().GetRepositories()...)
+	for pkgID, pkg := range rpm.GetContents().GetPackages() {
+		oci.Contents.Packages[pkgID] = pkg
+	}
+	oci.Contents.PackagesDEPRECATED = append(oci.Contents.PackagesDEPRECATED, rpm.GetContents().GetPackagesDEPRECATED()...)
+	for repoID, repo := range rpm.GetContents().GetRepositories() {
+		oci.Contents.Repositories[repoID] = repo
+	}
+	oci.Contents.RepositoriesDEPRECATED = append(oci.Contents.RepositoriesDEPRECATED, rpm.GetContents().GetRepositoriesDEPRECATED()...)
 	for envId, list := range rpm.GetContents().GetEnvironments() {
 		oci.Contents.Environments[envId] = list
 	}
@@ -410,7 +416,28 @@ func buildRHCOSIndexReport(Id, version, arch string) *v4.IndexReport {
 		Success: true,
 		Err:     "",
 		Contents: &v4.Contents{
-			Packages: []*v4.Package{
+			Packages: map[string]*v4.Package{
+				Id: {
+					Id:      Id,
+					Name:    "rhcos",
+					Version: version,
+					NormalizedVersion: &v4.NormalizedVersion{
+						Kind: "rhctag",
+						V:    normalizeVersion(version), // Only two first fields matter for the db-query.
+					},
+					Kind: "binary",
+					Source: &v4.Package{
+						Id:      Id,
+						Name:    "rhcos",
+						Kind:    "source",
+						Version: version,
+						Cpe:     "cpe:2.3:*", // required to pass validation of scanner V4 API
+					},
+					Arch: arch,
+					Cpe:  "cpe:2.3:*", // required to pass validation of scanner V4 API
+				},
+			},
+			PackagesDEPRECATED: []*v4.Package{
 				{
 					Id:      Id,
 					Name:    "rhcos",
@@ -431,7 +458,16 @@ func buildRHCOSIndexReport(Id, version, arch string) *v4.IndexReport {
 					Cpe:  "cpe:2.3:*", // required to pass validation of scanner V4 API
 				},
 			},
-			Repositories: []*v4.Repository{
+			Repositories: map[string]*v4.Repository{
+				Id: {
+					Id:   Id,
+					Name: goldenName,
+					Key:  "",
+					Uri:  goldenURI,
+					Cpe:  "cpe:2.3:*", // required to pass validation of scanner V4 API
+				},
+			},
+			RepositoriesDEPRECATED: []*v4.Repository{
 				{
 					Id:   Id,
 					Name: goldenName,

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -55,15 +55,15 @@ func fakeNodeIndex(arch string) *v4.IndexReport {
 		HashId:  fmt.Sprintf("sha256:%s", strings.Repeat("a", 64)),
 		Success: true,
 		Contents: &v4.Contents{
-			Packages: []*v4.Package{
-				exemplaryPackage("0", "vim-minimal", arch),
-				exemplaryPackage("1", "vim-minimal-noarch", "noarch"),
-				exemplaryPackage("2", "vim-minimal-empty-arch", ""),
+			Packages: map[string]*v4.Package{
+				"0": exemplaryPackage("0", "vim-minimal", arch),
+				"1": exemplaryPackage("1", "vim-minimal-noarch", "noarch"),
+				"2": exemplaryPackage("2", "vim-minimal-empty-arch", ""),
 			},
-			Repositories: []*v4.Repository{
-				exemplaryRepo("0"),
-				exemplaryRepo("1"),
-				exemplaryRepo("2"),
+			Repositories: map[string]*v4.Repository{
+				"0": exemplaryRepo("0"),
+				"1": exemplaryRepo("1"),
+				"2": exemplaryRepo("2"),
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Claircore v1.5.40 brings an update to the RHEL coalescer. This update modifies the vulnerability report's repositories map to map name -> repo instead of ID -> repo.

Scanner V4 originally assumed it'd always be ID -> repo, which is now incorrect. This assumption makes it so we could no longer match RPMs against vulnerabilities. This PR aims to fix this by deprecating the old and instroduce a new map to match Claircore more closely.

I attempt to keep this as backwards compatible as possible to account for various installations (differing Scanner V4 versions, differing Central/Sensor versions, etc). The hope is that one day (when at least when 4.8 is out of support), we can remove the deprecated fields.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
