### PR TITLE
ROX-30991: Replace relative path to subfolder of src in some import

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginLimited.js
+++ b/ui/apps/platform/eslint-plugins/pluginLimited.js
@@ -1,6 +1,17 @@
-/* globals module require */
+/* globals __dirname module require */
 
+const fs = require('node:fs');
 const path = require('node:path');
+
+// Adapted from getSrcAliases in vite.config.js file.
+const srcPath = path.resolve(__dirname, '..', 'src'); // src is sibling of eslint-plugins folder
+const srcSubfolders = fs
+    .readdirSync(srcPath, { withFileTypes: true })
+    .filter((dirent) => {
+        // Avoid hidden directories, like `.DS_Store`
+        return dirent.isDirectory() && !dirent.name.startsWith('.');
+    })
+    .map(({ name }) => name);
 
 // Limited rules have exceptions via ignores property.
 // When ESLint plugin for Visual Studio Code has support for suppressions, they might supersede limited rules.
@@ -116,29 +127,6 @@ const rules = {
             schema: [],
         },
         create(context) {
-            // Too bad, so sad, that this array might become inconsistent with reality.
-            const subfolders = [
-                'Components',
-                'ConsolePlugin',
-                'constants',
-                'Containers',
-                'css',
-                'hooks',
-                'images',
-                'init',
-                'messages',
-                'mockData',
-                'providers',
-                'queries',
-                'reducers',
-                'sagas',
-                'services',
-                'sorters',
-                'test-utils',
-                'types',
-                'utils',
-            ];
-
             return {
                 Literal(node) {
                     if (typeof node.value === 'string') {
@@ -157,8 +145,8 @@ const rules = {
                                 const depth = [...filenameAfterBase.matchAll(/\//g)].length;
                                 const relativePrefix = depth === 0 ? './' : '../'.repeat(depth - 1);
                                 if (
-                                    subfolders.some((subfolder) =>
-                                        node.value.startsWith(`${relativePrefix}${subfolder}/`)
+                                    srcSubfolders.some((srcSubfolder) =>
+                                        node.value.startsWith(`${relativePrefix}${srcSubfolder}/`)
                                     )
                                 ) {
                                     context.report({

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -766,6 +766,7 @@ module.exports = [
             '@typescript-eslint/consistent-type-imports': 'error',
             'limited/no-inline-type-imports': 'error',
             'limited/no-qualified-name-react': 'error',
+            'limited/no-relative-path-to-src-in-import': 'error',
         },
     },
     {

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -3,12 +3,12 @@ import type { ReactNode } from 'react';
 import { ApolloProvider } from '@apollo/client';
 
 import axios from 'services/instance';
+import configureApolloClient from 'init/configureApolloClient';
 import { UserPermissionProvider } from 'providers/UserPermissionProvider';
 import { FeatureFlagsProvider } from 'providers/FeatureFlagProvider';
 import { MetadataProvider } from 'providers/MetadataProvider';
 import { PublicConfigProvider } from 'providers/PublicConfigProvider';
 
-import configureApolloClient from '../init/configureApolloClient';
 import consoleFetchAxiosAdapter from './consoleFetchAxiosAdapter';
 import PluginContent from './PluginContent';
 

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -1,5 +1,5 @@
 /* constants specific to Roles */
-import type { ResourceName } from '../types/roleResources';
+import type { ResourceName } from 'types/roleResources';
 
 export const NO_ACCESS = 'NO_ACCESS';
 export const READ_ACCESS = 'READ_ACCESS';

--- a/ui/apps/platform/src/hooks/useTabs.test.jsx
+++ b/ui/apps/platform/src/hooks/useTabs.test.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { act, render, renderHook, screen } from '@testing-library/react';
 
+import Tab from 'Components/Tab';
+
 import useTabs from './useTabs';
-import Tab from '../Components/Tab';
 
 const initialProps = {
     children: [

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -35,7 +35,7 @@ import { PublicConfigProvider } from 'providers/PublicConfigProvider';
 import { TelemetryConfigProvider } from 'providers/TelemetryConfigProvider';
 import { MetadataProvider } from 'providers/MetadataProvider';
 import ReduxUserPermissionProvider from 'Containers/ReduxUserPermissionProvider';
-import { fetchCentralCapabilitiesThunk } from './reducers/centralCapabilities';
+import { fetchCentralCapabilitiesThunk } from 'reducers/centralCapabilities';
 
 // We need to call this MobX utility function, to prevent the error
 //   Uncaught Error: [MobX] There are multiple, different versions of MobX active. Make sure MobX is loaded only once or use `configure({ isolateGlobalState: true })`

--- a/ui/apps/platform/src/init/installRaven.js
+++ b/ui/apps/platform/src/init/installRaven.js
@@ -1,6 +1,6 @@
 import Raven from 'raven-js';
 
-import axios from '../services/instance';
+import axios from 'services/instance';
 
 let ravenInstalled = false;
 

--- a/ui/apps/platform/src/reducers/cloudSources.js
+++ b/ui/apps/platform/src/reducers/cloudSources.js
@@ -1,6 +1,8 @@
 import isEqual from 'lodash/isEqual';
+
 import { combineReducers } from 'redux';
-import { createFetchingActions, createFetchingActionTypes } from '../utils/fetchingReduxRoutines';
+
+import { createFetchingActions, createFetchingActionTypes } from 'utils/fetchingReduxRoutines';
 
 export const types = {
     FETCH_CLOUD_SOURCES: createFetchingActionTypes('cloudSources/FETCH_CLOUD_SOURCES'),

--- a/ui/apps/platform/src/reducers/machineAccessConfigs.js
+++ b/ui/apps/platform/src/reducers/machineAccessConfigs.js
@@ -1,6 +1,7 @@
 import isEqual from 'lodash/isEqual';
 import { combineReducers } from 'redux';
-import { createFetchingActions, createFetchingActionTypes } from '../utils/fetchingReduxRoutines';
+
+import { createFetchingActions, createFetchingActionTypes } from 'utils/fetchingReduxRoutines';
 
 export const types = {
     FETCH_MACHINE_ACCESS_CONFIGS: createFetchingActionTypes(

--- a/ui/apps/platform/src/reducers/roles.js
+++ b/ui/apps/platform/src/reducers/roles.js
@@ -1,8 +1,8 @@
 import { combineReducers } from 'redux';
 import isEqual from 'lodash/isEqual';
 
+import { replacedResourceMapping } from 'constants/accessControl';
 import { createFetchingActionTypes, createFetchingActions } from 'utils/fetchingReduxRoutines';
-import { replacedResourceMapping } from '../constants/accessControl';
 
 export const ACCESS_LEVEL = Object.freeze({
     READ_WRITE_ACCESS: 'READ_WRITE_ACCESS',

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -1,6 +1,7 @@
+import type { Traits } from 'types/traits.proto';
+
 import axios from './instance';
 import type { Empty } from './types';
-import type { Traits } from '../types/traits.proto';
 
 const accessScopessUrl = '/v1/simpleaccessscopes';
 

--- a/ui/apps/platform/src/services/AdministrationUsageService.ts
+++ b/ui/apps/platform/src/services/AdministrationUsageService.ts
@@ -1,10 +1,12 @@
 import qs from 'qs';
-import axios from './instance';
+
 import type {
     MaxSecuredUnitsUsageResponse,
     SecuredUnitsUsage,
     TimeRange,
-} from '../types/administrationUsage.proto';
+} from 'types/administrationUsage.proto';
+
+import axios from './instance';
 import { saveFile } from './DownloadService';
 
 export function fetchCurrentAdministrationUsage() {

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import store from 'store';
 
-import axios from 'services/instance';
 import queryString from 'qs';
 
+import { authProviderLabels } from 'constants/accessControl';
 import type { Role } from 'services/RolesService';
 import type { Empty } from 'services/types';
+import type { Traits } from 'types/traits.proto';
 import { isUserResource } from 'utils/traits.utils';
 
+import axios from '../instance';
 import AccessTokenManager from './AccessTokenManager';
 import addTokenRefreshInterceptors, {
     doNotStallRequestConfig,
 } from './addTokenRefreshInterceptors';
-import { authProviderLabels } from '../../constants/accessControl';
-import type { Traits } from '../../types/traits.proto';
 
 const authProvidersUrl = '/v1/authProviders';
 const authLoginProvidersUrl = '/v1/login/authproviders';

--- a/ui/apps/platform/src/services/DeclarativeConfigHealthService.ts
+++ b/ui/apps/platform/src/services/DeclarativeConfigHealthService.ts
@@ -1,6 +1,6 @@
-import axios from './instance';
+import type { DeclarativeConfigHealth } from 'types/declarativeConfigHealth.proto';
 
-import type { DeclarativeConfigHealth } from '../types/declarativeConfigHealth.proto';
+import axios from './instance';
 
 const healthUrl = '/v1/declarative-config/health';
 

--- a/ui/apps/platform/src/services/IntegrationHealthService.ts
+++ b/ui/apps/platform/src/services/IntegrationHealthService.ts
@@ -1,4 +1,4 @@
-import type { IntegrationHealth } from '../types/integrationHealth.proto';
+import type { IntegrationHealth } from 'types/integrationHealth.proto';
 
 import axios from './instance';
 

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -16,10 +16,11 @@ import type {
 import type { ApiSortOption, SearchFilter } from 'types/search';
 import { getListQueryParams, getPaginationParams } from 'utils/searchUtils';
 import type { ReportNotificationMethod, ReportStatus } from 'types/reportJob';
+import { sanitizeFilename } from 'utils/fileUtils';
+
 import axios from './instance';
 import type { Empty } from './types';
 import { saveFile } from './DownloadService';
-import { sanitizeFilename } from '../utils/fileUtils';
 
 // The following functions are built around the new VM Reporting Enhancements
 export const reportDownloadURL = '/api/reports/jobs/download';

--- a/ui/apps/platform/src/services/ReportsService.types.ts
+++ b/ui/apps/platform/src/services/ReportsService.types.ts
@@ -1,5 +1,5 @@
+import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { Snapshot } from 'types/reportJob';
-import type { VulnerabilitySeverity } from '../types/cve.proto';
 
 // Core report types
 

--- a/ui/apps/platform/src/services/SystemConfigService.ts
+++ b/ui/apps/platform/src/services/SystemConfigService.ts
@@ -1,4 +1,4 @@
-import type { PublicConfig, SystemConfig } from '../types/config.proto';
+import type { PublicConfig, SystemConfig } from 'types/config.proto';
 
 import axios from './instance';
 


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

Prerequisite so `import` statements from other containers can have consistent order:
* follow package dependencies
* precede relative path within container

### Bonus

Mental slow cooker decided what to do about false positives, therefore we can fix these errors at same time as `import type` and React qualified name.

1. Add `'no-relative-path-to-src-in-import'` to pluginLimited.js file with `ignores` array:

    * Components
    * ConsolePlugins
    * Containers subfolders

    Decide what to do about ConsolePlugins or Containers subfolders that do have relative paths to subfolders like:

    * Components
    * hooks

### Residue

1. Distinguish path in folder from path in package dependency.

    Investigate options of lint rules in `eslint-plugin-import` package.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.