### PR TITLE
ROX-31216: show signature integration name

### DIFF
--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -748,6 +748,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"verificationTime: Time",
 		"verifiedImageReferences: [String!]!",
 		"verifierId: String!",
+		"verifierName: String!",
 	}))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.ImageSignatureVerificationResult_Status(0)))
 	utils.Must(builder.AddType("ImageV2", []string{
@@ -8913,6 +8914,11 @@ func (resolver *imageSignatureVerificationResultResolver) VerifiedImageReference
 
 func (resolver *imageSignatureVerificationResultResolver) VerifierId(ctx context.Context) string {
 	value := resolver.data.GetVerifierId()
+	return value
+}
+
+func (resolver *imageSignatureVerificationResultResolver) VerifierName(ctx context.Context) string {
+	value := resolver.data.GetVerifierName()
 	return value
 }
 

--- a/central/graphql/resolvers/vulnerability_requests_test.go
+++ b/central/graphql/resolvers/vulnerability_requests_test.go
@@ -807,7 +807,7 @@ func (s *VulnRequestResolverTestSuite) TestGetVulnerabilityRequests() {
 func getQueryWithVulnReqSelector(name, function string) string {
 	return fmt.Sprintf(
 		`%s {
-			%s { 
+			%s {
 				%s
 			}}`,
 		name,

--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/signatureintegration"
 )
 
 // DataStore is an intermediary to AlertStorage.
@@ -35,6 +36,10 @@ type DataStore interface {
 
 	DeleteImages(ctx context.Context, ids ...string) error
 	Exists(ctx context.Context, id string) (bool, error)
+
+	// SetSignatureIntegrationGetterFunc sets the function to get signature integrations.
+	// This is used to break the circular dependency with the signature integration datastore.
+	SetSignatureIntegrationGetterFunc(fn signatureintegration.GetterFunc)
 }
 
 // NewWithPostgres returns a new instance of DataStore using the input store, and searcher.

--- a/central/image/datastore/datastore_impl_signature_integration_test.go
+++ b/central/image/datastore/datastore_impl_signature_integration_test.go
@@ -1,0 +1,284 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	mockStore "github.com/stackrox/rox/central/image/datastore/store/mocks"
+	"github.com/stackrox/rox/central/ranking"
+	mockRisks "github.com/stackrox/rox/central/risk/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/signatureintegration"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+type mockSignatureIntegrationGetter struct {
+	integrations map[string]*storage.SignatureIntegration
+}
+
+func (m *mockSignatureIntegrationGetter) GetSignatureIntegration(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error) {
+	integration, found := m.integrations[id]
+	return integration, found, nil
+}
+
+func TestSignatureIntegrationInjection(t *testing.T) {
+	suite.Run(t, new(SignatureIntegrationTestSuite))
+}
+
+type SignatureIntegrationTestSuite struct {
+	suite.Suite
+
+	ctx        context.Context
+	mockCtrl   *gomock.Controller
+	mockStore  *mockStore.MockStore
+	mockRisk   *mockRisks.MockDataStore
+	datastore  DataStore
+	mockGetter *mockSignatureIntegrationGetter
+}
+
+func (s *SignatureIntegrationTestSuite) SetupTest() {
+	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Image),
+		),
+	)
+
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockStore = mockStore.NewMockStore(s.mockCtrl)
+	s.mockRisk = mockRisks.NewMockDataStore(s.mockCtrl)
+
+	// Mock the initializeRankers call that happens in a goroutine
+	s.mockStore.EXPECT().GetImagesRiskView(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	s.datastore = NewWithPostgres(s.mockStore, s.mockRisk, ranking.NewRanker(), ranking.NewRanker())
+
+	s.mockGetter = &mockSignatureIntegrationGetter{
+		integrations: map[string]*storage.SignatureIntegration{
+			"integration-1": {
+				Id:   "integration-1",
+				Name: "Test Integration 1",
+			},
+			"integration-2": {
+				Id:   "integration-2",
+				Name: "Test Integration 2",
+			},
+		},
+	}
+}
+
+func (s *SignatureIntegrationTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *SignatureIntegrationTestSuite) TestInjectSignatureIntegrationName_WithoutGetter() {
+	// Test that method gracefully handles case where getter is not set
+	image := s.createTestImageWithSignatures()
+
+	// Don't set the getter function - should log warning and not crash
+	result := []*storage.Image{image}
+
+	// Call the datastore method that internally calls injectSignatureIntegrationName
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.Image) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.Image) error {
+		// Verify that verifier names are still empty since getter wasn't set
+		for _, result := range img.GetSignatureVerificationData().GetResults() {
+			s.Empty(result.GetVerifierName(), "VerifierName should be empty when getter is not set")
+		}
+		return nil
+	})
+	s.NoError(err)
+
+	// Verify original verifier names are still empty
+	for _, result := range result[0].GetSignatureVerificationData().GetResults() {
+		s.Empty(result.GetVerifierName(), "VerifierName should remain empty without getter")
+	}
+}
+
+func (s *SignatureIntegrationTestSuite) TestInjectSignatureIntegrationName_WithGetter() {
+	// Set the getter function
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithSignatures()
+
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.Image) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.Image) error {
+		results := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(results, 2, "Should have 2 signature verification results")
+
+		// Verify that verifier names were injected correctly
+		s.Equal("Test Integration 1", results[0].GetVerifierName(), "First verifier name should be injected")
+		s.Equal("Test Integration 2", results[1].GetVerifierName(), "Second verifier name should be injected")
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *SignatureIntegrationTestSuite) TestInjectSignatureIntegrationName_UnknownIntegration() {
+	// Set the getter function
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithUnknownSignature()
+
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.Image) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.Image) error {
+		results := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(results, 1, "Should have 1 signature verification result")
+
+		// Verify that unknown integration ID results in empty verifier name
+		s.Empty(results[0].GetVerifierName(), "VerifierName should be empty for unknown integration")
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *SignatureIntegrationTestSuite) TestInjectSignatureIntegrationName_EmptyVerifierId() {
+	// Set the getter function
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithEmptyVerifierId()
+
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.Image) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.Image) error {
+		results := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(results, 1, "Should have 1 signature verification result")
+
+		// Verify that empty verifier ID results in empty verifier name
+		s.Empty(results[0].GetVerifierName(), "VerifierName should be empty for empty verifier ID")
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *SignatureIntegrationTestSuite) TestInjectSignatureIntegrationName_GetImageMetadata() {
+	// Test injection through GetImageMetadata method
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithSignatures()
+	imageID := "test-image-id"
+
+	s.mockStore.EXPECT().GetImageMetadata(gomock.Any(), imageID).Return(image, true, nil)
+
+	result, found, err := s.datastore.GetImageMetadata(s.ctx, imageID)
+	s.NoError(err)
+	s.True(found)
+	s.NotNil(result)
+
+	// Verify verifier names were injected
+	results := result.GetSignatureVerificationData().GetResults()
+	s.Require().Len(results, 2, "Should have 2 signature verification results")
+	s.Equal("Test Integration 1", results[0].GetVerifierName())
+	s.Equal("Test Integration 2", results[1].GetVerifierName())
+}
+
+func (s *SignatureIntegrationTestSuite) TestInjectSignatureIntegrationName_GetManyImageMetadata() {
+	// Test injection through GetManyImageMetadata method
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image1 := s.createTestImageWithSignatures()
+	image2 := s.createTestImageWithSignatures()
+	imageIDs := []string{"image1", "image2"}
+
+	s.mockStore.EXPECT().GetManyImageMetadata(gomock.Any(), imageIDs).Return([]*storage.Image{image1, image2}, nil)
+
+	results, err := s.datastore.GetManyImageMetadata(s.ctx, imageIDs)
+	s.NoError(err)
+	s.Len(results, 2)
+
+	// Verify both images have verifier names injected
+	for _, img := range results {
+		verificationResults := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(verificationResults, 2, "Should have 2 signature verification results")
+		s.Equal("Test Integration 1", verificationResults[0].GetVerifierName())
+		s.Equal("Test Integration 2", verificationResults[1].GetVerifierName())
+	}
+}
+
+// Helper methods
+
+func (s *SignatureIntegrationTestSuite) createTestImageWithSignatures() *storage.Image {
+	return &storage.Image{
+		Id: "test-image-id",
+		SignatureVerificationData: &storage.ImageSignatureVerificationData{
+			Results: []*storage.ImageSignatureVerificationResult{
+				{
+					VerifierId:   "integration-1",
+					Status:       storage.ImageSignatureVerificationResult_VERIFIED,
+					Description:  "Successfully verified with integration 1",
+					VerifierName: "", // Should be populated by injection
+				},
+				{
+					VerifierId:   "integration-2",
+					Status:       storage.ImageSignatureVerificationResult_VERIFIED,
+					Description:  "Successfully verified with integration 2",
+					VerifierName: "", // Should be populated by injection
+				},
+			},
+		},
+	}
+}
+
+func (s *SignatureIntegrationTestSuite) createTestImageWithUnknownSignature() *storage.Image {
+	return &storage.Image{
+		Id: "test-image-id",
+		SignatureVerificationData: &storage.ImageSignatureVerificationData{
+			Results: []*storage.ImageSignatureVerificationResult{
+				{
+					VerifierId:   "unknown-integration",
+					Status:       storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
+					Description:  "Unknown integration",
+					VerifierName: "", // Should remain empty
+				},
+			},
+		},
+	}
+}
+
+func (s *SignatureIntegrationTestSuite) createTestImageWithEmptyVerifierId() *storage.Image {
+	return &storage.Image{
+		Id: "test-image-id",
+		SignatureVerificationData: &storage.ImageSignatureVerificationData{
+			Results: []*storage.ImageSignatureVerificationResult{
+				{
+					VerifierId:   "", // Empty verifier ID
+					Status:       storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
+					Description:  "Empty verifier ID",
+					VerifierName: "", // Should remain empty
+				},
+			},
+		},
+	}
+}

