### PR TITLE
fix(risk): improve reprocess deployment risk

### DIFF
--- a/central/processbaseline/evaluator/bench_test.go
+++ b/central/processbaseline/evaluator/bench_test.go
@@ -5,6 +5,7 @@ package evaluator
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -206,16 +208,40 @@ func BenchmarkEvaluateBaselinesAndPersistResult(b *testing.B) {
 			require.NoError(b, err)
 			require.NotNil(b, baseline)
 
-			b.ResetTimer()
+			var maxHeap uint64
+			var maxHeapObj uint64
+			ticker := time.NewTicker(10 * time.Millisecond)
+			go func() {
+				var m runtime.MemStats
+				for range ticker.C {
+					runtime.GC()
+					runtime.ReadMemStats(&m)
+					maxHeap = max(maxHeap, m.HeapAlloc)
+					maxHeapObj = max(maxHeap, m.HeapObjects)
+				}
+			}()
 
 			// Run the benchmark
-			for i := 0; i < b.N; i++ {
-				violatingProcesses, err := evaluator.EvaluateBaselinesAndPersistResult(deployment)
-				require.NoError(b, err)
-
-				// Ensure we have realistic violation patterns
-				_ = violatingProcesses // Startup processes are filtered out by evaluator
+			b.ResetTimer()
+			for b.Loop() {
+				wg := sync.WaitGroup{}
+				const parallelism = 10
+				wg.Add(parallelism)
+				for j := 0; j < parallelism; j++ {
+					go func() {
+						defer wg.Done()
+						violatingProcesses, err := evaluator.EvaluateBaselinesAndPersistResult(deployment)
+						require.NoError(b, err)
+						// Ensure we have realistic violation patterns
+						_ = violatingProcesses // Startup processes are filtered out by evaluator
+					}()
+				}
+				wg.Wait()
 			}
+			// Report custom metric
+			ticker.Stop()
+			b.ReportMetric(float64(maxHeap), "max_heap_bytes")
+			b.ReportMetric(float64(maxHeapObj), "max_heap_objects")
 		})
 	}
 }

--- a/central/processbaseline/evaluator/evaluator_integration_test.go
+++ b/central/processbaseline/evaluator/evaluator_integration_test.go
@@ -10,6 +10,7 @@ import (
 	baselineDatastore "github.com/stackrox/rox/central/processbaseline/datastore"
 	resultDatastore "github.com/stackrox/rox/central/processbaselineresults/datastore"
 	indicatorDatastore "github.com/stackrox/rox/central/processindicator/datastore"
+	"github.com/stackrox/rox/central/processindicator/views"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/logging"
@@ -825,7 +826,11 @@ func (suite *ProcessBaselineEvaluatorIntegrationTestSuite) TestQueryProcessIndic
 
 	// Query for indicators by deployment ID
 	query := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deployment.GetId()).ProtoQuery()
-	riskViews, err := suite.indicatorsDatastore.GetProcessIndicatorsRiskView(suite.ctx, query)
+	riskViews := make([]*views.ProcessIndicatorRiskView, 0, len(indicators))
+	err = suite.indicatorsDatastore.IterateOverProcessIndicatorsRiskView(suite.ctx, query, func(view *views.ProcessIndicatorRiskView) error {
+		riskViews = append(riskViews, view)
+		return nil
+	})
 	suite.NoError(err)
 	suite.Len(riskViews, 2)
 

