### PR TITLE
fix(ci): build scanner for a specific commit

### DIFF
--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -1,6 +1,12 @@
 name: Scanner build and push images
 
 on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit SHA to build'
+        required: true
+        type: string
   workflow_call:
   push:
     tags:
@@ -28,7 +34,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
     - name: Define the matrix for build jobs
       id: define-scanner-job-matrix


### PR DESCRIPTION
In order to suppor external contributions we need to push images to quay. Currently we only have a way to push them for central and operator not for scanner. This PR will allow us to build and push scanner from arbitrary commit.

Refs:
- #13942
- https://github.com/stackrox/stackrox/pull/17160
- #5321  