### PR TITLE
ROX-31079: Reduce OOM kills in Konflux pipelines

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -64,13 +64,13 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          memory: 2Gi
+          memory: 3Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-central-db

--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -61,6 +61,17 @@ spec:
   pipelineRef:
     name: basic-component-pipeline
 
+  taskRunSpecs:
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    - name: build
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-central-db
 

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -89,6 +89,7 @@ spec:
       # [build] @stackrox/platform-app: The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
       computeResources:
         limits:
+          cpu: 4
           memory: 7Gi
         requests:
           cpu: 4

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -127,6 +127,15 @@ spec:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    - name: build
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-main

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -68,13 +68,13 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
-    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 6Gi
+          cpu: 2
         requests:
-          memory: 6Gi
+          cpu: 2
   # For all sbom-syft-generate steps:
   # Memory is increased for the syft command to succeed. Otherwise, there's an error like this in log and container
   # exits with 137 (OOMKilled):

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -66,6 +66,15 @@ spec:
     name: main-pipeline
 
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    stepSpecs:
+    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    - name: prefetch-dependencies
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          memory: 6Gi
   # For all sbom-syft-generate steps:
   # Memory is increased for the syft command to succeed. Otherwise, there's an error like this in log and container
   # exits with 137 (OOMKilled):

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -83,16 +83,12 @@ spec:
     stepSpecs:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
-      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml#L921
       #
       # Memory is increased for UI builds to succeed. Otherwise, there's an error like this in logs:
       # [build] @stackrox/platform-app: The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
-      #
-      # Not using buildah-6gb/-8gb/... because these don't have memory requests equal to limits which still occasionally
-      # leads to failing builds.
       computeResources:
         limits:
-          cpu: 4
           memory: 7Gi
         requests:
           cpu: 4

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -113,13 +113,13 @@ spec:
       computeResources: *sbom-syft-resources
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          memory: 2Gi
+          memory: 3Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-main

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -94,7 +94,7 @@ spec:
           cpu: 4
           memory: 7Gi
     - name: sbom-syft-generate
-      computeResources:
+      computeResources: &sbom-syft-resources
         limits:
           memory: 3Gi
         requests:
@@ -102,27 +102,15 @@ spec:
   - pipelineTaskName: build-container-s390x
     stepSpecs:
     - name: sbom-syft-generate
-      computeResources:
-        limits:
-          memory: 3Gi
-        requests:
-          memory: 3Gi
+      computeResources: *sbom-syft-resources
   - pipelineTaskName: build-container-ppc64le
     stepSpecs:
     - name: sbom-syft-generate
-      computeResources:
-        limits:
-          memory: 3Gi
-        requests:
-          memory: 3Gi
+      computeResources: *sbom-syft-resources
   - pipelineTaskName: build-container-arm64
     stepSpecs:
     - name: sbom-syft-generate
-      computeResources:
-        limits:
-          memory: 3Gi
-        requests:
-          memory: 3Gi
+      computeResources: *sbom-syft-resources
   - pipelineTaskName: build-source-image
     stepSpecs:
     # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -76,6 +76,8 @@ spec:
       # CPU requests are increased to speed up builds compared to the defaults.
       # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml#L921
       computeResources:
+        limits:
+          cpu: 2
         requests:
           cpu: 2
   - pipelineTaskName: build-source-image

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -80,13 +80,13 @@ spec:
           cpu: 2
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          memory: 2Gi
+          memory: 3Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -74,10 +74,8 @@ spec:
     stepSpecs:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
-      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml#L921
       computeResources:
-        limits:
-          cpu: 2
         requests:
           cpu: 2
   - pipelineTaskName: build-source-image

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -63,13 +63,13 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
-    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 6Gi
+          cpu: 2
         requests:
-          memory: 6Gi
+          cpu: 2
   - pipelineTaskName: build-container-amd64
     stepSpecs:
     - name: build

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -80,6 +80,15 @@ spec:
           cpu: 2
         requests:
           cpu: 2
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    - name: build
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -61,6 +61,15 @@ spec:
     name: basic-component-pipeline
 
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    stepSpecs:
+    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    - name: prefetch-dependencies
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          memory: 6Gi
   - pipelineTaskName: build-container-amd64
     stepSpecs:
     - name: build

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -61,6 +61,17 @@ spec:
   pipelineRef:
     name: operator-bundle-pipeline
 
