### PR TITLE
ROX-30813:  Wait for scale to finish

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -526,7 +526,7 @@ class Kubernetes {
         Timer t = new Timer(30, 5)
         while (t.IsValid()) {
             try {
-                client.apps().deployments().inNamespace(ns).withName(name).scale(replicas)
+                client.apps().deployments().inNamespace(ns).withName(name).scale(replicas, true)
                 mostRecentException = null
                 break
             } catch (Exception e) {


### PR DESCRIPTION
## Description

We have problem that scaling to 0 does not finish properly.

This is the situation:
- we scale deployment to 0
- deployment's replica set is still 1
- we delete pod (in test)
- replica set starts new pod
- we continue with test **expecting that sensor is down**
- a few moments after that replica set is set to 0
- pod is removed
- ...

This change should wait for scale to finish.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] let CI pipeline run changed test