### PR TITLE
ROX-31257: Use import type in miscellaneous folders

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -766,15 +766,9 @@ module.exports = [
         ignores: [
             'src/Components/**',
             'src/Containers/Compliance/**', // deprecated
-            'src/Containers/MitreAttackVectors/**',
             'src/Containers/Policies/**',
-            'src/Containers/PolicyCategories/**',
-            'src/Containers/PolicyManagement/**',
             'src/Containers/Risk/**',
-            'src/Containers/Search/**',
             'src/Containers/SystemConfig/**',
-            'src/Containers/SystemHealth/**',
-            'src/Containers/User/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
             'src/Containers/Workflow/**', // deprecated

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackLink.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackLink.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
@@ -1,7 +1,9 @@
-import React, { ReactElement } from 'react';
-import { Alert, Flex, FlexItem, Spinner, TreeView, TreeViewDataItem } from '@patternfly/react-core';
+import React from 'react';
+import type { ReactElement } from 'react';
+import { Alert, Flex, FlexItem, Spinner, TreeView } from '@patternfly/react-core';
+import type { TreeViewDataItem } from '@patternfly/react-core';
 
-import { MitreAttackVector } from 'types/mitre.proto';
+import type { MitreAttackVector } from 'types/mitre.proto';
 
 import MitreAttackLink from './MitreAttackLink';
 import { getMitreTacticUrl, getMitreTechniqueUrl } from './MitreAttackVectors.utils';

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { gql, useQuery } from '@apollo/client';
 
 import { fetchMitreAttackVectors } from 'services/MitreService';
-import { MitreAttackVector } from 'types/mitre.proto';
+import type { MitreAttackVector } from 'types/mitre.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import {

--- a/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { FormEvent, ReactElement } from 'react';
 import * as yup from 'yup';
 import {
     Modal,
@@ -14,7 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { FormikProvider, useFormik } from 'formik';
 
-import { PolicyCategory } from 'types/policy.proto';
+import type { PolicyCategory } from 'types/policy.proto';
 import { postPolicyCategory } from 'services/PolicyCategoriesService';
 
 type CreatePolicyCategoryModalProps = {
@@ -35,7 +36,7 @@ function CreatePolicyCategoryModal({
     onClose,
     addToast,
     refreshPolicyCategories,
-}: CreatePolicyCategoryModalProps) {
+}: CreatePolicyCategoryModalProps): ReactElement {
     const formik = useFormik({
         initialValues: emptyPolicyCategory as PolicyCategory,
         onSubmit: (values, { setSubmitting, resetForm }) => {
@@ -66,7 +67,7 @@ function CreatePolicyCategoryModal({
 
     const { values, handleChange, handleSubmit, resetForm, isValid } = formik;
 
-    function onChange(event: React.FormEvent) {
+    function onChange(event: FormEvent) {
         handleChange(event);
     }
 

--- a/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
@@ -17,7 +17,7 @@ import {
 
 import { getPolicies } from 'services/PoliciesService';
 import { deletePolicyCategory } from 'services/PolicyCategoriesService';
-import { PolicyCategory, ListPolicy } from 'types/policy.proto';
+import type { PolicyCategory, ListPolicy } from 'types/policy.proto';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 type DeletePolicyCategoryModalProps = {

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesList.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SimpleList, SimpleListItem } from '@patternfly/react-core';
 
-import { PolicyCategory } from 'types/policy.proto';
+import type { PolicyCategory } from 'types/policy.proto';
 
 type PolicyCategoriesListProps = {
     policyCategories: PolicyCategory[];

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { PageSection, Divider, Title, Flex, FlexItem, TextInput } from '@patternfly/react-core';
 
-import { PolicyCategory } from 'types/policy.proto';
+import type { PolicyCategory } from 'types/policy.proto';
 import PolicyCategoriesList from './PolicyCategoriesList';
-import PolicyCategoriesFilterSelect, { CategoryFilter } from './PolicyCategoriesFilterSelect';
+import PolicyCategoriesFilterSelect from './PolicyCategoriesFilterSelect';
+import type { CategoryFilter } from './PolicyCategoriesFilterSelect';
 import PolicyCategorySidePanel from './PolicyCategorySidePanel';
 import DeletePolicyCategoryModal from './DeletePolicyCategoryModal';
 

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import {
     PageSection,
     Bullseye,
@@ -15,15 +16,16 @@ import {
 } from '@patternfly/react-core';
 
 import usePermissions from 'hooks/usePermissions';
-import useToasts, { Toast } from 'hooks/patternfly/useToasts';
+import useToasts from 'hooks/patternfly/useToasts';
+import type { Toast } from 'hooks/patternfly/useToasts';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { PolicyCategory } from 'types/policy.proto';
+import type { PolicyCategory } from 'types/policy.proto';
 import { getPolicyCategories } from 'services/PolicyCategoriesService';
 import PolicyManagementHeader from 'Containers/PolicyManagement/PolicyManagementHeader';
 import PolicyCategoriesListSection from './PolicyCategoriesListSection';
 import CreatePolicyCategoryModal from './CreatePolicyCategoryModal';
 
-function PolicyCategoriesPage(): React.ReactElement {
+function PolicyCategoriesPage(): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForPolicy = hasReadWriteAccess('WorkflowAdministration');
 

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { FormEvent, ReactElement } from 'react';
 import { FormikProvider, useFormik } from 'formik';
 import {
     PageSection,
@@ -14,7 +15,7 @@ import {
     HelperTextItem,
 } from '@patternfly/react-core';
 
-import { PolicyCategory } from 'types/policy.proto';
+import type { PolicyCategory } from 'types/policy.proto';
 import { renamePolicyCategory } from 'services/PolicyCategoriesService';
 
 type PolicyCategorySidePanelProps = {
@@ -31,7 +32,7 @@ function PolicyCategorySidePanel({
     addToast,
     refreshPolicyCategories,
     openDeleteModal,
-}: PolicyCategorySidePanelProps) {
+}: PolicyCategorySidePanelProps): ReactElement {
     const formik = useFormik({
         initialValues: selectedCategory,
         onSubmit: (values, { setSubmitting }) => {
@@ -54,7 +55,7 @@ function PolicyCategorySidePanel({
 
     const { values, handleChange, dirty, handleSubmit } = formik;
 
-    function onChange(event: React.FormEvent) {
+    function onChange(event: FormEvent) {
         handleChange(event);
     }
 

--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -1,13 +1,14 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-import { SearchResultCategory } from 'services/SearchService';
-import { SearchFilter } from 'types/search';
+import type { SearchResultCategory } from 'services/SearchService';
+import type { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 
 import NotApplicable from './NotApplicable';
-import { SearchResultCategoryMap } from './searchCategories';
+import type { SearchResultCategoryMap } from './searchCategories';
 
 type FilterLinksProps = {
     filterValue: string;

--- a/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
+++ b/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 function NotApplicable(): ReactElement {
     return <span className="pf-v5-u-color-200 pf-v5-u-text-nowrap">Not applicable</span>;

--- a/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
@@ -1,13 +1,15 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem, Nav, NavItem, NavList, Split, SplitItem } from '@patternfly/react-core';
 
-import { SearchResponse } from 'services/SearchService';
-import { SearchFilter } from 'types/search';
+import type { SearchResponse } from 'services/SearchService';
+import type { SearchFilter } from 'types/search';
 import { searchPath } from 'routePaths';
 
 import SearchTable from './SearchTable';
-import { SearchNavCategory, searchNavMap } from './searchCategories';
+import { searchNavMap } from './searchCategories';
+import type { SearchNavCategory } from './searchCategories';
 import { stringifyQueryObject } from './searchQuery';
 
 type SearchNavAndTableProps = {

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {
     Alert,
@@ -12,12 +13,9 @@ import {
 
 import PageTitle from 'Components/PageTitle';
 import SearchFilterInput from 'Components/SearchFilterInput';
-import {
-    SearchResponse,
-    fetchGlobalSearchResults,
-    getSearchOptionsForCategory,
-} from 'services/SearchService';
-import { SearchFilter } from 'types/search';
+import { fetchGlobalSearchResults, getSearchOptionsForCategory } from 'services/SearchService';
+import type { SearchResponse } from 'services/SearchService';
+import type { SearchFilter } from 'types/search';
 import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -1,18 +1,16 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { SearchResult, SearchResultCategory } from 'services/SearchService';
-import { SearchFilter } from 'types/search';
+import type { SearchResult, SearchResultCategory } from 'services/SearchService';
+import type { SearchFilter } from 'types/search';
 
 import FilterLinks from './FilterLinks';
 import ViewLinks from './ViewLinks';
-import {
-    SearchNavCategory,
-    searchNavMap,
-    searchResultCategoryMapFilteredIsRouteEnabled,
-} from './searchCategories';
+import { searchNavMap, searchResultCategoryMapFilteredIsRouteEnabled } from './searchCategories';
+import type { SearchNavCategory } from './searchCategories';
 
 function getLocationTextForCategory(location: string, category: SearchResultCategory) {
     return category === 'DEPLOYMENTS' ? location.replace(/^\//, '') : location.replace(/\/.+/, '');

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -1,12 +1,13 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-import { SearchResult } from 'services/SearchService';
+import type { SearchResult } from 'services/SearchService';
 import { safeGeneratePath } from 'utils/urlUtils';
 
 import NotApplicable from './NotApplicable';
-import { SearchResultCategoryMap } from './searchCategories';
+import type { SearchResultCategoryMap } from './searchCategories';
 
 type ViewLinksProps = {
     searchResult: SearchResult & {

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -1,9 +1,8 @@
 import cloneDeep from 'lodash/cloneDeep';
 
-import { IsRouteEnabled } from 'hooks/useIsRouteEnabled';
-import { SearchResultCategory } from 'services/SearchService';
+import type { IsRouteEnabled } from 'hooks/useIsRouteEnabled';
+import type { SearchResultCategory } from 'services/SearchService';
 import {
-    RouteKey,
     clustersBasePath,
     configManagementPath,
     policiesBasePath,
@@ -12,8 +11,9 @@ import {
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesNodeCvesPath,
 } from 'routePaths';
+import type { RouteKey } from 'routePaths';
 import { getQueryString } from 'utils/queryStringUtils';
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 
 const configManagementRolesPath = `${configManagementPath}/roles`;
 const configManagementSecretsPath = `${configManagementPath}/secrets`;

--- a/ui/apps/platform/src/Containers/Search/searchQuery.ts
+++ b/ui/apps/platform/src/Containers/Search/searchQuery.ts
@@ -1,8 +1,9 @@
 import qs from 'qs';
 
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
-import { SearchNavCategory, searchNavMap } from './searchCategories';
+import { searchNavMap } from './searchCategories';
+import type { SearchNavCategory } from './searchCategories';
 
 export type SearchQueryObject = {
     searchFilter: SearchFilter;

--- a/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Icon, Spinner } from '@patternfly/react-core';
 import {
     CheckCircleIcon,

--- a/ui/apps/platform/src/Containers/SystemHealth/CentralDatabaseHealth/CentralDatabaseHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CentralDatabaseHealth/CentralDatabaseHealthCard.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Card,
     CardBody,
@@ -11,7 +12,7 @@ import {
 
 import useRestQuery from 'hooks/useRestQuery';
 import { fetchDatabaseStatus } from 'services/DatabaseService';
-import { DatabaseStatus } from 'types/databaseService.proto';
+import type { DatabaseStatus } from 'types/databaseService.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import { ErrorIcon, SpinnerIcon, SuccessIcon, WarningIcon } from '../CardHeaderIcons';

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Button,
@@ -16,7 +17,7 @@ import useMetadata from 'hooks/useMetadata';
 import usePermissions from 'hooks/usePermissions';
 import { generateCertSecretForComponent } from 'services/CertGenerationService';
 import { fetchCertExpiryForComponent } from 'services/CredentialExpiryService';
-import { CertExpiryComponent } from 'types/credentialExpiryService.proto';
+import type { CertExpiryComponent } from 'types/credentialExpiryService.proto';
 import {
     getCredentialExpiryPhrase,
     getCredentialExpiryVariant,

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import { Table, Tbody, Th, Tr } from '@patternfly/react-table';
 
-import { Cluster } from 'types/cluster.proto';
+import type { Cluster } from 'types/cluster.proto';
 
 import { getClusterBecauseOfStatusCounts, getClusterStatusCounts } from './ClustersHealth.utils';
 import ClustersHealthCardHeader from './ClustersHealthCardHeader';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealth.utils.ts
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealth.utils.ts
@@ -2,10 +2,10 @@ import {
     findUpgradeState,
     getCredentialExpirationStatus,
 } from 'Containers/Clusters/cluster.helpers';
-import { CertExpiryStatus } from 'Containers/Clusters/clusterTypes'; // TODO types/cluster.proto.ts
-import { Cluster } from 'types/cluster.proto';
+import type { CertExpiryStatus } from 'Containers/Clusters/clusterTypes'; // TODO types/cluster.proto.ts
+import type { Cluster } from 'types/cluster.proto';
 
-import { HealthVariant } from '../CardHeaderIcons';
+import type { HealthVariant } from '../CardHeaderIcons';
 
 export type ClusterStatus = 'HEALTHY' | 'UNHEALTHY' | 'DEGRADED' | 'UNAVAILABLE' | 'UNINITIALIZED';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
@@ -6,11 +7,8 @@ import { clustersBasePath } from 'routePaths';
 
 import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
 
-import {
-    ClusterStatusCounts,
-    getClustersHealthPhrase,
-    getClustersHealthVariant,
-} from './ClustersHealth.utils';
+import { getClustersHealthPhrase, getClustersHealthVariant } from './ClustersHealth.utils';
+import type { ClusterStatusCounts } from './ClustersHealth.utils';
 
 export type ClustersHealthCardHeaderProps = {
     counts: ClusterStatusCounts | null;

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { GridItem } from '@patternfly/react-core';
 
 import { fetchClusters } from 'services/ClustersService';
-import { Cluster } from 'types/cluster.proto';
+import type { Cluster } from 'types/cluster.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import ClusterStatusCard from './ClusterStatusCard';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthTable.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthTable.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import { Table, Tbody, Th, Tr } from '@patternfly/react-table';
 
-import { Cluster } from 'types/cluster.proto';
+import type { Cluster } from 'types/cluster.proto';
 
 import { getCertificateExpirationCounts } from './ClustersHealth.utils';
 import ClustersHealthCardHeader from './ClustersHealthCardHeader';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import { Table, Tbody, Th, Tr } from '@patternfly/react-table';
 
-import { Cluster } from 'types/cluster.proto';
+import type { Cluster } from 'types/cluster.proto';
 
 import { getSensorUpgradeCounts } from './ClustersHealth.utils';
 import ClustersHealthCardHeader from './ClustersHealthCardHeader';

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/BackupIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/BackupIntegrationHealthWidget.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useEffect, ReactElement } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 
 import { fetchBackupIntegrationsHealth } from 'services/IntegrationHealthService';
 import { fetchBackupIntegrations } from 'services/BackupIntegrationsService';
 import { backupIntegrationsDescriptors } from 'Containers/Integrations/utils/integrationsList';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import IntegrationHealthWidgetVisual from './IntegrationHealthWidgetVisual';
-import { mergeIntegrationResponses, IntegrationMergedItem } from '../utils/integrations';
+import { mergeIntegrationResponses } from '../utils/integrations';
+import type { IntegrationMergedItem } from '../utils/integrations';
 
 type WidgetProps = {
     pollingCount: number;

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/ImageIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/ImageIntegrationHealthWidget.tsx
@@ -1,11 +1,13 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 
 import { fetchImageIntegrationsHealth } from 'services/IntegrationHealthService';
 import { fetchImageIntegrations } from 'services/ImageIntegrationsService';
 import { imageIntegrationsDescriptors } from 'Containers/Integrations/utils/integrationsList';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import IntegrationHealthWidgetVisual from './IntegrationHealthWidgetVisual';
-import { IntegrationMergedItem, mergeIntegrationResponses } from '../utils/integrations';
+import { mergeIntegrationResponses } from '../utils/integrations';
+import type { IntegrationMergedItem } from '../utils/integrations';
 
 type WidgetProps = {
     pollingCount: number;

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Card,
@@ -11,7 +12,7 @@ import {
 
 import pluralize from 'pluralize';
 import IntegrationsHealth from './IntegrationsHealth';
-import { IntegrationMergedItem } from '../utils/integrations';
+import type { IntegrationMergedItem } from '../utils/integrations';
 import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
 
 type IntegrationHealthWidgetVisualProps = {

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { getDateTime } from 'utils/dateUtils';
 
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { IntegrationMergedItem } from '../utils/integrations';
+import type { IntegrationMergedItem } from '../utils/integrations';
 
 type Props = {
     integrations: IntegrationMergedItem[];

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/NotifierIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/NotifierIntegrationHealthWidget.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useEffect, ReactElement } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 
 import { fetchNotifierIntegrationsHealth } from 'services/IntegrationHealthService';
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
 import { notifierIntegrationsDescriptors } from 'Containers/Integrations/utils/integrationsList';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import IntegrationHealthWidgetVisual from './IntegrationHealthWidgetVisual';
-import { mergeIntegrationResponses, IntegrationMergedItem } from '../utils/integrations';
-import { getAxiosErrorMessage } from '../../../utils/responseErrorUtils';
+import { mergeIntegrationResponses } from '../utils/integrations';
+import type { IntegrationMergedItem } from '../utils/integrations';
 
 type WidgetProps = {
     pollingCount: number;

--- a/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, ReactElement } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Card,
@@ -12,11 +13,11 @@ import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
 import { fetchDeclarativeConfigurationsHealth } from 'services/DeclarativeConfigHealthService';
+import type { DeclarativeConfigHealth } from 'types/declarativeConfigHealth.proto';
 import { getDateTime } from 'utils/dateUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
-import { DeclarativeConfigHealth } from '../../../types/declarativeConfigHealth.proto';
 
 type DeclarativeConfigurationHealthCardProps = {
     pollingCount: number;

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, ReactElement, FormEvent } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ChangeEvent, MouseEvent as ReactMouseEvent, FormEvent, ReactElement } from 'react';
 import {
     Form,
     FormGroup,
@@ -11,7 +12,7 @@ import { Select, SelectOption } from '@patternfly/react-core/deprecated';
 
 import usePermissions from 'hooks/usePermissions';
 import { fetchClusters } from 'services/ClustersService';
-import { DiagnosticBundleRequest } from 'services/DebugService';
+import type { DiagnosticBundleRequest } from 'services/DebugService';
 import FilterByStartingTimeValidationMessage from './FilterByStartingTimeValidationMessage';
 
 const startingTimeFormat = 'yyyy-mm-ddThh:mmZ'; // seconds are optional but UTC is required
@@ -58,7 +59,7 @@ function DiagnosticBundleForm({
         setClusterSelectOpen(!clusterSelectOpen);
     }
 
-    function onSelect(event: React.MouseEvent | React.ChangeEvent, selection) {
+    function onSelect(event: ReactMouseEvent | ChangeEvent, selection) {
         const newClusterFilter = values.filterByClusters.includes(selection)
             ? values.filterByClusters.filter((item) => item !== selection)
             : [...values.filterByClusters, selection];
@@ -72,7 +73,7 @@ function DiagnosticBundleForm({
         setFieldValue('filterByClusters', []);
     }
 
-    function startingTimeChangeHandler(value: string, event: React.FormEvent<HTMLInputElement>) {
+    function startingTimeChangeHandler(value: string, event: FormEvent<HTMLInputElement>) {
         onChangeStartingTime(event);
         return setFieldValue(event.currentTarget.id, value);
     }

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Flex, FlexItem, Icon } from '@patternfly/react-core';
 import {
     BanIcon,

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
@@ -1,4 +1,5 @@
-import React, { useState, ReactElement } from 'react';
+import React, { useState } from 'react';
+import type { FormEvent, ReactElement } from 'react';
 import { Button, Flex, Popover, PopoverPosition } from '@patternfly/react-core';
 import { AngleDownIcon, AngleUpIcon, DownloadIcon } from '@patternfly/react-icons';
 import { useFormik } from 'formik';
@@ -7,7 +8,8 @@ import { parse } from 'date-fns';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 import useMetadata from 'hooks/useMetadata';
-import downloadDiagnostics, { DiagnosticBundleRequest } from 'services/DebugService';
+import downloadDiagnostics from 'services/DebugService';
+import type { DiagnosticBundleRequest } from 'services/DebugService';
 import { getVersionedDocs } from 'utils/versioning';
 
 import DiagnosticBundleForm from './DiagnosticBundleForm';
@@ -25,7 +27,7 @@ function GenerateDiagnosticBundle(): ReactElement {
     const [currentTimeObject, setCurrentTimeObject] = useState<Date | null>(null); // for pure message
     const { version } = useMetadata();
 
-    function onChangeStartingTime(event: React.FormEvent<HTMLInputElement>): void {
+    function onChangeStartingTime(event: FormEvent<HTMLInputElement>): void {
         const trimmedText = event.currentTarget.value.trim();
 
         if (trimmedText.length === 0) {

--- a/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/AdministrationUsageForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/AdministrationUsageForm.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Button,
@@ -15,7 +16,10 @@ import {
     Title,
     yyyyMMddFormat,
 } from '@patternfly/react-core';
-import { MaxSecuredUnitsUsageResponse, SecuredUnitsUsage } from 'types/administrationUsage.proto';
+import type {
+    MaxSecuredUnitsUsageResponse,
+    SecuredUnitsUsage,
+} from 'types/administrationUsage.proto';
 import {
     downloadAdministrationUsageCsv,
     fetchCurrentAdministrationUsage,

--- a/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button, Modal, ModalBoxBody } from '@patternfly/react-core';
 import useModal from 'hooks/useModal';
 import AdministrationUsageForm from './AdministrationUsageForm';

--- a/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Card,
@@ -10,10 +11,8 @@ import {
 } from '@patternfly/react-core';
 import { differenceInMinutes } from 'date-fns';
 
-import {
-    fetchVulnerabilityDefinitionsInfo,
-    ScannerComponent,
-} from 'services/IntegrationHealthService';
+import { fetchVulnerabilityDefinitionsInfo } from 'services/IntegrationHealthService';
+import type { ScannerComponent } from 'services/IntegrationHealthService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';

--- a/ui/apps/platform/src/Containers/SystemHealth/utils/integrations.ts
+++ b/ui/apps/platform/src/Containers/SystemHealth/utils/integrations.ts
@@ -1,4 +1,4 @@
-import { IntegrationBase } from 'services/IntegrationsService';
+import type { IntegrationBase } from 'services/IntegrationsService';
 
 interface IdNameInterface {
     id: string;

--- a/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
+++ b/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, Icon } from '@patternfly/react-core';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/User/UserPermissionsForRolesTable.tsx
+++ b/ui/apps/platform/src/Containers/User/UserPermissionsForRolesTable.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, ReactElement } from 'react';
+import React from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import RolesForResourceAccess from './RolesForResourceAccess';

--- a/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { PermissionsMap } from 'services/RolesService';
+import type { PermissionsMap } from 'services/RolesService';
 
 import {
     ReadAccessIcon,
@@ -10,8 +11,8 @@ import {
 import {
     deprecatedResourceRowStyle,
     resourceRemovalReleaseVersions,
-} from '../../constants/accessControl';
-import { ResourceName } from '../../types/roleResources';
+} from 'constants/accessControl';
+import type { ResourceName } from 'types/roleResources';
 
 export type UserPermissionsTableProps = {
     permissions: PermissionsMap;


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select folders that will not cause merge conflicts with feature work in progress.

That is, wait until at least end of sprint to fix folders of features in 4.9 effort.

While we wait, fix errors for sort-named-imports rule in other folders.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.