### PR TITLE
ROX-13221: Fixes splitting of policy criteria values that contain '='

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
@@ -87,10 +87,10 @@ describe('policies.utils', () => {
                                 negate: false,
                                 values: [
                                     {
-                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
+                                        value: 'RAW=SOMEVAR=val_with=equals',
                                     },
                                     {
-                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
+                                        value: 'RAW=OTHERVAR=normal_value',
                                     },
                                 ],
                             },
@@ -212,12 +212,12 @@ describe('policies.utils', () => {
                                 negate: false,
                                 values: [
                                     {
-                                        source: 'SECRET_KEY',
+                                        source: 'RAW',
                                         key: 'SOMEVAR',
                                         value: 'val_with=equals',
                                     },
                                     {
-                                        source: 'SECRET_KEY',
+                                        source: 'RAW',
                                         key: 'OTHERVAR',
                                         value: 'normal_value',
                                     },
@@ -290,10 +290,10 @@ describe('policies.utils', () => {
                                 negate: false,
                                 values: [
                                     {
-                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
+                                        value: 'RAW=SOMEVAR=val_with=equals',
                                     },
                                     {
-                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
+                                        value: 'RAW=OTHERVAR=normal_value',
                                     },
                                 ],
                             },
@@ -405,10 +405,10 @@ describe('policies.utils', () => {
                                 negate: false,
                                 values: [
                                     {
-                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
+                                        value: 'RAW=SOMEVAR=val_with=equals',
                                     },
                                     {
-                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
+                                        value: 'RAW=OTHERVAR=normal_value',
                                     },
                                 ],
                             },
@@ -530,12 +530,12 @@ describe('policies.utils', () => {
                                 negate: false,
                                 values: [
                                     {
-                                        source: 'SECRET_KEY',
+                                        source: 'RAW',
                                         key: 'SOMEVAR',
                                         value: 'val_with=equals',
                                     },
                                     {
-                                        source: 'SECRET_KEY',
+                                        source: 'RAW',
                                         key: 'OTHERVAR',
                                         value: 'normal_value',
                                     },
@@ -608,10 +608,10 @@ describe('policies.utils', () => {
                                 negate: false,
                                 values: [
                                     {
-                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
+                                        value: 'RAW=SOMEVAR=val_with=equals',
                                     },
                                     {
-                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
+                                        value: 'RAW=OTHERVAR=normal_value',
                                     },
                                 ],
                             },

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
@@ -608,14 +608,10 @@ describe('policies.utils', () => {
                                 negate: false,
                                 values: [
                                     {
-                                        source: 'SECRET_KEY',
-                                        key: 'SOMEVAR',
-                                        value: 'val_with=equals',
+                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
                                     },
                                     {
-                                        source: 'SECRET_KEY',
-                                        key: 'OTHERVAR',
-                                        value: 'normal_value',
+                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
                                     },
                                 ],
                             },

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
@@ -69,7 +69,7 @@ describe('policies.utils', () => {
                                 fieldName: 'Dockerfile Line',
                                 booleanOperator: 'OR',
                                 negate: false,
-                                values: [{ value: 'ENV=ENV=myapp=test' }, { value: 'USER=root' }],
+                                values: [{ value: 'ENV=myapp=test' }, { value: 'USER=root' }],
                             },
                             {
                                 fieldName: 'Image Signature Verified By',
@@ -78,6 +78,19 @@ describe('policies.utils', () => {
                                 values: [
                                     {
                                         value: 'io.stackrox.signatureintegration.bef8ab45-2f06-4937-9a97-5c8b5b049f54',
+                                    },
+                                ],
+                            },
+                            {
+                                fieldName: 'Environment Variable',
+                                booleanOperator: 'OR',
+                                negate: false,
+                                values: [
+                                    {
+                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
+                                    },
+                                    {
+                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
                                     },
                                 ],
                             },
@@ -177,7 +190,7 @@ describe('policies.utils', () => {
                                 booleanOperator: 'OR',
                                 negate: false,
                                 values: [
-                                    { value: 'ENV=ENV=myapp=test' },
+                                    { key: 'ENV', value: 'myapp=test' },
                                     { key: 'USER', value: 'root' },
                                 ],
                             },
@@ -190,6 +203,23 @@ describe('policies.utils', () => {
                                         arrayValue: [
                                             'io.stackrox.signatureintegration.bef8ab45-2f06-4937-9a97-5c8b5b049f54',
                                         ],
+                                    },
+                                ],
+                            },
+                            {
+                                fieldName: 'Environment Variable',
+                                booleanOperator: 'OR',
+                                negate: false,
+                                values: [
+                                    {
+                                        source: 'SECRET_KEY',
+                                        key: 'SOMEVAR',
+                                        value: 'val_with=equals',
+                                    },
+                                    {
+                                        source: 'SECRET_KEY',
+                                        key: 'OTHERVAR',
+                                        value: 'normal_value',
                                     },
                                 ],
                             },
@@ -242,7 +272,7 @@ describe('policies.utils', () => {
                                 fieldName: 'Dockerfile Line',
                                 booleanOperator: 'OR',
                                 negate: false,
-                                values: [{ value: 'ENV=ENV=myapp=test' }, { value: 'USER=root' }],
+                                values: [{ value: 'ENV=myapp=test' }, { value: 'USER=root' }],
                             },
                             {
                                 fieldName: 'Image Signature Verified By',
@@ -251,6 +281,19 @@ describe('policies.utils', () => {
                                 values: [
                                     {
                                         value: 'io.stackrox.signatureintegration.bef8ab45-2f06-4937-9a97-5c8b5b049f54',
+                                    },
+                                ],
+                            },
+                            {
+                                fieldName: 'Environment Variable',
+                                booleanOperator: 'OR',
+                                negate: false,
+                                values: [
+                                    {
+                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
+                                    },
+                                    {
+                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
                                     },
                                 ],
                             },
@@ -344,7 +387,7 @@ describe('policies.utils', () => {
                                 fieldName: 'Dockerfile Line',
                                 booleanOperator: 'OR',
                                 negate: false,
-                                values: [{ value: 'ENV=ENV=myapp=test' }, { value: 'USER=root' }],
+                                values: [{ value: 'ENV=myapp=test' }, { value: 'USER=root' }],
                             },
                             {
                                 fieldName: 'Image Signature Verified By',
@@ -353,6 +396,19 @@ describe('policies.utils', () => {
                                 values: [
                                     {
                                         value: 'io.stackrox.signatureintegration.bef8ab45-2f06-4937-9a97-5c8b5b049f54',
+                                    },
+                                ],
+                            },
+                            {
+                                fieldName: 'Environment Variable',
+                                booleanOperator: 'OR',
+                                negate: false,
+                                values: [
+                                    {
+                                        value: 'SECRET_KEY=SOMEVAR=val_with=equals',
+                                    },
+                                    {
+                                        value: 'SECRET_KEY=OTHERVAR=normal_value',
                                     },
                                 ],
                             },
@@ -452,7 +508,7 @@ describe('policies.utils', () => {
                                 booleanOperator: 'OR',
                                 negate: false,
                                 values: [
-                                    { value: 'ENV=ENV=myapp=test' },
+                                    { key: 'ENV', value: 'myapp=test' },
                                     { key: 'USER', value: 'root' },
                                 ],
                             },
@@ -465,6 +521,23 @@ describe('policies.utils', () => {
                                         arrayValue: [
                                             'io.stackrox.signatureintegration.bef8ab45-2f06-4937-9a97-5c8b5b049f54',
                                         ],
+                                    },
+                                ],
+                            },
+                            {
+                                fieldName: 'Environment Variable',
+                                booleanOperator: 'OR',
+                                negate: false,
+                                values: [
+                                    {
+                                        source: 'SECRET_KEY',
+                                        key: 'SOMEVAR',
+                                        value: 'val_with=equals',
+                                    },
+                                    {
+                                        source: 'SECRET_KEY',
+                                        key: 'OTHERVAR',
+                                        value: 'normal_value',
                                     },
                                 ],
                             },
@@ -517,7 +590,7 @@ describe('policies.utils', () => {
                                 fieldName: 'Dockerfile Line',
                                 booleanOperator: 'OR',
                                 negate: false,
-                                values: [{ value: 'ENV=ENV=myapp=test' }, { value: 'USER=root' }],
+                                values: [{ value: 'ENV=myapp=test' }, { value: 'USER=root' }],
                             },
                             {
                                 fieldName: 'Image Signature Verified By',
@@ -526,6 +599,23 @@ describe('policies.utils', () => {
                                 values: [
                                     {
                                         value: 'io.stackrox.signatureintegration.bef8ab45-2f06-4937-9a97-5c8b5b049f54',
+                                    },
+                                ],
+                            },
+                            {
+                                fieldName: 'Environment Variable',
+                                booleanOperator: 'OR',
+                                negate: false,
+                                values: [
+                                    {
+                                        source: 'SECRET_KEY',
+                                        key: 'SOMEVAR',
+                                        value: 'val_with=equals',
+                                    },
+                                    {
+                                        source: 'SECRET_KEY',
+                                        key: 'OTHERVAR',
+                                        value: 'normal_value',
                                     },
                                 ],
                             },

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -337,7 +337,7 @@ export function parseNumericComparisons(str): [string, string] {
     return [matches[1], matches[2]];
 }
 
-export function parseValueStr(value, fieldName): ValueObj {
+export function parseValueStr(value: string, fieldName: string): ValueObj {
     // TODO: work with API to update contract for returning number comparison fields
     //   until that improves, we short-circuit those fields here
 
@@ -356,19 +356,23 @@ export function parseValueStr(value, fieldName): ValueObj {
     if (typeof value === 'string' && isCompoundField(fieldName)) {
         // handle all other string fields
         const valueArr = value.split('=');
-        // for nested policy criteria fields
-        if (valueArr.length === 2) {
+
+        // for the Environment Variable policy criteria
+        if (fieldName === 'Environment Variable') {
+            const [source, key, ...values] = valueArr;
             return {
-                key: valueArr[0],
-                value: valueArr[1],
+                source,
+                key,
+                value: values.join('='),
             };
         }
-        // for the Environment Variable policy criteria
-        if (valueArr.length === 3) {
+
+        // for nested policy criteria fields
+        if (valueArr.length > 1) {
+            const [key, ...values] = valueArr;
             return {
-                source: valueArr[0],
-                key: valueArr[1],
-                value: valueArr[2],
+                key,
+                value: values.join('='),
             };
         }
     }
@@ -493,7 +497,6 @@ function getFormattedServerPolicyFields(policy: ClientPolicy): Policy['policySec
 
 // Impure function assumes caller has cloned the scope!
 function trimPolicyScope(scope: PolicyScope) {
-    /* eslint-disable no-param-reassign */
     if (typeof scope.cluster === 'string') {
         scope.cluster = scope.cluster.trim();
     }
@@ -514,7 +517,6 @@ function trimPolicyScope(scope: PolicyScope) {
         }
     }
     */
-    /* eslint-enable no-param-reassign */
 
     return scope;
 }

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -497,6 +497,7 @@ function getFormattedServerPolicyFields(policy: ClientPolicy): Policy['policySec
 
 // Impure function assumes caller has cloned the scope!
 function trimPolicyScope(scope: PolicyScope) {
+    /* eslint-disable no-param-reassign */
     if (typeof scope.cluster === 'string') {
         scope.cluster = scope.cluster.trim();
     }
@@ -517,6 +518,7 @@ function trimPolicyScope(scope: PolicyScope) {
         }
     }
     */
+    /* eslint-enable no-param-reassign */
 
     return scope;
 }


### PR DESCRIPTION
## Description

Fixes a long standing issue (3.72!) where splitting of policy criteria values for "Disallowed Dockerfile line" with a key of `ENV` and a value that contains `=`, as well as "Environment Variable" where the value contains `=`, mangles the output value. I believe this causes this criteria to function incorrectly as well, but I would need to test it.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Modified exiting unit tests for the ENV case and added criteria for the "Environment variable" case.

Manual testing with the following criteria:
<img width="833" height="763" alt="image" src="https://github.com/user-attachments/assets/a33f1e64-6ffe-42f8-9274-0858cb847f07" />


Before:
<img width="1289" height="674" alt="image" src="https://github.com/user-attachments/assets/6ce7f423-8a11-45fd-91c7-ce6d43dc330b" />

After:
<img width="1289" height="674" alt="image" src="https://github.com/user-attachments/assets/0d06a966-7e9c-4dd7-8bf6-1f46304540bf" />

