### PR TITLE
fix: Mount host directories, allowing to free up more disk space

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -582,6 +582,9 @@ jobs:
       - define-job-matrix
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.9
+      volumes:
+        - /usr:/mnt/usr
+        - /opt:/mnt/opt
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}


### PR DESCRIPTION
## Description

So, merging https://github.com/stackrox/stackrox/pull/17140 apparently again caused master branch breakage. The operator image building failed on the master branch due to "no space left on device".

This is an attempt at fixing this by leveraging the "mount host directories into container" trick, which seems to allow the `job-preamble` to more aggressively delete certain unused tools and thus freeing up more disk space.

## User-facing documentation & Tests

This is merely a CI fix, nothing user facing -> neither docs, nor tests required for this change.
