### PR TITLE
ROX-30965: Rename image signature policy field

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
@@ -383,7 +383,7 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
                 clearPolicyCriteriaCards();
                 clickPolicyKeyGroup('Image registry');
                 dragFieldIntoSection(
-                    `${selectors.step3.policyCriteria.key}:contains('Required image signature')`
+                    `${selectors.step3.policyCriteria.key}:contains('Require image signature')`
                 );
                 cy.wait('@getSignatureIntegrations');
             });

--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -118,7 +118,7 @@ describe.skip('Policy wizard, Step 3 Policy Criteria', () => {
             'Image registry',
             'Image name',
             'Image tag',
-            'Required image signature',
+            'Require image signature',
         ];
         cy.get('.pf-v5-c-tree-view__list-item:first').click();
         cy.get(TREE_VIEW_FIRST_LEVEL_CHILD).each((element, index) => {
@@ -387,7 +387,7 @@ describe.skip('Policy wizard, Step 3 Policy Criteria', () => {
 
                 goToPoliciesAndCloneToStep3();
                 clearPolicyCriteriaCards();
-                addPolicyField('Required image signature');
+                addPolicyField('Require image signature');
                 cy.wait('@getSignatureIntegrations');
             });
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -355,9 +355,9 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
-        label: 'Required image signature',
+        label: 'Require image signature',
         name: imageSigningCriteriaName,
-        shortName: 'Required image signature',
+        shortName: 'Require image signature',
         longName: 'Image must be signed by a trusted signer',
         category: policyCriteriaCategories.IMAGE_REGISTRY,
         type: 'tableModal',


### PR DESCRIPTION
## Description

This PR is a follow up to [ROX-30116 ImageSignature criteria does not work in conjunction with other criteria in a policy group](https://issues.redhat.com/browse/ROX-30116), where we concluded that the image signature policy field has several unique features that can make it hard to grasp in some situations. Here, I try to make it easier to understand by changing its name so that it reflects what it actually does and follows the existing conventions.
 
### Policy field "short name"
Before this PR, the image signature policy criterion's short name was "Image signature":

<img width="224" height="320" alt="Screenshot 2025-10-27 at 11 12 28" src="https://github.com/user-attachments/assets/66798c13-ac2c-426e-94d1-993f2abb758d" />

This can be confusing because it does not follow the naming conventions of the rest of the criteria, that is, either of:

- "**$attribute**": the policy triggers a violation when $attribute is detected. For example, the "image name" field triggers a violation when an image with the specified name is detected. These fields often have a "negate" checkbox to achieve the opposite behavior (e.g. a negated "image name" field fires when an image does not have the specified name).
- "**Required/Disallowed $attribute**": the policy triggers a violation when the attribute is not present or present. These don't have a "negate" checkbox, instead the opposite check exists as a separate field. For example:
  - Required image label: triggers a violation for images that don't have the specified label
  - Disallowed image label: triggers a violation for images that have the specified label

The name "Image signature" seems to follow convention 1) above, but it actually triggers when the image is not signed.

In order to follow 1) properly, it should fire when images are signed and provide an option to negate the behavior. However this is not possible, because the image signature field only supports firing on unsigned images. That option is also unlikely to be useful: it is reasonable to expect that users want to be notified when images are not signed.

Therefore the image signature field should follow the "required/disallowed" semantics, and be changed to "required image signature". This PR implements that.


#### Exact wording decision

Even if the field name should follow the existing convention, some fields use "required" and others "require":

```console
$ grep "shortName: 'Required " ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
        shortName: 'Required label',
        shortName: 'Required annotation',
$ grep "shortName: 'Require " ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
        shortName: 'Require image label',
```

Even if there are more fields using the "require**d**" form, the image signature field is displayed next to the "Require image label" field, and using a different form looks unpleasant:

<img width="456" height="525" alt="image" src="https://github.com/user-attachments/assets/eee7a551-1fd4-4422-b7ad-f5c225de9fd1" />


### Policy field "long name"

`longName` is the string displayed under the label when the field is dragged into a rule. When present, this is a somewhat longer explanation of either of:
- What is expected to happen in order to raise a violation. This is used when the `shortName` follows convention 1 above. Example: "Image name is"
- What the desired status is, otherwise a violation will be raised. This is used when the `shortName` follows convention 2 above. Example: "Required deployment label"


<img width="483" height="676" alt="image" src="https://github.com/user-attachments/assets/8872c017-7d5e-4b68-81b3-ea97060420c9" />


When the image signature field's `shortName` is updated to "Require image signature" leaving the `longName` as-is looks confusing:

<img width="480" height="228" alt="Screenshot 2025-10-27 at 11 44 58" src="https://github.com/user-attachments/assets/c371e0c5-47c2-4156-a6c0-136823bc8ae0" />

Therefore it has been updated to read "Image must be signed by a trusted signer", to describe the desired status, similarly to other fields whose `shortName` follow convention 2.

<img width="481" height="230" alt="Screenshot 2025-10-27 at 11 50 01" src="https://github.com/user-attachments/assets/18259ff4-db5d-488b-a07f-62079cac92b7" />

### Notes

The change is only done at the UI level, because
- That is where the UX challenge lies
- Other fields also use different display vs backend names
- Changing the backend name provides little/no benefit and requires handling the old vs new names in existing policies (migrations).


## User-facing documentation

Here's the documentation PR: https://github.com/openshift/openshift-docs/pull/101154

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI, and I manually deployed Stackrox and verified that the updated text is visible and the policy field works as before.