--- a/central/image/datastore/mocks/datastore.go
+++ b/central/image/datastore/mocks/datastore.go
@@ -16,6 +16,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	search "github.com/stackrox/rox/pkg/search"
+	signatureintegration "github.com/stackrox/rox/pkg/signatureintegration"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -243,6 +244,18 @@ func (m *MockDataStore) SearchRawImages(ctx context.Context, q *v1.Query) ([]*st
 func (mr *MockDataStoreMockRecorder) SearchRawImages(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawImages", reflect.TypeOf((*MockDataStore)(nil).SearchRawImages), ctx, q)
+}
+
+// SetSignatureIntegrationGetterFunc mocks base method.
+func (m *MockDataStore) SetSignatureIntegrationGetterFunc(fn signatureintegration.GetterFunc) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSignatureIntegrationGetterFunc", fn)
+}
+
+// SetSignatureIntegrationGetterFunc indicates an expected call of SetSignatureIntegrationGetterFunc.
+func (mr *MockDataStoreMockRecorder) SetSignatureIntegrationGetterFunc(fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSignatureIntegrationGetterFunc", reflect.TypeOf((*MockDataStore)(nil).SetSignatureIntegrationGetterFunc), fn)
 }
 
 // UpdateVulnerabilityState mocks base method.

--- a/central/imagev2/datastore/datastore.go
+++ b/central/imagev2/datastore/datastore.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/signatureintegration"
 )
 
 // DataStore is an intermediary to ImageV2Storage.
