### PR TITLE
ROX-30973: Use import type in Containers Clusters

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -768,7 +768,6 @@ module.exports = [
         files: ['src/*/**/*.{js,jsx,ts,tsx}'], // product files, except for unit tests (including test-utils folder)
         ignores: [
             'src/Components/**',
-            'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/MainPage/**',
             'src/Containers/MitreAttackVectors/**',

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Button, Flex, FlexItem, Switch, Text, Title } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 import { CheckCircle } from 'react-feather';
 import { ClipLoader } from 'react-spinners';
 
-import { ClusterManagerType } from 'types/cluster.proto';
+import type { ClusterManagerType } from 'types/cluster.proto';
 import useAnalytics, { LEGACY_CLUSTER_DOWNLOAD_YAML } from 'hooks/useAnalytics';
 
 export type ClusterDeploymentProps = {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Button, Icon, TextInput, Tooltip, ValidatedOptions } from '@patternfly/react-core';
 import { PlusCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import { ClusterLabels } from 'services/ClustersService';
+import type { ClusterLabels } from 'services/ClustersService';
 import { getIsValidLabelKey, getIsValidLabelValue } from 'utils/labels';
 
 export type ClusterLabelsTableProps = {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Alert,
@@ -30,8 +31,8 @@ import {
     downloadClusterYaml,
     getClusterDefaults,
 } from 'services/ClustersService';
-import { Cluster, ClusterManagerType } from 'types/cluster.proto';
-import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
+import type { Cluster, ClusterManagerType } from 'types/cluster.proto';
+import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { clustersBasePath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     DescriptionList,
     DescriptionListDescription,
@@ -6,7 +7,7 @@ import {
     DescriptionListTerm,
 } from '@patternfly/react-core';
 
-import { ClusterRegistrationSecret } from 'services/ClustersService';
+import type { ClusterRegistrationSecret } from 'services/ClustersService';
 
 export type ClusterRegistrationSecretDescriptionProps = {
     clusterRegistrationSecret: ClusterRegistrationSecret;

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     ActionGroup,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.utils.ts
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.utils.ts
@@ -1,6 +1,6 @@
 import FileSaver from 'file-saver';
 
-import { GenerateClusterRegistrationSecretResponse } from 'services/ClustersService';
+import type { GenerateClusterRegistrationSecretResponse } from 'services/ClustersService';
 
 export function downloadClusterRegistrationSecret(
     name: string,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
@@ -1,13 +1,12 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Bullseye, Button, Divider, PageSection, Spinner } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useAnalytics, { CREATE_CLUSTER_REGISTRATION_SECRET_CLICKED } from 'hooks/useAnalytics';
 import useRestQuery from 'hooks/useRestQuery';
-import {
-    ClusterRegistrationSecret,
-    fetchClusterRegistrationSecrets,
-} from 'services/ClustersService';
+import { fetchClusterRegistrationSecrets } from 'services/ClustersService';
+import type { ClusterRegistrationSecret } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { clustersClusterRegistrationSecretsPath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { ClusterRegistrationSecret } from 'services/ClustersService';
+import type { ClusterRegistrationSecret } from 'services/ClustersService';
 import { clustersClusterRegistrationSecretsPath } from 'routePaths';
 
 export type ClusterRegistrationSecretsTableProps = {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Button,
@@ -12,10 +13,8 @@ import {
 
 import useAnalytics, { REVOKE_CLUSTER_REGISTRATION_SECRET } from 'hooks/useAnalytics';
 import useRestMutation from 'hooks/useRestMutation';
-import {
-    ClusterRegistrationSecret,
-    revokeClusterRegistrationSecrets,
-} from 'services/ClustersService';
+import { revokeClusterRegistrationSecrets } from 'services/ClustersService';
+import type { ClusterRegistrationSecret } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type RevokeClusterRegistrationSecretModalProps = {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 import {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     ClipboardCopy,
     ClipboardCopyButton,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
 
 export type SecureClusterUsingOperatorProps = {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterStatusGrid.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterStatusGrid.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Grid, GridItem } from '@patternfly/react-core';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import AdmissionControlPanel from './Components/AdmissionControl/AdmissionControlPanel';
 import CollectorPanel from './Components/Collector/CollectorPanel';

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import type { MouseEvent, ReactElement } from 'react';
 import {
     ActionsColumn,
     ExpandableRowContent,
@@ -32,7 +33,7 @@ export type ClustersTableProps = {
     tableState: TableUIState<Cluster>;
     selectedClusterIds: string[];
     onClearFilters: () => void;
-    onDeleteCluster: (cluster: Cluster) => (event: React.MouseEvent) => void;
+    onDeleteCluster: (cluster: Cluster) => (event: MouseEvent) => void;
     toggleAllClusters: () => void;
     toggleCluster: (clusterId) => void;
     upgradeSingleCluster: (clusterId: string) => void;
@@ -56,7 +57,7 @@ function ClustersTable({
     toggleAllClusters,
     toggleCluster,
     upgradeSingleCluster,
-}: ClustersTableProps) {
+}: ClustersTableProps): ReactElement {
     const [expanded, setExpanded] = useState<ExpansionMap>({});
 
     function toggle(clusterId: string, col: ExpandableColumnId) {

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlPanel.tsx
@@ -8,7 +8,7 @@ import {
     ListItem,
 } from '@patternfly/react-core';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 import { buildStatusMessage } from 'Containers/Clusters/cluster.helpers';
 
 import AdmissionControlStatus from './AdmissionControlStatus';

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlPanel.tsx
@@ -9,10 +9,10 @@ import {
 } from '@patternfly/react-core';
 
 import type { ClusterHealthStatus } from 'types/cluster.proto';
-import { buildStatusMessage } from 'Containers/Clusters/cluster.helpers';
 
-import AdmissionControlStatus from './AdmissionControlStatus';
+import { buildStatusMessage } from '../../cluster.helpers';
 import ClusterHealthPanel from '../ClusterHealthPanel';
+import AdmissionControlStatus from './AdmissionControlStatus';
 
 export type AdmissionControlPanelProps = {
     healthStatus: ClusterHealthStatus;

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import {
     delayedAdmissionControlStatusStyle,

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatusLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatusLegacy.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import DetailedTooltipContent from 'Components/DetailedTooltipContent';
@@ -11,7 +12,7 @@ import {
 } from '../../cluster.helpers';
 import AdmissionControlStatusTotals from './AdmissionControlStatusTotals';
 import AdmissionControlUnavailableStatus from './AdmissionControlUnavailableStatus';
-import { ClusterHealthStatus } from '../../clusterTypes';
+import type { ClusterHealthStatus } from '../../clusterTypes';
 import HealthLabelWithDelayed from '../HealthLabelWithDelayed';
 import HealthStatusNotApplicable from '../HealthStatusNotApplicable';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatusTotals.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatusTotals.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import { healthStatusStylesLegacy } from '../../cluster.helpers';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlUnavailableStatus.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import HealthStatus from '../HealthStatus';

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
-import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
+import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterHealthPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterHealthPanel.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Panel, PanelHeader, PanelMain, PanelMainBody, Divider } from '@patternfly/react-core';
 
 type ClusterHealthPanelProps = {
@@ -6,7 +7,7 @@ type ClusterHealthPanelProps = {
     header: ReactNode;
 };
 
-function ClusterHealthPanel({ children, header }: ClusterHealthPanelProps) {
+function ClusterHealthPanel({ children, header }: ClusterHealthPanelProps): ReactElement {
     return (
         <Panel variant="bordered" className="pf-v5-u-h-100">
             <PanelHeader>{header}</PanelHeader>

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex } from '@patternfly/react-core';
-import { Cluster } from 'types/cluster.proto';
+import type { Cluster } from 'types/cluster.proto';
 import HelmIndicator from './HelmIndicator';
 import OperatorIndicator from './OperatorIndicator';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import { healthStatusLabels } from '../cluster.constants';
 import { healthStatusStyles } from '../cluster.helpers';

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatusLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatusLegacy.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons';
 
@@ -11,7 +12,7 @@ import { healthStatusLabels } from '../cluster.constants';
 import HealthStatus from './HealthStatus';
 import ClusterStatusPill from './ClusterStatusPill';
 import { healthStatusStylesLegacy } from '../cluster.helpers';
-import { ClusterHealthStatus } from '../clusterTypes';
+import type { ClusterHealthStatus } from '../clusterTypes';
 
 /*
  * Cluster Status in Clusters list or Cluster side panel

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatusPill.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatusPill.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import CollectorStatusLegacy from './Collector/CollectorStatusLegacy';
 import AdmissionControlStatusLegacy from './AdmissionControl/AdmissionControlStatusLegacy';
 import SensorStatusLegacy from './SensorStatusLegacy';
-import { ClusterHealthStatus } from '../clusterTypes';
+import type { ClusterHealthStatus } from '../clusterTypes';
 import ScannerStatusLegacy from './Scanner/ScannerStatusLegacy';
 
 type ClusterStatusPillProps = {

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorPanel.tsx
@@ -8,7 +8,7 @@ import {
     ListItem,
 } from '@patternfly/react-core';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 import { buildStatusMessage } from '../../cluster.helpers';
 
 import ClusterHealthPanel from '../ClusterHealthPanel';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import {
     delayedCollectorStatusStyle,

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusLegacy.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import DetailedTooltipContent from 'Components/DetailedTooltipContent';
@@ -12,7 +13,7 @@ import {
     healthStatusStylesLegacy,
     isDelayedSensorHealthStatus,
 } from '../../cluster.helpers';
-import { ClusterHealthStatus } from '../../clusterTypes';
+import type { ClusterHealthStatus } from '../../clusterTypes';
 import HealthStatusNotApplicable from '../HealthStatusNotApplicable';
 
 /*

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import { healthStatusStylesLegacy } from '../../cluster.helpers';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import HealthStatus from '../HealthStatus';

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { differenceInDays } from 'date-fns';
 import { Tooltip } from '@patternfly/react-core';
 
@@ -9,7 +10,7 @@ import { getVersionedDocs } from 'utils/versioning';
 import HealthStatus from './HealthStatus';
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
 import { getCredentialExpirationStatus, healthStatusStylesLegacy } from '../cluster.helpers';
-import { CertExpiryStatus } from '../clusterTypes';
+import type { CertExpiryStatus } from '../clusterTypes';
 
 const testId = 'credentialExpiration';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpirationWidget.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpirationWidget.tsx
@@ -5,7 +5,7 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 import useAuthStatus from 'hooks/useAuthStatus';
 import { clustersInitBundlesPath } from 'routePaths';
 
-import { ClusterStatus } from '../clusterTypes';
+import type { ClusterStatus } from '../clusterTypes';
 import CredentialExpiration from './CredentialExpiration';
 import CredentialInteraction from './CredentialInteraction';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialInteraction.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialInteraction.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 
 import { generateSecuredClusterCertSecret } from 'services/CertGenerationService';
 import { rotateClusterCerts } from 'services/ClustersService';
@@ -11,7 +12,7 @@ import {
     isCertificateExpiringSoon,
     isUpToDateStateObject,
 } from '../cluster.helpers';
-import { CertExpiryStatus, SensorUpgradeStatus } from '../clusterTypes';
+import type { CertExpiryStatus, SensorUpgradeStatus } from '../clusterTypes';
 
 /*
  * The heading is a simple explanation of what did not happen because of the error.

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthLabelWithDelayed.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthLabelWithDelayed.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import { healthStatusLabels } from '../cluster.constants';
-import { ClusterHealthItemStatus, ClusterHealthItem } from '../clusterTypes';
+import type { ClusterHealthItemStatus, ClusterHealthItem } from '../clusterTypes';
 
 type HealthLabelWithDelayedProps = {
     delayedText: string;

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthStatus.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 /*
  * Display the contents of a health status cell in Clusters list or Cluster side panel

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthStatusNotApplicable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthStatusNotApplicable.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 type HealthStatusNotApplicableProps = { testId: string; isList?: boolean };
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import helm from 'images/helm.svg';

--- a/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import operatorLogo from 'images/operator-logo.png';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerPanel.tsx
@@ -8,10 +8,10 @@ import {
     ListItem,
 } from '@patternfly/react-core';
 
-import { buildStatusMessage } from 'Containers/Clusters/cluster.helpers';
 import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import { healthStatusLabels } from '../../cluster.constants';
+import { buildStatusMessage } from '../../cluster.helpers';
 import ClusterHealthPanel from '../ClusterHealthPanel';
 import ScannerStatus from './ScannerStatus';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from '@patternfly/react-core';
 
 import { buildStatusMessage } from 'Containers/Clusters/cluster.helpers';
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import { healthStatusLabels } from '../../cluster.constants';
 import ClusterHealthPanel from '../ClusterHealthPanel';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import {
     delayedScannerStatusStyle,

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatusLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatusLegacy.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from '@patternfly/react-core';
 
 import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
-import { ClusterHealthStatus } from '../../clusterTypes';
+import type { ClusterHealthStatus } from '../../clusterTypes';
 import {
     delayedScannerStatusStyle,
     healthStatusStylesLegacy,

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerUnavailableStatus.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import HealthStatus from '../HealthStatus';

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorPanel.tsx
@@ -6,7 +6,7 @@ import {
     DescriptionListDescription,
 } from '@patternfly/react-core';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 import { getDateTime } from 'utils/dateUtils';
 
 import { buildStatusMessage } from '../cluster.helpers';

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
-import { ClusterHealthStatus } from 'types/cluster.proto';
+import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import { healthStatusStyles, isDelayedSensorHealthStatus } from '../cluster.helpers';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorStatusLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorStatusLegacy.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import { getDateTime, getDistanceStrict } from 'utils/dateUtils';
 import HealthStatus from './HealthStatus';
 import { healthStatusStylesLegacy, isDelayedSensorHealthStatus } from '../cluster.helpers';
-import { ClusterHealthStatus } from '../clusterTypes';
+import type { ClusterHealthStatus } from '../clusterTypes';
 import HealthLabelWithDelayed from './HealthLabelWithDelayed';
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import HealthStatus from './HealthStatus';
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
 import { findUpgradeState, sensorUpgradeStyles } from '../cluster.helpers';
-import { SensorUpgradeStatus } from '../clusterTypes';
+import type { SensorUpgradeStatus } from '../clusterTypes';
 
 const testId = 'sensorUpgrade';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradeLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradeLegacy.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 import HealthStatus from './HealthStatus';
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
 import { findUpgradeState, formatSensorVersion, sensorUpgradeStyles } from '../cluster.helpers';
-import { SensorUpgradeStatus } from '../clusterTypes';
+import type { SensorUpgradeStatus } from '../clusterTypes';
 
 const trClassName = 'align-top leading-normal';
 const thClassName = 'font-700 pl-0 pr-1 py-0 text-left';

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
@@ -15,7 +15,7 @@ import upperFirst from 'lodash/upperFirst';
 
 import { findUpgradeState } from '../cluster.helpers';
 import SensorUpgrade from './SensorUpgrade';
-import { SensorUpgradeStatus } from '../clusterTypes';
+import type { SensorUpgradeStatus } from '../clusterTypes';
 
 export type SensorUpgradePanelProps = {
     actionProps?: {

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -1,22 +1,23 @@
 import React, { useState } from 'react';
+import type { ReactElement, Ref } from 'react';
 import {
     Button,
     FormHelperText,
     HelperText,
     HelperTextItem,
-    MenuToggleElement,
     MenuToggle,
     Select,
     SelectOption,
     TextInput,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { MinusCircleIcon } from '@patternfly/react-icons';
-import { FormikContextType } from 'formik';
+import type { FormikContextType } from 'formik';
 import get from 'lodash/get';
 import * as yup from 'yup';
 
-import {
+import type {
     DelegatedRegistry,
     DelegatedRegistryCluster,
     DelegatedRegistryConfig,
@@ -53,7 +54,7 @@ function DelegatedRegistriesTable({
     registries,
     setRegistryClusterId,
     setRegistryPath,
-}: DelegatedRegistriesTableProps) {
+}: DelegatedRegistriesTableProps): ReactElement {
     const [openRow, setRowOpen] = useState<number>(-1);
     function toggleSelect(rowToToggle: number) {
         setRowOpen((prev) => (rowToToggle === prev ? -1 : rowToToggle));
@@ -145,7 +146,7 @@ function DelegatedRegistriesTable({
                                     onSelect={(_, value) => onSelect(rowIndex, value)}
                                     isOpen={openRow === rowIndex}
                                     selected={registry.clusterId}
-                                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                                    toggle={(toggleRef: Ref<MenuToggleElement>) => (
                                         <MenuToggle
                                             aria-label="Select destination cluster"
                                             ref={toggleRef}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import type { ReactElement, Ref } from 'react';
 import {
     Flex,
     FlexItem,
@@ -6,13 +7,13 @@ import {
     FormHelperText,
     HelperText,
     HelperTextItem,
-    MenuToggleElement,
     MenuToggle,
     Select,
     SelectOption,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
-import { DelegatedRegistryCluster } from 'services/DelegatedRegistryConfigService';
+import type { DelegatedRegistryCluster } from 'services/DelegatedRegistryConfigService';
 
 import { getClusterName } from '../cluster';
 
@@ -28,7 +29,7 @@ function DelegatedScanningSettings({
     defaultClusterId,
     isEditing,
     setDefaultClusterId,
-}: DelegatedScanningSettingsProps) {
+}: DelegatedScanningSettingsProps): ReactElement {
     const [isOpen, setIsOpen] = useState(false);
 
     // Options consist of valid clusters, plus default cluster (in unlikely case that it is not valid).
@@ -58,7 +59,7 @@ function DelegatedScanningSettings({
                         isOpen={isOpen}
                         selected={defaultClusterId}
                         shouldFocusToggleOnSelect
-                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                        toggle={(toggleRef: Ref<MenuToggleElement>) => (
                             <MenuToggle
                                 aria-label="Select default cluster"
                                 ref={toggleRef}

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormGroup, Radio } from '@patternfly/react-core';
 
-import { DelegatedRegistryConfigEnabledFor } from 'services/DelegatedRegistryConfigService';
+import type { DelegatedRegistryConfigEnabledFor } from 'services/DelegatedRegistryConfigService';
 
 type ToggleDelegatedScanningProps = {
     enabledFor: DelegatedRegistryConfigEnabledFor;

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -20,6 +20,8 @@ import { clustersBasePath } from 'routePaths';
 import {
     fetchDelegatedRegistryConfig,
     fetchDelegatedRegistryClusters,
+} from 'services/DelegatedRegistryConfigService';
+import type {
     DelegatedRegistryConfig,
     DelegatedRegistryCluster,
 } from 'services/DelegatedRegistryConfigService';

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegatedImageScanningForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegatedImageScanningForm.tsx
@@ -4,10 +4,10 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
-import {
+import { updateDelegatedRegistryConfig } from 'services/DelegatedRegistryConfigService';
+import type {
     DelegatedRegistryCluster,
     DelegatedRegistryConfig,
-    updateDelegatedRegistryConfig,
 } from 'services/DelegatedRegistryConfigService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/cluster.ts
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/cluster.ts
@@ -1,4 +1,4 @@
-import { DelegatedRegistryCluster } from 'services/DelegatedRegistryConfigService';
+import type { DelegatedRegistryCluster } from 'services/DelegatedRegistryConfigService';
 
 // Caller is responsible to handle special case of empty string.
 export function getClusterName(clusters: DelegatedRegistryCluster[], clusterId: string) {

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { CheckCircleIcon, SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
 import { Icon } from '@patternfly/react-core';
 
-import {
+import type {
     DiscoveredClusterProviderType,
     DiscoveredClusterStatus,
     DiscoveredClusterType,

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersEmptyState.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Bullseye,
     EmptyState,

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Breadcrumb,
@@ -19,13 +20,13 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { fetchCloudSources } from 'services/CloudSourceService';
 import {
-    DiscoveredCluster,
     countDiscoveredClusters,
     defaultSortOption,
     getListDiscoveredClustersArg,
     listDiscoveredClusters,
     sortFields,
 } from 'services/DiscoveredClusterService';
+import type { DiscoveredCluster } from 'services/DiscoveredClusterService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { clustersBasePath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -1,16 +1,17 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import {
-    DiscoveredCluster,
     firstDiscoveredAtField,
     hasDiscoveredClustersFilter,
     nameField,
 } from 'services/DiscoveredClusterService';
-import { SearchFilter } from 'types/search';
+import type { DiscoveredCluster } from 'services/DiscoveredClusterService';
+import type { SearchFilter } from 'types/search';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
 import {

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Pagination,
     Toolbar,
@@ -11,8 +12,6 @@ import {
 
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import {
-    DiscoveredClusterStatus,
-    DiscoveredClusterType,
     getDiscoveredClustersFilter,
     isStatus,
     isType,
@@ -20,7 +19,11 @@ import {
     replaceSearchFilterStatuses,
     replaceSearchFilterTypes,
 } from 'services/DiscoveredClusterService';
-import { SearchFilter } from 'types/search';
+import type {
+    DiscoveredClusterStatus,
+    DiscoveredClusterType,
+} from 'services/DiscoveredClusterService';
+import type { SearchFilter } from 'types/search';
 
 import SearchFilterTypes from './SearchFilterTypes';
 // import SearchFilterNames from './SearchFilterNames';

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { Divider } from '@patternfly/react-core';
 import { SelectOption, Select } from '@patternfly/react-core/deprecated';
 
-import { DiscoveredClusterStatus, isStatus, statuses } from 'services/DiscoveredClusterService';
+import { isStatus, statuses } from 'services/DiscoveredClusterService';
+import type { DiscoveredClusterStatus } from 'services/DiscoveredClusterService';
 
 import { getStatusText } from './DiscoveredCluster';
 

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { Divider } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
-import { DiscoveredClusterType, isType, types } from 'services/DiscoveredClusterService';
+import { isType, types } from 'services/DiscoveredClusterService';
+import type { DiscoveredClusterType } from 'services/DiscoveredClusterService';
 
 import { getTypeText } from './DiscoveredCluster';
 

--- a/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
@@ -1,4 +1,5 @@
-import React, { useState, ReactElement } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { Button, Flex, FlexItem, Text, Title } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleDescription.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     DescriptionList,
     DescriptionListDescription,
@@ -6,7 +7,7 @@ import {
     DescriptionListTerm,
 } from '@patternfly/react-core';
 
-import { ClusterInitBundle } from 'services/ClustersService';
+import type { ClusterInitBundle } from 'services/ClustersService';
 
 export type InitBundleDescriptionProps = {
     initBundle: ClusterInitBundle;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     ActionGroup,
@@ -27,13 +28,8 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import InitBundlesHeader from './InitBundlesHeader';
 
-import {
-    InstallationKey,
-    PlatformKey,
-    downloadBundle,
-    installationOptions,
-    platformOptions,
-} from './InitBundleForm.utils';
+import { downloadBundle, installationOptions, platformOptions } from './InitBundleForm.utils';
+import type { InstallationKey, PlatformKey } from './InitBundleForm.utils';
 
 export type InitBundleFormValues = {
     installation: InstallationKey;

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.utils.ts
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.utils.ts
@@ -1,6 +1,6 @@
 import FileSaver from 'file-saver';
 
-import { GenerateClusterInitBundleResponse } from 'services/ClustersService';
+import type { GenerateClusterInitBundleResponse } from 'services/ClustersService';
 
 export const installationOptions: Record<string, string> = {
     Operator: 'Operator (recommended)',

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -1,10 +1,12 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useAnalytics, { CREATE_INIT_BUNDLE_CLICKED } from 'hooks/useAnalytics';
 import useRestQuery from 'hooks/useRestQuery';
-import { ClusterInitBundle, fetchClusterInitBundles } from 'services/ClustersService';
+import { fetchClusterInitBundles } from 'services/ClustersService';
+import type { ClusterInitBundle } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { clustersInitBundlesPath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { ClusterInitBundle } from 'services/ClustersService';
+import type { ClusterInitBundle } from 'services/ClustersService';
 import { clustersInitBundlesPath } from 'routePaths';
 
 export type InitBundlesTableProps = {

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Button,
@@ -13,11 +14,8 @@ import {
 } from '@patternfly/react-core';
 
 import useAnalytics, { REVOKE_INIT_BUNDLE } from 'hooks/useAnalytics';
-import {
-    ClusterInitBundle,
-    ImpactedCluster,
-    revokeClusterInitBundles,
-} from 'services/ClustersService';
+import { revokeClusterInitBundles } from 'services/ClustersService';
+import type { ClusterInitBundle, ImpactedCluster } from 'services/ClustersService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type RevokeBundleModalProps = {

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Button,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import qs from 'qs';
 import {

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     ClipboardCopy,
     ClipboardCopyButton,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -14,11 +14,15 @@ import {
     UnknownIcon,
 } from '@patternfly/react-icons';
 
-import { Cluster, ClusterHealthStatusLabel, ClusterProviderMetadata } from 'types/cluster.proto';
+import type {
+    Cluster,
+    ClusterHealthStatusLabel,
+    ClusterProviderMetadata,
+} from 'types/cluster.proto';
 import { getDate, getDistanceStrict } from 'utils/dateUtils';
 
 import { healthStatusLabels } from './cluster.constants';
-import { CertExpiryStatus } from './clusterTypes';
+import type { CertExpiryStatus } from './clusterTypes';
 
 export const runtimeOptions = [
     {


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

Also fix 2 errors for `'limtied/no-absolute-path-within-container-in-import'` rule so we can add the rule in an independent contribution.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.