### PR TITLE
fix(ci): Bump Glibc CVE for ImageScanningTest to pass

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -454,7 +454,7 @@ class ImageScanningTest extends BaseSpecification {
         new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "RHSA-2019:0483" | RHEL7_IMAGE     | ""
         new StackroxScannerIntegration() | "openssl-libs"             | "1:1.0.2k-12.el7"             | 0   | "CVE-2018-0735"  | RHEL7_IMAGE     | ""
         new StackroxScannerIntegration() | "systemd"                  | "229-4ubuntu21.29"            | 0   | "CVE-2021-33910" | OCI_IMAGE       | ""
-        new StackroxScannerIntegration() | "glibc"                    | "2.35-0ubuntu3.1"             | 4   | "CVE-2016-20013" | LIST_IMAGE_OCI_MANIFEST | ""
+        new StackroxScannerIntegration() | "glibc"                    | "2.35-0ubuntu3.1"             | 4   | "CVE-2023-4911" | LIST_IMAGE_OCI_MANIFEST | ""
         new ClairScannerIntegration()    | "apt"                      | "1.4.8"                       | 0   | "CVE-2011-3374"  | NGINX_IMAGE     | ""
         new ClairScannerIntegration()    | "bash"                     | "4.4-5"                       | 0   | "CVE-2019-18276" | NGINX_IMAGE     | ""
         new ClairV4ScannerIntegration()  | "openssl-libs"             | "1:1.1.1-8.el8"               | 0   | "RHSA-2021:1024" | UBI8_0_IMAGE    | ""


### PR DESCRIPTION
## Description

Backport of https://github.com/stackrox/stackrox/pull/16634

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Only CI.