@@ -31,6 +32,10 @@ type DataStore interface {
 
 	DeleteImages(ctx context.Context, ids ...string) error
 	Exists(ctx context.Context, id string) (bool, error)
+
+	// SetSignatureIntegrationGetterFunc sets the function to get signature integrations.
+	// This is used to break the circular dependency with the signature integration datastore.
+	SetSignatureIntegrationGetterFunc(fn signatureintegration.GetterFunc)
 }
 
 // NewWithPostgres returns a new instance of DataStore using the input store, and searcher.

--- a/central/imagev2/datastore/datastore_impl_signature_integration_test.go
+++ b/central/imagev2/datastore/datastore_impl_signature_integration_test.go
@@ -1,0 +1,316 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	mockStore "github.com/stackrox/rox/central/imagev2/datastore/store/mocks"
+	"github.com/stackrox/rox/central/ranking"
+	mockRisks "github.com/stackrox/rox/central/risk/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/signatureintegration"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+type mockSignatureIntegrationGetter struct {
+	integrations map[string]*storage.SignatureIntegration
+}
+
+func (m *mockSignatureIntegrationGetter) GetSignatureIntegration(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error) {
+	integration, found := m.integrations[id]
+	return integration, found, nil
+}
+
+func TestSignatureIntegrationInjectionV2(t *testing.T) {
+	suite.Run(t, new(SignatureIntegrationV2TestSuite))
+}
+
+type SignatureIntegrationV2TestSuite struct {
+	suite.Suite
+
+	ctx        context.Context
+	mockCtrl   *gomock.Controller
+	mockStore  *mockStore.MockStore
+	mockRisk   *mockRisks.MockDataStore
+	datastore  DataStore
+	mockGetter *mockSignatureIntegrationGetter
+}
+
+func (s *SignatureIntegrationV2TestSuite) SetupTest() {
+	s.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Image),
+		),
+	)
+
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockStore = mockStore.NewMockStore(s.mockCtrl)
+	s.mockRisk = mockRisks.NewMockDataStore(s.mockCtrl)
+
+	// Mock the initializeRankers call that happens in a goroutine
+	s.mockStore.EXPECT().GetImagesRiskView(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	s.datastore = NewWithPostgres(s.mockStore, s.mockRisk, ranking.NewRanker(), ranking.NewRanker())
+
+	s.mockGetter = &mockSignatureIntegrationGetter{
+		integrations: map[string]*storage.SignatureIntegration{
+			"integration-1": {
+				Id:   "integration-1",
+				Name: "Test Integration 1",
+			},
+			"integration-2": {
+				Id:   "integration-2",
+				Name: "Test Integration 2",
+			},
+		},
+	}
+}
+
+func (s *SignatureIntegrationV2TestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *SignatureIntegrationV2TestSuite) TestInjectSignatureIntegrationName_WithoutGetter() {
+	// Test that method gracefully handles case where getter is not set
+	image := s.createTestImageWithSignatures()
+
+	// Don't set the getter function - should log warning and not crash
+	result := []*storage.ImageV2{image}
+
+	// Call the datastore method that internally calls injectSignatureIntegrationName
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.ImageV2) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.ImageV2) error {
+		// Verify that verifier names are still empty since getter wasn't set
+		for _, result := range img.GetSignatureVerificationData().GetResults() {
+			s.Empty(result.GetVerifierName(), "VerifierName should be empty when getter is not set")
+		}
+		return nil
+	})
+	s.NoError(err)
+
+	// Verify original verifier names are still empty
+	for _, result := range result[0].GetSignatureVerificationData().GetResults() {
+		s.Empty(result.GetVerifierName(), "VerifierName should remain empty without getter")
+	}
+}
+
+func (s *SignatureIntegrationV2TestSuite) TestInjectSignatureIntegrationName_WithGetter() {
+	// Set the getter function
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithSignatures()
+
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.ImageV2) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.ImageV2) error {
+		results := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(results, 2, "Should have 2 signature verification results")
+
+		// Verify that verifier names were injected correctly
+		s.Equal("Test Integration 1", results[0].GetVerifierName(), "First verifier name should be injected")
+		s.Equal("Test Integration 2", results[1].GetVerifierName(), "Second verifier name should be injected")
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *SignatureIntegrationV2TestSuite) TestInjectSignatureIntegrationName_UnknownIntegration() {
+	// Set the getter function
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithUnknownSignature()
+
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.ImageV2) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.ImageV2) error {
+		results := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(results, 1, "Should have 1 signature verification result")
+
+		// Verify that unknown integration ID results in empty verifier name
+		s.Empty(results[0].GetVerifierName(), "VerifierName should be empty for unknown integration")
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *SignatureIntegrationV2TestSuite) TestInjectSignatureIntegrationName_EmptyVerifierId() {
+	// Set the getter function
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithEmptyVerifierId()
+
+	s.mockStore.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, q interface{}, fn func(*storage.ImageV2) error) error {
+			return fn(image)
+		},
+	)
+
+	err := s.datastore.WalkByQuery(s.ctx, nil, func(img *storage.ImageV2) error {
+		results := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(results, 1, "Should have 1 signature verification result")
+
+		// Verify that empty verifier ID results in empty verifier name
+		s.Empty(results[0].GetVerifierName(), "VerifierName should be empty for empty verifier ID")
+		return nil
+	})
+	s.NoError(err)
+}
+
+func (s *SignatureIntegrationV2TestSuite) TestInjectSignatureIntegrationName_GetImageMetadata() {
+	// Test injection through GetImageMetadata method
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image := s.createTestImageWithSignatures()
+	imageID := "test-image-id"
+
+	s.mockStore.EXPECT().GetImageMetadata(gomock.Any(), imageID).Return(image, true, nil)
+
+	result, found, err := s.datastore.GetImageMetadata(s.ctx, imageID)
+	s.NoError(err)
+	s.True(found)
+	s.NotNil(result)
+
+	// Verify verifier names were injected
+	results := result.GetSignatureVerificationData().GetResults()
+	s.Require().Len(results, 2, "Should have 2 signature verification results")
+	s.Equal("Test Integration 1", results[0].GetVerifierName())
+	s.Equal("Test Integration 2", results[1].GetVerifierName())
+}
+
+func (s *SignatureIntegrationV2TestSuite) TestInjectSignatureIntegrationName_GetManyImageMetadata() {
+	// Test injection through GetManyImageMetadata method
+	s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+		return s.mockGetter
+	})
+
+	image1 := s.createTestImageWithSignatures()
+	image2 := s.createTestImageWithSignatures()
+	imageIDs := []string{"image1", "image2"}
+
+	s.mockStore.EXPECT().GetManyImageMetadata(gomock.Any(), imageIDs).Return([]*storage.ImageV2{image1, image2}, nil)
+
+	results, err := s.datastore.GetManyImageMetadata(s.ctx, imageIDs)
+	s.NoError(err)
+	s.Len(results, 2)
+
+	// Verify both images have verifier names injected
+	for _, img := range results {
+		verificationResults := img.GetSignatureVerificationData().GetResults()
+		s.Require().Len(verificationResults, 2, "Should have 2 signature verification results")
+		s.Equal("Test Integration 1", verificationResults[0].GetVerifierName())
+		s.Equal("Test Integration 2", verificationResults[1].GetVerifierName())
+	}
+}
+
+func (s *SignatureIntegrationV2TestSuite) TestSetSignatureIntegrationGetterFunc_ThreadSafety() {
+	// Test that the setter is thread-safe
+	done := make(chan bool, 2)
+
+	// Simulate concurrent setter calls
+	go func() {
+		s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+			return s.mockGetter
+		})
+		done <- true
+	}()
+
+	go func() {
+		s.datastore.SetSignatureIntegrationGetterFunc(func() signatureintegration.Getter {
+			return &mockSignatureIntegrationGetter{integrations: make(map[string]*storage.SignatureIntegration)}
+		})
+		done <- true
+	}()
+
+	// Wait for both goroutines to complete
+	<-done
+	<-done
+
+	// Verify the datastore is still functional
+	image := s.createTestImageWithSignatures()
+	s.mockStore.EXPECT().GetImageMetadata(gomock.Any(), "test").Return(image, true, nil)
+
+	_, found, err := s.datastore.GetImageMetadata(s.ctx, "test")
+	s.NoError(err)
+	s.True(found)
+}
+
+// Helper methods
+
+func (s *SignatureIntegrationV2TestSuite) createTestImageWithSignatures() *storage.ImageV2 {
+	return &storage.ImageV2{
+		Id: "test-image-id",
+		SignatureVerificationData: &storage.ImageSignatureVerificationData{
+			Results: []*storage.ImageSignatureVerificationResult{
+				{
+					VerifierId:   "integration-1",
+					Status:       storage.ImageSignatureVerificationResult_VERIFIED,
+					Description:  "Successfully verified with integration 1",
+					VerifierName: "", // Should be populated by injection
+				},
+				{
+					VerifierId:   "integration-2",
+					Status:       storage.ImageSignatureVerificationResult_VERIFIED,
+					Description:  "Successfully verified with integration 2",
+					VerifierName: "", // Should be populated by injection
+				},
+			},
+		},
+	}
+}
+
+func (s *SignatureIntegrationV2TestSuite) createTestImageWithUnknownSignature() *storage.ImageV2 {
+	return &storage.ImageV2{
+		Id: "test-image-id",
+		SignatureVerificationData: &storage.ImageSignatureVerificationData{
+			Results: []*storage.ImageSignatureVerificationResult{
+				{
+					VerifierId:   "unknown-integration",
+					Status:       storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
+					Description:  "Unknown integration",
+					VerifierName: "", // Should remain empty
+				},
+			},
+		},
+	}
+}
+
+func (s *SignatureIntegrationV2TestSuite) createTestImageWithEmptyVerifierId() *storage.ImageV2 {
+	return &storage.ImageV2{
+		Id: "test-image-id",
+		SignatureVerificationData: &storage.ImageSignatureVerificationData{
+			Results: []*storage.ImageSignatureVerificationResult{
+				{
+					VerifierId:   "", // Empty verifier ID
+					Status:       storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
+					Description:  "Empty verifier ID",
+					VerifierName: "", // Should remain empty
+				},
+			},
+		},
+	}
+}

