### PR TITLE
ROX-27636: Prevent network graph crash

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -195,8 +195,12 @@ const TopologyComponent = ({
     }
 
     const resetViewCallback = useCallback(() => {
-        controller.getGraph().reset();
-        controller.getGraph().layout();
+        const graph = controller.getGraph();
+        graph.reset();
+        // only layout if there are nodes to layout, otherwise it will throw an error
+        if (graph.getNodes().length > 0) {
+            graph.layout();
+        }
     }, [controller]);
 
     const panNodeIntoView = useCallback(


### PR DESCRIPTION
## Description

Bug fix: Network Graph no longer crashes when toggling “Active flows” ↔ “Inactive flows” when 0 nodes are being displayed.

Alternative option that would require larger effort:
* Display an empty state when there are no nodes for the given selection

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Select cluster and namespace that have 0 nodes, switch from "Active flows" to "Inactive flows", observe no page crash.
