### PR TITLE
ROX-31018: Add rules or options from eslint-plugin-import

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginLimited.js
+++ b/ui/apps/platform/eslint-plugins/pluginLimited.js
@@ -65,33 +65,6 @@ const rules = {
     // However, we can write forbid instead of disallow as the verb in description and message.
 
     // TODO move rule to pluginGeneric after all errors have been fixed.
-    'no-inline-type-imports': {
-        // Although @typescript-eslint/consistent-type-imports has options:
-        // fixStyle: 'separate-type-imports'
-        // fixStyle: 'inline-type-imports'
-        // it not (at the moment) have a similar option to enforce only separate type imports.
-        meta: {
-            type: 'problem',
-            docs: {
-                description: 'Replace inline type import with separate type import statement',
-            },
-            schema: [],
-        },
-        create(context) {
-            return {
-                ImportSpecifier(node) {
-                    if (node.importKind === 'type') {
-                        context.report({
-                            node,
-                            message:
-                                'Replace inline type import with separate type import statement',
-                        });
-                    }
-                },
-            };
-        },
-    },
-    // TODO move rule to pluginGeneric after all errors have been fixed.
     'no-qualified-name-react': {
         // React.Whatever is possible with default import.
         // For consistency and as prerequisite to replace default import with JSX transform.

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -392,7 +392,6 @@ module.exports = [
             'import/no-self-import': 'error',
             'import/no-useless-path-segments': ['error', { commonjs: true }],
             'import/no-webpack-loader-syntax': 'error',
-            'import/order': ['error', { groups: [['builtin', 'external', 'internal']] }],
             // 'import/prefer-default-export' is intentional omission
 
             // Turn on rules from airbnb style config that are not in ESLint recommended.
@@ -475,6 +474,12 @@ module.exports = [
             // 'no-shadow': 'error', // fix 15 errors
             'no-undef-init': 'error',
 
+            // Turn on rules not from (or with difference options than) airbnb config.
+            'import/no-empty-named-blocks': 'error',
+            'import/order': [
+                'error',
+                { groups: [['builtin', 'external', 'internal', 'parent', 'sibling']] },
+            ],
             'prettier/prettier': 'error',
         },
 
@@ -684,6 +689,7 @@ module.exports = [
         // Key of plugin is namespace of its rules.
         plugins: {
             '@typescript-eslint': pluginTypeScriptESLint,
+            import: pluginImport,
         },
         rules: {
             // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslint-recommended.ts
@@ -707,6 +713,8 @@ module.exports = [
 
             '@typescript-eslint/array-type': 'error',
             '@typescript-eslint/consistent-type-exports': 'error',
+
+            'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
         },
     },
     // Limited rules have ignores for specific files or folders.
@@ -764,7 +772,6 @@ module.exports = [
         },
         rules: {
             '@typescript-eslint/consistent-type-imports': 'error',
-            'limited/no-inline-type-imports': 'error',
             'limited/no-qualified-name-react': 'error',
             'limited/no-relative-path-to-src-in-import': 'error',
         },

--- a/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.jsx
+++ b/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import PrevPaginationButton from '.';
 import PaginationInput from '../PaginationInput';
+import PrevPaginationButton from '.';
 
 const MockPagination = ({ defaultPage = 1 }) => {
     const [currentPage, setPage] = useState(defaultPage);

--- a/ui/apps/platform/src/Containers/Clusters/Components/AutoUpgradeToggle.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AutoUpgradeToggle.tsx
@@ -1,4 +1,5 @@
-import React, { type ReactElement, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 
 import { Switch } from '@patternfly/react-core';
 import {


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

Small changes that I found during search for solution to sort named imports.

1. Replace unneeded project-specific rule.
2. Enable rule for edge case in `import` statements.
3. Add groups for order of `import` statements.

### Information

https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/consistent-type-specifier-style.md

> 'prefer-top-level' enforces that named type-only specifiers only ever written as part of a top-level, type-only import; and never with an inline marker.

Although `@typescript-eslint` does not have a rule, I did not look in `import` and therefore wrote unneeded `'no-inline-type-imports'` rule in #16332

https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-empty-named-blocks.md

https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#groups

Add `'parent'` and `'sibling'` to `groups` array.

How convenient that 2 out of the 3 rules report errors. Enough but not too many.

### Residue

Once in a while, an external source with path notation like `lodash/whatever` hides in plain sight among internal `import` statements.

Might the trick in our project configuration to omit `src/` and instead alias top-level folders tricks the rule not to distinguish external and internal?

There might be a work around, but it is rare enough that I let it go for now.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.