### PR TITLE
ROX-31118: Consistent filter chip display in Vuln Reporting

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -31,6 +31,8 @@ import {
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
+    platformComponentDescriptor,
+    vulnerabilityStateDescriptor,
 } from '../../searchFilterConfig';
 
 // Build combined config for all possible filters in view-based reports
@@ -49,6 +51,8 @@ const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportFilterCon
     cveSeverityFilterDescriptor,
     cveStatusFixableDescriptor,
     cveStatusClusterFixableDescriptor,
+    platformComponentDescriptor,
+    vulnerabilityStateDescriptor,
 ]);
 
 export type ViewBasedReportJobDetailsProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -20,31 +20,14 @@ import {
 } from 'utils/searchUtils';
 import { isVulnerabilitySeverity } from 'types/cve.proto';
 import { formatCveDiscoveredTime } from '../../utils/vulnerabilityUtils';
-
-// CompoundSearchFilter utilities
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
-
-// Search filter configurations
 import { viewBasedReportSearchFilterConfigs } from '../../searchFilterConfig';
-
-// Filter chip descriptors
-import {
-    cveStatusClusterFixableDescriptor,
-    cveStatusFixableDescriptor,
-    cveSeverityFilterDescriptor,
-    platformComponentDescriptor,
-    vulnerabilityStateDescriptor,
-} from '../../filterChipDescriptors';
+import { viewBasedReportFilterChipDescriptors } from '../../filterChipDescriptor';
 
 // Create filter chip descriptors with proper display names and rendering
