### PR TITLE
chore(be): cleanup unwanted function and its usage in field metadata

### DIFF
--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -138,22 +138,10 @@ func (f *FieldMetadata) ensureFieldIsUnique(fieldName string) {
 
 func (f *FieldMetadata) registerFieldMetadata(fieldName string, qb querybuilders.QueryBuilder,
 	contextFields violationmessages.ContextQueryFields,
-	valueRegex func(configuration *validateConfiguration) *regexp.Regexp,
+	regex func(configuration *validateConfiguration) *regexp.Regexp,
 	source []storage.EventSource, fieldTypes []RuntimeFieldType, options ...option) {
 	f.ensureFieldIsUnique(fieldName)
-
-	m := newFieldMetadata(qb, contextFields, valueRegex, source, fieldTypes, options...)
-	f.fieldsToQB[fieldName] = m
-}
-
-func (f *FieldMetadata) registerFieldMetadataConditionally(
-	fieldName string,
-	qb querybuilders.QueryBuilder, contextFields violationmessages.ContextQueryFields,
-	conditionalRegexp func(*validateConfiguration) *regexp.Regexp,
-	source []storage.EventSource, fieldTypes []RuntimeFieldType, options ...option) {
-	f.ensureFieldIsUnique(fieldName)
-	f.fieldsToQB[fieldName] = newFieldMetadata(qb, contextFields, conditionalRegexp, source, fieldTypes, options...)
-
+	f.fieldsToQB[fieldName] = newFieldMetadata(qb, contextFields, regex, source, fieldTypes, options...)
 }
 
 func initializeFieldMetadata() FieldMetadata {
@@ -330,8 +318,7 @@ func initializeFieldMetadata() FieldMetadata {
 		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
 		[]RuntimeFieldType{}, negationForbidden)
 
-	f.registerFieldMetadataConditionally(
-		fieldnames.EnvironmentVariable,
+	f.registerFieldMetadata(fieldnames.EnvironmentVariable,
 		querybuilders.ForCompound(augmentedobjs.EnvironmentVarCustomTag, 3),
 		violationmessages.EnvVarContextFields,
 		func(c *validateConfiguration) *regexp.Regexp {
@@ -739,7 +726,7 @@ func initializeFieldMetadata() FieldMetadata {
 		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
 		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
 
-	f.registerFieldMetadataConditionally(fieldnames.KubeAPIVerb,
+	f.registerFieldMetadata(fieldnames.KubeAPIVerb,
 		querybuilders.ForFieldLabel(augmentedobjs.KubernetesAPIVerbCustomTag),
 		nil,
 		func(c *validateConfiguration) *regexp.Regexp {
@@ -749,7 +736,7 @@ func initializeFieldMetadata() FieldMetadata {
 		negationForbidden,
 	)
 
-	f.registerFieldMetadataConditionally(fieldnames.KubeResource,
+	f.registerFieldMetadata(fieldnames.KubeResource,
 		querybuilders.ForFieldLabel(augmentedobjs.KubernetesResourceCustomTag),
 		nil,
 		func(c *validateConfiguration) *regexp.Regexp {


### PR DESCRIPTION
## Description

`registerFieldMetadata` and `registerFieldMetadataConditionally` were essentially identical and just a source of confusion to have policy criteria registered by two different functions which do the same thing. Clean up PR for that.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
CI only
