### PR TITLE
ROX-31239: Use import type in PlatformCves subfolder

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -7,10 +7,10 @@ import { Table, Thead, Tr, Th, Td, ExpandableRowContent, Tbody } from '@patternf
 import CvssFormatted from 'Components/CvssFormatted';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 import useSet from 'hooks/useSet';
 
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import ExpandRowTh from 'Components/ExpandRowTh';
 import {
     CLUSTER_CVE_STATUS_SORT_FIELD,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -23,7 +23,8 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import { detailsTabValues } from '../../types';
 
-import ClusterPageHeader, { ClusterMetadata, clusterMetadataFragment } from './ClusterPageHeader';
+import ClusterPageHeader, { clusterMetadataFragment } from './ClusterPageHeader';
+import type { ClusterMetadata } from './ClusterPageHeader';
 import ClusterPageDetails from './ClusterPageDetails';
 import ClusterPageVulnerabilities from './ClusterPageVulnerabilities';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
@@ -19,7 +19,8 @@ import { getDateTime } from 'utils/dateUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import ExpandableLabelSection from '../../components/ExpandableLabelSection';
-import useClusterExtendedDetails, { ProviderMetadata } from './useClusterExtendedDetails';
+import useClusterExtendedDetails from './useClusterExtendedDetails';
+import type { ProviderMetadata } from './useClusterExtendedDetails';
 import { displayClusterType } from '../utils/stringUtils';
 
 function getCloudProviderText(providerMetadata: ProviderMetadata | undefined): string | null {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -21,7 +21,7 @@ import { DynamicTableLabel } from 'Components/DynamicIcon';
 import useURLSort from 'hooks/useURLSort';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { PLATFORM_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
-import { platformCVESearchFilterConfig } from 'Containers/Vulnerabilities/searchFilterConfig';
+import { platformCVESearchFilterConfig } from '../../searchFilterConfig';
 import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
 import { getHiddenStatuses, parseQuerySearchFilter } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import { Card, CardTitle, CardBody, Flex, Text, pluralize } from '@patternfly/react-core';
 import { MinusIcon, WrenchIcon } from '@patternfly/react-icons';
-import { FixableStatus } from '../../types';
+import type { FixableStatus } from '../../types';
 
 const disabledColor100 = 'var(--pf-v5-global--disabled-color--100)';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterExtendedDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterExtendedDetails.ts
@@ -1,5 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
-import { ClusterType } from 'types/cluster.proto';
+import type { ClusterType } from 'types/cluster.proto';
 
 const clusterExtendedDetailsQuery = gql`
     query getClusterExtendedDetails($id: ID!) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterSummaryData.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterSummaryData.ts
@@ -1,12 +1,8 @@
 import { gql, useQuery } from '@apollo/client';
-import {
-    PlatformCVECountByStatus,
-    platformCveCountByStatusFragment,
-} from './PlatformCvesByStatusSummaryCard';
-import {
-    PlatformCVECountByType,
-    platformCveCountByTypeFragment,
-} from './PlatformCvesByTypeSummaryCard';
+import { platformCveCountByStatusFragment } from './PlatformCvesByStatusSummaryCard';
+import type { PlatformCVECountByStatus } from './PlatformCvesByStatusSummaryCard';
+import { platformCveCountByTypeFragment } from './PlatformCvesByTypeSummaryCard';
+import type { PlatformCVECountByType } from './PlatformCvesByTypeSummaryCard';
 
 export const clusterSummaryDataQuery = gql`
     ${platformCveCountByStatusFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/useClusterVulnerabilities.ts
@@ -2,8 +2,9 @@ import { gql, useQuery } from '@apollo/client';
 
 import { getPaginationParams } from 'utils/searchUtils';
 
-import { ClientPagination, Pagination } from 'services/types';
-import { ClusterVulnerability, clusterVulnerabilityFragment } from './CVEsTable';
+import type { ClientPagination, Pagination } from 'services/types';
+import { clusterVulnerabilityFragment } from './CVEsTable';
+import type { ClusterVulnerability } from './CVEsTable';
 
 const clusterVulnerabilitiesQuery = gql`
     ${clusterVulnerabilityFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -4,7 +4,6 @@ import { Text } from '@patternfly/react-core';
 import {
     ActionsColumn,
     ExpandableRowContent,
-    IAction,
     Table,
     Thead,
     Tr,
@@ -12,13 +11,14 @@ import {
     Tbody,
     Td,
 } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 import { gql, useQuery } from '@apollo/client';
 
-import useURLPagination from 'hooks/useURLPagination';
-import useMap from 'hooks/useMap';
+import type useURLPagination from 'hooks/useURLPagination';
+import type useMap from 'hooks/useMap';
 import useSet from 'hooks/useSet';
-import { UseURLSortResult } from 'hooks/useURLSort';
-import { ApiSortOption } from 'types/search';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { ApiSortOption } from 'types/search';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 import { getTableUIState } from 'utils/getTableUIState';
 
@@ -33,7 +33,7 @@ import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
-import { QuerySearchFilter } from '../../types';
+import type { QuerySearchFilter } from '../../types';
 import usePlatformCves from './usePlatformCves';
 import { displayCveType } from '../utils/stringUtils';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -5,11 +5,11 @@ import { Link } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import useURLPagination from 'hooks/useURLPagination';
-import { UseURLSortResult } from 'hooks/useURLSort';
-import { Pagination } from 'services/types';
-import { ClusterType } from 'types/cluster.proto';
-import { ApiSortOption } from 'types/search';
+import type useURLPagination from 'hooks/useURLPagination';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { Pagination } from 'services/types';
+import type { ClusterType } from 'types/cluster.proto';
+import type { ApiSortOption } from 'types/search';
 import { getTableUIState } from 'utils/getTableUIState';
 
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
@@ -21,7 +21,7 @@ import {
     CVE_COUNT_SORT_FIELD,
 } from '../../utils/sortFields';
 import { getPlatformEntityPagePath, getRegexScopedQueryString } from '../../utils/searchUtils';
-import { QuerySearchFilter } from '../../types';
+import type { QuerySearchFilter } from '../../types';
 import { displayClusterType } from '../utils/stringUtils';
 
 const clusterListQuery = gql`

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useApolloClient } from '@apollo/client';
 
 import PageTitle from 'Components/PageTitle';
+import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -23,21 +24,17 @@ import useAnalytics, {
 } from 'hooks/useAnalytics';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
-import TableEntityToolbar from 'Containers/Vulnerabilities/components/TableEntityToolbar';
 import useMap from 'hooks/useMap';
 import useURLSort from 'hooks/useURLSort';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
-import useSnoozeCveModal from 'Containers/Vulnerabilities/components/SnoozeCvesModal/useSnoozeCveModal';
-import SnoozeCvesModal from 'Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal';
-import MenuDropdown from 'Components/PatternFly/MenuDropdown';
+import useSnoozeCveModal from '../../components/SnoozeCvesModal/useSnoozeCveModal';
+import SnoozeCvesModal from '../../components/SnoozeCvesModal/SnoozeCvesModal';
+import TableEntityToolbar from '../../components/TableEntityToolbar';
 
-import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
-import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
-import useSnoozedCveCount from 'Containers/Vulnerabilities/hooks/useSnoozedCveCount';
-import {
-    clusterSearchFilterConfig,
-    platformCVESearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
+import { parseQuerySearchFilter } from '../../utils/searchUtils';
+import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
+import useSnoozedCveCount from '../../hooks/useSnoozedCveCount';
+import { clusterSearchFilterConfig, platformCVESearchFilterConfig } from '../../searchFilterConfig';
 import SnoozedCveToggleButton from '../../components/SnoozedCveToggleButton';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCveEntityCounts.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCveEntityCounts.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { QuerySearchFilter } from '../../types';
+import type { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
 const entityCountsQuery = gql`

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/usePlatformCves.ts
@@ -1,7 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
-import { ClientPagination, Pagination } from 'services/types';
-import { QuerySearchFilter } from '../../types';
+import type { ClientPagination, Pagination } from 'services/types';
+import type { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
 type PlatformCVE = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -5,11 +5,10 @@ import { Truncate } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { UseURLSortResult } from 'hooks/useURLSort';
-import { TableUIState } from 'utils/getTableUIState';
-import { ClusterType } from 'types/cluster.proto';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { TableUIState } from 'utils/getTableUIState';
+import type { ClusterType } from 'types/cluster.proto';
 
-import { getIsSomeVulnerabilityFixable } from 'Containers/Vulnerabilities/utils/vulnerabilityUtils';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 import {
     CLUSTER_KUBERNETES_VERSION_SORT_FIELD,
@@ -18,6 +17,7 @@ import {
 } from '../../utils/sortFields';
 import { getPlatformEntityPagePath } from '../../utils/searchUtils';
 import { displayClusterType } from '../utils/stringUtils';
+import { getIsSomeVulnerabilityFixable } from '../../utils/vulnerabilityUtils';
 
 export const sortFields = [
     CLUSTER_SORT_FIELD,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -23,10 +23,6 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getTableUIState } from 'utils/getTableUIState';
-import {
-    SummaryCardLayout,
-    SummaryCard,
-} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import { getHasSearchApplied } from 'utils/searchUtils';
@@ -34,8 +30,9 @@ import useURLSort from 'hooks/useURLSort';
 import { getDateTime } from 'utils/dateUtils';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { PLATFORM_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
-import { clusterSearchFilterConfig } from 'Containers/Vulnerabilities/searchFilterConfig';
+import { clusterSearchFilterConfig } from '../../searchFilterConfig';
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
+import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import {
     getOverviewPagePath,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/useAffectedClusters.ts
@@ -1,7 +1,8 @@
 import { gql, useQuery } from '@apollo/client';
-import { ClientPagination, Pagination } from 'services/types';
+import type { ClientPagination, Pagination } from 'services/types';
 import { getPaginationParams } from 'utils/searchUtils';
-import { AffectedCluster, affectedClusterFragment } from './AffectedClustersTable';
+import { affectedClusterFragment } from './AffectedClustersTable';
+import type { AffectedCluster } from './AffectedClustersTable';
 
 const affectedClustersQuery = gql`
     ${affectedClusterFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveMetadata.ts
@@ -1,6 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { ClustersByType, clustersByTypeFragment } from './ClustersByTypeSummaryCard';
+import { clustersByTypeFragment } from './ClustersByTypeSummaryCard';
+import type { ClustersByType } from './ClustersByTypeSummaryCard';
 
 const platformCveMetadataQuery = gql`
     ${clustersByTypeFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveSummaryData.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/usePlatformCveSummaryData.tsx
@@ -1,6 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { ClustersByType, clustersByTypeFragment } from './ClustersByTypeSummaryCard';
+import { clustersByTypeFragment } from './ClustersByTypeSummaryCard';
+import type { ClustersByType } from './ClustersByTypeSummaryCard';
 
 const platformCveSummaryDataQuery = gql`
     ${clustersByTypeFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/utils/stringUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/utils/stringUtils.ts
@@ -1,4 +1,4 @@
-import { ClusterType } from 'types/cluster.proto';
+import type { ClusterType } from 'types/cluster.proto';
 import { ensureExhaustive } from 'utils/type.utils';
 
 export function displayClusterType(type: ClusterType): string {


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

Last updated 3 months ago.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

### Residue

1. Error limited/no-absolute-path-within-container-in-import from might specify the change.
    I hesitate about a `fix` function because the `import` statement is usually out of order, but import/order rule is not reporting these errors consistently.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Temporarily replace in `ignores` array:

```diff
- 'src/Containers/Vulnerabilities/**',
+ 'src/Containers/Vulnerabilities/*',
+ 'src/Containers/Vulnerabilities/components/**',
+ 'src/Containers/Vulnerabilities/ExceptionManagement/**',
+ 'src/Containers/Vulnerabilities/hooks/**',
+ 'src/Containers/Vulnerabilities/NodeCves/**',
+ 'src/Containers/Vulnerabilities/utils/**',
+ 'src/Containers/Vulnerabilities/VirtualMachineCves/**',
+ 'src/Containers/Vulnerabilities/VulnerablityReporting/**',
+ 'src/Containers/Vulnerabilities/WorkloadCves/**',
```

By the way, temporary `ignores` was not quite right when I typed `VulnerabilityReporting` instead of `VulnerablityReporting` ;)

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.