-const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportSearchFilterConfigs).concat([
-    // Add descriptors for special filters that aren't in CompoundSearchFilter config
-    cveSeverityFilterDescriptor,
-    cveStatusFixableDescriptor,
-    cveStatusClusterFixableDescriptor,
-    platformComponentDescriptor,
-    vulnerabilityStateDescriptor,
-]);
+const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportSearchFilterConfigs).concat(
+    viewBasedReportFilterChipDescriptors
+);
 
 export type ViewBasedReportJobDetailsProps = {
     reportSnapshot: ViewBasedReportSnapshot;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -23,6 +23,9 @@ import { formatCveDiscoveredTime } from '../../utils/vulnerabilityUtils';
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
 import {
     clusterSearchFilterConfig,
+    cveStatusClusterFixableDescriptor,
+    cveStatusFixableDescriptor,
+    cveSeverityFilterDescriptor,
     deploymentSearchFilterConfig,
     imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
@@ -41,7 +44,12 @@ const viewBasedReportFilterConfig = [
 ];
 
 // Create filter chip descriptors with proper display names and rendering
-const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportFilterConfig);
+const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportFilterConfig).concat([
+    // Add descriptors for special filters that aren't in CompoundSearchFilter config
+    cveSeverityFilterDescriptor,
+    cveStatusFixableDescriptor,
+    cveStatusClusterFixableDescriptor,
+]);
 
 export type ViewBasedReportJobDetailsProps = {
     reportSnapshot: ViewBasedReportSnapshot;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -25,14 +25,7 @@ import { formatCveDiscoveredTime } from '../../utils/vulnerabilityUtils';
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
 
 // Search filter configurations
-import {
-    clusterSearchFilterConfig,
-    deploymentSearchFilterConfig,
-    imageComponentSearchFilterConfig,
-    imageCVESearchFilterConfig,
-    imageSearchFilterConfig,
-    namespaceSearchFilterConfig,
-} from '../../searchFilterConfig';
+import { viewBasedReportSearchFilterConfigs } from '../../searchFilterConfig';
 
 // Filter chip descriptors
 import {
@@ -43,18 +36,8 @@ import {
     vulnerabilityStateDescriptor,
 } from '../../filterChipDescriptors';
 
-// Build combined config for all possible filters in view-based reports
-const viewBasedReportFilterConfig = [
-    imageCVESearchFilterConfig,
-    imageSearchFilterConfig,
-    imageComponentSearchFilterConfig,
-    deploymentSearchFilterConfig,
-    namespaceSearchFilterConfig,
-    clusterSearchFilterConfig,
-];
-
 // Create filter chip descriptors with proper display names and rendering
-const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportFilterConfig).concat([
+const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportSearchFilterConfigs).concat([
     // Add descriptors for special filters that aren't in CompoundSearchFilter config
     cveSeverityFilterDescriptor,
     cveStatusFixableDescriptor,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -23,17 +23,19 @@ import { formatCveDiscoveredTime } from '../../utils/vulnerabilityUtils';
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
 import {
     clusterSearchFilterConfig,
-    cveStatusClusterFixableDescriptor,
-    cveStatusFixableDescriptor,
-    cveSeverityFilterDescriptor,
     deploymentSearchFilterConfig,
     imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
+} from '../../searchFilterConfig';
+import {
+    cveStatusClusterFixableDescriptor,
+    cveStatusFixableDescriptor,
+    cveSeverityFilterDescriptor,
     platformComponentDescriptor,
     vulnerabilityStateDescriptor,
-} from '../../searchFilterConfig';
+} from '../../filterChipDescriptors';
 
 // Build combined config for all possible filters in view-based reports
 const viewBasedReportFilterConfig = [

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -20,7 +20,11 @@ import {
 } from 'utils/searchUtils';
 import { isVulnerabilitySeverity } from 'types/cve.proto';
 import { formatCveDiscoveredTime } from '../../utils/vulnerabilityUtils';
+
+// CompoundSearchFilter utilities
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
+
+// Search filter configurations
 import {
     clusterSearchFilterConfig,
     deploymentSearchFilterConfig,
@@ -29,6 +33,8 @@ import {
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from '../../searchFilterConfig';
+
+// Filter chip descriptors
 import {
     cveStatusClusterFixableDescriptor,
     cveStatusFixableDescriptor,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -20,10 +20,28 @@ import {
 } from 'utils/searchUtils';
 import { isVulnerabilitySeverity } from 'types/cve.proto';
 import { formatCveDiscoveredTime } from '../../utils/vulnerabilityUtils';
+import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
+import {
+    clusterSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    imageSearchFilterConfig,
+    namespaceSearchFilterConfig,
+} from '../../searchFilterConfig';
 
-const toTitleCase = (str: string) => {
-    return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
-};
+// Build combined config for all possible filters in view-based reports
+const viewBasedReportFilterConfig = [
+    imageCVESearchFilterConfig,
+    imageSearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+    clusterSearchFilterConfig,
+];
+
+// Create filter chip descriptors with proper display names and rendering
+const filterChipDescriptors = makeFilterChipDescriptors(viewBasedReportFilterConfig);
 
 export type ViewBasedReportJobDetailsProps = {
     reportSnapshot: ViewBasedReportSnapshot;
@@ -55,20 +73,20 @@ function ViewBasedReportJobDetails({ reportSnapshot }: ViewBasedReportJobDetails
         if (!value) {
             return null;
         }
-        if (typeof value === 'string') {
-            return (
-                <ChipGroup key={key} categoryName={toTitleCase(key)}>
-                    <Chip key={value} isReadOnly>
-                        {value}
-                    </Chip>
-                </ChipGroup>
-            );
-        }
+
+        // Find the descriptor for this filter to get proper display name and rendering
+        const descriptor = filterChipDescriptors.find(
+            (desc) => desc.searchFilterName.toLowerCase() === key.toLowerCase()
+        );
+        const categoryName = descriptor?.displayName || key;
+
+        const values = typeof value === 'string' ? [value] : value;
+
         return (
-            <ChipGroup key={key} categoryName={toTitleCase(key)}>
-                {value.map((currentChip) => (
-                    <Chip key={currentChip} isReadOnly>
-                        {currentChip}
+            <ChipGroup key={key} categoryName={categoryName}>
+                {values.map((currentValue) => (
+                    <Chip key={currentValue} isReadOnly>
+                        {descriptor?.render ? descriptor.render(currentValue) : currentValue}
                     </Chip>
                 ))}
             </ChipGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -17,7 +17,7 @@ import {
     cveStatusFixableDescriptor,
     cveSeverityFilterDescriptor,
     cveSnoozedDescriptor,
-} from '../searchFilterConfig';
+} from '../filterChipDescriptors';
 import CVESeverityDropdown from './CVESeverityDropdown';
 import CVEStatusDropdown from './CVEStatusDropdown';
 
@@ -82,7 +82,10 @@ function AdvancedFiltersToolbar({
             includeCveStatusFilters
                 ? [
                       makeDefaultFilterDescriptor(defaultFilters, cveStatusFixableDescriptor),
-                      makeDefaultFilterDescriptor(defaultFilters, cveStatusClusterFixableDescriptor),
+                      makeDefaultFilterDescriptor(
+                          defaultFilters,
+                          cveStatusClusterFixableDescriptor
+                      ),
                   ]
                 : []
         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -71,24 +71,24 @@ function AdvancedFiltersToolbar({
     additionalContextFilter,
     children,
 }: AdvancedFiltersToolbarProps) {
-    const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig)
-        .concat(cveSnoozedDescriptor)
-        .concat(
-            includeCveSeverityFilters
-                ? makeDefaultFilterDescriptor(defaultFilters, cveSeverityFilterDescriptor)
-                : []
-        )
-        .concat(
-            includeCveStatusFilters
-                ? [
-                      makeDefaultFilterDescriptor(defaultFilters, cveStatusFixableDescriptor),
-                      makeDefaultFilterDescriptor(
-                          defaultFilters,
-                          cveStatusClusterFixableDescriptor
-                      ),
-                  ]
-                : []
-        );
+    const baseDescriptors = makeFilterChipDescriptors(searchFilterConfig);
+
+    const severityDescriptors = includeCveSeverityFilters
+        ? [makeDefaultFilterDescriptor(defaultFilters, cveSeverityFilterDescriptor)]
+        : [];
+
+    const statusDescriptors = includeCveStatusFilters
+        ? [
+              makeDefaultFilterDescriptor(defaultFilters, cveStatusFixableDescriptor),
+              makeDefaultFilterDescriptor(defaultFilters, cveStatusClusterFixableDescriptor),
+          ]
+        : [];
+
+    const filterChipGroupDescriptors = baseDescriptors.concat(
+        cveSnoozedDescriptor,
+        severityDescriptors,
+        statusDescriptors
+    );
 
     function onFilterApplied({ category, value, action }: OnSearchPayload) {
         const selectedSearchFilter = searchValueAsArray(searchFilter[category]);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -12,6 +12,12 @@ import { SearchFilter } from 'types/search';
 import { getHasSearchApplied, searchValueAsArray } from 'utils/searchUtils';
 
 import { DefaultFilters } from '../types';
+import {
+    cveStatusClusterFixableDescriptor,
+    cveStatusFixableDescriptor,
+    cveSeverityFilterDescriptor,
+    cveSnoozedDescriptor,
+} from '../searchFilterConfig';
 import CVESeverityDropdown from './CVESeverityDropdown';
 import CVEStatusDropdown from './CVEStatusDropdown';
 
@@ -66,29 +72,17 @@ function AdvancedFiltersToolbar({
     children,
 }: AdvancedFiltersToolbarProps) {
     const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig)
-        .concat({
-            displayName: 'CVE snoozed',
-            searchFilterName: 'CVE Snoozed',
-        })
+        .concat(cveSnoozedDescriptor)
         .concat(
             includeCveSeverityFilters
-                ? makeDefaultFilterDescriptor(defaultFilters, {
-                      displayName: 'CVE severity',
-                      searchFilterName: 'SEVERITY',
-                  })
+                ? makeDefaultFilterDescriptor(defaultFilters, cveSeverityFilterDescriptor)
                 : []
         )
         .concat(
             includeCveStatusFilters
                 ? [
-                      makeDefaultFilterDescriptor(defaultFilters, {
-                          displayName: 'CVE status',
-                          searchFilterName: 'FIXABLE',
-                      }),
-                      makeDefaultFilterDescriptor(defaultFilters, {
-                          displayName: 'CVE status',
-                          searchFilterName: 'CLUSTER CVE FIXABLE',
-                      }),
+                      makeDefaultFilterDescriptor(defaultFilters, cveStatusFixableDescriptor),
+                      makeDefaultFilterDescriptor(defaultFilters, cveStatusClusterFixableDescriptor),
                   ]
                 : []
         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -17,7 +17,7 @@ import {
     cveStatusFixableDescriptor,
     cveSeverityFilterDescriptor,
     cveSnoozedDescriptor,
-} from '../filterChipDescriptors';
+} from '../filterChipDescriptor';
 import CVESeverityDropdown from './CVESeverityDropdown';
 import CVEStatusDropdown from './CVEStatusDropdown';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptor.ts
@@ -1,8 +1,11 @@
-import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
+/*
+ * Descriptors for rendering search filters as chips in toolbars, reports, and other views.
+ *
+ * If you add a new descriptor that should be available in view-based reports,
+ * add it to the viewBasedReportFilterChipDescriptors array at the bottom of this file.
+ */
 
-// Filter chip descriptors for displaying filter values in chip format
-// These are used for rendering filter chips in reports, toolbars, and other views
-// where filters need to be displayed to users.
+import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
 
 export const cveSeverityFilterDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE severity',
@@ -33,3 +36,13 @@ export const vulnerabilityStateDescriptor: FilterChipGroupDescriptor = {
     displayName: 'Vulnerability state',
     searchFilterName: 'Vulnerability State',
 };
+
+// These descriptors represent special filters that aren't part of CompoundSearchFilter config.
+// Only add descriptors here if they should be available in view-based reports.
+export const viewBasedReportFilterChipDescriptors = [
+    cveSeverityFilterDescriptor,
+    cveStatusFixableDescriptor,
+    cveStatusClusterFixableDescriptor,
+    platformComponentDescriptor,
+    vulnerabilityStateDescriptor,
+];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptor.ts
@@ -5,7 +5,18 @@
  * add it to the viewBasedReportFilterChipDescriptors array at the bottom of this file.
  */
 
+import React from 'react';
 import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
+
+function renderFixableStatus(value: string): React.ReactNode {
+    if (value === 'true') {
+        return 'Fixable';
+    }
+    if (value === 'false') {
+        return 'Not fixable';
+    }
+    return value;
+}
 
 export const cveSeverityFilterDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE severity',
@@ -15,11 +26,13 @@ export const cveSeverityFilterDescriptor: FilterChipGroupDescriptor = {
 export const cveStatusFixableDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE status',
     searchFilterName: 'FIXABLE',
+    render: renderFixableStatus,
 };
 
 export const cveStatusClusterFixableDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE status',
     searchFilterName: 'CLUSTER CVE FIXABLE',
+    render: renderFixableStatus,
 };
 
 export const cveSnoozedDescriptor: FilterChipGroupDescriptor = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptors.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptors.ts
@@ -1,0 +1,35 @@
+import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
+
+// Filter chip descriptors for displaying filter values in chip format
+// These are used for rendering filter chips in reports, toolbars, and other views
+// where filters need to be displayed to users.
+
+export const cveSeverityFilterDescriptor: FilterChipGroupDescriptor = {
+    displayName: 'CVE severity',
+    searchFilterName: 'SEVERITY',
+};
+
+export const cveStatusFixableDescriptor: FilterChipGroupDescriptor = {
+    displayName: 'CVE status',
+    searchFilterName: 'FIXABLE',
+};
+
+export const cveStatusClusterFixableDescriptor: FilterChipGroupDescriptor = {
+    displayName: 'CVE status',
+    searchFilterName: 'CLUSTER CVE FIXABLE',
+};
+
+export const cveSnoozedDescriptor: FilterChipGroupDescriptor = {
+    displayName: 'CVE snoozed',
+    searchFilterName: 'CVE Snoozed',
+};
+
+export const platformComponentDescriptor: FilterChipGroupDescriptor = {
+    displayName: 'Platform component',
+    searchFilterName: 'Platform Component',
+};
+
+export const vulnerabilityStateDescriptor: FilterChipGroupDescriptor = {
+    displayName: 'Vulnerability state',
+    searchFilterName: 'Vulnerability State',
+};

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,3 +1,7 @@
+// This file defines search filter configurations for vulnerability views.
+// If you add a new filter config that should be available in view-based reports,
+// add it to the viewBasedReportSearchFilterConfigs array at the bottom of this file.
+
 import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
 import {
     clusterIdAttribute,
@@ -98,3 +102,14 @@ export const virtualMachineComponentSearchFilterConfig: CompoundSearchFilterEnti
     searchCategory: 'SEARCH_UNSET', // doesn't matter since we don't have autocomplete for virtual machines
     attributes: [VirtualMachineComponentName, VirtualMachineComponentVersion],
 };
+
+// Combined export for view-based vulnerability reports
+// This array includes all filter configs that can be used in view-based reports
+export const viewBasedReportSearchFilterConfigs = [
+    imageCVESearchFilterConfig,
+    imageSearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    namespaceSearchFilterConfig,
+    clusterSearchFilterConfig,
+];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,5 +1,4 @@
 import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
-import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
 import {
     clusterIdAttribute,
     clusterLabelAttribute,
@@ -98,38 +97,4 @@ export const virtualMachineComponentSearchFilterConfig: CompoundSearchFilterEnti
     displayName: 'Component',
     searchCategory: 'SEARCH_UNSET', // doesn't matter since we don't have autocomplete for virtual machines
     attributes: [VirtualMachineComponentName, VirtualMachineComponentVersion],
-};
-
-// Special filter descriptors for filters not in CompoundSearchFilter config
-// These are used for SEVERITY, FIXABLE, and other special filters that are handled
-// separately from the standard CompoundSearchFilter system
-
-export const cveSeverityFilterDescriptor: FilterChipGroupDescriptor = {
-    displayName: 'CVE severity',
-    searchFilterName: 'SEVERITY',
-};
-
-export const cveStatusFixableDescriptor: FilterChipGroupDescriptor = {
-    displayName: 'CVE status',
-    searchFilterName: 'FIXABLE',
-};
-
-export const cveStatusClusterFixableDescriptor: FilterChipGroupDescriptor = {
-    displayName: 'CVE status',
-    searchFilterName: 'CLUSTER CVE FIXABLE',
-};
-
-export const cveSnoozedDescriptor: FilterChipGroupDescriptor = {
-    displayName: 'CVE snoozed',
-    searchFilterName: 'CVE Snoozed',
-};
-
-export const platformComponentDescriptor: FilterChipGroupDescriptor = {
-    displayName: 'Platform component',
-    searchFilterName: 'Platform Component',
-};
-
-export const vulnerabilityStateDescriptor: FilterChipGroupDescriptor = {
-    displayName: 'Vulnerability state',
-    searchFilterName: 'Vulnerability State',
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,6 +1,9 @@
-// This file defines search filter configurations for vulnerability views.
-// If you add a new filter config that should be available in view-based reports,
-// add it to the viewBasedReportSearchFilterConfigs array at the bottom of this file.
+/*
+ * Search filter configurations for vulnerability views.
+ *
+ * If you add a new filter config that should be available in view-based reports,
+ * add it to the viewBasedReportSearchFilterConfigs array at the bottom of this file.
+ */
 
 import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
 import {
@@ -103,8 +106,8 @@ export const virtualMachineComponentSearchFilterConfig: CompoundSearchFilterEnti
     attributes: [VirtualMachineComponentName, VirtualMachineComponentVersion],
 };
 
-// Combined export for view-based vulnerability reports
-// This array includes all filter configs that can be used in view-based reports
+// This array includes filter configs that are relevant to view-based reports.
+// Only add configs here if they should be available as filters in vulnerability reports.
 export const viewBasedReportSearchFilterConfigs = [
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -98,3 +98,27 @@ export const virtualMachineComponentSearchFilterConfig: CompoundSearchFilterEnti
     searchCategory: 'SEARCH_UNSET', // doesn't matter since we don't have autocomplete for virtual machines
     attributes: [VirtualMachineComponentName, VirtualMachineComponentVersion],
 };
+
+// Special filter descriptors for filters not in CompoundSearchFilter config
+// These are used for SEVERITY, FIXABLE, and other special filters that are handled
+// separately from the standard CompoundSearchFilter system
+
+export const cveSeverityFilterDescriptor = {
+    displayName: 'CVE severity',
+    searchFilterName: 'SEVERITY',
+};
+
+export const cveStatusFixableDescriptor = {
+    displayName: 'CVE status',
+    searchFilterName: 'FIXABLE',
+};
+
+export const cveStatusClusterFixableDescriptor = {
+    displayName: 'CVE status',
+    searchFilterName: 'CLUSTER CVE FIXABLE',
+};
+
+export const cveSnoozedDescriptor = {
+    displayName: 'CVE snoozed',
+    searchFilterName: 'CVE Snoozed',
+};

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,4 +1,5 @@
 import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
+import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
 import {
     clusterIdAttribute,
     clusterLabelAttribute,
@@ -103,32 +104,32 @@ export const virtualMachineComponentSearchFilterConfig: CompoundSearchFilterEnti
 // These are used for SEVERITY, FIXABLE, and other special filters that are handled
 // separately from the standard CompoundSearchFilter system
 
-export const cveSeverityFilterDescriptor = {
+export const cveSeverityFilterDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE severity',
     searchFilterName: 'SEVERITY',
 };
 
-export const cveStatusFixableDescriptor = {
+export const cveStatusFixableDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE status',
     searchFilterName: 'FIXABLE',
 };
 
-export const cveStatusClusterFixableDescriptor = {
+export const cveStatusClusterFixableDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE status',
     searchFilterName: 'CLUSTER CVE FIXABLE',
 };
 
-export const cveSnoozedDescriptor = {
+export const cveSnoozedDescriptor: FilterChipGroupDescriptor = {
     displayName: 'CVE snoozed',
     searchFilterName: 'CVE Snoozed',
 };
 
-export const platformComponentDescriptor = {
+export const platformComponentDescriptor: FilterChipGroupDescriptor = {
     displayName: 'Platform component',
     searchFilterName: 'Platform Component',
 };
 
-export const vulnerabilityStateDescriptor = {
+export const vulnerabilityStateDescriptor: FilterChipGroupDescriptor = {
     displayName: 'Vulnerability state',
     searchFilterName: 'Vulnerability State',
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -122,3 +122,13 @@ export const cveSnoozedDescriptor = {
     displayName: 'CVE snoozed',
     searchFilterName: 'CVE Snoozed',
 };
+
+export const platformComponentDescriptor = {
+    displayName: 'Platform component',
+    searchFilterName: 'Platform Component',
+};
+
+export const vulnerabilityStateDescriptor = {
+    displayName: 'Vulnerability state',
+    searchFilterName: 'Vulnerability State',
+};


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Centralized filter chip descriptors to ensure consistent display between compound search filters and view-based report filters.

**Key Changes**:
  - Created `filterChipDescriptor.ts` to centralize filter chip display configuration
  - Added render function to display fixable status as `"Fixable"/"Not fixable"` instead of `"true"/"false"`
  - Created `viewBasedReportSearchFilterConfigs` array for report-available filters
  - Updated `ViewBasedReportJobDetails` to use centralized descriptors for consistent formatting
  - Refactored `AdvancedFiltersToolbar` to reuse shared descriptors instead of inline definitions

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [x] added regression tests
- [x] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

#### Adding filters in Vuln Results
<img width="1434" height="739" alt="Screenshot 2025-10-06 at 4 26 09 PM" src="https://github.com/user-attachments/assets/2830f16a-4ac8-47ed-b166-0b3fccfccb89" />

#### Respective scope filters and vulnerability parameters showing incorrectly/imperfectly [BEFORE CHANGES]
<img width="1431" height="737" alt="Screenshot 2025-10-06 at 4 28 19 PM" src="https://github.com/user-attachments/assets/4cfc7e86-d59f-4005-a5cd-0511962b4962" />

#### Respective scope filters and vulnerability parameters showing correctly [AFTER CHANGES]
<img width="1436" height="739" alt="Screenshot 2025-10-06 at 4 26 20 PM" src="https://github.com/user-attachments/assets/1eceef1e-1b1b-4dd8-b137-871e729a834d" />

