### PR TITLE
ROX-31210: Use import type in Containers Violations

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -777,7 +777,6 @@ module.exports = [
             'src/Containers/SystemConfig/**',
             'src/Containers/SystemHealth/**',
             'src/Containers/User/**',
-            'src/Containers/Violations/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
             'src/Containers/Workflow/**', // deprecated

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
 
-import { Deployment } from 'types/deployment.proto';
+import type { Deployment } from 'types/deployment.proto';
 import { vulnerabilitiesPlatformPath, vulnerabilitiesUserWorkloadsPath } from 'routePaths';
 import ContainerConfigurationDescriptionList from './ContainerConfigurationDescriptionList';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { Container } from 'types/deployment.proto';
+import type { Container } from 'types/deployment.proto';
 
 import ContainerImage from './ContainerImage';
 import ContainerResourcesDescriptionList from './ContainerResourcesDescriptionList';

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import DescriptionListItem from 'Components/DescriptionListItem';

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerResourcesDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerResourcesDescriptionList.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { ContainerResources } from 'types/deployment.proto';
+import type { ContainerResources } from 'types/deployment.proto';
 
 export type ContainerResourcesDescriptionListProps = {
     resources: ContainerResources;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerSecretDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerSecretDescriptionList.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { EmbeddedSecret } from 'types/deployment.proto';
+import type { EmbeddedSecret } from 'types/deployment.proto';
 
 export type ContainerSecretDescriptionListProps = {
     secret: EmbeddedSecret;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerVolumeDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerVolumeDescriptionList.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { ContainerVolume } from 'types/deployment.proto';
+import type { ContainerVolume } from 'types/deployment.proto';
 
 export type ContainerVolumeDescriptionListProps = {
     volume: ContainerVolume;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -1,11 +1,12 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 import { vulnerabilitiesPlatformPath, vulnerabilitiesUserWorkloadsPath } from 'routePaths';
-import { AlertDeployment } from 'types/alert.proto';
-import { Deployment } from 'types/deployment.proto';
+import type { AlertDeployment } from 'types/alert.proto';
+import type { Deployment } from 'types/deployment.proto';
 import { getDateTime } from 'utils/dateUtils';
 
 import FlatObjectDescriptionList from './FlatObjectDescriptionList';

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Card, CardBody, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
 import useFetchDeployment from 'hooks/useFetchDeployment';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-import { AlertDeployment } from 'types/alert.proto';
+import type { AlertDeployment } from 'types/alert.proto';
 
 import DeploymentOverview from './DeploymentOverview';
 import SecurityContext from './SecurityContext';

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithoutReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithoutReadAccessForDeployment.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
-import { AlertDeployment } from 'types/alert.proto';
+import type { AlertDeployment } from 'types/alert.proto';
 
 import DeploymentOverview from './DeploymentOverview';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/FlatObjectDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/FlatObjectDescriptionList.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
 
-import { Deployment } from 'types/deployment.proto';
+import type { Deployment } from 'types/deployment.proto';
 import PortDescriptionList from './PortDescriptionList';
 
 export type PortConfigurationProps = {

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortDescriptionList.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 import { portExposureLabels } from 'messages/common';
-import { PortConfig } from 'types/deployment.proto';
+import type { PortConfig } from 'types/deployment.proto';
 
 type PortDescriptionListProps = {
     port: PortConfig;

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { Deployment } from 'types/deployment.proto';
+import type { Deployment } from 'types/deployment.proto';
 
 export type SecurityContextProps = {
     deployment: Deployment | null;

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploytimeMessages.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploytimeMessages.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Card, CardBody } from '@patternfly/react-core';
 
 type DeploytimeMessageProps = {

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Divider } from '@patternfly/react-core';
 
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
-import { LifecycleStage } from 'types/policy.proto';
+import type { LifecycleStage } from 'types/policy.proto';
 
 function getEnforcementExplanation(lifecycleStage: LifecycleStage, message: string) {
     if (lifecycleStage === LIFECYCLE_STAGES.DEPLOY) {

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import { ENFORCEMENT_ACTIONS, ENFORCEMENT_ACTIONS_AS_STRING } from 'constants/enforcementActions';
-import { LifecycleStage } from 'types/policy.proto';
+import type { LifecycleStage } from 'types/policy.proto';
 
 function getDeployHeader(count) {
     let message = '';

--- a/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import uniqBy from 'lodash/uniqBy';
 import { Flex, FlexItem, Divider, Card } from '@patternfly/react-core';
 
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
-import { Alert } from 'types/alert.proto';
+import type { Alert } from 'types/alert.proto';
 import Header from './Enforcement/Header';
 import Explanation from './Enforcement/Explanation';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import capitalize from 'lodash/capitalize';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Card,
     CardHeader,
@@ -9,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { NetworkFlowInfo } from 'types/alert.proto';
+import type { NetworkFlowInfo } from 'types/alert.proto';
 import { getDateTime } from 'utils/dateUtils';
 
 export type NetworkFlowCardProps = {

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPoliciesTab.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPoliciesTab.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Button, Card, CardBody, CardTitle, List, ListItem } from '@patternfly/react-core';
 
 import { fetchNetworkPoliciesInNamespace } from 'services/NetworkService';
-import { NetworkPolicy } from 'types/networkPolicy.proto';
+import type { NetworkPolicy } from 'types/networkPolicy.proto';
 
 import NetworkPolicyModal from './NetworkPolicyModal';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPolicyModal.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPolicyModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Flex, Modal } from '@patternfly/react-core';
 
-import { NetworkPolicy } from 'types/networkPolicy.proto';
+import type { NetworkPolicy } from 'types/networkPolicy.proto';
 import download from 'utils/download';
 import CodeViewer from 'Components/CodeViewer';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/RuntimeMessages.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/RuntimeMessages.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
-import { ProcessViolation, Violation } from 'types/alert.proto';
+import type { ProcessViolation, Violation } from 'types/alert.proto';
 import ProcessCard from './ProcessCard';
 import NetworkFlowCard from './NetworkFlowCard';
 import K8sCard from './K8sCard';

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetails.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Divider, Flex, FlexItem, Title } from '@patternfly/react-core';
 
-import { LifecycleStage } from 'types/policy.proto';
-import { ProcessViolation, Violation } from 'types/alert.proto';
+import type { LifecycleStage } from 'types/policy.proto';
+import type { ProcessViolation, Violation } from 'types/alert.proto';
 
 import DeploytimeMessages from './DeploytimeMessages';
 import RuntimeMessages from './RuntimeMessages';

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import startCase from 'lodash/startCase';
 import {
@@ -19,7 +20,8 @@ import { getClientWizardPolicy } from 'Containers/Policies/policies.utils';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
 import { fetchAlert } from 'services/AlertsService';
-import { Alert, isDeploymentAlert, isResourceAlert } from 'types/alert.proto';
+import { isDeploymentAlert, isResourceAlert } from 'types/alert.proto';
+import type { Alert } from 'types/alert.proto';
 import { getDateTime } from 'utils/dateUtils';
 import { VIOLATION_STATE_LABELS } from 'constants/violationStates';
 

--- a/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
@@ -1,11 +1,12 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
 
 import { excludeDeployments } from 'services/PoliciesService';
-import { DeploymentListAlert, ListAlert } from 'types/alert.proto';
+import type { DeploymentListAlert, ListAlert } from 'types/alert.proto';
 import useRestMutation from 'hooks/useRestMutation';
-import { Empty } from 'services/types';
+import type { Empty } from 'services/types';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 // Filter the excludableAlerts displayed down to the ones checked, and group them into a map from policy ID to a list of

--- a/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 import { Button, Modal } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/ViolationNotFoundPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationNotFoundPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import { violationsBasePath } from 'routePaths';
 import useFilteredWorkflowViewURLState, {

--- a/ui/apps/platform/src/Containers/Violations/ViolationsBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsBreadcrumbs.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Breadcrumb, BreadcrumbItem, Divider, PageSection } from '@patternfly/react-core';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
+import type { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 
 import {
     violationsFullViewPath,

--- a/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import ViolationsTablePage from './ViolationsTablePage';

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, ReactElement } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Bullseye,
@@ -21,14 +22,14 @@ import useEntitiesByIdsCache from 'hooks/useEntitiesByIdsCache';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import { VIOLATION_STATES } from 'constants/violationStates';
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
-import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
-import { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
-import { SearchFilter } from 'types/search';
+import type { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
+import type { SearchFilter } from 'types/search';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useEffectAfterFirstRender from 'hooks/useEffectAfterFirstRender';
 import useURLSort from 'hooks/useURLSort';
-import { SortOption } from 'types/table';
+import type { SortOption } from 'types/table';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
 import useInterval from 'hooks/useInterval';
@@ -36,7 +37,8 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useFilteredWorkflowViewURLState from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
 import ViolationsTablePanel from './ViolationsTablePanel';
 import { getViolationsTableColumnDescriptors } from './violationsTableColumnDescriptors';
-import { ViolationStateTab, violationStateTabs } from './types';
+import { violationStateTabs } from './types';
+import type { ViolationStateTab } from './types';
 
 import './ViolationsTablePage.css';
 

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -1,4 +1,5 @@
-import React, { useState, ReactElement } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     AlertActionCloseButton,
@@ -22,16 +23,16 @@ import TableCell from 'Components/PatternFly/TableCell';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
 import useTableSelection from 'hooks/useTableSelection';
-import { GetSortParams } from 'hooks/useURLSort';
+import type { GetSortParams } from 'hooks/useURLSort';
 import useRestMutation from 'hooks/useRestMutation';
 import useToasts from 'hooks/patternfly/useToasts';
 import { resolveAlert } from 'services/AlertsService';
 import { excludeDeployments } from 'services/PoliciesService';
-import { ListAlert } from 'types/alert.proto';
-import { TableColumn } from 'types/table';
+import type { ListAlert } from 'types/alert.proto';
+import type { TableColumn } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { SearchFilter } from 'types/search';
-import { OnSearchCallback } from 'Components/CompoundSearchFilter/types';
+import type { SearchFilter } from 'types/search';
+import type { OnSearchCallback } from 'Components/CompoundSearchFilter/types';
 import ResolveConfirmation from './Modals/ResolveConfirmation';
 import ExcludeConfirmation from './Modals/ExcludeConfirmation';
 import ViolationsTableSearchFilter from './ViolationsTableSearchFilter';

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import useAnalytics from 'hooks/useAnalytics';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
-import {
+import type {
     CompoundSearchFilterConfig,
     OnSearchCallback,
     OnSearchPayload,

--- a/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import startCase from 'lodash/startCase';
@@ -15,8 +16,8 @@ import {
 import { resourceTypes } from 'constants/entityTypes';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import { violationsBasePath } from 'routePaths';
-import { ListAlert } from 'types/alert.proto';
-import { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
+import type { ListAlert } from 'types/alert.proto';
+import type { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
 import { getDateTime } from 'utils/dateUtils';
 
 type EntityTableCellProps = {


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.