### PR TITLE
chore(CI): Check no empty alert results in network policy tests

### DIFF
--- a/sensor/tests/helper/helper.go
+++ b/sensor/tests/helper/helper.go
@@ -773,6 +773,17 @@ func AssertNoViolations() func(result *central.AlertResults) error {
 	}
 }
 
+// AssertNoEmptyAlertResults creates a matcher function that checks that no empty alert results are sent.
+func AssertNoEmptyAlertResults() func(result *central.AlertResults) error {
+	return func(result *central.AlertResults) error {
+		if len(result.GetAlerts()) == 0 {
+			return errors.New("found empty alert results")
+		}
+
+		return nil
+	}
+}
+
 func alertResultMatchesFn(result *central.AlertResults, violations ...string) error {
 	expectedSet := set.NewStringSet(violations...)
 	actualSet := set.NewStringSet()

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -66,11 +66,13 @@ func (s *NetworkPolicySuite) Test_NetworkPolicyViolations() {
 			deploymentID := string(k8sDeployment.GetUID())
 
 			tc.LastViolationStateByID(t, deploymentID, helper.AssertViolationsMatch(egressNetpolViolationName, ingressNetpolViolationName), "", false)
+			tc.AssertViolationStateByID(t, deploymentID, helper.AssertNoEmptyAlertResults(), "Should not have received empty AlertResults", false)
 
 			_, err = tc.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, EgressPolicyBlockAllEgress, nil)
 			require.NoError(t, err)
 
 			tc.LastViolationStateByID(t, deploymentID, helper.AssertViolationsMatch(ingressNetpolViolationName), "", false)
+			tc.AssertViolationStateByID(t, deploymentID, helper.AssertNoEmptyAlertResults(), "Should not have received empty AlertResults", false)
 
 			_, err = tc.ApplyResourceAndWaitNoObject(ctx, t, helper.DefaultNamespace, IngressPolicyAllow443, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

Add check that no empty alert results are sent during network policy evaluation in network policy tests.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] will let CI check it