--- a/central/imagev2/datastore/mapper/datastore/datastore_impl.go
+++ b/central/imagev2/datastore/mapper/datastore/datastore_impl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/types"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
 	searchPkg "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/signatureintegration"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -222,4 +223,9 @@ func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
 		return ds.imageDataStore.Exists(ctx, id)
 	}
 	return ds.imageV2DataStore.Exists(ctx, id)
+}
+
+func (ds *datastoreImpl) SetSignatureIntegrationGetterFunc(fn signatureintegration.GetterFunc) {
+	ds.imageDataStore.SetSignatureIntegrationGetterFunc(fn)
+	ds.imageV2DataStore.SetSignatureIntegrationGetterFunc(fn)
 }

--- a/central/imagev2/datastore/mocks/datastore.go
+++ b/central/imagev2/datastore/mocks/datastore.go
@@ -16,6 +16,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	search "github.com/stackrox/rox/pkg/search"
+	signatureintegration "github.com/stackrox/rox/pkg/signatureintegration"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -197,6 +198,18 @@ func (m *MockDataStore) SearchRawImages(ctx context.Context, q *v1.Query) ([]*st
 func (mr *MockDataStoreMockRecorder) SearchRawImages(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchRawImages", reflect.TypeOf((*MockDataStore)(nil).SearchRawImages), ctx, q)
+}
+
+// SetSignatureIntegrationGetterFunc mocks base method.
+func (m *MockDataStore) SetSignatureIntegrationGetterFunc(fn signatureintegration.GetterFunc) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSignatureIntegrationGetterFunc", fn)
+}
+
+// SetSignatureIntegrationGetterFunc indicates an expected call of SetSignatureIntegrationGetterFunc.
+func (mr *MockDataStoreMockRecorder) SetSignatureIntegrationGetterFunc(fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSignatureIntegrationGetterFunc", reflect.TypeOf((*MockDataStore)(nil).SetSignatureIntegrationGetterFunc), fn)
 }
 
 // UpdateVulnerabilityState mocks base method.

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestImagesWithSignaturesQuery(t *testing.T) {
-
 	testCtx := sac.WithAllAccess(context.Background())
 
 	testingDB := pgtest.ForT(t)

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -1476,6 +1476,10 @@
           "type": "string",
           "description": "verifier_id correlates to the ID of the signature integration used to verify the signature."
         },
