### PR TITLE
ROX-30945: Include collector-slim in our custom snapshot

### DIFF
--- a/.tekton/operator-bundle-pipeline.yaml
+++ b/.tekton/operator-bundle-pipeline.yaml
@@ -808,6 +808,12 @@ spec:
             "revision": "$(tasks.wait-for-collector-image.results.GIT_REF)"
           },
           {
+            "name": "collector-slim",
+            "containerImage": "$(params.collector-slim-image-build-repo)@$(tasks.wait-for-collector-slim-image.results.IMAGE_DIGEST)",
+            "repository": "$(tasks.wait-for-collector-slim-image.results.GIT_REPO)",
+            "revision": "$(tasks.wait-for-collector-slim-image.results.GIT_REF)"
+          },
+          {
             "name": "main",
             "containerImage": "$(params.main-image-build-repo)@$(tasks.wait-for-main-image.results.IMAGE_DIGEST)",
             "repository": "$(tasks.wait-for-main-image.results.GIT_REPO)",

--- a/scripts/ci/jobs/check-konflux-setup.sh
+++ b/scripts/ci/jobs/check-konflux-setup.sh
@@ -41,9 +41,7 @@ check_all_components_are_part_of_custom_snapshot() {
     local expected_components_from_images
     local expected_components
     expected_components_from_images="$(yq eval '.spec.tasks[] | select(.name == "wait-for-*-image") | .name | sub("(wait-for-|-image)", "")' ${pipeline_path})"
-    # `collector-slim` is excluded because there's no separate component for it. There's only `collector` which is
-    # intended to be released in two repos (as normal and as slim).
-    expected_components=$(echo "${expected_components_from_images} operator-bundle" | tr " " "\n" | grep -vF collector-slim | sort)
+    expected_components=$(echo "${expected_components_from_images} operator-bundle" | tr " " "\n" | sort)
 
     echo
     echo "➤ ${pipeline_path} // checking ${task_name}: COMPONENTS contents shall include all ACS images."


### PR DESCRIPTION
## Description

To make Conforma happy.
See https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1758739440034849

I had a feeling that I missed something in https://github.com/stackrox/stackrox/pull/16959 and this is it. CI did not trigger a failure in our `check-konflux-setup.sh` because `collector-slim` was excluded there.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

- [x] Checked that our custom snapshot includes entry for collector-slim.
