### PR TITLE
fix(gha): backport changes for job-preamble

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -1,18 +1,103 @@
 name: Job Preamble
 description: Common steps for most jobs
 inputs:
+  free-disk-space:
+    description: 'Free disk space desired in GB (2025-06 ubuntu-24.04 runner starts with 20GB free and we can delete and reach 40GB)'
+    required: false
+    default: 25
   gcp-account:
     description: 'Account to be used to upload tests data'
     required: true
 runs:
   using: composite
   steps:
-    - name: Recover docker image cache space
-      run: |
-        df --si /
-        docker system prune --force --all
-        df --si /
+    - name: Check disk space
+      id: disk-check
+      continue-on-error: true
       shell: bash
+      run: |
+        free=$(df -BGB --output=avail / | tail -1)
+        echo "free=${free}" | tee -a "$GITHUB_OUTPUT"
+        if [[ ${free%GB} -ge "${{ inputs.free-disk-space }}" ]]; then
+          echo "Reached requested free disk space ${{ inputs.free-disk-space }} [${free} free]."
+          exit 0
+        else
+          df --si
+          exit 1
+        fi
+
+    - name: Free disk space (delete unused tools)
+      id: delete-unused-tools
+      if: steps.disk-check.outcome == 'failure'
+      continue-on-error: true
+      shell: bash
+      run: |
+        # delete preinstalled unused tools
+        cleanup=(
+          # non-container jobs are first priority (every second may be a high % of the total)
+          /usr/share/dotnet
+          /usr/share/miniconda
+          /usr/share/swift
+          /usr/share/kotlinc
+          /opt/ghc
+          /opt/hostedtoolcache/CodeQL
+          /opt/hostedtoolcache/Ruby
+          /opt/az
+          /usr/local/lib/android
+          # container jobs are lower priority: they are already slowed by container image pulls
+          /__t/CodeQL
+          /__t/Ruby
+          /__t/PyPy
+          /__t/Python
+          /__t/go
+          /__t/node
+          /__t/gcloud
+        )
+        for d in "${cleanup[@]}"; do
+          if [[ -d "$d" ]]; then
+            rm -rf -- "$d" && echo "deleted $d"
+          elif [[ -d "/mnt${d}" ]]; then
+            rm -rf -- "/mnt${d}" && echo "deleted /mnt${d}"
+          else
+            echo "$d not found"
+            continue
+          fi
+          free=$(df -BGB --output=avail / | tail -1)
+          if [[ ${free%GB} -ge "${{ inputs.free-disk-space }}" ]]; then
+            echo "Reached requested free disk space ${{ inputs.free-disk-space }} [${free} free]."
+            exit 0
+          fi
+        done
+        echo "Failed to free requested disk space, ${{ inputs.free-disk-space }} [${free} free]."
+        exit 1
+
+    - name: Free more disk space (docker system prune)
+      id: delete-docker-cache
+      if: steps.delete-unused-tools.outcome == 'failure'
+      continue-on-error: true
+      shell: bash
+      run: |
+        printf 'Docker prune: '
+        docker system prune --force --all
+
+    - name: Verify free disk space
+      id: disk-check-cleaned
+      if: steps.disk-check.outcome == 'failure'
+      continue-on-error: true
+      shell: bash
+      run: |
+        free=$(df -BGB --output=avail / | tail -1)
+        echo "free=${free}" | tee -a "$GITHUB_OUTPUT"
+        if [[ ${free%GB} -lt "${{ inputs.free-disk-space }}" ]]; then
+          echo "Failed to free requested disk space, ${{ inputs.free-disk-space }} [${free} free]." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          if [[ ! -d /opt/hostedtoolcache && ! -d /mnt/opt/hostedtoolcache && ! -d /mnt/usr/local ]]; then
+            printf 'For container workflows, you can mount the host /usr and /opt to allow deleting more unused tools:\n```\nvolumes:\n\t- /usr:/mnt/usr\n\t- /opt:/mnt/opt\n```' \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+          df --si /
+          exit 1
+        fi
 
     - name: Ignore dubious repository ownership
       run: |


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/stackrox/stackrox/pull/17027 to `release-4.6` in order to fix RCE builds.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Only by looking at CI status.