+        "verifierName": {
+          "type": "string",
+          "description": "verifier_name is the name of the signature integration associated with `verifier_id`."
+        },
         "status": {
           "$ref": "#/definitions/storageImageSignatureVerificationResultStatus"
         },
@@ -1491,7 +1495,7 @@
           "description": "The full image names that are verified by this specific signature integration ID."
         }
       },
-      "title": "Next Tag: 6"
+      "title": "Next Tag: 7"
     },
     "storageImageSignatureVerificationResultStatus": {
       "type": "string",

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -1183,6 +1183,10 @@
           "type": "string",
           "description": "verifier_id correlates to the ID of the signature integration used to verify the signature."
         },
+        "verifierName": {
+          "type": "string",
+          "description": "verifier_name is the name of the signature integration associated with `verifier_id`."
+        },
         "status": {
           "$ref": "#/definitions/storageImageSignatureVerificationResultStatus"
         },
@@ -1198,7 +1202,7 @@
           "description": "The full image names that are verified by this specific signature integration ID."
         }
       },
-      "title": "Next Tag: 6"
+      "title": "Next Tag: 7"
     },
     "storageImageSignatureVerificationResultStatus": {
       "type": "string",

--- a/generated/storage/image.pb.go
+++ b/generated/storage/image.pb.go
@@ -751,13 +751,15 @@ func (x *ImageSignatureVerificationData) GetResults() []*ImageSignatureVerificat
 	return nil
 }
 
