### PR TITLE
ROX-31208: Use import type in Containers MainPage

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -766,7 +766,6 @@ module.exports = [
         ignores: [
             'src/Components/**',
             'src/Containers/Compliance/**', // deprecated
-            'src/Containers/MainPage/**',
             'src/Containers/MitreAttackVectors/**',
             'src/Containers/NetworkGraph/**',
             'src/Containers/Policies/**',

--- a/ui/apps/platform/src/Containers/MainPage/AcsFeedbackModal.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AcsFeedbackModal.tsx
@@ -1,7 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import { FeedbackModal, FeedbackLocale } from '@patternfly/react-user-feedback';
+import { FeedbackModal } from '@patternfly/react-user-feedback';
+import type { FeedbackLocale } from '@patternfly/react-user-feedback';
 
 import { getProductBranding } from 'constants/productBranding';
 import redFeedbackImage from 'images/feedback_illo.svg';

--- a/ui/apps/platform/src/Containers/MainPage/AuthenticatedRoutes.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AuthenticatedRoutes.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, useLocation } from 'react-router-dom-v5-compat';
 import { createStructuredSelector } from 'reselect';

--- a/ui/apps/platform/src/Containers/MainPage/Banners/AnnouncementBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/AnnouncementBanner.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Banner, Button } from '@patternfly/react-core';
 
 import { fetchDatabaseStatus } from 'services/DatabaseService';

--- a/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/Banners.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';

--- a/ui/apps/platform/src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Banner, Button } from '@patternfly/react-core';
 
 import { generateCertSecretForComponent } from 'services/CertGenerationService';
 import { fetchCertExpiryForComponent } from 'services/CredentialExpiryService';
-import { CertExpiryComponent } from 'types/credentialExpiryService.proto';
+import type { CertExpiryComponent } from 'types/credentialExpiryService.proto';
 import {
     getBannerVariant,
     getCredentialExpiryPhrase,

--- a/ui/apps/platform/src/Containers/MainPage/Banners/DatabaseStatusBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/DatabaseStatusBanner.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, ReactElement } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { Banner } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/MainPage/Banners/OutdatedVersionBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/OutdatedVersionBanner.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Banner, Button } from '@patternfly/react-core';
 
 import useMetadata from 'hooks/useMetadata';

--- a/ui/apps/platform/src/Containers/MainPage/Banners/ServerStatusBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/ServerStatusBanner.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { Banner, Button } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -1,11 +1,11 @@
-import React, { ElementType, ReactElement, useEffect } from 'react';
+import React, { useEffect } from 'react';
+import type { ElementType, ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 
 // Import path variables in alphabetical order to minimize merge conflicts when multiple people add routes.
 import {
-    RouteKey,
     accessControlBasePath,
     administrationEventsPathWithParam,
     apidocsPath,
@@ -51,12 +51,14 @@ import {
     vulnerabilitiesImagesWithoutCvesPath,
     vulnerabilitiesVirtualMachineCvesPath,
 } from 'routePaths';
+import type { RouteKey } from 'routePaths';
 
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 import ErrorBoundary from 'Components/PatternFly/ErrorBoundary/ErrorBoundary';
-import usePermissions, { HasReadAccess } from 'hooks/usePermissions';
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+import type { HasReadAccess } from 'hooks/usePermissions';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import useAnalytics from 'hooks/useAnalytics';
 import { selectors } from 'reducers';
 

--- a/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
@@ -1,4 +1,5 @@
-import React, { useState, ReactElement } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { DownloadIcon } from '@patternfly/react-icons';
 import {

--- a/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusButton.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusButton.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, ReactElement } from 'react';
+import React from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 import { Activity } from 'react-feather';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Tooltip } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusProblems.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusProblems.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import Raven from 'raven-js';
 

--- a/ui/apps/platform/src/Containers/MainPage/Header/GlobalSearchButton.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/GlobalSearchButton.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Masthead,
     MastheadBrand,

--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { useDispatch } from 'react-redux';
 import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/MainPage/Header/Notifications.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/Notifications.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { ToastContainer, toast } from 'react-toastify';
 

--- a/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { Switch } from '@patternfly/react-core';
 
 import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';

--- a/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/UserMenu.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties } from 'react';
+import React from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
@@ -20,7 +21,7 @@ const userMenuStyleConstant = {
     pointerEvents: 'none',
 } as CSSProperties;
 
