### PR TITLE
fix(operator): CA rotation failure after version upgrade

### DIFF
--- a/operator/internal/central/extensions/reconcile_tls_ca_rotation_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_ca_rotation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stackrox/rox/generated/storage"
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
+	"github.com/stackrox/rox/operator/internal/central/carotation"
 	commonExtensions "github.com/stackrox/rox/operator/internal/common/extensions"
 	"github.com/stackrox/rox/operator/internal/common/rendercache"
 	"github.com/stackrox/rox/operator/internal/types"
@@ -23,6 +24,7 @@ import (
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stretchr/testify/require"
 	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -112,6 +114,68 @@ func TestCentralCARotation(t *testing.T) {
 			updateSecondaryCANotBefore(t, client, currentTime)
 		}
 	}
+}
+
+func TestCentralCARotationUpgradeAfter4Years(t *testing.T) {
+	// This test simulates an upgrade from an ACS version that does not have CA rotation enabled to a version that does.
+	// The Central CA is 4+ years old, and so a new secondary CA should be added and then promoted to primary, in
+	// two distinct reconciliations.
+	t.Setenv(envCentralCARotationEnabled, "true")
+
+	oldCA, err := certgen.GenerateCA()
+	require.NoError(t, err)
+
+	// Update the CA's NotBefore to be 4+ years ago to simulate an old deployment
+	privateKey, err := helpers.ParsePrivateKeyPEM(oldCA.KeyPEM())
+	require.NoError(t, err)
+	oldCATime := time.Now().Add(-4*365*24*time.Hour - 24*time.Hour)
+	oldCACertBytes, err := updateCertificateNotBefore(oldCA.Certificate(), privateKey, oldCATime)
+	require.NoError(t, err)
+	oldCAPEM, err := mtls.LoadCAForSigning(oldCACertBytes, oldCA.KeyPEM())
+	require.NoError(t, err)
+
+	centralCert, err := oldCAPEM.IssueCertForSubject(mtls.CentralSubject, mtls.WithNamespace(testutils.TestNamespace), mtls.WithValidityNotBefore(oldCATime))
+	require.NoError(t, err)
+
+	fileMap := map[string][]byte{
+		mtls.CACertFileName:      oldCAPEM.CertPEM(),
+		mtls.CAKeyFileName:       oldCAPEM.KeyPEM(),
+		mtls.ServiceCertFileName: centralCert.CertPEM,
+		mtls.ServiceKeyFileName:  centralCert.KeyPEM,
+	}
+
+	testCase := secretReconciliationTestCase{
+		Spec: basicSpecWithScanner(true, true),
+		ExistingManaged: []*coreV1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "central-tls",
+					Namespace: testutils.TestNamespace,
+				},
+				Data: fileMap,
+			},
+		},
+	}
+
+	central := buildFakeCentral(testCase)
+	client := buildFakeClient(t, testCase, central)
+	run := &createCentralTLSExtensionRun{
+		SecretReconciliator: commonExtensions.NewSecretReconciliator(client, client, central),
+		centralObj:          central,
+		currentTime:         time.Now(),
+	}
+
+	err = run.Execute(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, carotation.AddSecondary, run.caRotationAction)
+
+	err = run.Execute(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, carotation.PromoteSecondary, run.caRotationAction)
+
+	err = run.Execute(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, carotation.NoAction, run.caRotationAction)
 }
 
 func verifyCentralCertNoSecondaryCA(t *testing.T, fileMap types.SecretDataMap, atTime *time.Time) {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR fixes a bug where the Operator would enter an irreconcilable state during CA rotation, after an upgrade from a previous version of ACS that does not support CA rotation, and has a CA older than 4 years:
- Initial `central-tls` secrets validation determined `AddSecondary` CA rotation action is needed (typically done after 3 years)
- Post-generation validation now sees that `PromoteSecondary` CA rotation action is needed
- Which causes "CA rotation action needed" error in post-generation validation

So the existing assumption that there must be no CA rotation action needed after a reconcile is wrong. In fact, this was [already known](https://github.com/stackrox/stackrox/blob/b0f2155f5763bfc29ca00e9e0b947e0aae9b43d7/operator/internal/central/carotation/rotation.go#L41):
```go
	// Promote secondary to primary after 4/5 of the primary's validity period has elapsed.
	// If no secondary CA exists at this point, the rotation will be done in two steps:
	// first reconcile - AddSecondary, subsequent reconcile - PromoteSecondary
```

To fix this issue, post-generation validation now only verifies certificate integrity and does not re-check CA rotation.

The bug was introduced in https://github.com/stackrox/stackrox/pull/15074

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual testing on [this branch](https://github.com/stackrox/stackrox/pull/15349):
- replaced Operator in Irreconciliable state with a version that includes this fix
- verified that the Operator created the secondary CA, and then performed the rotation in the next reconcile