-// Next Tag: 6
+// Next Tag: 7
 type ImageSignatureVerificationResult struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	VerificationTime *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=verification_time,json=verificationTime,proto3" json:"verification_time,omitempty"`
 	// verifier_id correlates to the ID of the signature integration used to verify the signature.
-	VerifierId string                                  `protobuf:"bytes,2,opt,name=verifier_id,json=verifierId,proto3" json:"verifier_id,omitempty"`
-	Status     ImageSignatureVerificationResult_Status `protobuf:"varint,3,opt,name=status,proto3,enum=storage.ImageSignatureVerificationResult_Status" json:"status,omitempty"`
+	VerifierId string `protobuf:"bytes,2,opt,name=verifier_id,json=verifierId,proto3" json:"verifier_id,omitempty"`
+	// verifier_name is the name of the signature integration associated with `verifier_id`.
+	VerifierName string                                  `protobuf:"bytes,6,opt,name=verifier_name,json=verifierName,proto3" json:"verifier_name,omitempty"`
+	Status       ImageSignatureVerificationResult_Status `protobuf:"varint,3,opt,name=status,proto3,enum=storage.ImageSignatureVerificationResult_Status" json:"status,omitempty"`
 	// description is set in the case of an error with the specific error's message. Otherwise, this will not be set.
 	Description string `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
 	// The full image names that are verified by this specific signature integration ID.
@@ -806,6 +808,13 @@ func (x *ImageSignatureVerificationResult) GetVerificationTime() *timestamppb.Ti
 func (x *ImageSignatureVerificationResult) GetVerifierId() string {
 	if x != nil {
 		return x.VerifierId
+	}
+	return ""
+}
+
+func (x *ImageSignatureVerificationResult) GetVerifierName() string {
+	if x != nil {
+		return x.VerifierName
 	}
 	return ""
 }
@@ -1980,11 +1989,12 @@ const file_storage_image_proto_rawDesc = "" +
 	"\x1fCERTIFIED_RHEL_SCAN_UNAVAILABLE\x10\x06B\v\n" +
 	"\thashoneof\"e\n" +
 	"\x1eImageSignatureVerificationData\x12C\n" +
-	"\aresults\x18\x01 \x03(\v2).storage.ImageSignatureVerificationResultR\aresults\"\xb9\x03\n" +
+	"\aresults\x18\x01 \x03(\v2).storage.ImageSignatureVerificationResultR\aresults\"\xde\x03\n" +
 	" ImageSignatureVerificationResult\x12G\n" +
 	"\x11verification_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x10verificationTime\x12\x1f\n" +
 	"\vverifier_id\x18\x02 \x01(\tR\n" +
-	"verifierId\x12H\n" +
+	"verifierId\x12#\n" +
+	"\rverifier_name\x18\x06 \x01(\tR\fverifierName\x12H\n" +
 	"\x06status\x18\x03 \x01(\x0e20.storage.ImageSignatureVerificationResult.StatusR\x06status\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12:\n" +
 	"\x19verified_image_references\x18\x05 \x03(\tR\x17verifiedImageReferences\"\x82\x01\n" +

--- a/generated/storage/image_vtproto.pb.go
+++ b/generated/storage/image_vtproto.pb.go
@@ -204,6 +204,7 @@ func (m *ImageSignatureVerificationResult) CloneVT() *ImageSignatureVerification
 	r := new(ImageSignatureVerificationResult)
 	r.VerificationTime = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.VerificationTime).CloneVT())
 	r.VerifierId = m.VerifierId
+	r.VerifierName = m.VerifierName
 	r.Status = m.Status
 	r.Description = m.Description
 	if rhs := m.VerifiedImageReferences; rhs != nil {
@@ -983,6 +984,9 @@ func (this *ImageSignatureVerificationResult) EqualVT(that *ImageSignatureVerifi
 		if vx != vy {
 			return false
 		}
+	}
+	if this.VerifierName != that.VerifierName {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -2142,6 +2146,13 @@ func (m *ImageSignatureVerificationResult) MarshalToSizedBufferVT(dAtA []byte) (
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.VerifierName) > 0 {
+		i -= len(m.VerifierName)
+		copy(dAtA[i:], m.VerifierName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.VerifierName)))
+		i--
+		dAtA[i] = 0x32
 	}
 	if len(m.VerifiedImageReferences) > 0 {
 		for iNdEx := len(m.VerifiedImageReferences) - 1; iNdEx >= 0; iNdEx-- {
@@ -3411,6 +3422,10 @@ func (m *ImageSignatureVerificationResult) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	l = len(m.VerifierName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5115,6 +5130,38 @@ func (m *ImageSignatureVerificationResult) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.VerifiedImageReferences = append(m.VerifiedImageReferences, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VerifierName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.VerifierName = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -8993,6 +9040,42 @@ func (m *ImageSignatureVerificationResult) UnmarshalVTUnsafe(dAtA []byte) error 
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.VerifiedImageReferences = append(m.VerifiedImageReferences, stringValue)
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VerifierName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.VerifierName = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/signatureintegration/getter.go
+++ b/pkg/signatureintegration/getter.go
@@ -1,0 +1,37 @@
+package signatureintegration
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// Getter is a subset of the signature integration datastore, which is used by
+// the image datastore to query signature integration for their name.
+// The getter allows us to enrich the signature verification results with a user readable
+// integration name when images are queried. The goal is to avoid the data denormalization
+// that would otherwise occur if we were to set the name upon verification time. This is
+// because integration names may change over time, but ids are immutable.
+type Getter interface {
+	GetSignatureIntegration(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error)
+}
+
+type GetterFunc func() Getter
+
+// GetVerifierName returns the signature integration name for a verification result.
+func GetVerifierName(ctx context.Context, getter Getter, result *storage.ImageSignatureVerificationResult) (string, error) {
+	verifierID := result.GetVerifierId()
+	if verifierID == "" {
+		return "", errors.New("empty verifier ID")
+	}
+	verifier, found, err := getter.GetSignatureIntegration(ctx, verifierID)
+	if !found {
+		return "", nil
+	}
+	if err != nil {
+		return "", errors.Wrap(err, "getting signature integration")
+	}
+
+	return verifier.GetName(), nil
+}

--- a/proto/storage/image.proto
+++ b/proto/storage/image.proto
@@ -90,11 +90,13 @@ message ImageSignatureVerificationData {
   repeated ImageSignatureVerificationResult results = 1;
 }
 
-// Next Tag: 6
+// Next Tag: 7
 message ImageSignatureVerificationResult {
   google.protobuf.Timestamp verification_time = 1;
   // verifier_id correlates to the ID of the signature integration used to verify the signature.
   string verifier_id = 2;
+  // verifier_name is the name of the signature integration associated with `verifier_id`.
+  string verifier_name = 6;
   // Status represents the status of the result.
   enum Status {
     UNSET = 0;

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -8776,6 +8776,11 @@
                 "type": "string"
               },
               {
+                "id": 6,
+                "name": "verifier_name",
+                "type": "string"
+              },
+              {
                 "id": 3,
                 "name": "status",
                 "type": "Status"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageSignatureVerification.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageSignatureVerification.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { Divider, Flex, FlexItem, Label, PageSection, Text } from '@patternfly/react-core';
 import { Table, TableText, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+import { integrationsPath } from 'routePaths';
 
 import DateDistance from 'Components/DateDistance';
+import useIntegrationPermissions from 'Containers/Integrations/hooks/useIntegrationPermissions';
 import { SignatureVerificationResult, VerifiedStatus } from '../../types';
 
 export type ImagePageSignatureVerificationProps = {
@@ -46,6 +49,23 @@ function getStatusMessage({ status, description }: SignatureVerificationResult) 
 }
 
 function ImagePageSignatureVerification({ results }: ImagePageSignatureVerificationProps) {
+    const permissions = useIntegrationPermissions();
+    const getIntegrationDetailsUrl = (verifierId: string): string => {
+        return `${integrationsPath}/signatureIntegrations/signature/view/${verifierId}`;
+    };
+
+    const renderIntegrationCell = (result: SignatureVerificationResult) => {
+        const displayName = result.verifierName || result.verifierId;
+
+        // Show as link only if user has permissions.
+        if (permissions.signatureIntegrations.read) {
+            return <Link to={getIntegrationDetailsUrl(result.verifierId)}>{displayName}</Link>;
+        }
+
+        // Fallback to plain text.
+        return displayName;
+    };
+
     return (
         <>
             <PageSection component="div" variant="light" className="pf-v5-u-py-md pf-v5-u-px-xl">
@@ -75,7 +95,9 @@ function ImagePageSignatureVerification({ results }: ImagePageSignatureVerificat
                                     }}
                                 >
                                     <Tr>
-                                        <Td dataLabel="Integration">{result.verifierId}</Td>
+                                        <Td dataLabel="Integration">
+                                            {renderIntegrationCell(result)}
+                                        </Td>
                                         <Td dataLabel="Status">{getStatusMessage(result)}</Td>
                                         <Td dataLabel="Verification time">
                                             <DateDistance date={result.verificationTime} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -48,6 +48,7 @@ export const imageDetailsFragment = gql`
                 verificationTime
                 verifiedImageReferences
                 verifierId
