### PR TITLE
ROX-30504: Allow sorting by CVE severity across affected deployments

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -20,6 +20,7 @@ import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { VulnerabilitySeverityLabel } from '../../types';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { getSeveritySortOptions } from '../../utils/sortUtils';
 
 export const tableId = 'WorkloadCvesDeploymentOverviewTable';
 
@@ -135,6 +136,10 @@ function DeploymentOverviewTable({
                     <TooltipTh
                         className={getVisibilityClass('cvesBySeverity')}
                         tooltip="CVEs by severity across this deployment"
+                        sort={getSortParams(
+                            'CVEs By Severity',
+                            getSeveritySortOptions(filteredSeverities)
+                        )}
                     >
                         CVEs by severity
                         {isFiltered && <DynamicColumnIcon />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -69,7 +69,19 @@ export function getWorkloadCveOverviewSortFields(
                 'Image Scan Time',
             ];
         case 'Deployment':
-            return ['Deployment', 'Cluster', 'Namespace', 'Created'];
+            return [
+                'Deployment',
+                [
+                    'Critical Severity Count',
+                    'Important Severity Count',
+                    'Moderate Severity Count',
+                    'Low Severity Count',
+                    'Unknown Severity Count',
+                ],
+                'Cluster',
+                'Namespace',
+                'Created',
+            ];
         default:
             return ensureExhaustive(entityTab);
     }


### PR DESCRIPTION
## Description

As titled, adds sorting to the Deployment Overview list "CVEs by severity" column.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the Deployment Tab in Vuln Management and sort by the CVE severity column:
<img width="1255" height="769" alt="image" src="https://github.com/user-attachments/assets/265555bc-4f5d-417a-8e1e-5d5847ca093d" />
<img width="1255" height="769" alt="image" src="https://github.com/user-attachments/assets/bb25c834-56b4-467a-9f5d-2e5bd76160ca" />
<img width="1255" height="769" alt="image" src="https://github.com/user-attachments/assets/720d5d83-ae01-4dba-9ff6-7f4fd57a4801" />

