### PR TITLE
fix(risk): improve reprocess deployment risk

### DIFF
--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -26,6 +26,7 @@ type DataStore interface {
 
 	Search(ctx context.Context, q *v1.Query) ([]pkgSearch.Result, error)
 	SearchRawProcessIndicators(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.ProcessIndicator) error) error
 
 	GetProcessIndicator(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
 	GetProcessIndicators(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, bool, error)

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -58,6 +58,10 @@ func (ds *datastoreImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Q
 	return ds.storage.GetByQuery(ctx, q)
 }
 
+func (ds *datastoreImpl) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.ProcessIndicator) error) error {
+	return ds.storage.GetByQueryFn(ctx, query, fn)
+}
+
 func (ds *datastoreImpl) GetProcessIndicator(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error) {
 	indicator, exists, err := ds.storage.Get(ctx, id)
 	if err != nil || !exists {

--- a/central/processindicator/datastore/mocks/datastore.go
+++ b/central/processindicator/datastore/mocks/datastore.go
@@ -78,6 +78,20 @@ func (mr *MockDataStoreMockRecorder) Count(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockDataStore)(nil).Count), ctx, q)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockDataStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.ProcessIndicator) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockDataStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockDataStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // GetProcessIndicator mocks base method.
 func (m *MockDataStore) GetProcessIndicator(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/processindicator/store/mocks/store.go
+++ b/central/processindicator/store/mocks/store.go
@@ -117,6 +117,20 @@ func (mr *MockStoreMockRecorder) GetByQuery(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
 }
 
+// GetByQueryFn mocks base method.
+func (m *MockStore) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(*storage.ProcessIndicator) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQueryFn", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetByQueryFn indicates an expected call of GetByQueryFn.
+func (mr *MockStoreMockRecorder) GetByQueryFn(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQueryFn", reflect.TypeOf((*MockStore)(nil).GetByQueryFn), ctx, query, fn)
+}
+
 // GetMany mocks base method.
 func (m *MockStore) GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error) {
 	m.ctrl.T.Helper()

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -17,6 +17,7 @@ type Store interface {
 
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
 	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *storage.ProcessIndicator) error) error
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
 
 	UpsertMany(context.Context, []*storage.ProcessIndicator) error


### PR DESCRIPTION
`SearchRawProcessIndicators` calls `GetByQuery` and that is not optimal in our use case where we need to loop over elements of the process indicators return set. Instead let's use `GetByQueryFn` and pass a function callback. This will reduce memory and GC pressure as we do not need to load all objects into a slice but iterate one by one.

<img width="1367" height="1033" alt="localhost_8102_ui_flamegraph_" src="https://github.com/user-attachments/assets/76cfb265-0e93-4c18-a736-5c31e775a436" />
<img width="1367" height="1033" alt="localhost_8102_ui_flamegraph_si=inuse_space p=%5Egithub%5C com%2Fstackrox%2Frox%2Fcentral%2Fprocessbaseline%2Fevaluator%5C %5C%28%5C_evaluator%5C%29%5C EvaluateBaselinesAndPersistResult%24" src="https://github.com/user-attachments/assets/d76439f7-9273-4348-8568-1982aebd1c5f" />

refs:
- https://github.com/stackrox/stackrox/pull/15085
- https://github.com/stackrox/stackrox/pull/15010