### PR TITLE
ROX-28636: Add collector health check before network edge test

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -29,6 +29,7 @@ import services.ClusterService
 import services.DeploymentService
 import services.NetworkGraphService
 import services.NetworkPolicyService
+import util.ApplicationHealth
 import util.CollectorUtil
 import util.Env
 import util.Helpers
@@ -301,7 +302,10 @@ class NetworkFlowTest extends BaseSpecification {
         then:
         "Check for edge between collector and sensor, if collector is installed"
         if (collectorUid != null) {
-            log.info "Checking for edge between collector and sensor"
+            log.info "Waiting for collector to be healthy before checking network edges"
+            ApplicationHealth ah = new ApplicationHealth(orchestrator, 120)
+            ah.waitForCollectorHealthiness()
+            log.info "Collector is healthy, now checking for edge between collector and sensor"
             edges = NetworkGraphUtil.checkForEdge(collectorUid, sensorUid)
             assert edges
         }


### PR DESCRIPTION
ROX-28636: Add collector health check before network edge verification

Wait for collector to be healthy before checking collector->sensor network edges in NetworkFlowTest. This prevents test failures caused by timing issues where the test runs before collector has established proper communication with the sensor.

- Add ApplicationHealth import to NetworkFlowTest
- Use waitForCollectorHealthiness() before edge verification
- Set 120-second timeout for collector health check
- Follows same pattern as PR #16689 for AdmissionControllerTest

This should resolve the flaky NetworkFlowTest failure where edges return null due to collector not being ready.

🤖 Generated with [Claude Code](https://claude.ai/code)
