### PR TITLE
chore(tweak): Make docker command priority in protogen

### DIFF
--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -2,8 +2,9 @@ BASE_PATH ?= $(CURDIR)
 # Set to empty string to echo some command lines which are hidden by default.
 SILENT ?= @
 
-# Set the container runtime command - prefer podman, fallback to docker
-DOCKER_CMD = $(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
+# Set the container runtime command - prefer docker, fallback to podman.
+# If none of them are available, fallback to docker.
+DOCKER_CMD = $(shell command -v docker >/dev/null 2>&1 && echo docker || (command -v podman >/dev/null 2>&1 && echo podman || echo docker))
 
 # GENERATED_API_XXX and PROTO_API_XXX variables contain standard paths used to
 # generate gRPC proto messages, services, and gateways for the API.


### PR DESCRIPTION
## Description

With PR: https://github.com/stackrox/stackrox/pull/16237 - support for podman is added.

There is a situation that is not well handled on systems with both commands available. Make will prioritize podman over docker. As mentioned in this comment: https://github.com/stackrox/stackrox/pull/16237#discussion_r2371085469

That comment was rejected because the expectations that make command, which triggers this target, is not often executed. There is one case that was neglected. If someone wants to build docker image locally, they require docs files, because they are copied into the image.

This PR is adding new changes.
- if both commands are there: docker will be used
- if podman is there and no docker: podman will be used
- if none of them can be found: docker will be used
- if calling command fails: docker will be used

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] there is no automated testing for build scripts

### How I validated my change

I have used shell command to test logic:
```
# Faking that docker exists with: ls
docker_y_podman_y=$(command -v ls >/dev/null 2>&1 && echo docker || (command -v podman >/dev/null 2>&1 && echo podman || echo docker));
echo "docker==$docker_y_podman_y";

docker_y_podman_n=$(command -v ls >/dev/null 2>&1 && echo docker || (command -v podman123 >/dev/null 2>&1 && echo podman || echo docker));
echo "docker==$docker_y_podman_n";

docker_n_podman_y=$(command -v docker >/dev/null 2>&1 && echo docker || (command -v podman >/dev/null 2>&1 && echo podman || echo docker));
echo "podman==$docker_n_podman_y";

docker_n_podman_n=$(command -v docker >/dev/null 2>&1 && echo docker || (command -v podman123 >/dev/null 2>&1 && echo podman || echo docker));
echo "docker==$docker_n_podman_n";

# Broken command -v
broken_command=$(command123 -v ls >/dev/null 2>&1 && echo docker || (command123 -v podman >/dev/null 2>&1 && echo podman || echo docker));
echo "docker==$broken_command";
```

Results:
```
docker==docker
docker==docker
podman==podman
docker==docker
docker==docker
```