### PR TITLE
ROX-31034: Virtual Machine CVEs Summary Cards

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -20,26 +20,26 @@ import { getTableUIState } from 'utils/getTableUIState';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
 import BySeveritySummaryCard from 'Containers/Vulnerabilities/components/BySeveritySummaryCard';
-import CvesByStatusSummaryCard from 'Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard';
 import useAnalytics, { NODE_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import {
     nodeCVESearchFilterConfig,
     nodeComponentSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
+
 import {
     getHiddenSeverities,
     getHiddenStatuses,
     getRegexScopedQueryString,
     parseQuerySearchFilter,
 } from '../../utils/searchUtils';
-
 import CVEsTable, { sortFields, defaultSortOption } from './CVEsTable';
 import useNodeVulnerabilities from './useNodeVulnerabilities';
 import useNodeSummaryData from './useNodeSummaryData';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
+import CvesByStatusSummaryCard from '../../components/CvesByStatusSummaryCard';
 
 const searchFilterConfig = [nodeCVESearchFilterConfig, nodeComponentSearchFilterConfig];
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeSummaryData.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeSummaryData.tsx
@@ -1,8 +1,9 @@
 import { gql, useQuery } from '@apollo/client';
+
 import {
     ResourceCountByCveSeverityAndStatus,
     resourceCountByCveSeverityAndStatusFragment,
-} from 'Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard';
+} from '../../components/CvesByStatusSummaryCard';
 
 const nodeSummaryDataQuery = gql`
     ${resourceCountByCveSeverityAndStatusFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
@@ -24,10 +24,19 @@ import { getTableUIState } from 'utils/getTableUIState';
 
 import { getHasSearchApplied } from 'utils/searchUtils';
 import {
-    getVirtualMachineCveTableData,
     applyVirtualMachineCveTableFilters,
+    getVirtualMachineCveTableData,
+    getVirtualMachineCveSeverityStatusCounts,
 } from '../aggregateUtils';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
+import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
+import CvesByStatusSummaryCard from '../../components/CvesByStatusSummaryCard';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
+import {
+    getHiddenSeverities,
+    getHiddenStatuses,
+    parseQuerySearchFilter,
+} from '../../utils/searchUtils';
 import VirtualMachineVulnerabilitiesTable from './VirtualMachineVulnerabilitiesTable';
 
 export type VirtualMachinePageVulnerabilitiesProps = {
@@ -51,6 +60,9 @@ function VirtualMachinePageVulnerabilities({
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { page, perPage, setPage, setPerPage } = pagination;
     const { searchFilter, setSearchFilter } = useURLSearch();
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
+    const hiddenStatuses = getHiddenStatuses(querySearchFilter);
+    const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const isFiltered = getHasSearchApplied(searchFilter);
 
     const virtualMachineTableData = useMemo(() => getVirtualMachineCveTableData(data), [data]);
@@ -93,6 +105,29 @@ function VirtualMachinePageVulnerabilities({
                     setPage(1, 'replace');
                 }}
             />
+            <SummaryCardLayout isLoading={isLoading} error={error}>
+                <SummaryCard
+                    loadingText={'Loading virtual machine CVEs by severity summary'}
+                    data={filteredVirtualMachineTableData}
+                    renderer={({ data }) => (
+                        <BySeveritySummaryCard
+                            title="CVEs by severity"
+                            severityCounts={getVirtualMachineCveSeverityStatusCounts(data)}
+                            hiddenSeverities={hiddenSeverities}
+                        />
+                    )}
+                />
+                <SummaryCard
+                    loadingText={'Loading virtual machine CVEs by status summary'}
+                    data={filteredVirtualMachineTableData}
+                    renderer={({ data }) => (
+                        <CvesByStatusSummaryCard
+                            cveStatusCounts={getVirtualMachineCveSeverityStatusCounts(data)}
+                            hiddenStatuses={hiddenStatuses}
+                        />
+                    )}
+                />
+            </SummaryCardLayout>
             <div className="pf-v5-u-flex-grow-1 pf-v5-u-background-color-100 pf-v5-u-p-lg">
                 <Split className="pf-v5-u-pb-lg pf-v5-u-align-items-baseline">
                     <SplitItem isFilled>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/aggregateUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/aggregateUtils.ts
@@ -6,6 +6,8 @@ import type { SearchFilter } from 'types/search';
 import type { Advisory, CVSSV3Severity, EmbeddedVulnerability } from 'types/vulnerability.proto';
 import { searchValueAsArray } from 'utils/searchUtils';
 
+import { severityToQuerySeverityKeys } from '../components/BySeveritySummaryCard';
+import type { ResourceCountByCveSeverityAndStatus } from '../components/CvesByStatusSummaryCard';
 import { isVulnerabilitySeverityLabel } from '../types';
 import type { FixableStatus } from '../types';
 import { severityLabelToSeverity } from '../utils/searchUtils';
@@ -50,6 +52,26 @@ export type CveTableRow = {
     epssProbability: number; // should be the same across all components
     affectedComponents: CveComponentRow[];
 };
+
+export function getVirtualMachineCveSeverityStatusCounts(
+    cveTableData: CveTableRow[]
+): ResourceCountByCveSeverityAndStatus {
+    const counts: ResourceCountByCveSeverityAndStatus = {
+        critical: { total: 0, fixable: 0 },
+        important: { total: 0, fixable: 0 },
+        moderate: { total: 0, fixable: 0 },
+        low: { total: 0, fixable: 0 },
+        unknown: { total: 0, fixable: 0 },
+    };
+
+    cveTableData.forEach((cveTableRow) => {
+        const severityKey = severityToQuerySeverityKeys[cveTableRow.severity];
+        counts[severityKey].total += 1;
+        counts[severityKey].fixable += cveTableRow.isFixable ? 1 : 0;
+    });
+
+    return counts;
+}
 
 function defaultCveTableSort(a: CveTableRow, b: CveTableRow): number {
     return severityRankings[b.severity] - severityRankings[a.severity] || b.cvss - a.cvss;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -40,7 +40,7 @@ import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import CvesByStatusSummaryCard, {
     resourceCountByCveSeverityAndStatusFragment,
     ResourceCountByCveSeverityAndStatus,
-} from '../SummaryCards/CvesByStatusSummaryCard';
+} from '../../components/CvesByStatusSummaryCard';
 import {
     parseQuerySearchFilter,
     getHiddenSeverities,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -39,10 +39,11 @@ import {
 import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import type { VulnerabilityState } from 'types/cve.proto';
+
 import CvesByStatusSummaryCard, {
     ResourceCountByCveSeverityAndStatus,
     resourceCountByCveSeverityAndStatusFragment,
-} from '../SummaryCards/CvesByStatusSummaryCard';
+} from '../../components/CvesByStatusSummaryCard';
 import ImageVulnerabilitiesTable, {
     ImageVulnerability,
     defaultColumns,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -70,7 +70,7 @@ import AffectedImages from '../SummaryCards/AffectedImages';
 import BySeveritySummaryCard, {
     ResourceCountsByCveSeverity,
 } from '../../components/BySeveritySummaryCard';
-import { resourceCountByCveSeverityAndStatusFragment } from '../SummaryCards/CvesByStatusSummaryCard';
+import { resourceCountByCveSeverityAndStatusFragment } from '../../components/CvesByStatusSummaryCard';
 import VulnerabilityStateTabs, {
     vulnStateTabContentId,
 } from '../components/VulnerabilityStateTabs';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
@@ -14,7 +14,7 @@ const severitiesDescendingCriticality = [
     'UNKNOWN_VULNERABILITY_SEVERITY',
 ] as const;
 
-const severityToQuerySeverityKeys = {
+export const severityToQuerySeverityKeys = {
     CRITICAL_VULNERABILITY_SEVERITY: 'critical',
     IMPORTANT_VULNERABILITY_SEVERITY: 'important',
     MODERATE_VULNERABILITY_SEVERITY: 'moderate',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvesByStatusSummaryCard.tsx
@@ -13,7 +13,7 @@ import { MinusIcon, WrenchIcon } from '@patternfly/react-icons';
 import { gql } from '@apollo/client';
 import sumBy from 'lodash/sumBy';
 
-import { FixableStatus } from '../../types';
+import { FixableStatus } from '../types';
 
 export type ResourceCountByCveSeverityAndStatus = {
     critical: { total: number; fixable: number };


### PR DESCRIPTION
## Description

Adds Virtual Machine CVEs Summary Cards

Summary cards added for the following:
* CVEs by severity
* CVEs by status (fixable/non-fixable)

Additional Notes:
* Lifted `CvesByStatusSummaryCard` out of the `WorkloadCves` container and into the generic `Vulnerabilities/components` directory.
* Hidden statuses – Currently we could show all severities/statuses counts even when filtered, however I'm under the assumption that once filtering is implemented on the backend we will lose that capability.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

#### Default unfiltered
<img width="1329" height="778" alt="Screenshot 2025-09-26 at 8 02 43 AM" src="https://github.com/user-attachments/assets/fe25f836-edf1-4284-b0ff-52c5055ef48f" />

---
#### Filtered by severity – shows correct "hidden" severities
<img width="1329" height="778" alt="Screenshot 2025-09-26 at 8 03 04 AM" src="https://github.com/user-attachments/assets/37e29fb2-1052-4958-910f-71bcddfd2ede" />

---
#### Filtered by CVE - shows correct total counts
<img width="1329" height="565" alt="Screenshot 2025-09-26 at 8 03 38 AM" src="https://github.com/user-attachments/assets/87cd8f4f-e31f-4925-a9bf-9d32c74f3a7b" />

---
#### Table exceeds 1 page - shows correct total counts across all pages
<img width="1329" height="680" alt="Screenshot 2025-09-26 at 8 04 09 AM" src="https://github.com/user-attachments/assets/9058f8c6-3958-43f6-9136-cd8f41738369" />
