### PR TITLE
ROX-31165: Remove tech preview from generated SBOM

### DIFF
--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -231,13 +231,14 @@ func (s *scannerv4) GetVulnerabilities(image *storage.Image, components *types.S
 	ctx, cancel := context.WithTimeout(context.Background(), scanTimeout)
 	defer cancel()
 
+	imageScanScannerVersion := components.IndexerVersion
+	if version.GetVersionKind(components.IndexerVersion) == version.InvalidKind {
+		imageScanScannerVersion = ""
+	}
+
 	if features.SBOMGeneration.Enabled() && features.ScannerV4StoreExternalIndexReports.Enabled() {
 		// Store the index report from external scanners. Note that this will use
 		// some time from the scan timeout.
-		imageScanScannerVersion := components.IndexerVersion
-		if version.GetVersionKind(components.IndexerVersion) == version.InvalidKind {
-			imageScanScannerVersion = ""
-		}
 		err := s.scannerClient.StoreImageIndex(ctx, digest, imageScanScannerVersion, v4Contents)
 		if err != nil {
 			log.Warnf("Failed to store external index report: %v", err)
@@ -248,6 +249,10 @@ func (s *scannerv4) GetVulnerabilities(image *storage.Image, components *types.S
 	vr, err := s.scannerClient.GetVulnerabilities(ctx, digest, v4Contents, client.Version(&scannerVersion))
 	if err != nil {
 		return nil, fmt.Errorf("get vulnerability report (reference: %q): %w", digest.Name(), err)
+	}
+
+	if scannerVersion.Indexer == "" {
+		scannerVersion.Indexer = imageScanScannerVersion
 	}
 	scannerVersionStr, err := scannerVersion.Encode()
 	if err != nil {

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -186,7 +186,7 @@ func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*
 	sbom, err := s.matcher.GetSBOM(ctx, ir, &sbom.Options{
 		Name:      req.GetId(),
 		Namespace: req.GetUri(),
-		Comment:   fmt.Sprintf("Tech Preview - generated for '%s'", req.GetName()),
+		Comment:   fmt.Sprintf("Generated for '%s'", req.GetName()),
 	})
 	if err != nil {
 		zlog.Error(ctx).Err(err).Msg("generating SBOM")


### PR DESCRIPTION
## Description

SBOM generation is going GA in next release, remove the tech preview comment from the generated SBOM.

Also as a 'nice to have' add the indexer version (in addition to the matcher version) to `.scan.scannerVersion` in Central

## User-facing documentation

- [X] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [X] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [X] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

N/A

### How I validated my change

Manually, pushed image to ocp integrated registry to ensure only delegated scanning can scan it:

```sh
image=image-registry.openshift-image-registry.svc:5000/default/nginx:1.26.3
```
---
#### The indexer version is added to the `scannerVersion`:
```sh
$ rctl image scan --image=$image --cluster=remote 2>/dev/null | jq -r '.scan.scannerVersion'
indexer=4.9.x-972-g468542efd0-dirty&matcher=4.9.x-972-g468542efd0-dirty
```

Prior to this PR
```sh
$ rctl image scan --image=$image --cluster=remote 2>/dev/null | jq -r '.scan.scannerVersion'
matcher=4.9.x-971-gc5cda58d16
```
---
#### The tech preview comment is removed:

```sh
$ rctl image sbom --image=$image --cluster=remote 2>/dev/null | jq -r '.comment'
Generated for 'image-registry.openshift-image-registry.svc:5000/default/nginx:1.26.3'
```

Prior to this PR

```sh
$ rctl image sbom --image=$image --cluster=remote 2>/dev/null | jq -r '.comment'
Tech Preview - generated for 'image-registry.openshift-image-registry.svc:5000/default/nginx:1.26.3'
```