### PR TITLE
fix(flakes): Avoid pulling images from `docker.io` in tests

### DIFF
--- a/tests/active_vuln_test.go
+++ b/tests/active_vuln_test.go
@@ -21,6 +21,9 @@ type nginxImage struct {
 	activeComponents int
 }
 
+// TODO(ROX-29771): When re-enabling this test, replace docker.io images with quay.io equivalents
+// to avoid Docker Hub rate limiting. Use images from qa-tests-backend/scripts/images-to-prefetch.txt
+// such as quay.io/rhacs-eng/qa-multi-arch:nginx-1-12-1, nginx-1-17-1, nginx-1.21.1, etc.
 func (i *nginxImage) getImage() string {
 	return fmt.Sprintf("docker.io/library/nginx:%s@%s", i.version, i.SHA)
 }

--- a/tests/backup_test.go
+++ b/tests/backup_test.go
@@ -31,7 +31,7 @@ func TestBackup(t *testing.T) {
 	}
 	deploymentName := fmt.Sprintf("test-backup-%d", rand.Intn(10000))
 
-	setupDeployment(t, "nginx", deploymentName)
+	setupDeployment(t, "quay.io/rhacs-eng/qa-multi-arch-nginx:latest", deploymentName)
 	defer teardownDeploymentWithoutCheck(t, deploymentName)
 	waitForDeployment(t, deploymentName)
 

--- a/tests/excluded_scopes_test.go
+++ b/tests/excluded_scopes_test.go
@@ -24,7 +24,7 @@ func TestExcludedScopes(t *testing.T) {
 	}
 	deploymentName := fmt.Sprintf("test-excluded-scopes-%d", rand.Intn(10000))
 
-	setupDeployment(t, "nginx", deploymentName)
+	setupDeployment(t, "quay.io/rhacs-eng/qa-multi-arch-nginx:latest", deploymentName)
 	defer teardownDeploymentWithoutCheck(t, deploymentName)
 	waitForDeployment(t, deploymentName)
 


### PR DESCRIPTION
## Description

I noticed that [this flake](https://github.com/stackrox/stackrox/pull/17216) was caused (among others - not the only cause of flakes) by docker.io rate limiting. I asked the AI whether we have similar issues in the rest of the code and it fount this.

Here, we replace the images against their copies that are pre-fetched in the CI, so that we no longer need to fetch them from remote registries. 

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Run CI 
- Hard to test whether it fixes something as this is a preventive measure
