### PR TITLE
ROX-31238: Use import type in ExceptionManagement subfolder

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -11,7 +11,8 @@ import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionSer
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
+import { getTableUIState } from 'utils/getTableUIState';
 import {
     RequestExpires,
     RequestIDLink,
@@ -22,7 +23,6 @@ import {
     RequestScope,
 } from './components/ExceptionRequestTableCells';
 
-import { getTableUIState } from '../../../utils/getTableUIState';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
 import { vulnRequestSearchFilterConfig } from './searchFilterConfig';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -12,7 +12,8 @@ import useURLSort from 'hooks/useURLSort';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import PageTitle from 'Components/PageTitle';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
+import { getTableUIState } from 'utils/getTableUIState';
 import {
     RequestIDLink,
     RequestedAction,
@@ -21,7 +22,6 @@ import {
     Requester,
     RequestScope,
 } from './components/ExceptionRequestTableCells';
-import { getTableUIState } from '../../../utils/getTableUIState';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
 import { vulnRequestSearchFilterConfig } from './searchFilterConfig';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -11,7 +11,8 @@ import { fetchVulnerabilityExceptions } from 'services/VulnerabilityExceptionSer
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
+import { getTableUIState } from 'utils/getTableUIState';
 import {
     RequestExpires,
     RequestIDLink,
@@ -22,7 +23,6 @@ import {
     RequestScope,
 } from './components/ExceptionRequestTableCells';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
-import { getTableUIState } from '../../../utils/getTableUIState';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
 import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -27,11 +27,11 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import useAuthStatus from 'hooks/useAuthStatus';
 import { ensureExhaustive } from 'utils/type.utils';
 import {
-    VulnerabilityException,
     fetchVulnerabilityExceptionById,
     isDeferralException,
     isFalsePositiveException,
 } from 'services/VulnerabilityExceptionService';
+import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 
 import PageTitle from 'Components/PageTitle';
 import NotFoundMessage from 'Components/NotFoundMessage';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -11,7 +11,8 @@ import useURLSort from 'hooks/useURLSort';
 import PageTitle from 'Components/PageTitle';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
+import { getTableUIState } from 'utils/getTableUIState';
 import {
     RequestExpires,
     RequestIDLink,
@@ -23,7 +24,6 @@ import {
 } from './components/ExceptionRequestTableCells';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
-import { getTableUIState } from '../../../utils/getTableUIState';
 import { vulnRequestSearchFilterConfig } from './searchFilterConfig';
 
 const sortFields = [

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
@@ -1,12 +1,9 @@
-import {
+import type {
     BaseVulnerabilityException,
     VulnerabilityException,
 } from 'services/VulnerabilityExceptionService';
-import {
-    getShouldUseUpdatedRequest,
-    getRequestedAction,
-    RequestContext,
-} from './ExceptionRequestTableCells';
+import { getShouldUseUpdatedRequest, getRequestedAction } from './ExceptionRequestTableCells';
+import type { RequestContext } from './ExceptionRequestTableCells';
 
 const baseException: BaseVulnerabilityException = {
     id: '4837bb34-5357-4b78-ad2b-188fc0b33e78',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -14,11 +14,13 @@ import {
 
 import { exceptionManagementPath } from 'routePaths';
 import {
+    isDeferralException,
+    isFalsePositiveException,
+} from 'services/VulnerabilityExceptionService';
+import type {
     ExceptionExpiry,
     VulnerabilityException,
     VulnerabilityExceptionComment,
-    isDeferralException,
-    isFalsePositiveException,
 } from 'services/VulnerabilityExceptionService';
 import { getDate, getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import useModal from 'hooks/useModal';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
@@ -5,10 +5,8 @@ import { useFormik } from 'formik';
 import isEqual from 'lodash/isEqual';
 
 import useModal from 'hooks/useModal';
-import {
-    VulnerabilityException,
-    approveVulnerabilityException,
-} from 'services/VulnerabilityExceptionService';
+import { approveVulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import useRestMutation from 'hooks/useRestMutation';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -15,10 +15,10 @@ import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import { vulnerabilitiesAllImagesPath } from 'routePaths';
-import { SetResult } from 'hooks/useSet';
+import type { SetResult } from 'hooks/useSet';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
-import {
+import type {
     VulnerabilityExceptionScope,
     VulnerabilityState,
 } from 'services/VulnerabilityExceptionService';
@@ -38,11 +38,9 @@ import {
     getWorkloadCveOverviewDefaultSortOption,
     getSeveritySortOptions,
 } from '../../utils/sortUtils';
-import {
-    CVEListQueryResult,
-    cveListQuery,
-} from '../../WorkloadCves/Tables/WorkloadCVEOverviewTable';
-import { VulnerabilitySeverityLabel } from '../../types';
+import { cveListQuery } from '../../WorkloadCves/Tables/WorkloadCVEOverviewTable';
+import type { CVEListQueryResult } from '../../WorkloadCves/Tables/WorkloadCVEOverviewTable';
+import type { VulnerabilitySeverityLabel } from '../../types';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getWorkloadEntityPagePath } from '../../utils/searchUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
 import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
 
-import {
-    VulnerabilityException,
-    cancelVulnerabilityException,
-} from 'services/VulnerabilityExceptionService';
+import { cancelVulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useModal from 'hooks/useModal';
 import useRestMutation from 'hooks/useRestMutation';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
@@ -5,10 +5,8 @@ import { useFormik } from 'formik';
 import isEqual from 'lodash/isEqual';
 
 import useModal from 'hooks/useModal';
-import {
-    VulnerabilityException,
-    denyVulnerabilityException,
-} from 'services/VulnerabilityExceptionService';
+import { denyVulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 import useRestMutation from 'hooks/useRestMutation';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
@@ -8,16 +8,16 @@ import {
     PageSection,
     Title,
 } from '@patternfly/react-core';
-import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 import {
     RequestComment,
     RequestComments,
-    RequestContext,
     RequestCreatedAt,
     RequestExpires,
     RequestScope,
     RequestedAction,
 } from './ExceptionRequestTableCells';
+import type { RequestContext } from './ExceptionRequestTableCells';
 
 export type RequestOverviewProps = {
     exception: VulnerabilityException;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestUpdateButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestUpdateButtonModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core';
 
-import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
 import CompletedExceptionRequestModal from '../../components/ExceptionRequestModal/CompletedExceptionRequestModal';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/hooks/useRequestCVEsDetails.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { VulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';
 import { sortCveDistroList } from '../../utils/sortUtils';
 import { getImageScopeSearchValue } from '../utils';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/searchFilterConfig.ts
@@ -1,4 +1,4 @@
-import { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
+import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
 import { Name as ImageName } from 'Components/CompoundSearchFilter/attributes/image';
 import { Name as ImageCveName } from 'Components/CompoundSearchFilter/attributes/imageCVE';
 import { vulnerabilityRequestAttributes } from 'Components/CompoundSearchFilter/attributes/vulnerabilityRequests';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.test.ts
@@ -1,4 +1,7 @@
-import { ExceptionStatus, VulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type {
+    ExceptionStatus,
+    VulnerabilityException,
+} from 'services/VulnerabilityExceptionService';
 import { getImageScopeSearchValue, getVulnerabilityState } from './utils';
 
 describe('ExceptionManagement utils', () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/utils.ts
@@ -1,7 +1,7 @@
-import {
+import { isDeferralException } from 'services/VulnerabilityExceptionService';
+import type {
     VulnerabilityException,
     VulnerabilityExceptionScope,
-    isDeferralException,
 } from 'services/VulnerabilityExceptionService';
 
 export function getImageScopeSearchValue({ imageScope }: VulnerabilityExceptionScope): string {


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

Last updated 2 months ago.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

### Residue

1. Error limited/no-relative-path-to-src-in-import from might specify the change.
    I hesitate about a `fix` function because the `import` statement is usually out of order, but import/order rule is not reporting these errors consistently.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Temporarily replace in `ignores` array:

```diff
- 'src/Containers/Vulnerabilities/**',
+ 'src/Containers/Vulnerabilities/*',
+ 'src/Containers/Vulnerabilities/components/**',
+ 'src/Containers/Vulnerabilities/hooks/**',
+ 'src/Containers/Vulnerabilities/NodeCves/**',
+ 'src/Containers/Vulnerabilities/PlatformCves/**',
+ 'src/Containers/Vulnerabilities/utils/**',
+ 'src/Containers/Vulnerabilities/VirtualMachineCves/**',
+ 'src/Containers/Vulnerabilities/VulnerablityReporting/**',
+ 'src/Containers/Vulnerabilities/WorkloadCves/**',
```

By the way, temporary `ignores` was not quite right when I typed `VulnerabilityReporting` instead of `VulnerablityReporting` ;)

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.