### PR TITLE
ROX-31114: improve indicator migration

### DIFF
--- a/migrator/migrations/m_212_to_m_213_add_container_start_column_to_indicators/migration_impl.go
+++ b/migrator/migrations/m_212_to_m_213_add_container_start_column_to_indicators/migration_impl.go
@@ -51,7 +51,7 @@ func migrateByCluster(cluster string, database *types.Databases) error {
 	store := updatedStore.New(database.PostgresDB)
 
 	var storeIndicators []*storage.ProcessIndicator
-	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, cluster).ProtoQuery()
+	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, cluster).AddNullField(search.ProcessContainerStartTime).ProtoQuery()
 	storeIndicators, err := store.GetByQuery(ctx, query)
 	if err != nil {
 		return err

--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -83,12 +83,6 @@ func runMigrations(databases *types.Databases, startingSeqNum int) error {
 		// Add an outer transaction so migrations can be wrapped in a transaction.
 		ctx := sac.WithAllAccess(context.Background())
 
-		tx, err := databases.PostgresDB.Begin(ctx)
-		if err != nil {
-			return err
-		}
-		ctx = pgPkg.ContextWithTx(ctx, tx)
-
 		// Set the context with the databases so the wrapped transaction can be used
 		databases.DBCtx = ctx
 
@@ -102,9 +96,15 @@ func runMigrations(databases *types.Databases, startingSeqNum int) error {
 		} else {
 			err := migration.Run(databases)
 			if err != nil {
-				return wrapRollback(ctx, tx, errors.Wrapf(err, "error running migration starting at %d", seqNum))
+				return errors.Wrapf(err, "error running migration starting at %d", seqNum)
 			}
 		}
+
+		tx, err := databases.PostgresDB.Begin(ctx)
+		if err != nil {
+			return err
+		}
+		ctx = pgPkg.ContextWithTx(ctx, tx)
 
 		err = updateVersion(ctx, databases, migration.VersionAfter)
 		if err != nil {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Instead of pulling all indicators by cluster, pull them by cluster and signal time is null.  This way if a migration restarts we won't have to reprocess what we already updated.

The query generated is `select process_indicators.serialized from process_indicators where (process_indicators.ClusterId = $1 and process_indicators.ContainerStartTime is null)`

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Using my large snapshot on an external database, killing the migration part way through and verifying in the logs that the cluster in progress at time of bounce processes fewer rows 2nd time around.

Start the migration.  Restarted the pod where the log stops.
```
Migrator: 2025/10/01 14:50:08.357910 log.go:18: Info: Found DB at version 212, which is less than what we expect (213). Running migrations...
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:50:08.432283 migration_impl.go:33: Info: clusters found: [2902a528-8ae7-4936-86e7-1ccdc4c21afc caaaaaaa-bbbb-4011-0000-222222222222 89a8e9cc-e494-4a29-aba9-e76397aeb681 caaaaaaa-bbbb-4011-0000-333333333333 caaaaaaa-bbbb-4011-0000-111111111111 55986ed4-f2a2-4c73-a9ec-6ebfcebb16e1 032b0ee6-fb03-4d7f-b49d-571520bc880f b12f2627-4077-4017-8512-0f7da4b51860 7d4404a6-5dfe-472c-871e-dd53c790ead3 be78fb19-df6e-4526-af53-9300d27f8eab 1ee52fdf-87de-4cec-b5d7-a5bcefdecdbd]
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:50:08.462773 migration_impl.go:60: Info: Processing 2902a528-8ae7-4936-86e7-1ccdc4c21afc with 0 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:50:08.462872 migration_impl.go:70: Info: Populated container start time for 0 process indicators in cluster 2902a528-8ae7-4936-86e7-1ccdc4c21afc
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:51:02.084027 migration_impl.go:60: Info: Processing caaaaaaa-bbbb-4011-0000-222222222222 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:54:49.789338 migration_impl.go:70: Info: Populated container start time for 1500000 process indicators in cluster caaaaaaa-bbbb-4011-0000-222222222222
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:56:13.247851 migration_impl.go:60: Info: Processing 89a8e9cc-e494-4a29-aba9-e76397aeb681 with 1495000 indicators
```

Upon restart,  notice that `caaaaaaa-bbbb-4011-0000-222222222222` and `89a8e9cc-e494-4a29-aba9-e76397aeb681` have fewer that before.  Import to note that the migration for `caaaaaaa-bbbb-4011-0000-222222222222` started with 10 records without a signal time on purpose to test that case.  
```
Migrator: 2025/10/01 14:59:13.201222 log.go:18: Info: Migration version from DB = seq_num:212  version:"4.9.x-835-g4da825a5c7"  last_persisted:{seconds:1759330146  nanos:745248000}  min_seq_num:186.
Migrator: 2025/10/01 14:59:13.201297 log.go:18: Info: version for "stackrox" is &{ 4.9.x-835-g4da825a5c7 212 186 2025-10-01 14:49:06.745248 +0000 UTC}
Migrator: 2025/10/01 14:59:13.201309 log.go:18: Info: In runner.Run
Migrator: 2025/10/01 14:59:13.241774 log.go:18: Info: Migration version from DB = seq_num:212  version:"4.9.x-835-g4da825a5c7"  last_persisted:{seconds:1759330146  nanos:745248000}  min_seq_num:186.
Migrator: 2025/10/01 14:59:13.241841 log.go:18: Info: Found DB at version 212, which is less than what we expect (213). Running migrations...
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:59:13.312029 migration_impl.go:33: Info: clusters found: [2902a528-8ae7-4936-86e7-1ccdc4c21afc caaaaaaa-bbbb-4011-0000-222222222222 89a8e9cc-e494-4a29-aba9-e76397aeb681 caaaaaaa-bbbb-4011-0000-333333333333 caaaaaaa-bbbb-4011-0000-111111111111 55986ed4-f2a2-4c73-a9ec-6ebfcebb16e1 032b0ee6-fb03-4d7f-b49d-571520bc880f b12f2627-4077-4017-8512-0f7da4b51860 7d4404a6-5dfe-472c-871e-dd53c790ead3 be78fb19-df6e-4526-af53-9300d27f8eab 1ee52fdf-87de-4cec-b5d7-a5bcefdecdbd]
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:59:13.504498 migration_impl.go:60: Info: Processing 2902a528-8ae7-4936-86e7-1ccdc4c21afc with 0 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 14:59:13.504587 migration_impl.go:70: Info: Populated container start time for 0 process indicators in cluster 2902a528-8ae7-4936-86e7-1ccdc4c21afc
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:00:19.534029 migration_impl.go:60: Info: Processing caaaaaaa-bbbb-4011-0000-222222222222 with 10 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:00:19.551295 migration_impl.go:70: Info: Populated container start time for 10 process indicators in cluster caaaaaaa-bbbb-4011-0000-222222222222
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:00:23.386801 migration_impl.go:60: Info: Processing 89a8e9cc-e494-4a29-aba9-e76397aeb681 with 1040010 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:02:04.945710 migration_impl.go:70: Info: Populated container start time for 1040010 process indicators in cluster 89a8e9cc-e494-4a29-aba9-e76397aeb681
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:03:58.735035 migration_impl.go:60: Info: Processing caaaaaaa-bbbb-4011-0000-333333333333 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:06:30.568261 migration_impl.go:70: Info: Populated container start time for 1500000 process indicators in cluster caaaaaaa-bbbb-4011-0000-333333333333
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:06:39.602576 migration_impl.go:60: Info: Processing caaaaaaa-bbbb-4011-0000-111111111111 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:09:20.607012 migration_impl.go:70: Info: Populated container start time for 1500000 process indicators in cluster caaaaaaa-bbbb-4011-0000-111111111111
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:09:24.905398 migration_impl.go:60: Info: Processing 55986ed4-f2a2-4c73-a9ec-6ebfcebb16e1 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:12:13.063801 migration_impl.go:70: Info: Populated container start time for 1500000 process indicators in cluster 55986ed4-f2a2-4c73-a9ec-6ebfcebb16e1
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:12:13.069439 migration_impl.go:60: Info: Processing 032b0ee6-fb03-4d7f-b49d-571520bc880f with 0 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:12:13.069553 migration_impl.go:70: Info: Populated container start time for 0 process indicators in cluster 032b0ee6-fb03-4d7f-b49d-571520bc880f
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:13:59.153981 migration_impl.go:60: Info: Processing b12f2627-4077-4017-8512-0f7da4b51860 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:16:35.742293 migration_impl.go:70: Info: Populated container start time for 1500000 process indicators in cluster b12f2627-4077-4017-8512-0f7da4b51860
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:16:35.744724 migration_impl.go:60: Info: Processing 7d4404a6-5dfe-472c-871e-dd53c790ead3 with 0 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:16:35.744803 migration_impl.go:70: Info: Populated container start time for 0 process indicators in cluster 7d4404a6-5dfe-472c-871e-dd53c790ead3
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:16:44.386998 migration_impl.go:60: Info: Processing be78fb19-df6e-4526-af53-9300d27f8eab with 359000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:17:18.907723 migration_impl.go:70: Info: Populated container start time for 359000 process indicators in cluster be78fb19-df6e-4526-af53-9300d27f8eab
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:17:24.052100 migration_impl.go:60: Info: Processing 1ee52fdf-87de-4cec-b5d7-a5bcefdecdbd with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:19:57.637750 migration_impl.go:70: Info: Populated container start time for 1500000 process indicators in cluster 1ee52fdf-87de-4cec-b5d7-a5bcefdecdbd
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/10/01 15:19:57.637864 migration_impl.go:43: Info: Process Indicators migrated
Migrator: 2025/10/01 15:19:57.666648 log.go:18: Info: Successfully updated DB from version 212 to 213
pkg/mtls/certwatch: 2025/10/01 15:20:06.447168 certwatch.go:63: Info: No TLS certificate found. Using internal certificates for HTTPS. Watch dir: "/run/secrets/stackrox.io/default-tls-cert"
pkg/memlimit: 2025/10/01 15:20:06.447384 memlimit.go:43: Info: ROX_MEMLIMIT set to 60.80Gi
main: 2025/10/01 15:20:06.498560 main.go:304: Info: Running StackRox Version: 4.9.x-938-g7f4c9ef2d7
version: 2025/10/01 15:20:06.542678 ensure.go:55: Info: Version found in the DB was current. We're good to go!
```