-function UserMenu({ logout, setInviteModalVisibility, userData }) {
+function UserMenu({ logout, setInviteModalVisibility, userData }): ReactElement {
     const navigate = useNavigate();
     const { analyticsTrack } = useAnalytics();
     const { hasReadWriteAccess } = usePermissions();

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsers.utils.test.ts
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsers.utils.test.ts
@@ -1,4 +1,4 @@
-import { AuthProvider } from 'services/AuthService';
+import type { AuthProvider } from 'services/AuthService';
 
 import { splitEmailsIntoNewAndExisting } from './InviteUsers.utils';
 

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsers.utils.ts
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsers.utils.ts
@@ -1,4 +1,4 @@
-import { AuthProvider } from 'services/AuthService';
+import type { AuthProvider } from 'services/AuthService';
 
 export type BucketsForNewAndExistingEmails = {
     newEmails: string[];

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersConfirmationNoEmail.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, ClipboardCopy, Text } from '@patternfly/react-core';
 import { Link } from 'react-router-dom-v5-compat';
 
 import { accessControlBasePath } from 'routePaths';
-import { BucketsForNewAndExistingEmails } from './InviteUsers.utils';
+import type { BucketsForNewAndExistingEmails } from './InviteUsers.utils';
 
 type InviteUsersConfirmationNoEmailProps = {
     emailBuckets: BucketsForNewAndExistingEmails;

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersForm.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersForm.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Form, TextArea, SelectOption } from '@patternfly/react-core';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';

--- a/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/InviteUsers/InviteUsersModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, ReactElement } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Alert, Button, Modal, ModalBoxBody, ModalBoxFooter, Text } from '@patternfly/react-core';
@@ -13,13 +14,14 @@ import { actions as authActions } from 'reducers/auth';
 import { actions as groupActions } from 'reducers/groups';
 import { actions as roleActions } from 'reducers/roles';
 import { accessControlBasePath } from 'routePaths';
-import { AuthProvider } from 'services/AuthService';
+import type { AuthProvider } from 'services/AuthService';
 import { updateOrAddGroup } from 'services/GroupsService';
 import { dedupeDelimitedString } from 'utils/textUtils';
 import { mergeGroupsWithAuthProviders } from '../../AccessControl/AuthProviders/authProviders.utils';
 import InviteUsersForm from './InviteUsersForm';
 import InviteUsersConfirmationNoEmail from './InviteUsersConfirmationNoEmail';