+  taskRunSpecs:
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    - name: build
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-bundle
 

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -64,13 +64,13 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          memory: 2Gi
+          memory: 3Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-bundle

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -76,6 +76,8 @@ spec:
       # CPU requests are increased to speed up builds compared to the defaults.
       # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml#L921
       computeResources:
+        limits:
+          cpu: 2
         requests:
           cpu: 2
   - pipelineTaskName: build-source-image

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -80,13 +80,13 @@ spec:
           cpu: 2
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          memory: 2Gi
+          memory: 3Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-roxctl

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -80,6 +80,15 @@ spec:
           cpu: 2
         requests:
           cpu: 2
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    - name: build
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-roxctl

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -74,10 +74,8 @@ spec:
     stepSpecs:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
-      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml#L921
       computeResources:
-        limits:
-          cpu: 2
         requests:
           cpu: 2
   - pipelineTaskName: build-source-image

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -63,13 +63,13 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
-    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 6Gi
+          cpu: 2
         requests:
-          memory: 6Gi
+          cpu: 2
   - pipelineTaskName: build-container-amd64
     stepSpecs:
     - name: build

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -61,6 +61,15 @@ spec:
     name: basic-component-pipeline
 
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    stepSpecs:
+    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    - name: prefetch-dependencies
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          memory: 6Gi
   - pipelineTaskName: build-container-amd64
     stepSpecs:
     - name: build

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -76,6 +76,8 @@ spec:
       # CPU requests are increased to speed up builds compared to the defaults.
       # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml#L921
       computeResources:
+        limits:
+          cpu: 2
         requests:
           cpu: 2
   - pipelineTaskName: build-source-image

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -61,6 +61,15 @@ spec:
     name: scanner-v4-pipeline
 
   taskRunSpecs:
+  - pipelineTaskName: prefetch-dependencies
+    stepSpecs:
+    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    - name: prefetch-dependencies
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          memory: 6Gi
   - pipelineTaskName: build-container-amd64
     stepSpecs:
     - name: build

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -80,6 +80,15 @@ spec:
           cpu: 2
         requests:
           cpu: 2
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    - name: build
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-v4

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -80,13 +80,13 @@ spec:
           cpu: 2
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          memory: 2Gi
+          memory: 3Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-v4

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -74,10 +74,8 @@ spec:
     stepSpecs:
     - name: build
       # CPU requests are increased to speed up builds compared to the defaults.
-      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml#L147
+      # Defaults: https://github.com/konflux-ci/build-definitions/blob/main/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml#L921
       computeResources:
-        limits:
-          cpu: 2
         requests:
           cpu: 2
   - pipelineTaskName: build-source-image

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -63,13 +63,13 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
-    # Bump memory for Go dependencies prefetch which tends to be OOM-killed at the default setting of 3Gi.
+    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 6Gi
+          cpu: 2
         requests:
-          memory: 6Gi
+          cpu: 2
   - pipelineTaskName: build-container-amd64
     stepSpecs:
     - name: build

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -61,6 +61,17 @@ spec:
   pipelineRef:
     name: basic-component-pipeline
 
+  taskRunSpecs:
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    - name: build
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 2Gi
+
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-v4-db
 

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -64,13 +64,13 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Set memory requests==limits for source image build because the one tends to get sometimes killed at 0.5/2 values.
+    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
-          memory: 2Gi
+          memory: 3Gi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-v4-db


### PR DESCRIPTION
## Description

### prefetch-dependencies

From the Slack thread <https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1758784462802249>, my observations and trials in this PR it's clear that OOMs happen in `/root/.cache/hermeto/go/go1.21.0/bin/go mod download -json` command that's executed by Hermeto to prefetch Go dependencies.
The thread is inconclusive about the root cause of the error. On one hand, I'm sure little has changed on our side, especially in `release-4.6` branch. On the other, what exactly happens in `go mod download` and what to do to prevent it requesting lots of memory quickly is left without the answers.

I used https://github.com/stackrox/stackrox/pull/17053 to trigger multiple runs and validate the change is stable.

### Everything else

`build-source-image` tends to fail too. It's not news but the one started doing that more frequently.

Since I touched this area, I did a couple other cosmetic changes. You can see more info in the commit messages.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

- https://github.com/stackrox/stackrox/pull/17053 and just checking the last round of Konflux CI here to be happy.