### PR TITLE
ROX-3108: Fix compliance-operator version reporting in telemetry

### DIFF
--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -36,6 +36,7 @@ func init() {
 		telemetryInfo,
 		telemetrySecuredNodes,
 		telemetrySecuredVCPU,
+		telemetryComplianceOperatorVersion,
 		deploymentEnhancementQueueSize,
 		responsesChannelOperationCount,
 		ComponentQueueOperations,

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -259,6 +259,17 @@ var (
 		[]string{"central_id", "hosting", "install_method", "sensor_id"},
 	)
 
+	telemetryComplianceOperatorVersion = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   metrics.PrometheusNamespace,
+			Subsystem:   metrics.SensorSubsystem.String(),
+			Name:        "compliance_operator_version",
+			Help:        "Version of compliance operator",
+			ConstLabels: telemetryLabels,
+		},
+		[]string{"central_id", "hosting", "install_method", "sensor_id", "compliance_operator_version"},
+	)
+
 	// responsesChannelOperationCount a counter to track the operations in the responses channel
 	responsesChannelOperationCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
@@ -462,6 +473,9 @@ func SetTelemetryMetrics(clusterIDPeeker func() string, cm *central.ClusterMetri
 
 	telemetrySecuredVCPU.Reset()
 	telemetrySecuredVCPU.WithLabelValues(labels...).Set(float64(cm.GetCpuCapacity()))
+
+	telemetryComplianceOperatorVersion.Reset()
+	telemetryComplianceOperatorVersion.WithLabelValues(append(labels, cm.GetComplianceOperatorVersion())...).Set(1)
 }
 
 // ObserveCentralReceiverProcessMessageDuration records the duration of a ProcessMessage call

--- a/sensor/kubernetes/complianceoperator/info.go
+++ b/sensor/kubernetes/complianceoperator/info.go
@@ -23,7 +23,11 @@ func GetInstalledVersion(ctx context.Context, ns string, cli kubernetes.Interfac
 
 	foundInNamespace := complianceOperatorDeployment.GetNamespace()
 	version := extractVersionFromLabels(complianceOperatorDeployment.Labels)
-	return version, foundInNamespace, ErrUnableToExtractVersion
+	log.Debugf("Found CO version %s in namespace %s", version, foundInNamespace)
+	if version == "" {
+		err = ErrUnableToExtractVersion
+	}
+	return version, foundInNamespace, err
 }
 
 func extractVersionFromLabels(labels map[string]string) string {


### PR DESCRIPTION
## Description

This PR fixes compliance-operator version reporting through the telemetry. The issue was that the proper version was returned, however a mistakenly hardcoded error caused the version to be overwritten by a const string "installed; version unknown".

Also: Add telemetry-based compliance operator version prometheus metric (as for all other sensor telemetry metrics).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

On a cluster with installed Compliance Operator:

```
# enable debug logs
➜ logs-sensor | grep -i "Found CO version"
kubernetes/complianceoperator: 2025/09/30 15:46:10.682993 info.go:26: Debug: Found CO version v1.7.1 in namespace openshift-compliance
```

in metrics:

```
# HELP rox_sensor_compliance_operator_version Version of compliance operator
# TYPE rox_sensor_compliance_operator_version gauge
rox_sensor_compliance_operator_version{branding="StackRox",build="internal",central_id="d539f29d-72f8-465c-9090-aca0257daf86",compliance_operator_version="v1.7.1",hosting="self-managed",install_method="helm",sensor_id="53defeb2-e212-4b25-aeb9-a1115035751f",sensor_version="4.9.x-932-g76abb5bb42"} 1
```

