### PR TITLE
fix(CI): Revert "fix(CI): GKE region closer to PROW (#16328)"

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -134,7 +134,7 @@ create_cluster() {
     # The "services" secondary range is for ClusterIP services ("--services-ipv4-cidr").
     # See https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips#cluster_sizing.
 
-    REGION=us-east4
+    REGION=us-central1
     NUM_NODES="${NUM_NODES:-3}"
     GCP_IMAGE_TYPE="${GCP_IMAGE_TYPE:-UBUNTU_CONTAINERD}"
     POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"


### PR DESCRIPTION
Workaround for DNS issue: chat discussion of conflict in shared ip range https://redhat-internal.slack.com/archives/CC5UHD0KA/p1760029931505739?thread_ts=1760001789.655309&cid=CC5UHD0KA

Revert of the default location for CI test clusters which was moved from us-central1 to us-east4 (nearest to AWS us-east-1 where our PROW runners are running): https://github.com/stackrox/stackrox/pull/16328/files