### PR TITLE
ROX-31144: Fix verify listening endpoints are collector are reported

### DIFF
--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -283,7 +283,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         assert list.size() > 1
         assert processesListeningOnPorts.totalListeningEndpoints >= 2
 
-        def endpoint1 = list[0]
+        def endpoint1 = list.find { it.endpoint.port == 8080 }
 
         verifyAll(endpoint1) {
                 deploymentId
@@ -297,7 +297,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 endpoint.port == 8080
         }
 
-        def endpoint2 = list[1]
+        def endpoint2 = list.find { it.endpoint.port == 9090 }
 
         verifyAll(endpoint2) {
                 deploymentId


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This test has been failing recently, because sometimes collector reports the listening endpoint for its self-check and sometimes it doesn't. When the self-check is reported, the expected order of the listening endpoints is not found and the test fails.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

~~- [ ] added unit tests~~
~~- [ ] added e2e tests~~
~~- [ ] added regression tests~~
~~- [ ] added compatibility tests~~
~~- [ ] modified existing tests~~

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The e2e test was run in a loop with tearing down and redeploying ACS each time. When doing this on master the test failed on the 20th try with the following error

```
ProcessesListeningOnPortsTest > Verify listening endpoints for collector are reported FAILED
    org.gradle.internal.exceptions.DefaultMultiCauseException: Multiple Failures (3 failures)
        org.spockframework.runtime.SpockComparisonFailure: Condition not satisfied:

    signal.name == "collector"
    |      |    |
    |      |    false
    |      |    9 differences (18% similarity)
    |      |    (se)l(f-ch)ec(ks-)
    |      |    (co)l(l---)ec(tor)
    |      self-checks
    name: "self-checks"
    args: "13037"
    exec_file_path: "<NA>"

        org.spockframework.runtime.SpockComparisonFailure: Condition not satisfied:

    signal.execFilePath == "/usr/local/bin/collector"
    |      |            |
    |      <NA>         false
    |                   24 differences (0% similarity)
    |                   (<NA>--------------------)
    |                   (/usr/local/bin/collector)
    name: "self-checks"
    args: "13037"
    exec_file_path: "<NA>"

        org.spockframework.runtime.SpockComparisonFailure: Condition not satisfied:

    endpoint.port == 8080
    |        |    |
    |        |    false
    |        13037
    port: 13037
    protocol: L4_PROTOCOL_TCP
```

This is the error that has been observed in CI.

On this branch the test passed 130 times in a row and never failed.