### PR TITLE
ROX-30848: Add Orion config for ACS cluster-density-v2 job

### DIFF
--- a/tests/performance/scale/config/orion-acs-cluster-density-v2.yml
+++ b/tests/performance/scale/config/orion-acs-cluster-density-v2.yml
@@ -20,6 +20,7 @@ tests :
     - name: collector-cpu
       metricName: stackrox_container_cpu
       labels.container: collector
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -29,6 +30,7 @@ tests :
     - name: collector-mem
       metricName: stackrox_container_memory_working_set_bytes
       labels.container: collector
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -39,6 +41,7 @@ tests :
     - name: admission-cpu
       metricName: stackrox_container_cpu
       labels.container: admission-control
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -48,6 +51,7 @@ tests :
     - name: admission-mem
       metricName: stackrox_container_memory_working_set_bytes
       labels.container: admission-control
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -58,6 +62,7 @@ tests :
     - name: central-cpu
       metricName: stackrox_container_cpu
       labels.container: central
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -67,6 +72,7 @@ tests :
     - name: central-mem
       metricName: stackrox_container_memory_working_set_bytes
       labels.container: central
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -77,6 +83,7 @@ tests :
     - name: central-db-cpu
       metricName: stackrox_container_cpu
       labels.container: central-db
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -86,6 +93,7 @@ tests :
     - name: central-db-mem
       metricName: stackrox_container_memory_working_set_bytes
       labels.container: central-db
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -96,6 +104,7 @@ tests :
     - name: sensor-cpu
       metricName: stackrox_container_cpu
       labels.container: sensor
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"
@@ -105,6 +114,7 @@ tests :
     - name: sensor-mem
       metricName: stackrox_container_memory_working_set_bytes
       labels.container: sensor
+      threshold: 5
       metric_of_interest: value
       not:
         jobConfig.name: "garbage-collection"

--- a/tests/performance/scale/config/orion-acs-cluster-density-v2.yml
+++ b/tests/performance/scale/config/orion-acs-cluster-density-v2.yml
@@ -1,0 +1,113 @@
+tests :
+  - name : 24-node-scale-cdv2
+    index: {{ es_metadata_index }}
+    benchmarkIndex: {{ es_benchmark_index }}
+    metadata:
+      platform: AWS
+      clusterType: self-managed
+      masterNodesType: m6a.xlarge
+      masterNodesCount: 3
+      workerNodesType: m6a.xlarge
+      workerNodesCount: 24
+      benchmark.keyword: cluster-density-v2
+      ocpVersion: {{ version }}
+      networkType: OVNKubernetes
+      jobType: {{ jobtype | default('periodic') }}
+      not:
+        stream: okd
+
+    metrics :
+    - name: collector-cpu
+      metricName: stackrox_container_cpu
+      labels.container: collector
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: collector-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: collector
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: admission-cpu
+      metricName: stackrox_container_cpu
+      labels.container: admission-control
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: admission-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: admission-control
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: central-cpu
+      metricName: stackrox_container_cpu
+      labels.container: central
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: central-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: central
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: central-db-cpu
+      metricName: stackrox_container_cpu
+      labels.container: central-db
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: central-db-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: central-db
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg
+
+    - name: sensor-cpu
+      metricName: stackrox_container_cpu
+      labels.container: sensor
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: cpu
+        agg_type: avg
+    - name: sensor-mem
+      metricName: stackrox_container_memory_working_set_bytes
+      labels.container: sensor
+      metric_of_interest: value
+      not:
+        jobConfig.name: "garbage-collection"
+      agg:
+        value: mem
+        agg_type: avg


### PR DESCRIPTION
## Description

This PR is adding Orion configuration to check regression on ACS cluster-density-v2 job.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] tests in this repo are not relevant

### How I validated my change

I validated configuration manually:
```
# From BitWarden
export ES_SERVER=https://<username>:<password>@<elasticsearch>

export es_metadata_index='perf_scale_ci*'
export es_benchmark_index='ripsaw-kube-burner*'
```

I made a Docker image from: https://github.com/cloud-bulldozer/orion - and ran it with `tail -f /dev/null`.
After that, I could `exec` and copy files into the container.
```
orion --config orion-acs-cluster-density-v2.yml --hunter-analyze  --input-vars='{"version": "4.19"}'  --lookback=30d
```
