### PR TITLE
ROX-29575: add virtual machine agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@ pkg/search/**/*                     @stackrox/core-workflows
 */declarativeconfig/**/*          @stackrox/sensor-ecosystem
 */discoveredclusters/**/          @stackrox/sensor-ecosystem
 */signatureintegration/**/*       @stackrox/sensor-ecosystem
+compliance/virtualmachines/**/*   @stackrox/sensor-ecosystem
 pkg/features/**/*                 @stackrox/sensor-ecosystem
 pkg/images/defaults/**/*          @stackrox/sensor-ecosystem
 pkg/sac/**/*                      @stackrox/sensor-ecosystem

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -172,7 +172,7 @@ linters:
         path: ^(central|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor/tests/helper|tests|tools|scale)/
       - linters:
           - forbidigo
-        path: (central/graphql/schema/print|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale|govulncheck)/
+        path: (central/graphql/schema/print|compliance|integration-tests|local|migrator|operator|pkg|scanner|sensor|tests|tools|scale|govulncheck|compliance/virtualmachines/agent)/
       - linters:
           - forbidigo
         path: roxctl/central/generate/interactive.go

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -113,6 +113,8 @@ type NodeIndexerConfig struct {
 	Timeout time.Duration
 	// PackageDBFilter removes irrelevant packages. For node scanning, we are
 	// currently only interested in the RHCOS RPM database.
+	// Filters out all packages whose packageDB does not match the filter.
+	// Empty string corresponds to no filtering.
 	PackageDBFilter string
 }
 

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -156,7 +156,7 @@ func (l *localNodeIndexer) IndexNode(ctx context.Context) (*v4.IndexReport, erro
 	// claircore no longer returns an error if the host path does not exist.
 	_, err := os.Stat(l.cfg.HostPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "host path does not exist")
+		return nil, errors.Wrapf(err, "host path %q does not exist", l.cfg.HostPath)
 	}
 
 	layer, err := layer(ctx, layerDigest, l.cfg.HostPath)

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -36,7 +36,7 @@ import (
 const (
 	layerMediaType = "application/vnd.claircore.filesystem"
 
-	rhcosPackageDB = "usr/share/rpm"
+	rhcosPackageDB = "sqlite:usr/share/rpm"
 
 	// scannerDefinitionsRouteInSensor should be in sync with `scannerDefinitionsRoute` in sensor/sensor.go
 	// Direct import is prohibited by import rules

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -154,8 +154,7 @@ func (l *localNodeIndexer) GetIntervals() *utils.NodeScanIntervals {
 // IndexNode indexes a node at the configured host path mount.
 func (l *localNodeIndexer) IndexNode(ctx context.Context) (*v4.IndexReport, error) {
 	// claircore no longer returns an error if the host path does not exist.
-	_, err := os.Stat(l.cfg.HostPath)
-	if err != nil {
+	if _, err := os.Stat(l.cfg.HostPath); err != nil {
 		return nil, errors.Wrapf(err, "host path %q does not exist", l.cfg.HostPath)
 	}
 

--- a/compliance/node/index/indexer_test.go
+++ b/compliance/node/index/indexer_test.go
@@ -239,5 +239,6 @@ func (s *nodeIndexerSuite) TestIndexerE2ENoPath() {
 	report, err := indexer.IndexNode(context.Background())
 
 	s.ErrorContains(err, "no such file or directory")
+	s.ErrorIs(err, os.ErrNotExist)
 	s.Nil(report)
 }

--- a/compliance/node/index/indexer_test.go
+++ b/compliance/node/index/indexer_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const testdataRhcosPackageDB = "sqlite:usr/share/rpm"
-
 func TestNodeIndexerSuite(t *testing.T) {
 	suite.Run(t, new(nodeIndexerSuite))
 }
@@ -138,7 +136,7 @@ func (s *nodeIndexerSuite) TestRunRepositoryScannerAnyPath() {
 func (s *nodeIndexerSuite) TestRunPackageScanner() {
 	layer := s.mustCreateLayer("testdata")
 
-	packages, err := runPackageScanner(context.Background(), testdataRhcosPackageDB, layer)
+	packages, err := runPackageScanner(context.Background(), rhcosPackageDB, layer)
 	s.NoError(err)
 
 	s.Len(packages, 106)
@@ -157,7 +155,7 @@ func (s *nodeIndexerSuite) TestRunPackageScannerWithUnmatchedFilter() {
 func (s *nodeIndexerSuite) TestRunPackageScannerAnyPath() {
 	layer := s.mustCreateLayer(s.T().TempDir())
 
-	packages, err := runPackageScanner(context.Background(), testdataRhcosPackageDB, layer)
+	packages, err := runPackageScanner(context.Background(), rhcosPackageDB, layer)
 	s.NoError(err)
 
 	// The scanner must not error out, but produce 0 results
@@ -217,7 +215,7 @@ func (s *nodeIndexerSuite) TestIndexerE2E() {
 	cfg := DefaultNodeIndexerConfig()
 	cfg.HostPath = "testdata"
 	cfg.Repo2CPEMappingURL = server.URL
-	cfg.PackageDBFilter = testdataRhcosPackageDB
+	cfg.PackageDBFilter = rhcosPackageDB
 	indexer := NewNodeIndexer(cfg)
 
 	report, err := indexer.IndexNode(context.Background())
@@ -235,7 +233,7 @@ func (s *nodeIndexerSuite) TestIndexerE2ENoPath() {
 	cfg.Client = server.Client()
 	cfg.HostPath = "doesnotexist"
 	cfg.Repo2CPEMappingURL = server.URL
-	cfg.PackageDBFilter = testdataRhcosPackageDB
+	cfg.PackageDBFilter = rhcosPackageDB
 	indexer := NewNodeIndexer(cfg)
 
 	report, err := indexer.IndexNode(context.Background())

--- a/compliance/node/index/indexer_test.go
+++ b/compliance/node/index/indexer_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const testdataRhcosPackageDB = "sqlite:usr/share/rpm"
+
 func TestNodeIndexerSuite(t *testing.T) {
 	suite.Run(t, new(nodeIndexerSuite))
 }
@@ -136,16 +138,26 @@ func (s *nodeIndexerSuite) TestRunRepositoryScannerAnyPath() {
 func (s *nodeIndexerSuite) TestRunPackageScanner() {
 	layer := s.mustCreateLayer("testdata")
 
-	packages, err := runPackageScanner(context.Background(), layer)
+	packages, err := runPackageScanner(context.Background(), testdataRhcosPackageDB, layer)
 	s.NoError(err)
 
 	s.Len(packages, 106)
 }
 
+func (s *nodeIndexerSuite) TestRunPackageScannerWithUnmatchedFilter() {
+	layer := s.mustCreateLayer("testdata")
+
+	packages, err := runPackageScanner(context.Background(), "invalidPackageDB", layer)
+	s.NoError(err)
+
+	// All packages are filtered out.
+	s.Len(packages, 0)
+}
+
 func (s *nodeIndexerSuite) TestRunPackageScannerAnyPath() {
 	layer := s.mustCreateLayer(s.T().TempDir())
 
-	packages, err := runPackageScanner(context.Background(), layer)
+	packages, err := runPackageScanner(context.Background(), testdataRhcosPackageDB, layer)
 	s.NoError(err)
 
 	// The scanner must not error out, but produce 0 results
@@ -205,6 +217,7 @@ func (s *nodeIndexerSuite) TestIndexerE2E() {
 	cfg := DefaultNodeIndexerConfig()
 	cfg.HostPath = "testdata"
 	cfg.Repo2CPEMappingURL = server.URL
+	cfg.PackageDBFilter = testdataRhcosPackageDB
 	indexer := NewNodeIndexer(cfg)
 
 	report, err := indexer.IndexNode(context.Background())
@@ -222,6 +235,7 @@ func (s *nodeIndexerSuite) TestIndexerE2ENoPath() {
 	cfg.Client = server.Client()
 	cfg.HostPath = "doesnotexist"
 	cfg.Repo2CPEMappingURL = server.URL
+	cfg.PackageDBFilter = testdataRhcosPackageDB
 	indexer := NewNodeIndexer(cfg)
 
 	report, err := indexer.IndexNode(context.Background())

--- a/compliance/virtualmachines/agent/README.md
+++ b/compliance/virtualmachines/agent/README.md
@@ -2,7 +2,7 @@
 
 Runs inside VMs to scan for vulnerabilities and report back to the host via vsock.
 While not directly related to the `compliance` feature, the agent utilizes compliance
-node scannig code for package scanning in the virtual machine.
+node scanning code for package scanning in the virtual machine.
 
 ## What it does
 

--- a/compliance/virtualmachines/agent/README.md
+++ b/compliance/virtualmachines/agent/README.md
@@ -6,7 +6,7 @@ node scanning code for package scanning in the virtual machine.
 
 ## What it does
 
-Scans the VM for installed packages (RPM/DNF databases), creates vulnerability reports, and sends them to the host over vsock. Can run once or continuously in daemon mode.
+Scans the VM for installed packages (`rpm`/`dnf` databases), creates vulnerability reports, and sends them to the host over vsock. Can run once or continuously in daemon mode. Requires `sudo` privileges to scan packages.
 
 ## Usage
 
@@ -33,8 +33,8 @@ sudo ./agent --daemon --index-interval 10m --host-path /custom/path --port 2048
 
 ## How it works
 
-1. Scans filesystem for RPM/DNF package databases.
-2. Pulls repo-to-CPE mappings from Red Hat.
+1. Scans filesystem for `rpm`/`dnf` package databases.
+2. Pulls repo-to-CPE mappings from Red Hat. Network connection to the public Internet or to Sensor is required.
 3. Creates protobuf index report.
 4. Sends report to host via vsock.
 
@@ -58,7 +58,8 @@ GOOS=linux GOARCH=amd64 go build -o agent-linux .
 
 **No packages found**
 - Check `--host-path` points to the right place.
-- Verify RPM/DNF databases exist and are readable.
+- Verify `rpm`/`dnf` databases exist and are readable.
+- Use `--verbose` to examine the index report and compare with the content from `rpm`/`dnf` databases.
 
 **Scan failures**
 - Check internet access for repo-to-CPE downloads.

--- a/compliance/virtualmachines/agent/README.md
+++ b/compliance/virtualmachines/agent/README.md
@@ -12,13 +12,13 @@ Scans the VM for installed packages (RPM/DNF databases), creates vulnerability r
 
 ```bash
 # Single scan
-./agent
+sudo ./agent
 
 # Daemon mode (scans every 5 minutes)
-./agent --daemon
+sudo ./agent --daemon
 
 # Custom settings
-./agent --daemon --index-interval 10m --host-path /custom/path --port 2048
+sudo ./agent --daemon --index-interval 10m --host-path /custom/path --port 2048
 ```
 
 ## Flags

--- a/compliance/virtualmachines/agent/README.md
+++ b/compliance/virtualmachines/agent/README.md
@@ -1,0 +1,62 @@
+# VM Agent
+
+Runs inside VMs to scan for vulnerabilities and report back to the host via vsock.
+While not directly related to the `compliance` feature, the agent utilizes compliance
+node scannig code for package scanning in the virtual machine.
+
+## What it does
+
+Scans the VM for installed packages (RPM/DNF databases), creates vulnerability reports, and sends them to the host over vsock. Can run once or continuously in daemon mode.
+
+## Usage
+
+```bash
+# Single scan
+./agent
+
+# Daemon mode (scans every 5 minutes)
+./agent --daemon
+
+# Custom settings
+./agent --daemon --index-interval 10m --host-path /custom/path --port 2048
+```
+
+## Flags
+
+- `--daemon` - Run continuously (default: false).
+- `--index-interval` - Time between scans in daemon mode (default: 5m).
+- `--host-path` - Where to look for package databases (default: /).
+- `--port` - VSock port (default: 1024).
+
+## How it works
+
+1. Scans filesystem for RPM/DNF package databases.
+2. Pulls repo-to-CPE mappings from Red Hat.
+3. Creates protobuf index report.
+4. Sends report to host via vsock.
+
+The host receives these reports and forwards them to StackRox Central for vulnerability analysis.
+
+## Building
+
+```bash
+go build -o agent .
+
+# For Linux VMs
+GOOS=linux GOARCH=amd64 go build -o agent-linux .
+```
+
+## Troubleshooting
+
+**Can't connect to host**
+- Check if vsock is enabled in the VM.
+- Verify the port isn't in use.
+- Make sure vsock kernel modules are loaded.
+
+**No packages found**
+- Check `--host-path` points to the right place.
+- Verify RPM/DNF databases exist and are readable.
+
+**Scan failures**
+- Check internet access for repo-to-CPE downloads.
+- Look at logs for specific errors.

--- a/compliance/virtualmachines/agent/README.md
+++ b/compliance/virtualmachines/agent/README.md
@@ -27,6 +27,9 @@ Scans the VM for installed packages (RPM/DNF databases), creates vulnerability r
 - `--index-interval` - Time between scans in daemon mode (default: 5m).
 - `--host-path` - Where to look for package databases (default: /).
 - `--port` - VSock port (default: 1024).
+- `--repo-cpe-url` - URL for the repository to CPE mapping.
+- `--timeout` - VSock client timeout when sending index reports.
+- `--verbose` - Prints the index reports to stdout.
 
 ## How it works
 

--- a/compliance/virtualmachines/agent/cmd/cmd.go
+++ b/compliance/virtualmachines/agent/cmd/cmd.go
@@ -41,7 +41,7 @@ func RootCmd(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolVar(&cfg.Verbose, "verbose", false,
 		"Prints the index reports to stdout.",
 	)
-	cmd.Flags().Uint32Var(&cfg.VsockPort, "port", 1024,
+	cmd.Flags().Uint32Var(&cfg.VsockPort, "port", 818,
 		"VSock port to connect with the virtual machine host.",
 	)
 	cmd.Run = func(cmd *cobra.Command, _ []string) {

--- a/compliance/virtualmachines/agent/cmd/cmd.go
+++ b/compliance/virtualmachines/agent/cmd/cmd.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/stackrox/rox/compliance/virtualmachines/agent/config"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/common"
 	"github.com/stackrox/rox/compliance/virtualmachines/agent/index"
 	"github.com/stackrox/rox/compliance/virtualmachines/agent/vsock"
 	"github.com/stackrox/rox/pkg/logging"
@@ -22,7 +22,7 @@ func RootCmd(ctx context.Context) *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.SetContext(ctx)
-	cfg := &config.AgentConfig{}
+	cfg := &common.Config{}
 	cmd.Flags().BoolVar(&cfg.DaemonMode, "daemon", false,
 		"Run in daemon mode. Sends index reports continuously.",
 	)

--- a/compliance/virtualmachines/agent/cmd/cmd.go
+++ b/compliance/virtualmachines/agent/cmd/cmd.go
@@ -5,11 +5,13 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/compliance/virtualmachines/agent/config"
 	"github.com/stackrox/rox/compliance/virtualmachines/agent/index"
 	"github.com/stackrox/rox/compliance/virtualmachines/agent/vsock"
+	"github.com/stackrox/rox/pkg/logging"
 )
+
+const repoToCPEMappingURL = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
 
 var log = logging.LoggerForModule()
 
@@ -29,6 +31,9 @@ func RootCmd(ctx context.Context) *cobra.Command {
 	)
 	cmd.Flags().StringVar(&cfg.IndexHostPath, "host-path", "/",
 		"Path where the indexer starts searching for the RPM and DNF databases.",
+	)
+	cmd.Flags().StringVar(&cfg.RepoToCPEMappingURL, "repo-cpe-url", repoToCPEMappingURL,
+		"URL for the repository to CPE mapping.",
 	)
 	cmd.Flags().DurationVar(&cfg.Timeout, "timeout", 30*time.Second,
 		"VSock client timeout when sending index reports.",

--- a/compliance/virtualmachines/agent/cmd/cmd.go
+++ b/compliance/virtualmachines/agent/cmd/cmd.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/config"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/index"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/vsock"
+)
+
+var log = logging.LoggerForModule()
+
+func RootCmd(ctx context.Context) *cobra.Command {
+	cmd := cobra.Command{
+		Use:          "agent",
+		Short:        "Collects index reports for vulnerability scanning of virtual machines.",
+		SilenceUsage: true,
+	}
+	cmd.SetContext(ctx)
+	cfg := &config.AgentConfig{}
+	cmd.Flags().BoolVar(&cfg.DaemonMode, "daemon", false,
+		"Run in daemon mode. Sends index reports continuously.",
+	)
+	cmd.Flags().DurationVar(&cfg.IndexInterval, "index-interval", 5*time.Minute,
+		"Interval duration in which index reports are sent in daemon mode.",
+	)
+	cmd.Flags().StringVar(&cfg.IndexHostPath, "host-path", "/",
+		"Path where the indexer starts searching for the RPM and DNF databases.",
+	)
+	cmd.Flags().DurationVar(&cfg.Timeout, "timeout", 30*time.Second,
+		"VSock client timeout when sending index reports.",
+	)
+	cmd.Flags().BoolVar(&cfg.Verbose, "verbose", false,
+		"Prints the index reports to stdout.",
+	)
+	cmd.Flags().Uint32Var(&cfg.VsockPort, "port", 1024,
+		"VSock port to connect with the virtual machine host.",
+	)
+	cmd.Run = func(cmd *cobra.Command, _ []string) {
+		client := &vsock.Client{Port: cfg.VsockPort, Timeout: cfg.Timeout}
+		if cfg.DaemonMode {
+			if err := index.RunDaemon(ctx, cfg, client); err != nil {
+				log.Errorf("Running indexer daemon: %v", err)
+			}
+			return
+		}
+		if err := index.RunSingle(ctx, cfg, client); err != nil {
+			log.Errorf("Running indexer: %v", err)
+		}
+	}
+	return &cmd
+}

--- a/compliance/virtualmachines/agent/common/config.go
+++ b/compliance/virtualmachines/agent/common/config.go
@@ -1,8 +1,8 @@
-package config
+package common
 
 import "time"
 
-type AgentConfig struct {
+type Config struct {
 	DaemonMode          bool
 	IndexHostPath       string
 	IndexInterval       time.Duration

--- a/compliance/virtualmachines/agent/config/config.go
+++ b/compliance/virtualmachines/agent/config/config.go
@@ -1,0 +1,12 @@
+package config
+
+import "time"
+
+type AgentConfig struct {
+	DaemonMode    bool
+	IndexHostPath string
+	IndexInterval time.Duration
+	Timeout       time.Duration
+	Verbose       bool
+	VsockPort     uint32
+}

--- a/compliance/virtualmachines/agent/config/config.go
+++ b/compliance/virtualmachines/agent/config/config.go
@@ -3,10 +3,11 @@ package config
 import "time"
 
 type AgentConfig struct {
-	DaemonMode    bool
-	IndexHostPath string
-	IndexInterval time.Duration
-	Timeout       time.Duration
-	Verbose       bool
-	VsockPort     uint32
+	DaemonMode          bool
+	IndexHostPath       string
+	IndexInterval       time.Duration
+	RepoToCPEMappingURL string
+	Timeout             time.Duration
+	Verbose             bool
+	VsockPort           uint32
 }

--- a/compliance/virtualmachines/agent/index/index.go
+++ b/compliance/virtualmachines/agent/index/index.go
@@ -82,16 +82,5 @@ func runIndexer(ctx context.Context, cfg *config.AgentConfig) (*v4.IndexReport, 
 	if err != nil {
 		return nil, err
 	}
-	// This is currently needed because claircore 1.5.40 enumerates
-	// repositories as integers, but we reference repos by name in the
-	// environments.
-	report = fixupIndexReport(report)
 	return report, nil
-}
-
-func fixupIndexReport(report *v4.IndexReport) *v4.IndexReport {
-	for _, repo := range report.GetContents().GetRepositories() {
-		repo.Id = repo.GetName()
-	}
-	return report
 }

--- a/compliance/virtualmachines/agent/index/index.go
+++ b/compliance/virtualmachines/agent/index/index.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/compliance/node/index"
-	"github.com/stackrox/rox/compliance/virtualmachines/agent/config"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/common"
 	"github.com/stackrox/rox/compliance/virtualmachines/agent/vsock"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
@@ -21,7 +21,7 @@ const (
 	mappingClientTimeout = 30 * time.Second
 )
 
-func RunDaemon(ctx context.Context, cfg *config.AgentConfig, client *vsock.Client) error {
+func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client) error {
 	// Create the initial index report immediately.
 	if err := RunSingle(ctx, cfg, client); err != nil {
 		log.Errorf("Failed to run initial index: %v", err)
@@ -42,7 +42,7 @@ func RunDaemon(ctx context.Context, cfg *config.AgentConfig, client *vsock.Clien
 	}
 }
 
-func RunSingle(ctx context.Context, cfg *config.AgentConfig, client *vsock.Client) error {
+func RunSingle(ctx context.Context, cfg *common.Config, client *vsock.Client) error {
 	report, err := runIndexer(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("creating index report: %w", err)
@@ -64,7 +64,7 @@ func RunSingle(ctx context.Context, cfg *config.AgentConfig, client *vsock.Clien
 	return nil
 }
 
-func runIndexer(ctx context.Context, cfg *config.AgentConfig) (*v4.IndexReport, error) {
+func runIndexer(ctx context.Context, cfg *common.Config) (*v4.IndexReport, error) {
 	indexerCfg := index.NodeIndexerConfig{
 		HostPath: cfg.IndexHostPath,
 		// Client used to fetch the repo to cpe mapping json.

--- a/compliance/virtualmachines/agent/index/index.go
+++ b/compliance/virtualmachines/agent/index/index.go
@@ -1,0 +1,98 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/stackrox/rox/compliance/node/index"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/jsonutil"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/config"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/vsock"
+)
+
+var log = logging.LoggerForModule()
+
+const (
+	mappingClientTimeout = 30 * time.Second
+	repo2CPEMappingURL   = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+)
+
+func RunDaemon(ctx context.Context, cfg *config.AgentConfig, client *vsock.Client) error {
+	// Create the initial index report immediately.
+	if err := RunSingle(ctx, cfg, client); err != nil {
+		log.Errorf("Failed to run initial index: %v", err)
+	}
+
+	ticker := time.NewTicker(cfg.IndexInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := RunSingle(ctx, cfg, client); err != nil {
+				log.Errorf("Failed to run index: %v", err)
+			}
+		}
+	}
+}
+
+func RunSingle(ctx context.Context, cfg *config.AgentConfig, client *vsock.Client) error {
+	report, err := runIndexer(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("creating index report: %w", err)
+	}
+	if cfg.Verbose {
+		reportJson, err := jsonutil.ProtoToJSON(report)
+		if err != nil {
+			log.Errorf("failed to convert index report %q to json", report.GetHashId())
+		} else {
+			fmt.Println(reportJson)
+		}
+	}
+	if !report.GetSuccess() {
+		return fmt.Errorf("failed index report: %s", report.GetErr())
+	}
+	if err := client.SendIndexReport(report); err != nil {
+		return fmt.Errorf("sending index report: %w", err)
+	}
+	return nil
+}
+
+func runIndexer(ctx context.Context, cfg *config.AgentConfig) (*v4.IndexReport, error) {
+	indexerCfg := index.NodeIndexerConfig{
+		HostPath: cfg.IndexHostPath,
+		// Client used to fetch the repo to cpe mapping json.
+		Client: &http.Client{Transport: proxy.RoundTripper()},
+		// URL where to get the repo to cpe mapping json from.
+		// In ACS, we fetch it internally from the cluster (to prevent Collector from accessing the Internet):
+		// "https://sensor.stackrox.svc:443/scanner/definitions?file=repo2cpe"
+		Repo2CPEMappingURL: repo2CPEMappingURL,
+		Timeout:            mappingClientTimeout,
+		// Disable package filtering.
+		PackageDBFilter: "",
+	}
+
+	report, err := index.NewNodeIndexer(indexerCfg).IndexNode(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// This is currently needed because claircore 1.5.40 enumerates
+	// repositories as integers, but we reference repos by name in the
+	// environments.
+	report = fixupIndexReport(report)
+	return report, nil
+}
+
+func fixupIndexReport(report *v4.IndexReport) *v4.IndexReport {
+	for _, repo := range report.GetContents().GetRepositories() {
+		repo.Id = repo.GetName()
+	}
+	return report
+}

--- a/compliance/virtualmachines/agent/index/index.go
+++ b/compliance/virtualmachines/agent/index/index.go
@@ -7,19 +7,18 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/compliance/node/index"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/config"
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/vsock"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/compliance/virtualmachines/agent/config"
-	"github.com/stackrox/rox/compliance/virtualmachines/agent/vsock"
 )
 
 var log = logging.LoggerForModule()
 
 const (
 	mappingClientTimeout = 30 * time.Second
-	repo2CPEMappingURL   = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
 )
 
 func RunDaemon(ctx context.Context, cfg *config.AgentConfig, client *vsock.Client) error {
@@ -73,7 +72,7 @@ func runIndexer(ctx context.Context, cfg *config.AgentConfig) (*v4.IndexReport, 
 		// URL where to get the repo to cpe mapping json from.
 		// In ACS, we fetch it internally from the cluster (to prevent Collector from accessing the Internet):
 		// "https://sensor.stackrox.svc:443/scanner/definitions?file=repo2cpe"
-		Repo2CPEMappingURL: repo2CPEMappingURL,
+		Repo2CPEMappingURL: cfg.RepoToCPEMappingURL,
 		Timeout:            mappingClientTimeout,
 		// Disable package filtering.
 		PackageDBFilter: "",

--- a/compliance/virtualmachines/agent/main.go
+++ b/compliance/virtualmachines/agent/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/stackrox/rox/compliance/virtualmachines/agent/cmd"
 	"github.com/stackrox/rox/pkg/logging"
-	"golang.org/x/sys/unix"
 )
 
 var log = logging.LoggerForModule()
@@ -19,7 +19,7 @@ func main() {
 	defer cancel()
 	go func() {
 		sigC := make(chan os.Signal, 1)
-		signal.Notify(sigC, unix.SIGINT, unix.SIGTERM)
+		signal.Notify(sigC, syscall.SIGINT, syscall.SIGTERM)
 		sig := <-sigC
 		log.Errorf("%s caught, shutting down...", sig)
 		// Cancel the main context.

--- a/compliance/virtualmachines/agent/main.go
+++ b/compliance/virtualmachines/agent/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/stackrox/rox/compliance/virtualmachines/agent/cmd"
+	"github.com/stackrox/rox/pkg/logging"
+	"golang.org/x/sys/unix"
+)
+
+var log = logging.LoggerForModule()
+
+func main() {
+	// Create a context that is cancellable on the usual command line signals. Double
+	// signal forcefully exits.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		sigC := make(chan os.Signal, 1)
+		signal.Notify(sigC, unix.SIGINT, unix.SIGTERM)
+		sig := <-sigC
+		log.Errorf("%s caught, shutting down...", sig)
+		// Cancel the main context.
+		cancel()
+		go func() {
+			// A second signal will forcefully quit.
+			<-sigC
+			os.Exit(1)
+		}()
+	}()
+	if err := cmd.RootCmd(ctx).Execute(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/compliance/virtualmachines/agent/vsock/client.go
+++ b/compliance/virtualmachines/agent/vsock/client.go
@@ -1,0 +1,55 @@
+package vsock
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/mdlayher/vsock"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/protocompat"
+)
+
+var log = logging.LoggerForModule()
+
+type Client struct {
+	Port    uint32
+	Timeout time.Duration
+}
+
+func (c *Client) SendIndexReport(report *v4.IndexReport) error {
+	conn, err := vsock.Dial(vsock.Host, c.Port, &vsock.Config{})
+	if err != nil {
+		return fmt.Errorf("dialing vsock connection: %w", err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.Errorf("Failed to close vsock connection: %v", err)
+		}
+	}()
+	if err := conn.SetDeadline(time.Now().Add(c.Timeout)); err != nil {
+		return fmt.Errorf("setting connection deadline: %w", err)
+	}
+	vsockCid, err := vsock.ContextID()
+	if err != nil {
+		return fmt.Errorf("getting vsock context id: %w", err)
+	}
+	return c.writeIndexReport(conn,
+		&v1.IndexReport{VsockCid: strconv.Itoa(int(vsockCid)), IndexV4: report},
+	)
+}
+
+func (c *Client) writeIndexReport(conn net.Conn, report *v1.IndexReport) error {
+	reportBytes, err := protocompat.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("marshalling index report: %w", err)
+	}
+	if _, err := conn.Write(reportBytes); err != nil {
+		return fmt.Errorf("writing index report: %w", err)
+	}
+	log.Infof("Sent index report %q to host", report.GetIndexV4().GetHashId())
+	return nil
+}

--- a/compliance/virtualmachines/agent/vsock/client_test.go
+++ b/compliance/virtualmachines/agent/vsock/client_test.go
@@ -1,0 +1,82 @@
+package vsock
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func setupLocalTCPListener(t *testing.T) (net.Listener, uint64) {
+	port := testutils.GetFreeTestPort()
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err, "failed to create local TCP listener")
+
+	t.Cleanup(func() {
+		utils.IgnoreError(listener.Close)
+	})
+
+	return listener, port
+}
+
+func TestClient_writeIndexReport_LocalSocket(t *testing.T) {
+	listener, port := setupLocalTCPListener(t)
+	client := &Client{Port: uint32(port)}
+	testReport := &v1.IndexReport{
+		IndexV4: &v4.IndexReport{
+			HashId:  "test-hash-local",
+			State:   "completed",
+			Success: true,
+		},
+	}
+
+	receivedData := make(chan []byte, 1)
+	listenerErr := make(chan error, 1)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			listenerErr <- fmt.Errorf("accept failed: %w", err)
+			return
+		}
+		defer utils.IgnoreError(listener.Close)
+
+		buf := make([]byte, 4096)
+		n, err := conn.Read(buf)
+		if err != nil {
+			listenerErr <- fmt.Errorf("read failed: %w", err)
+			return
+		}
+
+		receivedData <- buf[:n]
+	}()
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err, "should be able to dial local TCP socket")
+	defer utils.IgnoreError(listener.Close)
+
+	err = client.writeIndexReport(conn, testReport)
+	require.NoError(t, err, "writeIndexReport should succeed")
+
+	select {
+	case data := <-receivedData:
+		var receivedReport v1.IndexReport
+		err = proto.Unmarshal(data, &receivedReport)
+		require.NoError(t, err, "should be able to unmarshal received data")
+		protoassert.Equal(t, testReport, &receivedReport)
+	case err := <-listenerErr:
+		close(receivedData)
+		t.Fatalf("listener error: %v", err)
+	case <-time.After(5 * time.Second):
+		close(receivedData)
+		t.Fatal("timeout waiting for data")
+	}
+}

--- a/compliance/virtualmachines/agent/vsock/client_test.go
+++ b/compliance/virtualmachines/agent/vsock/client_test.go
@@ -40,6 +40,10 @@ func TestClient_writeIndexReport_LocalSocket(t *testing.T) {
 
 	receivedData := make(chan []byte, 1)
 	listenerErr := make(chan error, 1)
+	defer func() {
+		close(receivedData)
+		close(listenerErr)
+	}()
 
 	go func() {
 		conn, err := listener.Accept()
@@ -73,10 +77,8 @@ func TestClient_writeIndexReport_LocalSocket(t *testing.T) {
 		require.NoError(t, err, "should be able to unmarshal received data")
 		protoassert.Equal(t, testReport, &receivedReport)
 	case err := <-listenerErr:
-		close(receivedData)
-		t.Fatalf("listener error: %v", err)
+		require.NoError(t, err, "listener error")
 	case <-time.After(5 * time.Second):
-		close(receivedData)
-		t.Fatal("timeout waiting for data")
+		t.Errorf("timeout waiting for data")
 	}
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Add a standalone virtual machine agent. The agent is meant to be run by users on a kube-virt virtual machine. It then gathers index reports, and sends the index reports to the collector relay (see #16929).

To index RHEL packages, we require at least claircore `1.5.40`, which requires other changes (see https://github.com/stackrox/stackrox/pull/16944). This PR is therefore rebased onto the claircore bump.

### Note to reviewers

`client_test.go` and `README` were generated with the help of claude.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

#### Agent -> Relay

I've tested that the agent produces expected `IndexReports` and sends them to the relay (https://github.com/stackrox/stackrox/pull/16929) via vsock. I set up the environment as follows:

* OpenShift ROSA cluster with one metal node.
* Enable vsock in kube-virt and on the virtualmachine (`"devices.autoattachVSOCK": true`).

#### Vulnerability matching

I send the index report generated by the agent and sent it to the scanner matcher.

```
sudo ./agent --verbose > out.json
go run ./scanner/cmd/scannerctl vm --insecure-skip-tls-verify --matcher-address=localhost:8443 --index-report-file=out.json
```

yielded

```
...
  "packageVulnerabilities": {
    "112": {
      "values": [
        "2001153"
      ]
    },
    "115": {
      "values": [
        "2228833",
        "1878733"
      ]
    },
    "131": {
      "values": [
        "1741621"
      ]
    },
...
```

#### Node scanning

I confirmed that node scanning vulnerabilities show in Central:

<img width="1205" height="743" alt="SCR-20251006-mrsr" src="https://github.com/user-attachments/assets/7f7f23bf-f930-4d86-bc3d-1cd094c6bbe6" />