+                verifierName
             }
         }
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
@@ -114,4 +114,5 @@ export type SignatureVerificationResult = {
     verificationTime: string | undefined; // ISO 8601 formatted date time.
     verifiedImageReferences: string[];
     verifierId: string; // Signature integration id of the form `io.stackrox.signatureintegration.<uuid>`.
+    verifierName: string; // Signature integration name.
 };


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Render the signature integration name instead of the id in the status table.

The backend injects the signature integration dynamically in the image datastore. This is because:
* we do not want to store the name in the image proto in the database, because the name may change over time - id is immutable, name is not.
* we don't want to force the UI to make additional requests to fetch the name from the id.

Unfortunately the image datastore cannot simply import the signature integration datastore because of an import cycle. To resolve the import cycle, we set a signature integration getter at runtime. The getter does not depend on the signature integration datastore schema, and therefore does not cause a cycle. The image datastore handles the edge case where the getter has not been set gracefully to avoid race conditions.

Before:

<img width="1234" height="459" alt="SCR-20251009-ltgu" src="https://github.com/user-attachments/assets/35b0fe1d-21bd-4554-84fc-99fadf04da25" />

After:

<img width="1229" height="559" alt="SCR-20251009-ltcq" src="https://github.com/user-attachments/assets/6646e227-ecdf-45fe-812c-66aba9795588" />


### Note to reviewers

The test code was entirely written by claude.

For backend reviewers: Just ignore everything in `ui/`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

see screenshots for UI / e2e
CI

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->