-import { splitEmailsIntoNewAndExisting, BucketsForNewAndExistingEmails } from './InviteUsers.utils';
+import { splitEmailsIntoNewAndExisting } from './InviteUsers.utils';
+import type { BucketsForNewAndExistingEmails } from './InviteUsers.utils';
 
 type InviteFormValues = {
     emails: string;

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Page, Button } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import type { MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
 import { matchPath, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {
     Nav,
@@ -6,11 +7,11 @@ import {
     DropdownItem,
     DropdownList,
     MenuToggle,
-    MenuToggleElement,
     NavItemSeparator,
     NavItem,
     NavList,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
 import {
     vulnerabilitiesNodeCvesPath,
@@ -25,12 +26,13 @@ import {
     vulnerabilitiesPlatformCvesPath,
     vulnerabilitiesVirtualMachineCvesPath,
 } from 'routePaths';
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
-import { HasReadAccess } from 'hooks/usePermissions';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import type { HasReadAccess } from 'hooks/usePermissions';
 import { hasSearchKeyValue } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import NavigationItem from './NavigationItem';
-import { filterNavDescriptions, isActiveLink, NavDescription } from './utils';
+import { filterNavDescriptions, isActiveLink } from './utils';
+import type { NavDescription } from './utils';
 
 import './HorizontalSubnav.css';
 
@@ -192,7 +194,10 @@ export type HorizontalSubnavProps = {
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
 };
 
-function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSubnavProps) {
+function HorizontalSubnav({
+    hasReadAccess,
+    isFeatureFlagEnabled,
+}: HorizontalSubnavProps): ReactElement | null {
     const navigate = useNavigate();
     const location = useLocation();
     const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
@@ -214,7 +219,7 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
     };
 
     const onSelect = (
-        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
         value: string | number | undefined
     ) => {
         if (value !== undefined) {
@@ -262,7 +267,7 @@ function HorizontalSubnav({ hasReadAccess, isFeatureFlagEnabled }: HorizontalSub
                                     onOpenChange={(isOpen: boolean) =>
                                         setOpenDropdownKey(isOpen ? key : null)
                                     }
-                                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                                    toggle={(toggleRef: Ref<MenuToggleElement>) => (
                                         <NavItem
                                             isActive={Boolean(activeChildLink)}
                                             onClick={() => onToggleClick(key)}

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationContent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationContent.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import { Label } from '@patternfly/react-core';
 
 import TechPreviewLabel from 'Components/PatternFly/TechPreviewLabel';

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationItem.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationItem.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { NavLink } from 'react-router-dom-v5-compat';
 import { NavItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -1,5 +1,7 @@
-import React, { ReactElement } from 'react';
-import { Location, matchPath, useLocation } from 'react-router-dom-v5-compat';
+import React from 'react';
+import type { ReactElement } from 'react';
+import { matchPath, useLocation } from 'react-router-dom-v5-compat';
+import type { Location } from 'react-router-dom-v5-compat';
 import {
     Nav,
     NavExpandable,
@@ -9,8 +11,8 @@ import {
     PageSidebarBody,
 } from '@patternfly/react-core';
 
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
-import { HasReadAccess } from 'hooks/usePermissions';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import type { HasReadAccess } from 'hooks/usePermissions';
 
 // Import path variables in alphabetical order to minimize merge conflicts when multiple people add routes.
 import {
@@ -48,7 +50,8 @@ import {
 
 import NavigationContent from './NavigationContent';
 import NavigationItem from './NavigationItem';
-import { NavDescription, ChildDescription, isActiveLink, filterNavDescriptions } from './utils';
+import { isActiveLink, filterNavDescriptions } from './utils';
+import type { ChildDescription, NavDescription } from './utils';
 
 import './NavigationSidebar.css';
 

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
@@ -1,9 +1,11 @@
-import { ReactElement } from 'react';
-import { Location, matchPath } from 'react-router-dom-v5-compat';
+import type { ReactElement } from 'react';
+import { matchPath } from 'react-router-dom-v5-compat';
+import type { Location } from 'react-router-dom-v5-compat';
 
-import { isRouteEnabled, RouteKey } from 'routePaths';
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
-import { HasReadAccess } from 'hooks/usePermissions';
+import { isRouteEnabled } from 'routePaths';
+import type { RouteKey } from 'routePaths';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import type { HasReadAccess } from 'hooks/usePermissions';
 
 // Child example; Compliance (1.0) if Compliance (2.0) is rendered and Compliance otherwise.
 // Parent example: Vulnerability Management (1.0) if Vulnerability Management (2.0) is rendered and so on.

--- a/ui/apps/platform/src/Containers/MainPage/PublicConfig/PublicConfig.utils.ts
+++ b/ui/apps/platform/src/Containers/MainPage/PublicConfig/PublicConfig.utils.ts
@@ -1,6 +1,6 @@
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
-import { BannerConfig, BannerConfigSize } from 'types/config.proto';
+import type { BannerConfig, BannerConfigSize } from 'types/config.proto';
 
 const sizeVarMap: Record<BannerConfigSize, string> = {
     UNSET: 'var(--pf-v5-global--FontSize--xs)',

--- a/ui/apps/platform/src/Containers/MainPage/PublicConfig/PublicConfigFooter.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/PublicConfig/PublicConfigFooter.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import usePublicConfig from 'hooks/usePublicConfig';
 

--- a/ui/apps/platform/src/Containers/MainPage/PublicConfig/PublicConfigHeader.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/PublicConfig/PublicConfigHeader.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import usePublicConfig from 'hooks/usePublicConfig';
 

--- a/ui/apps/platform/src/Containers/MainPage/asyncComponent.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/asyncComponent.tsx
@@ -1,4 +1,5 @@
-import React, { Component, ComponentProps, ComponentType, ElementType } from 'react';
+import React, { Component } from 'react';
+import type { ComponentProps, ComponentType, ElementType } from 'react';
 import Loader from 'Components/Loader';
 
 type State = {


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.