### PR TITLE
chore(ui): Update virtual machine route and severity counts

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
@@ -1,15 +1,5 @@
 import React from 'react';
-import {
-    Card,
-    CardBody,
-    Flex,
-    PageSection,
-    Split,
-    Text,
-    Title,
-    Button,
-} from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { Card, CardBody, Flex, PageSection, Text, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
 import DeveloperPreviewLabel from 'Components/PatternFly/DeveloperPreviewLabel';
@@ -17,27 +7,16 @@ import DeveloperPreviewLabel from 'Components/PatternFly/DeveloperPreviewLabel';
 import VirtualMachinesCvesTable from './VirtualMachinesCvesTable';
 
 function VirtualMachineCvesOverviewPage() {
-    const navigate = useNavigate();
-
-    const handleViewDetails = () => {
-        navigate('test-vm-123');
-    };
-
     return (
         <>
             <PageTitle title="Virtual Machine CVEs Overview" />
             <PageSection component="div" variant="light">
                 <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
-                    <Split hasGutter>
+                    <Flex alignItems={{ default: 'alignItemsCenter' }}>
                         <Title headingLevel="h1">Virtual Machine Vulnerabilities</Title>
                         <DeveloperPreviewLabel />
-                    </Split>
+                    </Flex>
                     <Text>Prioritize and remediate observed CVEs across virtual machines</Text>
-                    <div>
-                        <Button variant="primary" onClick={handleViewDetails}>
-                            Test VM Details
-                        </Button>
-                    </div>
                 </Flex>
             </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
@@ -9,6 +9,7 @@ import { getTableUIState } from 'utils/getTableUIState';
 
 import { getVirtualMachineSeveritiesCount } from '../aggregateUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
+import { getVirtualMachineEntityPagePath } from '../../utils/searchUtils';
 
 function VirtualMachinesCvesTable() {
     const fetchVirtualMachines = useCallback(() => listVirtualMachines(), []);
@@ -56,16 +57,33 @@ function VirtualMachinesCvesTable() {
                                 getVirtualMachineSeveritiesCount(virtualMachine);
                             return (
                                 <Tr key={virtualMachine.id}>
-                                    <Td dataLabel="Virtual machine">
-                                        <Link to={''}>{virtualMachine.name}</Link>
+                                    <Td dataLabel="Virtual machine" modifier="nowrap">
+                                        <Link
+                                            to={getVirtualMachineEntityPagePath(
+                                                'VirtualMachine',
+                                                virtualMachine.id
+                                            )}
+                                        >
+                                            {virtualMachine.name}
+                                        </Link>
                                     </Td>
                                     <Td dataLabel="CVEs by severity">
                                         <SeverityCountLabels
-                                            criticalCount={virtualMachineSeverityCounts.CRITICAL}
-                                            importantCount={virtualMachineSeverityCounts.HIGH}
-                                            moderateCount={virtualMachineSeverityCounts.MEDIUM}
-                                            lowCount={virtualMachineSeverityCounts.LOW}
-                                            unknownCount={virtualMachineSeverityCounts.UNKNOWN}
+                                            criticalCount={
+                                                virtualMachineSeverityCounts.CRITICAL_VULNERABILITY_SEVERITY
+                                            }
+                                            importantCount={
+                                                virtualMachineSeverityCounts.IMPORTANT_VULNERABILITY_SEVERITY
+                                            }
+                                            moderateCount={
+                                                virtualMachineSeverityCounts.MODERATE_VULNERABILITY_SEVERITY
+                                            }
+                                            lowCount={
+                                                virtualMachineSeverityCounts.LOW_VULNERABILITY_SEVERITY
+                                            }
+                                            unknownCount={
+                                                virtualMachineSeverityCounts.UNKNOWN_VULNERABILITY_SEVERITY
+                                            }
                                         />
                                     </Td>
                                     <Td dataLabel="Guest OS">ROX-30535</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Title, LabelGroup, Label, Split } from '@patternfly/react-core';
+import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 
 import { getDateTime } from 'utils/dateUtils';
 import DeveloperPreviewLabel from 'Components/PatternFly/DeveloperPreviewLabel';
@@ -54,10 +54,10 @@ function VirtualMachinePageHeader({ data }: VirtualMachinePageHeaderProps) {
 
     return (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
-            <Split hasGutter>
+            <Flex alignItems={{ default: 'alignItemsCenter' }}>
                 <Title headingLevel="h1">{data.name}</Title>
                 <DeveloperPreviewLabel />
-            </Split>
+            </Flex>
             <LabelGroup numLabels={5}>
                 <Label>GuestOS: {data.guestOS}</Label>
                 <Label>In: {data.namespace}</Label>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
@@ -18,7 +18,7 @@ function VirtualMachineCvesPage() {
             {hasReadAccessForIntegration && <ScannerV4IntegrationBanner />}
             <Routes>
                 <Route index element={<VirtualMachineCvesOverviewPage />} />
-                <Route path=":virtualMachineId" element={<VirtualMachinePage />} />
+                <Route path="virtualmachines/:virtualMachineId" element={<VirtualMachinePage />} />
                 <Route
                     path="*"
                     element={

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/aggregateUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/aggregateUtils.ts
@@ -3,7 +3,7 @@ import type { VirtualMachine } from 'services/VirtualMachineService';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { ScanComponent, SourceType } from 'types/scanComponent.proto';
 import type { SearchFilter } from 'types/search';
-import type { Advisory, CVSSV3Severity, EmbeddedVulnerability } from 'types/vulnerability.proto';
+import type { Advisory, EmbeddedVulnerability } from 'types/vulnerability.proto';
 import { searchValueAsArray } from 'utils/searchUtils';
 
 import { isVulnerabilitySeverityLabel } from '../types';
@@ -14,20 +14,18 @@ import { severityLabelToSeverity } from '../utils/searchUtils';
 
 export function getVirtualMachineSeveritiesCount(
     virtualMachine: VirtualMachine
-): Record<CVSSV3Severity, number> {
-    const severityCounts: Record<CVSSV3Severity, number> = {
-        CRITICAL: 0,
-        HIGH: 0,
-        MEDIUM: 0,
-        LOW: 0,
-        UNKNOWN: 0,
-        NONE: 0,
+): Record<VulnerabilitySeverity, number> {
+    const severityCounts: Record<VulnerabilitySeverity, number> = {
+        CRITICAL_VULNERABILITY_SEVERITY: 0,
+        IMPORTANT_VULNERABILITY_SEVERITY: 0,
+        MODERATE_VULNERABILITY_SEVERITY: 0,
+        LOW_VULNERABILITY_SEVERITY: 0,
+        UNKNOWN_VULNERABILITY_SEVERITY: 0,
     };
 
     virtualMachine.scan.components.forEach((component) => {
         component.vulns.forEach((vuln) => {
-            const { severity } = vuln.cvssV3;
-            severityCounts[severity] += 1;
+            severityCounts[vuln.severity] += 1;
         });
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -34,8 +34,8 @@ import {
     NodeEntityTab,
     PlatformEntityTab,
     QuerySearchFilter,
-    VulnerabilitySeverityLabel,
     VirtualMachineEntityTab,
+    VulnerabilitySeverityLabel,
     WorkloadEntityTab,
     isFixableStatus,
     isVulnerabilitySeverityLabel,
@@ -117,6 +117,22 @@ export function getNodeEntityPagePath(
             return `${vulnerabilitiesNodeCvesPath}/nodes/${id}${queryString}`;
         default:
             return ensureExhaustive(nodeCveEntity);
+    }
+}
+
+export function getVirtualMachineEntityPagePath(
+    virtualMachineCveEntity: VirtualMachineEntityTab,
+    id: string,
+    queryOptions?: qs.ParsedQs
+): string {
+    const queryString = getQueryString(queryOptions);
+    switch (virtualMachineCveEntity) {
+        case 'CVE':
+            return `${vulnerabilitiesVirtualMachineCvesPath}/cves/${id}${queryString}`;
+        case 'VirtualMachine':
+            return `${vulnerabilitiesVirtualMachineCvesPath}/virtualmachines/${id}${queryString}`;
+        default:
+            return ensureExhaustive(virtualMachineCveEntity);
     }
 }
 


### PR DESCRIPTION
## Description

Updates the following:
* Hooks up link between virtual machines page and single virtual machine page
  * Updates the single virtual machine route to be more consistent with other sections in vulnerabilities. Changed from `/vulnerabilities/virtual-machine-cves/:id` to `/vulnerabilities/virtual-machine-cves/virtualmachines/:id`.
* Severity count on the virtual machines list table is now based on `EmbeddedVulnerability.severity` as opposed to `EmbeddedVulnerability.cvssv3.severity`. 
* Title and dev preview label wrapper changed from `Split` to `Flex`. It seems that split uses flexbox under the hood with align items set to stretch causes the dev preview label to fill up the containers height (not respecting `isCompact`)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
