### PR TITLE
ROX-30988: Add import-type-order rule to pluginGeneric

### DIFF
--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -1,5 +1,9 @@
 import queryString from 'qs';
 
+import {
+    isConfiguredReportSnapshot,
+    isViewBasedReportSnapshot,
+} from 'services/ReportsService.types';
 import type {
     ReportConfiguration,
     ReportHistoryResponse,
@@ -8,10 +12,6 @@ import type {
     RunReportResponse,
     RunReportResponseViewBased,
     ConfiguredReportSnapshot,
-} from 'services/ReportsService.types';
-import {
-    isConfiguredReportSnapshot,
-    isViewBasedReportSnapshot,
 } from 'services/ReportsService.types';
 import type { ApiSortOption, SearchFilter } from 'types/search';
 import { getListQueryParams, getPaginationParams } from 'utils/searchUtils';


### PR DESCRIPTION
## Description

Double down on consistent use of `import type` statement to step forward instead of sideways.

Require `import type` to follow corresponding `import` statement (if it exists).

Use typescript-eslint playground:

https://typescript-eslint.io/play/#ts=5.9.2&showAST=es&fileType=.tsx

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.

    > src/services/ReportsService.ts
    > 3:1  error  Move import type to follow corresponding import statement  generic/import-type-order