### PR TITLE
ROX-31011: fix CA rotation failure after version upgrade

### DIFF
--- a/operator/internal/central/carotation/rotation_test.go
+++ b/operator/internal/central/carotation/rotation_test.go
@@ -37,7 +37,7 @@ func Test_DetermineAction(t *testing.T) {
 			wantAction:       AddSecondary,
 		},
 		"should add secondary just before 4/5 of validity": {
-			now:              "2028-12-31T23:59:59Z",
+			now:              "2028-12-31T00:00:00Z",
 			primaryNotBefore: "2025-01-01T00:00:00Z",
 			primaryNotAfter:  "2030-01-01T00:00:00Z",
 			wantAction:       AddSecondary,
@@ -49,6 +49,12 @@ func Test_DetermineAction(t *testing.T) {
 			secondaryNotBefore: "2028-01-01T00:00:00Z",
 			secondaryNotAfter:  "2033-01-01T00:00:00Z",
 			wantAction:         PromoteSecondary,
+		},
+		"should add secondary and promote it to primary after 4/5 of validity": {
+			now:              "2029-01-02T00:00:00Z",
+			primaryNotBefore: "2025-01-01T00:00:00Z",
+			primaryNotAfter:  "2030-01-01T00:00:00Z",
+			wantAction:       AddSecondaryAndPromote,
 		},
 		"should delete expired secondary": {
 			now:                "2031-01-02T00:00:00Z",

--- a/operator/internal/central/extensions/reconcile_tls.go
+++ b/operator/internal/central/extensions/reconcile_tls.go
@@ -222,7 +222,7 @@ func (r *createCentralTLSExtensionRun) generateCentralTLSData(old types.SecretDa
 			return nil, errors.Wrapf(err, "performing CA rotation action: %v", r.caRotationAction)
 		}
 
-		if r.caRotationAction == carotation.PromoteSecondary {
+		if r.caRotationAction != carotation.NoAction {
 			primaryCA, err := certgen.LoadCAFromFileMap(newFileMap)
 			if err != nil {
 				return nil, errors.Wrap(err, "reloading new primary CA failed")

--- a/operator/internal/central/extensions/reconcile_tls_ca_rotation_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_ca_rotation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stretchr/testify/require"
 	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -112,6 +113,75 @@ func TestCentralCARotation(t *testing.T) {
 			updateSecondaryCANotBefore(t, client, currentTime)
 		}
 	}
+}
+
+func TestCentralCARotationAddSecondaryAndPromote(t *testing.T) {
+	// This test simulates an upgrade from an ACS version that does not have CA rotation enabled to a version that does.
+	// The Central CA is 4+ years old, and so a new secondary CA should be added and simultaneously promoted to primary.
+	t.Setenv(envCentralCARotationEnabled, "true")
+
+	oldCA, err := certgen.GenerateCA()
+	require.NoError(t, err)
+
+	// Update the CA's NotBefore to be 4+ years ago to simulate an old deployment
+	privateKey, err := helpers.ParsePrivateKeyPEM(oldCA.KeyPEM())
+	require.NoError(t, err)
+	oldCATime := time.Now().Add(-4*365*24*time.Hour - 24*time.Hour)
+	oldCACertBytes, err := updateCertificateNotBefore(oldCA.Certificate(), privateKey, oldCATime)
+	require.NoError(t, err)
+	oldCAPEM, err := mtls.LoadCAForSigning(oldCACertBytes, oldCA.KeyPEM())
+	require.NoError(t, err)
+
+	centralCert, err := oldCAPEM.IssueCertForSubject(mtls.CentralSubject, mtls.WithNamespace(testutils.TestNamespace), mtls.WithValidityNotBefore(oldCATime))
+	require.NoError(t, err)
+
+	fileMap := map[string][]byte{
+		mtls.CACertFileName:      oldCAPEM.CertPEM(),
+		mtls.CAKeyFileName:       oldCAPEM.KeyPEM(),
+		mtls.ServiceCertFileName: centralCert.CertPEM,
+		mtls.ServiceKeyFileName:  centralCert.KeyPEM,
+	}
+
+	testCase := secretReconciliationTestCase{
+		Spec: basicSpecWithScanner(true, true),
+		ExistingManaged: []*coreV1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "central-tls",
+					Namespace: testutils.TestNamespace,
+				},
+				Data: fileMap,
+			},
+		},
+	}
+
+	central := buildFakeCentral(testCase)
+	client := buildFakeClient(t, testCase, central)
+	run := &createCentralTLSExtensionRun{
+		SecretReconciliator: commonExtensions.NewSecretReconciliator(client, client, central),
+		centralObj:          central,
+		currentTime:         time.Now(),
+	}
+
+	err = run.Execute(context.Background())
+	require.NoError(t, err)
+
+	secret := &coreV1.Secret{}
+	key := ctrlClient.ObjectKey{Namespace: testutils.TestNamespace, Name: "central-tls"}
+	err = client.Get(context.Background(), key, secret)
+	require.NoError(t, err)
+
+	// Verify secondary CA exists and is the old primary CA
+	secondaryCA, err := certgen.LoadSecondaryCAFromFileMap(secret.Data)
+	require.NoError(t, err, "secondary CA should exist after AddSecondaryAndPromote")
+	require.Equal(t, oldCAPEM.CertPEM(), secondaryCA.CertPEM(), "secondary CA should be the old primary CA")
+	require.Equal(t, oldCAPEM.KeyPEM(), secondaryCA.KeyPEM(), "secondary CA key should be the old primary CA key")
+
+	// Verify primary CA has changed
+	newPrimaryCA, err := certgen.LoadCAFromFileMap(secret.Data)
+	require.NoError(t, err, "primary CA should exist")
+	require.NotEqual(t, oldCAPEM.CertPEM(), newPrimaryCA.CertPEM(), "primary CA should have changed to a new CA")
+	require.NotEqual(t, oldCAPEM.KeyPEM(), newPrimaryCA.KeyPEM(), "primary CA key should have changed to a new CA key")
 }
 
 func verifyCentralCertNoSecondaryCA(t *testing.T, fileMap types.SecretDataMap, atTime *time.Time) {

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -673,6 +673,23 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 			},
 		},
 		{
+			name:   "add secondary and promote to primary",
+			action: carotation.AddSecondaryAndPromote,
+			assert: func(t *testing.T, old, new types.SecretDataMap) {
+				require.Contains(t, new, mtls.SecondaryCACertFileName, "secondary CA cert should be present")
+				require.Contains(t, new, mtls.SecondaryCAKeyFileName, "secondary CA key should be present")
+				require.NotEqual(t, old[mtls.CACertFileName], new[mtls.CACertFileName], "primary CA should have changed")
+				require.Equal(t, new[mtls.SecondaryCACertFileName], old[mtls.CACertFileName],
+					"secondary CA cert should be the old primary CA cert")
+				require.Equal(t, new[mtls.SecondaryCAKeyFileName], old[mtls.CAKeyFileName],
+					"secondary CA key should be the old primary CA key")
+				require.Contains(t, new, mtls.ServiceCertFileName, "central cert should be present")
+				require.Contains(t, new, mtls.ServiceKeyFileName, "central cert should be present")
+				require.NotEqual(t, old[mtls.ServiceCertFileName], new[mtls.ServiceCertFileName], "central cert should be reissued")
+				require.NotEqual(t, old[mtls.ServiceKeyFileName], new[mtls.ServiceKeyFileName], "central key should be reissued")
+			},
+		},
+		{
 			name:   "delete secondary CA",
 			action: carotation.DeleteSecondary,
 			additionalSetup: func(t *testing.T, old types.SecretDataMap) {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR fixes a bug where the Operator would enter an irreconcilable state during CA rotation, after an upgrade from a previous version of ACS that does not support CA rotation, and has a CA older than 4 years:

* Initial central-tls secrets validation determined AddSecondary CA rotation action is needed (typically done after 3 years)
* Post-generation validation now sees that PromoteSecondary CA rotation action is needed
* Which causes "CA rotation action needed" error in post-generation validation

To fix this scenario, this PR introduces a new CA rotation action, AddSecondaryAndPromote, which performs both actions (AddSecondary and PromoteSecondary) in a single step.

This is an alternative to the fix proposed in https://github.com/stackrox/stackrox/pull/16992

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual testing on [this branch](https://github.com/stackrox/stackrox/pull/15349):
- replaced Operator in Irreconciliable state with a version that includes this fix
- verified that the Operator created the secondary CA, and then performed the rotation in the next reconcile
