### PR TITLE
ROX-31240: Use import type in Components PatternFly

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -764,7 +764,7 @@ module.exports = [
     {
         files: ['src/*/**/*.{js,jsx,ts,tsx}'], // product files, except for unit tests (including test-utils folder)
         ignores: [
-            'src/Components/**',
+            'src/Components/CompoundSearchFilter/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/MitreAttackVectors/**',
             'src/Containers/Policies/**',

--- a/ui/apps/platform/src/Components/PatternFly/BackdropExporting.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BackdropExporting.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Backdrop, Bullseye, Spinner } from '@patternfly/react-core';
 
 function BackdropExporting(): ReactElement {

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -1,4 +1,5 @@
-import React, { Key, ReactNode } from 'react';
+import React from 'react';
+import type { Key, ReactElement, ReactNode } from 'react';
 import {
     Badge,
     Button,
@@ -12,7 +13,8 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
-import { BaseCellProps, Table, Tbody, Td, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
+import type { BaseCellProps } from '@patternfly/react-table';
 
 type BacklogTableProps<Item> = {
     type: 'selected' | 'deselected';
@@ -40,7 +42,7 @@ function BacklogTable<Item>({
     buttonText,
     searchFilter = () => true,
     showBadge,
-}: BacklogTableProps<Item>) {
+}: BacklogTableProps<Item>): ReactElement {
     const actionIcon =
         type === 'selected' ? (
             <Icon>

--- a/ui/apps/platform/src/Components/PatternFly/BrandLogo.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BrandLogo.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Brand } from '@patternfly/react-core';
 import { getProductBranding } from 'constants/productBranding';
 

--- a/ui/apps/platform/src/Components/PatternFly/Charts/LinkableChartLabel.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/Charts/LinkableChartLabel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { ChartLabel, ChartLabelProps } from '@patternfly/react-charts';
+import { ChartLabel } from '@patternfly/react-charts';
+import type { ChartLabelProps } from '@patternfly/react-charts';
 
 export type LinkableChartLabelProps = ChartLabelProps & {
     /**

--- a/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
@@ -1,15 +1,25 @@
-import React, { ReactElement, ReactNode, useState, useRef, useMemo } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
+import type {
+    FocusEvent,
+    FocusEventHandler,
+    MouseEvent as ReactMouseEvent,
+    ReactElement,
+    ReactNode,
+    Ref,
+} from 'react';
 import {
     Select,
     SelectOption,
-    SelectOptionProps,
     SelectGroup,
     MenuToggle,
-    MenuToggleElement,
     Badge,
     Flex,
     FlexItem,
     SelectList,
+} from '@patternfly/react-core';
+import type {
+    MenuToggleElement,
+    SelectOptionProps,
     SelectPopperProps,
 } from '@patternfly/react-core';
 
@@ -46,7 +56,7 @@ export type CheckboxSelectProps = {
     id?: string;
     selections: string[];
     onChange: (selection: string[]) => void;
-    onBlur?: React.FocusEventHandler<HTMLDivElement>;
+    onBlur?: FocusEventHandler<HTMLDivElement>;
     ariaLabel: string;
     children: ReactElement<SelectOptionProps>[];
     placeholderText?: string;
@@ -76,7 +86,7 @@ function CheckboxSelect({
         setIsOpen(!isOpen);
     }
 
-    function handleBlur(event: React.FocusEvent<HTMLDivElement>) {
+    function handleBlur(event: FocusEvent<HTMLDivElement>) {
         const { currentTarget, relatedTarget } = event;
 
         // Wait for focus to settle, then check if it moved outside the component
@@ -104,7 +114,7 @@ function CheckboxSelect({
     }
 
     function onSelect(
-        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
         selection: string | number | undefined
     ) {
         if (typeof selection !== 'string' || !selections || !onChange) {
@@ -117,7 +127,7 @@ function CheckboxSelect({
         }
     }
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             className="pf-v5-u-w-100"
             id={toggleId}

--- a/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Button, Modal } from '@patternfly/react-core';
 
 type ConfirmationModalProps = {

--- a/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { FocusEventHandler, ReactElement } from 'react';
 import { SelectOption } from '@patternfly/react-core';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
-import { IntervalType } from 'services/ComplianceScanConfigurationService';
+import type { IntervalType } from 'services/ComplianceScanConfigurationService';
 
 export type DayPickerDropdownProps = {
     fieldId: string;
@@ -10,7 +11,7 @@ export type DayPickerDropdownProps = {
     handleSelect: (id, selection) => void;
     isEditable?: boolean;
     intervalType: IntervalType | null;
-    onBlur?: React.FocusEventHandler<HTMLDivElement>;
+    onBlur?: FocusEventHandler<HTMLDivElement>;
     toggleId?: string;
 };
 

--- a/ui/apps/platform/src/Components/PatternFly/DeleteModal.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/DeleteModal.tsx
@@ -1,5 +1,6 @@
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button, Modal } from '@patternfly/react-core';
-import React, { ReactElement } from 'react';
 
 export type DeleteModalProps = {
     title: string;

--- a/ui/apps/platform/src/Components/PatternFly/DeveloperPreviewLabel.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/DeveloperPreviewLabel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Flex, FlexItem, Label, LabelProps, Popover } from '@patternfly/react-core';
+import { Flex, FlexItem, Label, Popover } from '@patternfly/react-core';
+import type { LabelProps } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react';
+import React, { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import Raven from 'raven-js';
 

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryCodeBlock.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryCodeBlock.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     ClipboardCopyButton,
     CodeBlock,

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryPage.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryPage.tsx
@@ -1,4 +1,5 @@
-import React, { ErrorInfo, ReactElement } from 'react';
+import React from 'react';
+import type { ErrorInfo, ReactElement } from 'react';
 import {
     EmptyState,
     EmptyStateIcon,

--- a/ui/apps/platform/src/Components/PatternFly/FormCancelButton.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormCancelButton.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button } from '@patternfly/react-core';
 
 export type FormCancelButtonProps = {

--- a/ui/apps/platform/src/Components/PatternFly/FormLabelGroup.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormLabelGroup.tsx
@@ -1,13 +1,14 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     FormGroup,
-    FormGroupProps,
     FormHelperText,
     HelperText,
     HelperTextItem,
     ValidatedOptions,
 } from '@patternfly/react-core';
-import { FormikTouched, FormikErrors } from 'formik';
+import type { FormGroupProps } from '@patternfly/react-core';
+import type { FormikTouched, FormikErrors } from 'formik';
 import get from 'lodash/get';
 
 export interface FormLabelGroupProps<T> extends FormGroupProps {

--- a/ui/apps/platform/src/Components/PatternFly/FormMessage.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormMessage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert } from '@patternfly/react-core';
 
 export type FormResponseMessage = {

--- a/ui/apps/platform/src/Components/PatternFly/FormSaveButton.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormSaveButton.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button } from '@patternfly/react-core';
 
 export type FormSaveButtonProps = {

--- a/ui/apps/platform/src/Components/PatternFly/FormTestButton.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormTestButton.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button } from '@patternfly/react-core';
 
 export type FormTestButtonProps = {

--- a/ui/apps/platform/src/Components/PatternFly/IconText/ExternalLink.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/ExternalLink.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Flex, Icon } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Components/PatternFly/IconText/IconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/IconText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 export type IconTextProps = {
     icon: ReactElement;

--- a/ui/apps/platform/src/Components/PatternFly/IconText/ImageActiveIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/ImageActiveIconText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { CheckIcon, MinusIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';

--- a/ui/apps/platform/src/Components/PatternFly/IconText/NotApplicableIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/NotApplicableIconText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { MinusIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';

--- a/ui/apps/platform/src/Components/PatternFly/IconText/PolicyDisabledIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/PolicyDisabledIconText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { CheckIcon, MinusIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';

--- a/ui/apps/platform/src/Components/PatternFly/IconText/PolicySeverityIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/PolicySeverityIconText.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import { severityLabels } from 'messages/common';
-import { VulnerabilitySeverity } from 'types/cve.proto';
-import { PolicySeverity } from 'types/policy.proto';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
+import type { PolicySeverity } from 'types/policy.proto';
 
 import SeverityIcons from '../SeverityIcons';
 

--- a/ui/apps/platform/src/Components/PatternFly/IconText/PolicyStatusIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/PolicyStatusIconText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Icon } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Components/PatternFly/IconText/VulnerabilityFixableIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/VulnerabilityFixableIconText.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { MinusIcon, WrenchIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';

--- a/ui/apps/platform/src/Components/PatternFly/IconText/VulnerabilitySeverityIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/VulnerabilitySeverityIconText.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import { vulnerabilitySeverityLabels } from 'messages/common';
-import { VulnerabilitySeverity } from 'types/cve.proto';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
 
 import SeverityIcons from '../SeverityIcons'; // TODO VulnerabilitySeverityIcons
 

--- a/ui/apps/platform/src/Components/PatternFly/LinkShim/LinkShim.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/LinkShim/LinkShim.tsx
@@ -1,4 +1,5 @@
-import React, { AnchorHTMLAttributes, ReactElement } from 'react';
+import React from 'react';
+import type { AnchorHTMLAttributes, ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 /*

--- a/ui/apps/platform/src/Components/PatternFly/MenuDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/MenuDropdown.tsx
@@ -1,13 +1,10 @@
-import React, { ReactElement, ReactNode, useState } from 'react';
-import {
-    Bullseye,
-    Dropdown,
-    DropdownList,
+import React, { useState } from 'react';
+import type { MouseEvent as ReactMouseEvent, ReactElement, ReactNode, Ref } from 'react';
+import { Bullseye, Dropdown, DropdownList, MenuToggle, Spinner } from '@patternfly/react-core';
+import type {
     DropdownPopperProps,
-    MenuToggle,
     MenuToggleElement,
     MenuToggleProps,
-    Spinner,
 } from '@patternfly/react-core';
 
 type MenuDropdownProps = {
@@ -18,7 +15,7 @@ type MenuDropdownProps = {
     toggleVariant?: MenuToggleProps['variant'];
     toggleIcon?: ReactNode;
     ariaLabel?: string;
-    onSelect?: (event?: React.MouseEvent<Element, MouseEvent>, value?: string | number) => void;
+    onSelect?: (event?: ReactMouseEvent<Element, MouseEvent>, value?: string | number) => void;
     isDisabled?: boolean;
     isPlain?: boolean;
     isLoading?: boolean;
@@ -59,7 +56,7 @@ function MenuDropdown({
             isPlain={isPlain}
             onSelect={onSelectHandler}
             onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
-            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            toggle={(toggleRef: Ref<MenuToggleElement>) => (
                 <MenuToggle
                     className={toggleClassName}
                     icon={toggleIcon}

--- a/ui/apps/platform/src/Components/PatternFly/RepeatScheduleDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/RepeatScheduleDropdown.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { FocusEventHandler, ReactElement } from 'react';
 import { SelectOption } from '@patternfly/react-core';
 
 import SelectSingle from 'Components/SelectSingle';
@@ -10,7 +11,7 @@ export type RepeatScheduleDropdownProps = {
     isEditable?: boolean;
     showNoResultsOption?: boolean;
     includeDailyOption?: boolean;
-    onBlur?: React.FocusEventHandler<HTMLDivElement>;
+    onBlur?: FocusEventHandler<HTMLDivElement>;
 };
 
 function RepeatScheduleDropdown({

--- a/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Button, ChipGroup, Chip, Flex, FlexItem, ToolbarChip } from '@patternfly/react-core';
+import type { ReactElement, ReactNode } from 'react';
+import { Button, ChipGroup, Chip, Flex, FlexItem } from '@patternfly/react-core';
+import type { ToolbarChip } from '@patternfly/react-core';
 import { Globe } from 'react-feather';
 
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { searchValueAsArray } from 'utils/searchUtils';
 
 import './SearchFilterChips.css';
@@ -30,7 +32,7 @@ export type FilterChipGroupDescriptor = {
     /** The name of the search filter category as it appears in the URL */
     searchFilterName: string;
     /** Optional render function for the chip. Defaults to rendering plain text inside a PatternFly `Chip` component */
-    render?: (filter: string) => React.ReactNode;
+    render?: (filter: string) => ReactNode;
 };
 
 export type SearchFilterChipsProps = {
@@ -50,7 +52,7 @@ function SearchFilterChips({
     filterChipGroupDescriptors,
     searchFilter,
     onFilterChange,
-}: SearchFilterChipsProps) {
+}: SearchFilterChipsProps): ReactElement {
     function onChangeSearchFilter(newFilter: SearchFilter) {
         onFilterChange(newFilter);
     }

--- a/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import {
     AngleDoubleDownIcon,
     AngleDoubleUpIcon,
@@ -6,7 +7,7 @@ import {
     EqualsIcon,
     UnknownIcon,
 } from '@patternfly/react-icons';
-import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 import { Icon } from '@patternfly/react-core';
 
 import {
@@ -16,8 +17,8 @@ import {
     MODERATE_MEDIUM_SEVERITY_COLOR,
     UNKNOWN_SEVERITY_COLOR,
 } from 'constants/severityColors';
-import { VulnerabilitySeverity } from 'types/cve.proto';
-import { PolicySeverity } from 'types/policy.proto';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
+import type { PolicySeverity } from 'types/policy.proto';
 
 // Defines the default PF icons that represent a CVE severity, and sets the default colors for the icons.
 // Color can be overridden by passing the standard `color` prop to the icon component.
@@ -59,10 +60,7 @@ export const UnknownSeverityIcon = ({ color, ...props }: SVGIconProps) => (
     </Icon>
 );
 
-const SeverityIcons: Record<
-    VulnerabilitySeverity,
-    React.FC<React.PropsWithChildren<SVGIconProps>>
-> = {
+const SeverityIcons: Record<VulnerabilitySeverity, FC<PropsWithChildren<SVGIconProps>>> = {
     CRITICAL_VULNERABILITY_SEVERITY: CriticalSeverityIcon,
     IMPORTANT_VULNERABILITY_SEVERITY: ImportantSeverityIcon,
     MODERATE_VULNERABILITY_SEVERITY: ModerateSeverityIcon,
@@ -70,10 +68,7 @@ const SeverityIcons: Record<
     UNKNOWN_VULNERABILITY_SEVERITY: UnknownSeverityIcon,
 };
 
-export const policySeverityIconMap: Record<
-    PolicySeverity,
-    React.FC<React.PropsWithChildren<SVGIconProps>>
-> = {
+export const policySeverityIconMap: Record<PolicySeverity, FC<PropsWithChildren<SVGIconProps>>> = {
     CRITICAL_SEVERITY: CriticalSeverityIcon,
     HIGH_SEVERITY: HighSeverityIcon,
     MEDIUM_SEVERITY: MediumSeverityIcon,

--- a/ui/apps/platform/src/Components/PatternFly/TableCell/TableCell.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/TableCell/TableCell.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import type { ReactElement } from 'react';
 import { Td } from '@patternfly/react-table';
 import get from 'lodash/get';
 
-function TableCell({ row, column }): React.ReactElement {
+function TableCell({ row, column }): ReactElement {
     let value = get(row, column.accessor);
     if (column.Cell) {
         value = column.Cell({ original: row, value });

--- a/ui/apps/platform/src/Components/PatternFly/TechPreviewLabel.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/TechPreviewLabel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Label, LabelProps } from '@patternfly/react-core';
+import { Label } from '@patternfly/react-core';
+import type { LabelProps } from '@patternfly/react-core';
 
 export type TechPreviewLabelProps = LabelProps;
 

--- a/ui/apps/platform/src/Components/PatternFly/WidgetCard.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/WidgetCard.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import { Skeleton, Card, CardBody, CardHeader } from '@patternfly/react-core';
 
 import { defaultChartHeight } from 'utils/chartUtils';
@@ -23,7 +24,7 @@ function WidgetCard({
     errorMessage,
     header,
     children,
-}: WidgetCardProps) {
+}: WidgetCardProps): ReactElement {
     let cardContent: ReactNode;
 
     if (isLoading && !error) {

--- a/ui/apps/platform/src/Components/PatternFly/WidgetErrorEmptyState.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/WidgetErrorEmptyState.tsx
@@ -1,7 +1,8 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Flex } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 
@@ -24,7 +25,7 @@ export default function WidgetErrorEmptyState({
     children,
     title,
     height,
-}: WidgetErrorEmptyStateProps) {
+}: WidgetErrorEmptyStateProps): ReactElement {
     return (
         <>
             <Flex


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

### Plan

Chunks for reasonable review of changed files:

1. Files in Components folder. Done in #17226
2. Files in Components subfolders, not including PatternFly nor CompoundSearchFilter.
    * Only file that rendered `RoleChips` was deleted in 7908
3. Files in Components/PatternFly subfolder. Update glob in `ignores` array.
4. Files in Components/CompoundSearchFilter subfolder, after chance of patches for release subsides. Delete glob from `ignores` array.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.