### PR TITLE
ROX-30704: Add implementation for Workload Security tab

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
@@ -1,6 +1,46 @@
 import React from 'react';
-import { PageSection } from '@patternfly/react-core';
+import { useParams } from 'react-router-dom-v5-compat';
+import { Spinner } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import EmptyStateTemplate from 'Components/EmptyStateTemplate';
+import useURLPagination from 'hooks/useURLPagination';
+import { DEFAULT_VM_PAGE_SIZE } from 'Containers/Vulnerabilities/constants';
+import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
+import DeploymentPageVulnerabilities from 'Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
+import { useWorkloadId } from '../hooks/useWorkloadId';
 
 export function WorkloadSecurityTab() {
-    return <PageSection>Security</PageSection>;
+    const context = useDefaultWorkloadCveViewContext();
+    const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const { ns, name } = useParams();
+    // TODO This is not usable with multiple clusters without backend support, as we cannot filter by cluster via information in the console
+    const { id, isLoading, error } = useWorkloadId({ ns, name });
+
+    return (
+        <WorkloadCveViewContext.Provider value={context}>
+            {isLoading && <Spinner aria-label="Loading workload security data" />}
+            {error && (
+                <EmptyStateTemplate
+                    headingLevel={'h2'}
+                    title={`Unable to find security data for workload "${name}" in namespace "${ns}"`}
+                    icon={ExclamationCircleIcon}
+                    iconClassName="pf-v5-u-danger-color-100"
+                >
+                    {error.message ?? getAxiosErrorMessage(error)}
+                </EmptyStateTemplate>
+            )}
+            {id && (
+                <DeploymentPageVulnerabilities
+                    deploymentId={id}
+                    pagination={pagination}
+                    showVulnerabilityStateTabs={false}
+                    vulnerabilityState="OBSERVED"
+                />
+            )}
+        </WorkloadCveViewContext.Provider>
+    );
 }

--- a/ui/apps/platform/src/ConsolePlugin/hooks/useWorkloadId.ts
+++ b/ui/apps/platform/src/ConsolePlugin/hooks/useWorkloadId.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+
+import useRestQuery from 'hooks/useRestQuery';
+import { listDeployments } from 'services/DeploymentsService';
+import type { SearchFilter, ApiSortOption } from 'types/search';
+
+export function useWorkloadId({ ns, name }: { ns: string | undefined; name: string | undefined }) {
+    const deploymentIdQuery = useCallback(() => {
+        // Quote search values to ensure exact match instead of prefix match
+        const searchFilter: SearchFilter = { Namespace: `"${ns}"`, Deployment: `"${name}"` };
+        const sortOption: ApiSortOption = { field: 'Deployment', reversed: false };
+        return listDeployments(searchFilter, sortOption, 1, 10);
+    }, [ns, name]);
+
+    const { data, isLoading, error } = useRestQuery(deploymentIdQuery);
+    const id = data?.[0]?.id;
+
+    if (!ns || !name) {
+        return {
+            id: undefined,
+            isLoading: false,
+            error: new Error(
+                `An invalid namespace or name was provided. Namespace: ${ns} Name: ${name}`
+            ),
+        };
+    }
+
+    if (!id && !isLoading && !error) {
+        return {
+            id: undefined,
+            isLoading: false,
+            error: new Error(`A workload id could not be found. Namespace: ${ns} Name: ${name}`),
+        };
+    }
+
+    return { id, isLoading, error };
+}

--- a/ui/apps/platform/src/ConsolePlugin/hooks/useWorkloadId.ts
+++ b/ui/apps/platform/src/ConsolePlugin/hooks/useWorkloadId.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import useRestQuery from 'hooks/useRestQuery';
 import { listDeployments } from 'services/DeploymentsService';
-import type { SearchFilter, ApiSortOption } from 'types/search';
+import type { ApiSortOption, SearchFilter } from 'types/search';
 
 export function useWorkloadId({ ns, name }: { ns: string | undefined; name: string | undefined }) {
     const deploymentIdQuery = useCallback(() => {

--- a/ui/apps/platform/src/ConsolePlugin/hooks/useWorkloadId.ts
+++ b/ui/apps/platform/src/ConsolePlugin/hooks/useWorkloadId.ts
@@ -4,12 +4,24 @@ import useRestQuery from 'hooks/useRestQuery';
 import { listDeployments } from 'services/DeploymentsService';
 import type { ApiSortOption, SearchFilter } from 'types/search';
 
-export function useWorkloadId({ ns, name }: { ns: string | undefined; name: string | undefined }) {
+type UseWorkloadIdResult = {
+    id: string | undefined;
+    isLoading: boolean;
+    error: Error | undefined;
+};
+
+export function useWorkloadId({
+    ns,
+    name,
+}: {
+    ns: string | undefined;
+    name: string | undefined;
+}): UseWorkloadIdResult {
     const deploymentIdQuery = useCallback(() => {
         // Quote search values to ensure exact match instead of prefix match
         const searchFilter: SearchFilter = { Namespace: `"${ns}"`, Deployment: `"${name}"` };
         const sortOption: ApiSortOption = { field: 'Deployment', reversed: false };
-        return listDeployments(searchFilter, sortOption, 1, 10);
+        return listDeployments(searchFilter, sortOption, 1, 1);
     }, [ns, name]);
 
     const { data, isLoading, error } = useRestQuery(deploymentIdQuery);


### PR DESCRIPTION
## Description

Adds the Deployment detail view to Workload pages in the OCP console.

### Caveats

The OCP Workload pages reference a workload by **workload name** and **namespace name**. Since ACS APIs expect a workload "id", we need to query ACS for a list of workloads matching the workload and namespace name in the URL and extract the ID from the response.

Due to the OCP console not providing any information about the cluster, and even if it did, ACS uses a separate model for cluster name/id on the backend, these queries are unable to restrict the data to a specific cluster when hitting central directly. **For this to work in production, we must have backend support to restrict to a single cluster.**

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the Deployments list in the console and select an individual deployment. From there, navigate to the Security tab.
<img width="1542" height="886" alt="image" src="https://github.com/user-attachments/assets/dca40abf-4454-448b-9362-6b78d0aa79a4" />
<img width="1542" height="886" alt="image" src="https://github.com/user-attachments/assets/68cb2cf5-b046-4f3f-842b-73cd4a54d4dc" />

Do the same with other workload types:
<img width="1542" height="886" alt="image" src="https://github.com/user-attachments/assets/ed895f6c-d228-4b2e-a6b5-101468932db4" />
<img width="1542" height="886" alt="image" src="https://github.com/user-attachments/assets/b5450682-42e5-4722-87bb-b7e57a4349b7" />

<img width="1542" height="886" alt="image" src="https://github.com/user-attachments/assets/df7aacc8-9837-45bb-a387-7b96e3daf5a7" />
<img width="1542" height="886" alt="image" src="https://github.com/user-attachments/assets/33e82514-ec5f-4501-a26d-727067aded5e" />

