### PR TITLE
tests: define /tmp/k8s-service-logs in a single place only.

### DIFF
--- a/scripts/ci/collect-collector-metrics.sh
+++ b/scripts/ci/collect-collector-metrics.sh
@@ -4,7 +4,7 @@ set -eu
 # Gather collector metrics script
 
 usage() {
-    echo "$0 <namespace> <output-dir> <pod-port> <path>"
+    echo "$0 <namespace> <output-dir> [<pod-port> [<path>]]"
     echo "e.g. $0 stackrox /logs 9090 metrics"
 }
 
@@ -16,16 +16,18 @@ die() {
 main() {
     service="collector"
 
-    if [ $# -gt 0 ]; then
-        namespace="$1"
+    if [ $# -eq 0 ]; then
+        usage
+        die "Please specify the namespace argument."
     else
-        namespace="stackrox"
+        namespace="$1"
     fi
 
-    if [ $# -gt 1 ]; then
-        metrics_dir="$2"
+    if [ $# -lt 2 ]; then
+        usage
+        die "Please specify the metrics dir argument."
     else
-        metrics_dir="/tmp/k8s-service-logs/$namespace/metrics"
+        metrics_dir="$2"
     fi
     mkdir -p "${metrics_dir}"
 

--- a/scripts/ci/collect-infrastructure-logs.sh
+++ b/scripts/ci/collect-infrastructure-logs.sh
@@ -7,24 +7,24 @@ set -eu
 # future examination.
 #
 # Usage:
-#   collect-infrastructure-logs.sh [<output-dir>]
+#   collect-infrastructure-logs.sh <output-dir>
 #
 # Example:
-# $ ./scripts/ci/collect-infrastructure-logs.sh
+# $ ./scripts/ci/collect-infrastructure-logs.sh /tmp/logs-dir
 #
 # Assumptions:
 # - Must be called from the root of the Apollo git repository.
-# - Logs are saved under /tmp/k8s-service-logs/ by default
+# - Requires a single argument: path to save logs to.
 
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 # shellcheck source=../../scripts/ci/lib.sh
 source "$SCRIPTS_ROOT/scripts/lib.sh"
 
-if [ $# -gt 0 ]; then
-    log_dir="$1"
+if [ $# -eq 0 ]; then
+    die "Usage: $0 <path-to-collect-logs-to>"
 else
-    log_dir="/tmp/k8s-service-logs"
+    log_dir="$1"
 fi
 
 # This will attempt to collect kube API server audit logs on OpenShift.

--- a/scripts/ci/collect-qa-service-logs.sh
+++ b/scripts/ci/collect-qa-service-logs.sh
@@ -7,20 +7,20 @@ set -eu
 # future examination.
 #
 # Usage:
-#   collect-qa-service-logs.sh [DIR]
+#   collect-qa-service-logs.sh DIR
 #
 # Example:
-# $ ./scripts/ci/collect-qa-service-logs.sh
+# $ ./scripts/ci/collect-qa-service-logs.sh /tmp/some-directory
 #
 # Assumptions:
 # - Must be called from the root of the Apollo git repository.
-# - Logs are saved under /tmp/k8s-service-logs/ or DIR if passed
+# - Requires a single argument: path to save logs to.
 
 main() {
 	set +e
     for ns in $(kubectl get ns -o json | jq -r '.items[].metadata.name' | grep -E '^qa'); do
         echo "Collecting from namespace: ${ns}"
-        ./scripts/ci/collect-service-logs.sh "${ns}" $@
+        ./scripts/ci/collect-service-logs.sh "${ns}" "$@"
     done
 }
 

--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -8,22 +8,23 @@ set -euo pipefail
 # future examination.
 #
 # Usage:
-#   collect-service-logs.sh NAMESPACE [DIR]
+#   collect-service-logs.sh NAMESPACE DIR
 #
 # Example:
-# $ ./scripts/ci/collect-service-logs.sh stackrox
+# $ ./scripts/ci/collect-service-logs.sh stackrox /tmp/some-directory
 #
 # Assumptions:
 # - Must be called from the root of the Apollo git repository.
-# - Logs are saved under /tmp/k8s-service-logs/ or DIR if passed
+# - Requires a two arguments: namespace name, and path to save logs to.
+# - Creates the path if missing.
 
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 # shellcheck source=../../scripts/ci/lib.sh
 source "$SCRIPTS_ROOT/scripts/ci/lib.sh"
 
 usage() {
-    echo "./scripts/ci/collect-service-logs.sh <namespace> [<output-dir>]"
-    echo "e.g. ./scripts/ci/collect-service-logs.sh stackrox"
+    echo "./scripts/ci/collect-service-logs.sh <namespace> <output-dir>"
+    echo "e.g. ./scripts/ci/collect-service-logs.sh stackrox /tmp/some-directory"
 }
 
 dump_logs() {
@@ -56,10 +57,10 @@ main() {
         exit 0
     fi
 
-    if [ $# -gt 1 ]; then
-        log_dir="$2"
+    if [ $# -lt 2 ]; then
+        die "Usage: $0 <namespace> <path-to-collect-logs-to>"
     else
-        log_dir="/tmp/k8s-service-logs"
+        log_dir="$2"
     fi
     log_dir="${log_dir}/${namespace}"
     mkdir -p "${log_dir}"

--- a/scripts/secured-cluster-diagnostics.sh
+++ b/scripts/secured-cluster-diagnostics.sh
@@ -227,16 +227,18 @@ save_collector_diagnostics() {
 }
 
 main() {
-    if [ $# -gt 0 ]; then
-        namespace="$1"
+    if [ $# -eq 0 ]; then
+        usage
+        die "Please specify the namespace argument."
     else
-        namespace="stackrox"
+        namespace="$1"
     fi
 
-    if [ $# -gt 1 ]; then
-        output_dir="$2"
+    if [ $# -lt 2 ]; then
+        usage
+        die "Please specify the output dir argument."
     else
-        output_dir="/tmp/k8s-service-logs/$namespace/metrics"
+        output_dir="$2"
     fi
     mkdir -p "${output_dir}"
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -687,7 +687,7 @@ check_stackrox_logs() {
     local dir="$1"
 
     if [[ ! -d "$dir/stackrox/pods" ]]; then
-        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox)"
+        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox $dir)"
     fi
 
     check_for_stackrox_OOMs "$dir"
@@ -703,7 +703,7 @@ check_for_stackrox_OOMs() {
     local dir="$1"
 
     if [[ ! -d "$dir/stackrox/pods" ]]; then
-        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox)"
+        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox $dir)"
     fi
 
     local objects
@@ -790,7 +790,7 @@ check_for_stackrox_restarts() {
     local dir="$1"
 
     if [[ ! -d "$dir/stackrox/pods" ]]; then
-        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox)"
+        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox $dir)"
     fi
 
     local previous_logs
@@ -822,7 +822,7 @@ check_for_errors_in_stackrox_logs() {
     local dir="$1/stackrox/pods"
 
     if [[ ! -d "${dir}" ]]; then
-        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox)"
+        die "StackRox logs were not collected. (Use ./scripts/ci/collect-service-logs.sh stackrox $dir)"
     fi
 
     local pod_objects=()
@@ -881,7 +881,7 @@ _verify_item_count() {
     # used by ./scripts/ci/collect-service-logs.sh
 
     if [[ ! -f "${dir}/ITEM_COUNT.txt" ]]; then
-        die "ITEM_COUNT.txt is missing. (Check output from ./scripts/ci/collect-service-logs.sh"
+        die "ITEM_COUNT.txt is missing. (Check output from ./scripts/ci/collect-service-logs.sh)"
     fi
 
     local item_count


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->


Backround: I'd like us to collect additional OLM artifacts in case of failed operator installation/upgrade.

However knowing where to drop them off for gathering into the additional stackrox e2e artifacts bucket is not so simple.
This is because we sometimes collect to `/tmp/k8s-service-logs` and sometimes to a more elaborate path like `.../part-1/k8s-logs`. There probably are other paths too. And these paths are sprinkled as magic strings all over the codebase.

Before:
```
[stackrox]$ git grep -c k8s-service-logs
.openshift-ci/post_tests.py:1
operator/tests/TROUBLESHOOTING_E2E_TESTS.md:1
scripts/ci/collect-collector-metrics.sh:1
scripts/ci/collect-infrastructure-logs.sh:2
scripts/ci/collect-qa-service-logs.sh:1
scripts/ci/collect-service-logs.sh:2
scripts/secured-cluster-diagnostics.sh:1
[stackrox]$ 
```

While providing some convenience, the practice of repeating such path in multiple places makes it really hard to evolve the codebase. This is a baby step towards taking this under control.

After:
```
[stackrox]$ git grep k8s-service-logs
.openshift-ci/post_tests.py:    K8S_LOG_DIR = "/tmp/k8s-service-logs"
operator/tests/TROUBLESHOOTING_E2E_TESTS.md:... then follow the path `k8s-service-logs/stackrox-operator/pods` ...
[stackrox]$ 
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] no tests changed

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

I carefully looked at where and how each script is being invoked and made sure no call omits the now-mandatory arguments. Then I had claude double check.

My prompt:
```
> Have a look at the last Commit.
  Check that it is sound and that the author did not miss any place which required changes for correctness reasons.
  In particular, pay close attention to cases where the scripts that now require a directory ath argument are called in a way which does not provide it.
  If you find such places make necessary connections but do not commit.
```

 It said:

```
● Analysis Summary

  I've thoroughly examined the last commit b19941aa51 and all the places where the modified scripts are called throughout the codebase. The commit is sound and complete.

  Scripts that now require directory path arguments:
  - collect-infrastructure-logs.sh - requires <output-dir>
  - collect-service-logs.sh - requires <namespace> and <output-dir>
  - collect-qa-service-logs.sh - requires DIR
  - collect-collector-metrics.sh - requires <namespace> and <output-dir>
  - secured-cluster-diagnostics.sh - requires <namespace> and <output-dir>

  All existing calls verified:
  1. .openshift-ci/post_tests.py:209,319,227 - ✅ All provide required arguments
  2. tests/common.go:828 - ✅ Provides both namespace and directory
  3. tests/e2e/run-scanner-v4-install.bats:421,427 - ✅ Provides both arguments
  4. qa-tests-backend/src/main/groovy/util/Helpers.groovy:124,125,126 - ✅ All provide required arguments
  5. tests/e2e/lib.sh:974 - ✅ Provides both arguments

  No issues found - all existing calls to these scripts already provide the required directory path arguments. The author correctly updated all necessary places in the codebase when making the scripts require explicit directory arguments.
```
