### PR TITLE
fix(ci): skip auth on external PRs

### DIFF
--- a/.github/actions/job-preamble/action.yaml
+++ b/.github/actions/job-preamble/action.yaml
@@ -13,6 +13,7 @@ runs:
   steps:
     # auth prepares the gcp environment to authenticate.
     - name: Auth gcloud
+      if: ${{ inputs.gcp-account }}
       uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ inputs.gcp-account }}'
@@ -141,7 +142,7 @@ runs:
       id: record_job_info
       env:
         GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ inputs.gcp-account }}
-      if: "${{ env.GCP_SERVICE_ACCOUNT_STACKROX_CI != '' }}"
+      if: "${{ env.GCP_SERVICE_ACCOUNT_STACKROX_CI != '' && inputs.gcp-account }}"
       with:
         shell: bash
         run: >


### PR DESCRIPTION
This PR skips job preamble steps when `inputs.gcp-account` is not set.

Should resolve failures on:
- https://github.com/stackrox/stackrox/pull/17129