--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -37,8 +37,8 @@ type DataStore interface {
 
 	WalkAll(ctx context.Context, fn func(pi *storage.ProcessIndicator) error) error
 
-	// GetProcessIndicatorsRiskView retrieves minimal fields from process indicator for risk evaluation
-	GetProcessIndicatorsRiskView(ctx context.Context, q *v1.Query) ([]*views.ProcessIndicatorRiskView, error)
+	// IterateOverProcessIndicatorsRiskView iterates over minimal fields from process indicator for risk evaluation
+	IterateOverProcessIndicatorsRiskView(ctx context.Context, q *v1.Query, fn func(*views.ProcessIndicatorRiskView) error) error
 
 	// Stop signals all goroutines associated with this object to terminate.
 	Stop()

--- a/central/processindicator/datastore/mocks/datastore.go
+++ b/central/processindicator/datastore/mocks/datastore.go
@@ -111,19 +111,18 @@ func (mr *MockDataStoreMockRecorder) GetProcessIndicators(ctx, ids any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessIndicators", reflect.TypeOf((*MockDataStore)(nil).GetProcessIndicators), ctx, ids)
 }
 
-// GetProcessIndicatorsRiskView mocks base method.
-func (m *MockDataStore) GetProcessIndicatorsRiskView(ctx context.Context, q *v1.Query) ([]*views.ProcessIndicatorRiskView, error) {
+// IterateOverProcessIndicatorsRiskView mocks base method.
+func (m *MockDataStore) IterateOverProcessIndicatorsRiskView(ctx context.Context, q *v1.Query, fn func(*views.ProcessIndicatorRiskView) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProcessIndicatorsRiskView", ctx, q)
-	ret0, _ := ret[0].([]*views.ProcessIndicatorRiskView)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "IterateOverProcessIndicatorsRiskView", ctx, q, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetProcessIndicatorsRiskView indicates an expected call of GetProcessIndicatorsRiskView.
-func (mr *MockDataStoreMockRecorder) GetProcessIndicatorsRiskView(ctx, q any) *gomock.Call {
+// IterateOverProcessIndicatorsRiskView indicates an expected call of IterateOverProcessIndicatorsRiskView.
+func (mr *MockDataStoreMockRecorder) IterateOverProcessIndicatorsRiskView(ctx, q, fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProcessIndicatorsRiskView", reflect.TypeOf((*MockDataStore)(nil).GetProcessIndicatorsRiskView), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IterateOverProcessIndicatorsRiskView", reflect.TypeOf((*MockDataStore)(nil).IterateOverProcessIndicatorsRiskView), ctx, q, fn)
 }
 
 // PruneProcessIndicators mocks base method.

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
 	pgsearch "github.com/stackrox/rox/pkg/search/postgres/query"
 	"github.com/stackrox/rox/pkg/utils"
@@ -41,7 +42,19 @@ func newDBScanAPI(opts ...dbscan.APIOption) *dbscan.API {
 
 // RunSelectRequestForSchema executes a select request against the database for given schema. The input query must
 // explicitly specify select fields.
+// Deprecated: Use RunSelectRequestForSchemaFn
 func RunSelectRequestForSchema[T any](ctx context.Context, db postgres.DB, schema *walker.Schema, q *v1.Query) ([]*T, error) {
+	result := make([]*T, 0, paginated.GetLimit(q.Pagination.GetLimit(), 100))
+	err := RunSelectRequestForSchemaFn(ctx, db, schema, q, func(t *T) error {
+		result = append(result, t)
+		return nil
+	})
+	return result, err
+}
+
+// RunSelectRequestForSchemaFn executes a select request against the database for given schema. The input query must
+// explicitly specify select fields.
+func RunSelectRequestForSchemaFn[T any](ctx context.Context, db postgres.DB, schema *walker.Schema, q *v1.Query, fn func(*T) error) error {
 	var query *query
 	var err error
 	// Add this to be safe and convert panics to errors,
@@ -62,14 +75,14 @@ func RunSelectRequestForSchema[T any](ctx context.Context, db postgres.DB, schem
 
 	query, err = standardizeSelectQueryAndPopulatePath(ctx, q, schema, SELECT)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	// A nil-query implies no results.
 	if query == nil {
-		return nil, nil
+		return nil
 	}
-	return pgutils.Retry2(ctx, func() ([]*T, error) {
-		return retryableRunSelectRequestForSchema[T](ctx, db, query)
+	return pgutils.Retry(ctx, func() error {
+		return retryableRunSelectRequestForSchemaFn[T](ctx, db, query, fn)
 	})
 }
 
@@ -134,24 +147,29 @@ func standardizeSelectQueryAndPopulatePath(ctx context.Context, q *v1.Query, sch
 	return parsedQuery, nil
 }
 
-func retryableRunSelectRequestForSchema[T any](ctx context.Context, db postgres.DB, query *query) ([]*T, error) {
+func retryableRunSelectRequestForSchemaFn[T any](ctx context.Context, db postgres.DB, query *query, fn func(*T) error) error {
 	if len(query.SelectedFields) == 0 {
-		return nil, errors.New("select fields required for select query")
+		return errors.New("select fields required for select query")
 	}
 
 	queryStr := query.AsSQL()
 
 	rows, err := tracedQuery(ctx, db, queryStr, query.Data...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error executing query %s", queryStr)
+		return errors.Wrapf(err, "error executing query %s", queryStr)
 	}
 	defer rows.Close()
 
-	var scannedRows []*T
-	if err := scanAPI.ScanAll(&scannedRows, rows); err != nil {
-		return nil, err
+	for rows.Next() {
+		var row T
+		if err := pgxscan.ScanRow(&row, rows); err != nil {
+			return err
+		}
+		if err := fn(&row); err != nil {
+			return err
+		}
 	}
-	return scannedRows, rows.Err()
+	return rows.Err()
 }
 
 func populateSelect(querySoFar *query, schema *walker.Schema, querySelects []*v1.QuerySelect, queryFields map[string]searchFieldMetadata, nowForQuery time.Time) error {

--- a/pkg/search/postgres/select.go
+++ b/pkg/search/postgres/select.go
@@ -160,9 +160,10 @@ func retryableRunSelectRequestForSchemaFn[T any](ctx context.Context, db postgre
 	}
 	defer rows.Close()
 
+	scanner := scanAPI.NewRowScanner(rows)
 	for rows.Next() {
 		var row T
-		if err := pgxscan.ScanRow(&row, rows); err != nil {
+		if err := scanner.Scan(&row); err != nil {
 			return err
 		}
 		if err := fn(&row); err != nil {


### PR DESCRIPTION
The current `GetProcessIndicatorsRiskView` calls are inefficient for our use case, since we need to loop through the returned process indicators. Switching to a callback-based approach allows us to process items one by one, avoiding the need to load all objects into a slice. This reduces memory usage and lowers GC pressure.


```bash
go test -tags sql_integration -run=NO -bench=BenchmarkEvaluateBaselinesAndPersistResult  ./central/processbaseline/evaluator/. -count 6 -benchmem -benchtime 3s 
```

```
                                                                              │ master-2.txt │               new.txt               │
                                                                              │    sec/op    │    sec/op     vs base               │
EvaluateBaselinesAndPersistResult/100_processes_2_containers-8                  1.781m ± 32%   1.720m ± 55%        ~ (p=0.240 n=6)
EvaluateBaselinesAndPersistResult/500_processes_3_containers-8                  4.968m ± 28%   4.865m ± 43%        ~ (p=0.485 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers-8                 9.076m ± 46%   8.471m ± 32%        ~ (p=0.180 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers_large_args-8      11.86m ± 12%   11.64m ±  9%        ~ (p=0.485 n=6)
EvaluateBaselinesAndPersistResult/2000_processes_10_containers-8                15.86m ± 29%   15.19m ± 29%        ~ (p=0.240 n=6)
EvaluateBaselinesAndPersistResult/10000_processes_20_containers-8               81.46m ± 44%   74.28m ± 17%        ~ (p=0.132 n=6)
EvaluateBaselinesAndPersistResult/25000_processes_50_containers-8               228.4m ± 14%   182.5m ± 12%  -20.12% (p=0.026 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers-8              483.2m ± 17%   346.9m ± 33%  -28.21% (p=0.009 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers_large_args-8   633.3m ± 24%   542.8m ± 13%  -14.30% (p=0.004 n=6)
geomean                                                                         35.34m         31.66m        -10.41%

                                                                              │  master-2.txt  │                new.txt                │
                                                                              │ max_heap_bytes │ max_heap_bytes  vs base               │
EvaluateBaselinesAndPersistResult/100_processes_2_containers-8                    11.23M ±  9%     11.23M ± 17%        ~ (p=0.818 n=6)
EvaluateBaselinesAndPersistResult/500_processes_3_containers-8                    13.56M ± 18%     12.79M ± 15%        ~ (p=0.132 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers-8                   15.10M ± 13%     13.50M ± 28%        ~ (p=0.240 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers_large_args-8        20.17M ± 35%     18.61M ± 33%   -7.73% (p=0.041 n=6)
EvaluateBaselinesAndPersistResult/2000_processes_10_containers-8                  16.49M ±  7%     15.79M ±  2%   -4.28% (p=0.004 n=6)
EvaluateBaselinesAndPersistResult/10000_processes_20_containers-8                 38.74M ±  9%     32.44M ±  8%  -16.27% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/25000_processes_50_containers-8                 76.33M ±  5%     39.86M ± 18%  -47.78% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers-8               137.26M ±  3%     41.16M ± 19%  -70.02% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers_large_args-8    362.78M ±  6%     86.84M ± 35%  -76.06% (p=0.002 n=6)
geomean                                                                           36.42M           23.99M        -34.12%

                                                                              │   master-2.txt   │                 new.txt                 │
                                                                              │ max_heap_objects │ max_heap_objects  vs base               │
EvaluateBaselinesAndPersistResult/100_processes_2_containers-8                      11.23M ±  9%       11.23M ± 17%        ~ (p=0.818 n=6)
EvaluateBaselinesAndPersistResult/500_processes_3_containers-8                      13.56M ± 18%       12.79M ± 15%        ~ (p=0.132 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers-8                     15.10M ± 13%       13.50M ± 28%        ~ (p=0.240 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers_large_args-8          20.17M ± 35%       18.61M ± 33%   -7.73% (p=0.041 n=6)
EvaluateBaselinesAndPersistResult/2000_processes_10_containers-8                    16.49M ±  7%       15.79M ±  2%   -4.28% (p=0.004 n=6)
EvaluateBaselinesAndPersistResult/10000_processes_20_containers-8                   38.74M ±  9%       32.44M ±  8%  -16.27% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/25000_processes_50_containers-8                   76.33M ±  5%       39.86M ± 18%  -47.78% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers-8                 137.26M ±  3%       41.16M ± 19%  -70.02% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers_large_args-8      362.78M ±  6%       86.84M ± 35%  -76.06% (p=0.002 n=6)
geomean                                                                             36.42M             23.99M        -34.12%

                                                                              │ master-2.txt │               new.txt               │
                                                                              │     B/op     │     B/op      vs base               │
EvaluateBaselinesAndPersistResult/100_processes_2_containers-8                  678.9Ki ± 0%   660.3Ki ± 0%   -2.74% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/500_processes_3_containers-8                  2.116Mi ± 0%   2.029Mi ± 0%   -4.11% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers-8                 3.774Mi ± 0%   3.609Mi ± 0%   -4.39% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers_large_args-8      8.955Mi ± 0%   8.790Mi ± 0%   -1.85% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/2000_processes_10_containers-8                7.132Mi ± 0%   6.673Mi ± 0%   -6.43% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/10000_processes_20_containers-8               34.66Mi ± 0%   31.69Mi ± 0%   -8.55% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/25000_processes_50_containers-8               87.49Mi ± 0%   77.93Mi ± 0%  -10.93% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers-8              175.7Mi ± 1%   155.0Mi ± 0%  -11.80% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers_large_args-8   463.0Mi ± 0%   442.3Mi ± 0%   -4.47% (p=0.002 n=6)
geomean                                                                         16.35Mi        15.33Mi        -6.20%

                                                                              │ master-2.txt │              new.txt              │
                                                                              │  allocs/op   │  allocs/op   vs base              │
EvaluateBaselinesAndPersistResult/100_processes_2_containers-8                   15.59k ± 0%   15.45k ± 0%  -0.90% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/500_processes_3_containers-8                   57.99k ± 0%   57.81k ± 0%  -0.31% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers-8                  108.7k ± 0%   108.5k ± 0%  -0.18% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/1000_processes_5_containers_large_args-8       108.7k ± 0%   108.5k ± 0%  -0.18% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/2000_processes_10_containers-8                 208.7k ± 0%   208.4k ± 0%  -0.11% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/10000_processes_20_containers-8                1.015M ± 0%   1.015M ± 0%  -0.03% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/25000_processes_50_containers-8                2.515M ± 0%   2.515M ± 0%  -0.02% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers-8               5.015M ± 0%   5.015M ± 0%  -0.01% (p=0.002 n=6)
EvaluateBaselinesAndPersistResult/50000_processes_100_containers_large_args-8    5.015M ± 0%   5.015M ± 0%  -0.01% (p=0.002 n=6)
geomean                                                                          374.0k        373.2k       -0.20%
```

refs:
- https://github.com/stackrox/stackrox/pull/15085
- https://github.com/stackrox/stackrox/pull/15010
- #17078 
- https://github.com/stackrox/stackrox/pull/16965
- https://github.com/stackrox/stackrox/pull/16987