### PR TITLE
ROX-31209: Use import type in Containers Network Graph

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -768,7 +768,6 @@ module.exports = [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/MainPage/**',
             'src/Containers/MitreAttackVectors/**',
-            'src/Containers/NetworkGraph/**',
             'src/Containers/Policies/**',
             'src/Containers/PolicyCategories/**',
             'src/Containers/PolicyManagement/**',

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -4,18 +4,18 @@ import { Visualization, VisualizationProvider } from '@patternfly/react-topology
 import stylesComponentFactory from './components/stylesComponentFactory';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import defaultComponentFactory from './components/defaultComponentFactory';
-import { CustomModel, CustomNodeModel } from './types/topology.type';
-import { Simulation } from './utils/getSimulation';
+import type { CustomModel, CustomNodeModel } from './types/topology.type';
+import type { Simulation } from './utils/getSimulation';
 
 import './Topology.css';
-import {
+import type {
     NetworkPolicySimulator,
     SetNetworkPolicyModification,
 } from './hooks/useNetworkPolicySimulator';
 import SimulationFrame from './simulation/SimulationFrame';
 import TopologyComponent from './TopologyComponent';
-import { EdgeState } from './components/EdgeStateSelect';
-import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
+import type { EdgeState } from './components/EdgeStateSelect';
+import type { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
 
 export type NetworkGraphProps = {
     isReadyForVisualization: boolean;

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -5,7 +5,7 @@ import relatedEntitySVG from 'images/network-graph/related-entity.svg';
 import filteredEntitySVG from 'images/network-graph/filtered-entity.svg';
 
 import NetworkGraph from './NetworkGraph';
-import {
+import type {
     CIDRBlockData,
     CustomEdgeModel,
     CustomModel,
@@ -15,10 +15,10 @@ import {
     NamespaceData,
     NetworkPolicyState,
 } from './types/topology.type';
-import { Simulation } from './utils/getSimulation';
+import type { Simulation } from './utils/getSimulation';
 import { getNodeById } from './utils/networkGraphUtils';
-import { EdgeState } from './components/EdgeStateSelect';
-import { DisplayOption } from './components/DisplayOptionsSelect';
+import type { EdgeState } from './components/EdgeStateSelect';
+import type { DisplayOption } from './components/DisplayOptionsSelect';
 import {
     createExtraneousNodes,
     createExtraneousEdges,
@@ -34,7 +34,7 @@ import {
     namespaceBadgeText,
 } from './common/NetworkGraphIcons';
 import useNetworkPolicySimulator from './hooks/useNetworkPolicySimulator';
-import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
+import type { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
 
 export type Models = {
     activeModel: CustomModel;

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -27,15 +27,17 @@ import { isCompleteSearchFilter } from 'utils/searchUtils';
 import { CodeViewerThemeProvider } from 'Components/CodeViewer';
 import PageTitle from 'Components/PageTitle';
 import useURLParameter from 'hooks/useURLParameter';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
-import NetworkGraphContainer, { Models } from './NetworkGraphContainer';
+import NetworkGraphContainer from './NetworkGraphContainer';
+import type { Models } from './NetworkGraphContainer';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
 import NodeUpdateSection from './components/NodeUpdateSection';
 import NetworkSearch from './components/NetworkSearch';
 import SimulateNetworkPolicyButton from './simulation/SimulateNetworkPolicyButton';
 import EdgeStateSelect from './components/EdgeStateSelect';
-import DisplayOptionsSelect, { DisplayOption } from './components/DisplayOptionsSelect';
+import DisplayOptionsSelect from './components/DisplayOptionsSelect';
+import type { DisplayOption } from './components/DisplayOptionsSelect';
 import TimeWindowSelector from './components/TimeWindowSelector';
 import { useScopeHierarchy } from './hooks/useScopeHierarchy';
 import {

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphURLStateContext.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphURLStateContext.tsx
@@ -1,12 +1,16 @@
-import React, { createContext, ReactNode, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
 
-import { timeWindows, TimeWindow } from 'constants/timeWindows';
+import { timeWindows } from 'constants/timeWindows';
+import type { TimeWindow } from 'constants/timeWindows';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLParameter, { HistoryAction, QueryValue } from 'hooks/useURLParameter';
+import useURLParameter from 'hooks/useURLParameter';
+import type { HistoryAction, QueryValue } from 'hooks/useURLParameter';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 
-import { edgeStates, EdgeState } from './components/EdgeStateSelect';
+import { edgeStates } from './components/EdgeStateSelect';
+import type { EdgeState } from './components/EdgeStateSelect';
 import { DEFAULT_NETWORK_GRAPH_PAGE_SIZE, EDGE_STATE, TIME_WINDOW } from './NetworkGraph.constants';
 
 export const SIDE_PANEL_SEARCH_PREFIX = 's2';

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat'
 import { Popover } from '@patternfly/react-core';
 import {
     SELECTION_EVENT,
-    SelectionEventListener,
     useEventListener,
     TopologySideBar,
     TopologyView,
@@ -13,13 +12,14 @@ import {
     useVisualizationController,
     VisualizationSurface,
 } from '@patternfly/react-topology';
+import type { SelectionEventListener } from '@patternfly/react-topology';
 
 import { networkBasePath } from 'routePaths';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import { getQueryString } from 'utils/queryStringUtils';
-import { QueryValue } from 'hooks/useURLParameter';
+import type { QueryValue } from 'hooks/useURLParameter';
 import DeploymentSideBar from './deployment/DeploymentSideBar';
 import NamespaceSideBar from './namespace/NamespaceSideBar';
 import GenericEntitiesSideBar from './genericEntities/GenericEntitiesSideBar';
@@ -29,17 +29,18 @@ import NetworkPolicySimulatorSidePanel, {
     clearSidePanelQuery,
 } from './simulation/NetworkPolicySimulatorSidePanel';
 import { getExternalEntitiesNode, getNodeById } from './utils/networkGraphUtils';
-import { CustomModel, CustomNodeModel, isNodeOfType } from './types/topology.type';
-import { Simulation } from './utils/getSimulation';
+import { isNodeOfType } from './types/topology.type';
+import type { CustomModel, CustomNodeModel } from './types/topology.type';
+import type { Simulation } from './utils/getSimulation';
 import LegendContent from './components/LegendContent';
 
-import { EdgeState } from './components/EdgeStateSelect';
+import type { EdgeState } from './components/EdgeStateSelect';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
-import {
+import type {
     NetworkPolicySimulator,
     SetNetworkPolicyModification,
 } from './hooks/useNetworkPolicySimulator';
-import { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
+import type { NetworkScopeHierarchy } from './types/networkScopeHierarchy';
 import { getSearchFilterFromScopeHierarchy } from './utils/simulatorUtils';
 import {
     CidrBlockIcon,

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchBaselineNetworkPolicy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchBaselineNetworkPolicy.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { fetchBaselineGeneratedNetworkPolicy } from 'services/NetworkService';
-import { NetworkPolicyModification } from 'types/networkPolicy.proto';
+import type { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type FetchBaselineNetworkPolicyParams = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 import uniqBy from 'lodash/uniqBy';
 
 import { fetchNetworkBaselines } from 'services/NetworkService';
-import { NetworkBaseline } from 'types/networkBaseline.proto';
+import type { NetworkBaseline } from 'types/networkBaseline.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { Flow, FlowEntityType } from '../types/flow.type';
+import type { Flow, FlowEntityType } from '../types/flow.type';
 
 type Result = {
     isLoading: boolean;

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 
 import { fetchNetworkBaselineStatuses } from 'services/NetworkService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { EdgeState } from '../components/EdgeStateSelect';
-import { BaselineStatus, BaselineStatusType, Flow } from '../types/flow.type';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { EdgeState } from '../components/EdgeStateSelect';
+import type { BaselineStatus, BaselineStatusType, Flow } from '../types/flow.type';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import {
     getNetworkFlows,
     getUniqueIdFromFlow,

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useModifyBaselineStatuses.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useModifyBaselineStatuses.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { markNetworkBaselineStatuses } from 'services/NetworkService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { BaselineStatusType, Flow } from '../types/flow.type';
+import type { BaselineStatusType, Flow } from '../types/flow.type';
 
 type Result = {
     isModifying: boolean;

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
 import {
     Select,
     SelectGroup,
@@ -7,12 +8,12 @@ import {
 } from '@patternfly/react-core/deprecated';
 
 import useMultiSelect from 'hooks/useMultiSelect';
-import { AdvancedFlowsFilterType } from './types';
+import type { AdvancedFlowsFilterType } from './types';
 import { filtersToSelections, selectionsToFilters } from './advancedFlowsFilterUtils';
 
 export type AdvancedFlowsFilterProps = {
     filters: AdvancedFlowsFilterType;
-    setFilters: React.Dispatch<React.SetStateAction<AdvancedFlowsFilterType>>;
+    setFilters: Dispatch<SetStateAction<AdvancedFlowsFilterType>>;
     allUniquePorts: string[];
 };
 
@@ -26,7 +27,7 @@ function AdvancedFlowsFilter({
     filters,
     setFilters,
     allUniquePorts,
-}: AdvancedFlowsFilterProps): React.ReactElement {
+}: AdvancedFlowsFilterProps): ReactElement {
     // derived state
     const selections = filtersToSelections(filters);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/advancedFlowsFilterUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/advancedFlowsFilterUtils.test.ts
@@ -1,4 +1,4 @@
-import { AdvancedFlowsFilterType } from './types';
+import type { AdvancedFlowsFilterType } from './types';
 import { filtersToSelections, selectionsToFilters } from './advancedFlowsFilterUtils';
 
 describe('advancedFlowsFilterUtils', () => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/advancedFlowsFilterUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/advancedFlowsFilterUtils.ts
@@ -1,4 +1,4 @@
-import { AdvancedFlowsFilterType, FilterValue } from './types';
+import type { AdvancedFlowsFilterType, FilterValue } from './types';
 
 function isValidPort(port: string): boolean {
     const portNum = parseInt(port, 10);

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/EntityNameSearchInput.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/EntityNameSearchInput.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
 import { SearchInput } from '@patternfly/react-core';
-import React, { ReactElement } from 'react';
 
 type EntityNameSearchInputProps = {
     value: string;
-    setValue: React.Dispatch<React.SetStateAction<string>>;
+    setValue: Dispatch<SetStateAction<string>>;
 };
 
 function EntityNameSearchInput({ value, setValue }: EntityNameSearchInputProps): ReactElement {

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsBulkActions.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsBulkActions.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import { DropdownItem } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/no-array-index-key */
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { CSSProperties, Dispatch, ReactElement, SetStateAction } from 'react';
 import {
     ActionsColumn,
     ExpandableRowContent,
-    IAction,
     Table,
     Tbody,
     Td,
@@ -11,6 +11,7 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 import {
     Button,
     Flex,
@@ -29,7 +30,7 @@ import {
 } from '@patternfly/react-icons';
 
 import { ensureExhaustive } from 'utils/type.utils';
-import { BaselineSimulationDiffState, Flow, FlowEntityType } from '../types/flow.type';
+import type { BaselineSimulationDiffState, Flow, FlowEntityType } from '../types/flow.type';
 import { protocolLabel } from '../utils/flowUtils';
 
 type FlowsTableProps = {
@@ -37,9 +38,9 @@ type FlowsTableProps = {
     flows: Flow[];
     numFlows: number;
     expandedRows: string[];
-    setExpandedRows: React.Dispatch<React.SetStateAction<string[]>>;
+    setExpandedRows: Dispatch<SetStateAction<string[]>>;
     selectedRows: string[];
-    setSelectedRows: React.Dispatch<React.SetStateAction<string[]>>;
+    setSelectedRows: Dispatch<SetStateAction<string[]>>;
     isEditable?: boolean;
     addToBaseline?: (flow: Flow) => void;
     markAsAnomalous?: (flow: Flow) => void;
@@ -72,8 +73,8 @@ function getFlowSubtext(flow: Flow): string {
 
 function getBaselineSimulatedRowStyle(
     baselineSimulationDiffState: BaselineSimulationDiffState | undefined
-): React.CSSProperties {
-    let customStyle: React.CSSProperties;
+): CSSProperties {
+    let customStyle: CSSProperties;
     if (baselineSimulationDiffState === 'ADDED') {
         customStyle = { backgroundColor: 'var(--pf-v5-global--palette--green-50)' };
     } else if (baselineSimulationDiffState === 'REMOVED') {

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 type FlowsTableHeaderTextProps = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/IPMatchFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/IPMatchFilter.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { Flex, SearchInput } from '@patternfly/react-core';
 
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
-import { SetSearchFilter } from 'hooks/useURLSearch';
-import { SearchFilter } from 'types/search';
+import type { SetSearchFilter } from 'hooks/useURLSearch';
+import type { SearchFilter } from 'types/search';
 import { isValidCidrBlock } from 'utils/urlUtils';
 
 import { EXTERNAL_SOURCE_ADDRESS_QUERY } from '../NetworkGraph.constants';

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Badge, BadgeProps } from '@patternfly/react-core';
+import { Badge } from '@patternfly/react-core';
+import type { BadgeProps } from '@patternfly/react-core';
 
 export const clusterBadgeText = 'CL';
 export const namespaceBadgeText = 'NS';

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     Alert,
     AlertGroup,
@@ -31,7 +32,7 @@ type NetworkPolicyYAML = {
 
 const allNetworkPoliciesId = 'All network policies';
 
-function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React.ReactElement {
+function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): ReactElement {
     const { networkPolicies, networkPolicyErrors, isLoading, error } =
         useFetchNetworkPolicies(policyIds);
 
@@ -93,7 +94,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
         );
     }
 
-    let policyErrorBanner: React.ReactNode = null;
+    let policyErrorBanner: ReactNode = null;
 
     if (networkPolicyErrors.length > 0) {
         policyErrorBanner = (

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
@@ -13,7 +13,8 @@ import {
 import useTimeout from 'hooks/useTimeout';
 import { getHasDuplicateCIDRNames, getHasDuplicateCIDRAddresses } from './cidrFormUtils';
 import DefaultCIDRToggle from './DefaultCIDRToggle';
-import CIDRForm, { emptyCIDRBlockRow, CIDRBlockEntity, CIDRBlockEntities } from './CIDRForm';
+import CIDRForm, { emptyCIDRBlockRow } from './CIDRForm';
+import type { CIDRBlockEntity, CIDRBlockEntities } from './CIDRForm';
 
 const validationSchema = Yup.object().shape({
     entities: Yup.array().of(

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 
-import { ClusterScopeObject } from 'services/RolesService';
+import type { ClusterScopeObject } from 'services/RolesService';
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
 import { ClusterIcon } from '../common/NetworkGraphIcons';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultCIDRToggle.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultCIDRToggle.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Flex, Switch } from '@patternfly/react-core';
 
 import { getHideDefaultExternalSrcs, setHideDefaultExternalSrcs } from 'services/NetworkService';

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import type { ReactElement, Ref } from 'react';
 import {
     Badge,
     Button,
@@ -13,14 +14,14 @@ import {
     MenuItem,
     MenuList,
     MenuToggle,
-    MenuToggleElement,
     SearchInput,
     MenuSearchInput,
     Select,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
+import type { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
 import { removeNullValues } from 'utils/removeNullValues';
 import { DeploymentIcon } from '../common/NetworkGraphIcons';
 
@@ -36,7 +37,7 @@ function DeploymentSelector({
     selectedDeployments = [],
     searchFilter,
     setSearchFilter,
-}: DeploymentSelectorProps) {
+}: DeploymentSelectorProps): ReactElement {
     const { isOpen: isDeploymentOpen, toggleSelect: toggleIsDeploymentOpen } = useSelectToggle();
     const [input, setInput] = React.useState('');
 
@@ -136,7 +137,7 @@ function DeploymentSelector({
         </Menu>
     );
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             ref={toggleRef}
             onClick={() => toggleIsDeploymentOpen(!isDeploymentOpen)}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EmptyUnscopedState.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EmptyUnscopedState.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Bullseye, Icon, Text } from '@patternfly/react-core';
 import { ModuleIcon } from '@patternfly/react-icons';
-import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/FlowBulkDropdown.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/FlowBulkDropdown.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement, Ref } from 'react';
 import {
     Badge,
     Divider,
@@ -6,8 +7,8 @@ import {
     DropdownItem,
     DropdownList,
     MenuToggle,
-    MenuToggleElement,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
 type Props = {
     selectedCount: number;
@@ -22,7 +23,7 @@ export function FlowBulkDropdown({ selectedCount, isOpen, setOpen, onClear, chil
         <Dropdown
             isOpen={isOpen}
             onOpenChange={setOpen}
-            toggle={(ref: React.Ref<MenuToggleElement>) => (
+            toggle={(ref: Ref<MenuToggleElement>) => (
                 <MenuToggle
                     ref={ref}
                     isExpanded={isOpen}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { ToolbarContent, ToolbarItem, Pagination } from '@patternfly/react-core';
-import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn, IAction } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
-import { NetworkBaselinePeerStatus } from 'types/networkBaseline.proto';
-import { TableUIState } from 'utils/getTableUIState';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { NetworkBaselinePeerStatus } from 'types/networkBaseline.proto';
+import type { TableUIState } from 'utils/getTableUIState';
 
-import { BaselineStatusType } from '../types/flow.type';
+import type { BaselineStatusType } from '../types/flow.type';
 import { getFlowKey } from '../utils/flowUtils';
 
 import { useSearchFilterSidePanel } from '../NetworkGraphURLStateContext';

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import type { ReactElement, Ref } from 'react';
 import {
     Badge,
     Button,
@@ -15,12 +16,12 @@ import {
     MenuSearchInput,
     Select,
     MenuToggle,
-    MenuToggleElement,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
-import { NamespaceScopeObject } from 'services/RolesService';
+import type { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
+import type { NamespaceScopeObject } from 'services/RolesService';
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
 
 export function getDeploymentLookupMap(
@@ -60,7 +61,7 @@ function NamespaceSelector({
     deploymentsByNamespace = [],
     searchFilter,
     setSearchFilter,
-}: NamespaceSelectorProps) {
+}: NamespaceSelectorProps): ReactElement {
     const { isOpen: isNamespaceOpen, toggleSelect: toggleIsNamespaceOpen } = useSelectToggle();
     const [input, setInput] = React.useState('');
 
@@ -162,7 +163,7 @@ function NamespaceSelector({
         </Menu>
     );
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             ref={toggleRef}
             onClick={() => toggleIsNamespaceOpen(!isNamespaceOpen)}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -5,8 +5,9 @@ import { useFetchClusterNamespacesForPermissions } from 'hooks/useFetchClusterNa
 import useFetchNamespaceDeployments from 'hooks/useFetchNamespaceDeployments';
 import { nonGlobalResourceNamesForNetworkGraph } from 'routePaths';
 
-import { SearchFilter } from 'types/search';
-import ClusterSelector, { ClusterSelectorProps } from './ClusterSelector';
+import type { SearchFilter } from 'types/search';
+import ClusterSelector from './ClusterSelector';
+import type { ClusterSelectorProps } from './ClusterSelector';
 import NamespaceSelector from './NamespaceSelector';
 import DeploymentSelector from './DeploymentSelector';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleEdge.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleEdge.tsx
@@ -2,7 +2,8 @@
 import React, { useMemo } from 'react';
 import type { FunctionComponent, PropsWithChildren } from 'react';
 import { observer } from 'mobx-react';
-import { Edge, DefaultEdge } from '@patternfly/react-topology';
+import { DefaultEdge } from '@patternfly/react-topology';
+import type { Edge } from '@patternfly/react-topology';
 
 type StyleEdgeProps = {
     element: Edge;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import React, { useMemo } from 'react';
 import type { ComponentClass, FunctionComponent, PropsWithChildren, ReactNode } from 'react';
-import {
+import { observer, ScaleDetailsLevel } from '@patternfly/react-topology';
+import type {
     Node,
-    observer,
-    ScaleDetailsLevel,
     ShapeProps,
     WithDragNodeProps,
     WithSelectionProps,
@@ -12,7 +11,7 @@ import {
 import AlternateIcon from '@patternfly/react-icons/dist/esm/icons/regions-icon';
 import DefaultIcon from '@patternfly/react-icons/dist/esm/icons/builder-image-icon';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
-import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import DefaultFakeGroup from './DefaultFakeGroup';
 
 const ICON_PADDING = 20;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
@@ -1,10 +1,8 @@
 import React, { useMemo } from 'react';
 import type { ComponentClass, FunctionComponent, PropsWithChildren, ReactNode } from 'react';
-import {
-    DefaultGroup,
+import { DefaultGroup, observer, ScaleDetailsLevel } from '@patternfly/react-topology';
+import type {
     Node,
-    observer,
-    ScaleDetailsLevel,
     ShapeProps,
     WithDragNodeProps,
     WithSelectionProps,
@@ -12,8 +10,8 @@ import {
 import AlternateIcon from '@patternfly/react-icons/dist/esm/icons/regions-icon';
 import DefaultIcon from '@patternfly/react-icons/dist/esm/icons/builder-image-icon';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
-import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
-import { CustomGroupNodeData } from '../types/topology.type';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import type { CustomGroupNodeData } from '../types/topology.type';
 
 const ICON_PADDING = 20;
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
@@ -15,14 +15,16 @@ import {
     DefaultNode,
     getDefaultShapeDecoratorCenter,
     Layer,
-    Node,
     NodeShape,
     observer,
     ScaleDetailsLevel,
-    ShapeProps,
     TOP_LAYER,
     TopologyQuadrant,
     useHover,
+} from '@patternfly/react-topology';
+import type {
+    Node,
+    ShapeProps,
     WithContextMenuProps,
     WithCreateConnectorProps,
     WithDragNodeProps,
@@ -31,14 +33,14 @@ import {
 import DefaultIcon from '@patternfly/react-icons/dist/esm/icons/builder-image-icon';
 import { PficonNetworkRangeIcon, ZoneIcon } from '@patternfly/react-icons';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
-import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 import BothPolicyRules from 'images/network-graph/both-policy-rules.svg?react';
 import EgressOnly from 'images/network-graph/egress-only.svg?react';
 import IngressOnly from 'images/network-graph/ingress-only.svg?react';
 import NoPolicyRules from 'images/network-graph/no-policy-rules.svg?react';
 import { ensureExhaustive } from 'utils/type.utils';
-import { NetworkPolicyState, DeploymentData, NodeDataType } from '../types/topology.type';
+import type { NetworkPolicyState, DeploymentData, NodeDataType } from '../types/topology.type';
 
 const ICON_PADDING = 20;
 const CUSTOM_DECORATOR_PADDING = 2.5;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/TimeWindowSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/TimeWindowSelector.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 
-import { TimeWindow, timeWindows } from 'constants/timeWindows';
+import { timeWindows } from 'constants/timeWindows';
+import type { TimeWindow } from 'constants/timeWindows';
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
 
 type TimeWindowSelectorProps = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
@@ -1,12 +1,6 @@
-import { ComponentType } from 'react';
-import {
-    GraphElement,
-    ComponentFactory,
-    GraphComponent,
-    DefaultNode,
-    DefaultEdge,
-    DefaultGroup,
-} from '@patternfly/react-topology';
+import type { ComponentType, PropsWithChildren } from 'react';
+import { GraphComponent, DefaultNode, DefaultEdge, DefaultGroup } from '@patternfly/react-topology';
+import type { ComponentFactory, GraphElement } from '@patternfly/react-topology';
 
 enum CustomModelKind {
     node = 'node',
@@ -20,7 +14,7 @@ const defaultComponentFactory: ComponentFactory = (
     kind: CustomModelKind,
     type: string
 ):
-    | ComponentType<React.PropsWithChildren<{ element: GraphElement }>>
+    | ComponentType<PropsWithChildren<{ element: GraphElement }>>
     | typeof DefaultGroup
     | typeof GraphComponent
     | typeof DefaultNode

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
-    ComponentFactory,
     withDragNode,
     withSelection,
     ModelKind,
@@ -11,6 +10,7 @@ import {
     graphDropTargetSpec,
     NODE_DRAG_TYPE,
 } from '@patternfly/react-topology';
+import type { ComponentFactory } from '@patternfly/react-topology';
 import StyleNode from './StyleNode';
 import StyleGroup from './StyleGroup';
 import StyleEdge from './StyleEdge';

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousFlows.tsx
@@ -3,7 +3,7 @@ import { FlexItem, Label } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import pluralize from 'pluralize';
 
-import { Flow } from '../types/flow.type';
+import type { Flow } from '../types/flow.type';
 import {
     getNumAnomalousExternalFlows,
     getNumAnomalousInternalFlows,

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousTraffic.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/AnomalousTraffic.tsx
@@ -9,8 +9,8 @@ import {
 } from '@patternfly/react-core';
 
 import useFetchNetworkFlows from '../api/useFetchNetworkFlows';
-import { EdgeState } from '../components/EdgeStateSelect';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { EdgeState } from '../components/EdgeStateSelect';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import AnomalousFlows from './AnomalousFlows';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
@@ -20,9 +20,9 @@ import { HelpIcon } from '@patternfly/react-icons';
 
 import download from 'utils/download';
 import usePermissions from 'hooks/usePermissions';
-import { Deployment } from 'types/deployment.proto';
-import { NetworkPolicyModification } from 'types/networkPolicy.proto';
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import type { Deployment } from 'types/deployment.proto';
+import type { NetworkPolicyModification } from 'types/networkPolicy.proto';
+import type { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { filterNetworkFlows, getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
 
 import AdvancedFlowsFilter, {
@@ -33,7 +33,7 @@ import FlowsTable from '../common/FlowsTable';
 import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
 import FlowsBulkActions from '../common/FlowsBulkActions';
 import useFetchNetworkBaselines from '../api/useFetchNetworkBaselines';
-import { Flow } from '../types/flow.type';
+import type { Flow } from '../types/flow.type';
 import useModifyBaselineStatuses from '../api/useModifyBaselineStatuses';
 import useToggleAlertingOnBaselineViolation from '../api/useToggleAlertingOnBaselineViolation';
 import useFetchBaselineNetworkPolicy from '../api/useFetchBaselineNetworkPolicy';

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -19,8 +19,8 @@ import {
 } from '@patternfly/react-core';
 
 import usePermissions from 'hooks/usePermissions';
-import { Deployment } from 'types/deployment.proto';
-import { ListenPort } from 'types/networkFlow.proto';
+import type { Deployment } from 'types/deployment.proto';
+import type { ListenPort } from 'types/networkFlow.proto';
 import { getDateTime } from 'utils/dateUtils';
 
 import DeploymentPortConfig from 'Components/DeploymentPortConfig';
@@ -31,8 +31,8 @@ import EgressOnly from 'images/network-graph/egress-only.svg?react';
 import IngressOnly from 'images/network-graph/ingress-only.svg?react';
 import NoPolicyRules from 'images/network-graph/no-policy-rules.svg?react';
 
-import { EdgeState } from '../components/EdgeStateSelect';
-import { CustomEdgeModel, CustomNodeModel, NetworkPolicyState } from '../types/topology.type';
+import type { EdgeState } from '../components/EdgeStateSelect';
+import type { CustomEdgeModel, CustomNodeModel, NetworkPolicyState } from '../types/topology.type';
 
 import AnomalousTraffic from './AnomalousTraffic';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -3,11 +3,11 @@ import { Divider, Stack, StackItem, ToggleGroup, ToggleGroupItem } from '@patter
 
 import useAnalytics, { DEPLOYMENT_FLOWS_TOGGLE_CLICKED } from 'hooks/useAnalytics';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { QueryValue } from 'hooks/useURLParameter';
+import type { QueryValue } from 'hooks/useURLParameter';
 
 import useFetchNetworkFlows from '../api/useFetchNetworkFlows';
-import { EdgeState } from '../components/EdgeStateSelect';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { EdgeState } from '../components/EdgeStateSelect';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import { isInternalFlow } from '../utils/networkGraphUtils';
 
 import InternalFlows from './InternalFlows';

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, CSSProperties } from 'react';
+import React, { useEffect } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 import {
     Alert,
     Bullseye,
@@ -16,12 +17,13 @@ import {
 } from '@patternfly/react-core';
 
 import useFetchDeployment from 'hooks/useFetchDeployment';
-import usePermissions, { HasReadAccess } from 'hooks/usePermissions';
-import { QueryValue } from 'hooks/useURLParameter';
+import usePermissions from 'hooks/usePermissions';
+import type { HasReadAccess } from 'hooks/usePermissions';
+import type { QueryValue } from 'hooks/useURLParameter';
 import { ensureExhaustive } from 'utils/type.utils';
 
 import { getListenPorts, getNodeById } from '../utils/networkGraphUtils';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import { DeploymentIcon } from '../common/NetworkGraphIcons';
 import DeploymentDetails from './DeploymentDetails';
@@ -29,7 +31,7 @@ import DeploymentFlows from './DeploymentFlows';
 import DeploymentBaseline from './DeploymentBaseline';
 import NetworkPolicies from '../common/NetworkPolicies';
 import useSimulation from '../hooks/useSimulation';
-import { EdgeState } from '../components/EdgeStateSelect';
+import type { EdgeState } from '../components/EdgeStateSelect';
 import { DEFAULT_NETWORK_GRAPH_PAGE_SIZE } from '../NetworkGraph.constants';
 import {
     usePagination,
@@ -81,7 +83,7 @@ function DeploymentSideBar({
     edges,
     edgeState,
     onNodeSelect,
-}: DeploymentSideBarProps) {
+}: DeploymentSideBarProps): ReactElement {
     // component state
     const { setPerPage: setPerPageAnomalous } = usePagination();
     const { setPerPage: setPerPageBaseline } = usePaginationSecondary();

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -19,7 +19,7 @@ import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { markNetworkBaselineStatuses } from 'services/NetworkService';
-import { NetworkBaselinePeerStatus, PeerStatus } from 'types/networkBaseline.proto';
+import type { NetworkBaselinePeerStatus, PeerStatus } from 'types/networkBaseline.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import FlowsTableHeaderText from '../common/FlowsTableHeaderText';

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/InternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/InternalFlows.tsx
@@ -19,7 +19,7 @@ import pluralize from 'pluralize';
 import usePermissions from 'hooks/usePermissions';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useModifyBaselineStatuses from '../api/useModifyBaselineStatuses';
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import type { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import {
     filterNetworkFlows,
     getAllUniquePorts,
@@ -27,9 +27,9 @@ import {
     getNumExtraneousIngressFlows,
     getNumFlows,
 } from '../utils/flowUtils';
-import { CustomNodeModel } from '../types/topology.type';
-import { EdgeState } from '../components/EdgeStateSelect';
-import { Flow } from '../types/flow.type';
+import type { CustomNodeModel } from '../types/topology.type';
+import type { EdgeState } from '../components/EdgeStateSelect';
+import type { Flow } from '../types/flow.type';
 
 import AdvancedFlowsFilter, {
     defaultAdvancedFlowsFilters,

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/EntityDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/EntityDetails.tsx
@@ -19,14 +19,14 @@ import { InnerScrollContainer, Table, Tbody, Td, Th, Thead, Tr } from '@patternf
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import useRestQuery from 'hooks/useRestQuery';
-import { QueryValue } from 'hooks/useURLParameter';
+import type { QueryValue } from 'hooks/useURLParameter';
 import { getExternalNetworkFlows } from 'services/NetworkService';
 import { getTableUIState } from 'utils/getTableUIState';
-import { ExternalNetworkFlowsResponse } from 'types/networkFlow.proto';
+import type { ExternalNetworkFlowsResponse } from 'types/networkFlow.proto';
 
 import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
 import { EXTERNAL_SOURCE_ADDRESS_QUERY } from '../NetworkGraph.constants';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import {
     SIDE_PANEL_SEARCH_PREFIX,
     usePagination,

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Divider,
     Flex,
@@ -11,13 +12,13 @@ import {
     ToggleGroupItem,
 } from '@patternfly/react-core';
 
-import { QueryValue } from 'hooks/useURLParameter';
+import type { QueryValue } from 'hooks/useURLParameter';
 
 import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
 import ExternalFlowsTable from './ExternalFlowsTable';
 import ExternalIpsContainer from './ExternalIpsContainer';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import { getNodeById } from '../utils/networkGraphUtils';
 import EntityDetails from './EntityDetails';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalFlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalFlowsTable.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Divider,
     Flex,
@@ -13,11 +14,11 @@ import {
 import AdvancedFlowsFilter, {
     defaultAdvancedFlowsFilters,
 } from '../common/AdvancedFlowsFilter/AdvancedFlowsFilter';
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import type { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import EntityNameSearchInput from '../common/EntityNameSearchInput';
 import FlowsTable from '../common/FlowsTable';
 import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import {
     filterNetworkFlows,
     getAllUniquePorts,

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Button,
     Divider,
@@ -15,13 +16,13 @@ import {
 
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { getEdgesByNodeId, getNodeById } from '../utils/networkGraphUtils';
-import {
+import { isOfType } from '../types/topology.type';
+import type {
     CIDRBlockNodeModel,
     CustomEdgeModel,
     CustomNodeModel,
     ExternalEntitiesNodeModel,
     ExternalGroupNodeModel,
-    isOfType,
 } from '../types/topology.type';
 
 import { CidrBlockIcon, ExternalEntitiesIcon } from '../common/NetworkGraphIcons';

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsContainer.tsx
@@ -4,11 +4,11 @@ import isEmpty from 'lodash/isEmpty';
 import useAnalytics, { EXTERNAL_IPS_SIDE_PANEL } from 'hooks/useAnalytics';
 import useRestQuery from 'hooks/useRestQuery';
 import { getExternalIpsFlowsMetadata } from 'services/NetworkService';
-import { ExternalNetworkFlowsMetadataResponse } from 'types/networkFlow.proto';
+import type { ExternalNetworkFlowsMetadataResponse } from 'types/networkFlow.proto';
 import { getTableUIState } from 'utils/getTableUIState';
 
 import ExternalIpsTable from './ExternalIpsTable';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { timeWindowToISO } from '../utils/timeWindow';
 
 import {

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalIpsTable.tsx
@@ -14,9 +14,9 @@ import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import useMetadata from 'hooks/useMetadata';
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 import { getVersionedDocs } from 'utils/versioning';
-import { ExternalNetworkFlowsMetadata } from 'types/networkFlow.proto';
+import type { ExternalNetworkFlowsMetadata } from 'types/networkFlow.proto';
 
 import IPMatchFilter from '../common/IPMatchFilter';
 import { EXTERNAL_SOURCE_ADDRESS_QUERY } from '../NetworkGraph.constants';

--- a/ui/apps/platform/src/Containers/NetworkGraph/genericEntities/GenericEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/genericEntities/GenericEntitiesSideBar.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Divider,
     Flex,
@@ -19,8 +20,8 @@ import {
     getNetworkFlows,
     getNumFlows,
 } from '../utils/flowUtils';
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import AdvancedFlowsFilter, {
     defaultAdvancedFlowsFilters,

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkBaselineStatus.ts
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 
-import { TimeWindow } from 'constants/timeWindows';
+import type { TimeWindow } from 'constants/timeWindows';
 import useRestQuery from 'hooks/useRestQuery';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { getNetworkBaselineExternalStatus } from 'services/NetworkService';
-import { NetworkBaselineExternalStatusResponse } from 'types/networkBaseline.proto';
-import { SearchFilter } from 'types/search';
+import type { NetworkBaselineExternalStatusResponse } from 'types/networkBaseline.proto';
+import type { SearchFilter } from 'types/search';
 import { getTableUIState } from 'utils/getTableUIState';
 
-import { BaselineStatusType } from '../types/flow.type';
+import type { BaselineStatusType } from '../types/flow.type';
 import { timeWindowToISO } from '../utils/timeWindow';
 
 export function useNetworkBaselineStatus(

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -3,12 +3,12 @@ import { useState } from 'react';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import * as networkService from 'services/NetworkService';
 import { ensureExhaustive } from 'utils/type.utils';
-import { NetworkPolicyModification } from 'types/networkPolicy.proto';
+import type { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { Simulation } from '../utils/getSimulation';
+import type { Simulation } from '../utils/getSimulation';
 import { getSearchFilterFromScopeHierarchy } from '../utils/simulatorUtils';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export type NetworkPolicySimulator =
     | {

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
@@ -1,8 +1,8 @@
 import cloneDeep from 'lodash/cloneDeep';
 
-import { ClusterScopeObject } from 'services/RolesService';
-import { SearchFilter } from 'types/search';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { ClusterScopeObject } from 'services/RolesService';
+import type { SearchFilter } from 'types/search';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 import { useSearchFilter } from '../NetworkGraphURLStateContext';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useSimulation.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useSimulation.ts
@@ -1,5 +1,6 @@
 import useURLParameter from 'hooks/useURLParameter';
-import getSimulation, { Simulation, SimulationType } from '../utils/getSimulation';
+import getSimulation from '../utils/getSimulation';
+import type { Simulation, SimulationType } from '../utils/getSimulation';
 
 export type UseSimulationResult = {
     simulation: Simulation;

--- a/ui/apps/platform/src/Containers/NetworkGraph/layouts/defaultLayoutFactory.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/layouts/defaultLayoutFactory.ts
@@ -1,7 +1,4 @@
 import {
-    Graph,
-    Layout,
-    LayoutFactory,
     ForceLayout,
     ColaLayout,
     ConcentricLayout,
@@ -9,6 +6,7 @@ import {
     GridLayout,
     BreadthFirstLayout,
 } from '@patternfly/react-topology';
+import type { Graph, Layout, LayoutFactory } from '@patternfly/react-topology';
 import { ColaGroupsLayout } from '@patternfly/react-topology/dist/esm/layouts/ColaGroupsLayout';
 
 const defaultLayoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -13,13 +13,13 @@ import {
 } from '@patternfly/react-core';
 import uniq from 'lodash/uniq';
 
-import { QueryValue } from 'hooks/useURLParameter';
+import type { QueryValue } from 'hooks/useURLParameter';
 import {
     getDeploymentNodesInNamespace,
     getNodeById,
     getNumDeploymentFlows,
 } from '../utils/networkGraphUtils';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
 import NamespaceDeployments from './NamespaceDeployments';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesGenerationScope.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Flex, pluralize } from '@patternfly/react-core';
 
 import DeploymentScopeModal from './DeploymentScopeModal';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { ClusterIcon, DeploymentIcon, NamespaceIcon } from '../common/NetworkGraphIcons';
 
 import './NetworkPoliciesGenerationScope.css';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 import { CodeBlockAction, Button } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -6,7 +6,6 @@ import {
     Checkbox,
     CodeBlockAction,
     Divider,
-    DropEvent,
     Flex,
     FlexItem,
     Popover,
@@ -20,9 +19,10 @@ import {
     Text,
     Title,
 } from '@patternfly/react-core';
+import type { DropEvent } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import sortBy from 'lodash/sortBy';
-import { ParsedQs } from 'qs';
+import type { ParsedQs } from 'qs';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 import usePermissions from 'hooks/usePermissions';
@@ -34,7 +34,7 @@ import { getQueryObject } from 'utils/queryStringUtils';
 import { fetchNetworkPoliciesByClusterId } from 'services/NetworkService';
 
 import ViewActiveYAMLs from './ViewActiveYAMLs';
-import {
+import type {
     NetworkPolicySimulator,
     SetNetworkPolicyModification,
 } from '../hooks/useNetworkPolicySimulator';
@@ -46,7 +46,7 @@ import {
 import UploadYAMLButton from './UploadYAMLButton';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 import NotifyYAMLModal from './NotifyYAMLModal';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import CompareYAMLModal from './CompareYAMLModal';
 import CodeCompareIcon from './CodeCompareIcon';
 import NetworkPoliciesGenerationScope from './NetworkPoliciesGenerationScope';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { DropdownItem, DropEvent, Split, SplitItem } from '@patternfly/react-core';
+import { DropdownItem, Split, SplitItem } from '@patternfly/react-core';
+import type { DropEvent } from '@patternfly/react-core';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import UploadYAMLButton from './UploadYAMLButton';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
 import { Alert, Bullseye, Button, Modal, Spinner } from '@patternfly/react-core';
 
-import { NetworkPolicyModification } from 'types/networkPolicy.proto';
+import type { NetworkPolicyModification } from 'types/networkPolicy.proto';
 import useTableSelection from 'hooks/useTableSelection';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { notifyNetworkPolicyModification } from 'services/NetworkService';
@@ -11,7 +12,7 @@ import useFetchNotifiers from './useFetchNotifiers';
 
 type NotifyYAMLModalProps = {
     isModalOpen: boolean;
-    setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    setIsModalOpen: Dispatch<SetStateAction<boolean>>;
     clusterId: string;
     modification: NetworkPolicyModification | null;
 };
@@ -21,7 +22,7 @@ function NotifyYAMLModal({
     setIsModalOpen,
     clusterId,
     modification,
-}: NotifyYAMLModalProps): React.ReactElement {
+}: NotifyYAMLModalProps): ReactElement {
     const { notifiers, isLoading, error } = useFetchNotifiers();
     const [errorMessage, setErrorMessage] = React.useState(error);
     const { selected, allRowsSelected, onSelect, onSelectAll, getSelectedIds, onClearAll } =
@@ -48,7 +49,7 @@ function NotifyYAMLModal({
         setIsModalOpen(!isModalOpen);
     }
 
-    let content: React.ReactElement = <div />;
+    let content: ReactElement = <div />;
 
     if (isLoading) {
         content = (

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { networkBasePath } from 'routePaths';
 import useAnalytics, { CLUSTER_LEVEL_SIMULATOR_OPENED } from 'hooks/useAnalytics';
 import useURLParameter from 'hooks/useURLParameter';
-import { Simulation } from '../utils/getSimulation';
+import type { Simulation } from '../utils/getSimulation';
 import { getPropertiesForAnalytics } from '../utils/networkGraphURLUtils';
 
 import { useSearchFilter } from '../NetworkGraphURLStateContext';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { ScreenIcon } from '@patternfly/react-icons';
 
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 type SimulationFrameProps = {
     isSimulating: boolean;
-    children: React.ReactNode;
+    children: ReactNode;
 };
 
-function SimulationFrame({ isSimulating, children }: SimulationFrameProps) {
+function SimulationFrame({ isSimulating, children }: SimulationFrameProps): ReactElement {
     let style = {};
     if (isSimulating) {
         style = { position: 'relative', border: '5px solid var(--pf-v5-global--info-color--100' };

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/UploadYAMLButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/UploadYAMLButton.tsx
@@ -1,4 +1,5 @@
-import { Button, DropEvent, FileUpload } from '@patternfly/react-core';
+import { Button, FileUpload } from '@patternfly/react-core';
+import type { DropEvent } from '@patternfly/react-core';
 import { FileUploadIcon } from '@patternfly/react-icons';
 import React from 'react';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -5,10 +5,10 @@ import {
     Stack,
     StackItem,
     EmptyStateHeader,
-    DropEvent,
     SelectOption,
 } from '@patternfly/react-core';
-import { NetworkPolicy } from 'types/networkPolicy.proto';
+import type { DropEvent } from '@patternfly/react-core';
+import type { NetworkPolicy } from 'types/networkPolicy.proto';
 import SelectSingle from 'Components/SelectSingle';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
 import NetworkSimulatorActions from './NetworkSimulatorActions';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/useFetchNotifiers.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/useFetchNotifiers.ts
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import {
-    NotifierIntegrationBase,
-    fetchNotifierIntegrations,
-} from 'services/NotifierIntegrationsService';
+import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
+import type { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
 
 type Result = { isLoading: boolean; notifiers: NotifierIntegrationBase[]; error: string | null };
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/flow.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/flow.type.ts
@@ -1,4 +1,4 @@
-import { L4Protocol } from 'types/networkFlow.proto';
+import type { L4Protocol } from 'types/networkFlow.proto';
 
 export type EntityType = 'DEPLOYMENT' | 'INTERNET' | 'EXTERNAL_SOURCE' | 'INTERNAL_ENTITIES';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/networkScopeHierarchy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/networkScopeHierarchy.ts
@@ -1,4 +1,4 @@
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 export type NetworkScopeHierarchy = {
     cluster: {

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -1,7 +1,7 @@
-import { EdgeModel, EdgeTerminalType, Model, NodeModel } from '@patternfly/react-topology';
+import type { EdgeModel, EdgeTerminalType, Model, NodeModel } from '@patternfly/react-topology';
 
-import { DeploymentDetails, EdgeProperties, OutEdges } from 'types/networkFlow.proto';
-import { Override } from 'utils/type.utils';
+import type { DeploymentDetails, EdgeProperties, OutEdges } from 'types/networkFlow.proto';
+import type { Override } from 'utils/type.utils';
 
 export type CustomModel = Override<Model, { nodes: CustomNodeModel[]; edges: CustomEdgeModel[] }>;
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.test.ts
@@ -1,6 +1,6 @@
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import { Flow, Peer } from '../types/flow.type';
-import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
+import type { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import type { Flow, Peer } from '../types/flow.type';
+import type { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 import {
     filterNetworkFlows,
     getAllUniquePorts,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -1,17 +1,17 @@
 import uniq from 'lodash/uniq';
 
-import { NetworkBaselinePeerStatus } from 'types/networkBaseline.proto';
-import {
+import type { NetworkBaselinePeerStatus } from 'types/networkBaseline.proto';
+import type {
     ExternalNetworkFlowProperties,
     L4Protocol,
     NetworkEntityInfoType as EntityType,
     DeploymentNetworkEntityInfo,
 } from 'types/networkFlow.proto';
-import { GroupedDiffFlows } from 'types/networkPolicyService';
+import type { GroupedDiffFlows } from 'types/networkPolicyService';
 
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import { BaselineSimulationDiffState, Flow, FlowEntityType, Peer } from '../types/flow.type';
-import {
+import type { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import type { BaselineSimulationDiffState, Flow, FlowEntityType, Peer } from '../types/flow.type';
+import type {
     CustomEdgeModel,
     CustomNodeModel,
     CustomSingleNodeData,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
@@ -1,4 +1,4 @@
-import { QueryValue } from 'hooks/useURLParameter';
+import type { QueryValue } from 'hooks/useURLParameter';
 
 export type SimulationType = 'baseline' | 'networkPolicy';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -1,6 +1,6 @@
 import { EdgeStyle, EdgeTerminalType, NodeShape } from '@patternfly/react-topology';
 
-import {
+import type {
     DeploymentNetworkEntityInfo,
     ExternalSourceNetworkEntityInfo,
     InternetNetworkEntityInfo,
@@ -12,7 +12,7 @@ import {
     InternalNetworkEntitiesInfo,
 } from 'types/networkFlow.proto';
 import { ensureExhaustive } from 'utils/type.utils';
-import {
+import type {
     CustomModel,
     CustomNodeModel,
     ExternalGroupNodeModel,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.ts
@@ -1,6 +1,6 @@
 import { networkBasePath } from 'routePaths';
 import { getQueryString } from 'utils/queryStringUtils';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 type GetURLLinkToDeploymentParams = {
     cluster: string;

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
@@ -1,6 +1,6 @@
-import { ListenPort } from 'types/networkFlow.proto';
-import { CustomEdgeModel, CustomNodeModel, DeploymentNodeModel } from '../types/topology.type';
-import { Flow } from '../types/flow.type';
+import type { ListenPort } from 'types/networkFlow.proto';
+import type { CustomEdgeModel, CustomNodeModel, DeploymentNodeModel } from '../types/topology.type';
+import type { Flow } from '../types/flow.type';
 
 /* node helper functions */
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -1,6 +1,6 @@
-import { NetworkPolicyModification } from 'types/networkPolicy.proto';
-import { SearchFilter } from 'types/search';
-import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
+import type { NetworkPolicyModification } from 'types/networkPolicy.proto';
+import type { SearchFilter } from 'types/search';
+import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export function getDisplayYAMLFromNetworkPolicyModification(
     modification: NetworkPolicyModification | null

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/timeWindow.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/timeWindow.ts
@@ -1,6 +1,6 @@
 import { subHours, subWeeks, subMonths } from 'date-fns';
 
-import { TimeWindow } from 'constants/timeWindows';
+import type { TimeWindow } from 'constants/timeWindows';
 
 function timeWindowToDate(timeWindow: TimeWindow): Date {
     const now = new Date();


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.