### PR TITLE
perf(node): near cache for GetMany/Walk

### DIFF
--- a/central/node/datastore/store/postgres/component_cache.go
+++ b/central/node/datastore/store/postgres/component_cache.go
@@ -1,0 +1,141 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// txWithCache defines an interface for database transactions with optional caching
+type txWithCache interface {
+	// Access to underlying transaction
+	GetTx() *postgres.Tx
+
+	// Cache-aware methods
+	GetNodeComponents(ctx context.Context, componentIDs []string) (map[string]*storage.NodeComponent, error)
+	GetComponentCVEEdges(ctx context.Context, componentIDs []string) (map[string][]*storage.NodeComponentCVEEdge, error)
+}
+
+// transactionCache is a transaction-scoped cache for node components and CVE edges
+// This cache is safe to use within a read-only transaction in WalkByQuery
+type transactionCache struct {
+	*postgres.Tx
+	nodeComponents map[string]*storage.NodeComponent
+	cveEdges       map[string][]*storage.NodeComponentCVEEdge
+}
+
+// transactionNoCache provides a no-cache implementation for single operations
+type transactionNoCache struct {
+	*postgres.Tx
+}
+
+// newTransactionCache creates a new transaction-scoped cache
+func newTransactionCache(tx *postgres.Tx) *transactionCache {
+	return &transactionCache{
+		Tx:             tx,
+		nodeComponents: make(map[string]*storage.NodeComponent),
+		cveEdges:       make(map[string][]*storage.NodeComponentCVEEdge),
+	}
+}
+
+// newTransactionNoCache creates a new no-cache transaction wrapper
+func newTransactionNoCache(tx *postgres.Tx) *transactionNoCache {
+	return &transactionNoCache{Tx: tx}
+}
+
+func (tc *transactionCache) GetTx() *postgres.Tx {
+	return tc.Tx
+}
+
+// GetNodeComponents returns cached components or fetches missing ones from database
+func (tc *transactionCache) GetNodeComponents(ctx context.Context, componentIDs []string) (map[string]*storage.NodeComponent, error) {
+	result := make(map[string]*storage.NodeComponent)
+	var missingIDs []string
+
+	// Check cache first
+	for _, id := range componentIDs {
+		if component, exists := tc.nodeComponents[id]; exists {
+			result[id] = component.CloneVT() // Clone for safety
+		} else {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+
+	// Fetch missing components from database
+	if len(missingIDs) > 0 {
+		dbComponents, err := getNodeComponents(ctx, tc.Tx, missingIDs)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add to cache and result
+		for id, component := range dbComponents {
+			tc.nodeComponents[id] = component
+			result[id] = component.CloneVT() // Clone for result
+		}
+	}
+
+	return result, nil
+}
+
+// GetComponentCVEEdges returns cached CVE edges or fetches missing ones from database
+func (tc *transactionCache) GetComponentCVEEdges(ctx context.Context, componentIDs []string) (map[string][]*storage.NodeComponentCVEEdge, error) {
+	result := make(map[string][]*storage.NodeComponentCVEEdge)
+	var missingIDs []string
+
+	// Check cache first
+	for _, id := range componentIDs {
+		if edges, exists := tc.cveEdges[id]; exists {
+			// Clone edges for safety
+			clonedEdges := make([]*storage.NodeComponentCVEEdge, len(edges))
+			for i, edge := range edges {
+				clonedEdges[i] = edge.CloneVT()
+			}
+			result[id] = clonedEdges
+		} else {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+
+	// Fetch missing edges from database
+	if len(missingIDs) > 0 {
+		dbEdges, err := getComponentCVEEdges(ctx, tc.Tx, missingIDs)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add to cache and result
+		for componentID, edges := range dbEdges {
+			// Clone for cache
+			cachedEdges := make([]*storage.NodeComponentCVEEdge, len(edges))
+			for i, edge := range edges {
+				cachedEdges[i] = edge
+			}
+			tc.cveEdges[componentID] = cachedEdges
+
+			// Clone for result
+			resultEdges := make([]*storage.NodeComponentCVEEdge, len(edges))
+			for i, edge := range edges {
+				resultEdges[i] = edge.CloneVT()
+			}
+			result[componentID] = resultEdges
+		}
+	}
+
+	return result, nil
+}
+
+func (tnc *transactionNoCache) GetTx() *postgres.Tx {
+	return tnc.Tx
+}
+
+// GetNodeComponents returns components directly from database without caching
+func (tnc *transactionNoCache) GetNodeComponents(ctx context.Context, componentIDs []string) (map[string]*storage.NodeComponent, error) {
+	return getNodeComponents(ctx, tnc.Tx, componentIDs)
+}
+
+// GetComponentCVEEdges returns CVE edges directly from database without caching
+func (tnc *transactionNoCache) GetComponentCVEEdges(ctx context.Context, componentIDs []string) (map[string][]*storage.NodeComponentCVEEdge, error) {
+	return getComponentCVEEdges(ctx, tnc.Tx, componentIDs)
+}

--- a/central/node/datastore/store/postgres/cve_store_test.go
+++ b/central/node/datastore/store/postgres/cve_store_test.go
@@ -24,7 +24,7 @@ type NodeCVEStoreSuite struct {
 	ctx    context.Context
 	pool   postgres.DB
 	gormDB *gorm.DB
-	store  nodeCVEStore
+	store  *nodeCVEStore
 }
 
 func TestNodeCVEStore(t *testing.T) {
@@ -303,7 +303,7 @@ func (s *NodeCVEStoreSuite) TestCacheMissingIDs() {
 	s.NotContains(cves, nonExistentID)
 
 	// Test cache directly to verify missing IDs are returned
-	cache := s.store.(*nodeCVEStoreImpl).cache
+	cache := s.store.cache
 	cachedCVEs, missingIDs := cache.GetMany([]string{cve1.GetId(), nonExistentID})
 
 	// Should return cached CVE and missing ID
@@ -355,7 +355,7 @@ func (s *NodeCVEStoreSuite) TestGetCVEsNothingFoundInDB() {
 	s.Empty(cves)
 
 	// Verify the cache path was also taken for missing IDs
-	cache := s.store.(*nodeCVEStoreImpl).cache
+	cache := s.store.cache
 	cachedCVEs, missingIDs := cache.GetMany(nonExistentIDs)
 	s.Empty(cachedCVEs)
 	s.Len(missingIDs, 2)
@@ -543,7 +543,7 @@ func (s *NodeCVEStoreSuite) TestGetCVEsFromDatabaseWithCacheMiss() {
 	s.Require().NoError(err)
 
 	// Verify cache is empty for this CVE (since we bypassed it)
-	cache := s.store.(*nodeCVEStoreImpl).cache
+	cache := s.store.cache
 	cachedCVEs, missingIDs := cache.GetMany([]string{cve.GetId()})
 	s.Empty(cachedCVEs)
 	s.Len(missingIDs, 1)


### PR DESCRIPTION
When we query for multiple nodes there is a chance we will fetch the same data multiple times as components might be shared between nodes. This PR adds a transaction cache that tries to minimise the db lookups to minimum. In the future we may want to use nodecompoent store and make it cached but for now let's create a small cache for transaction.

```
                                   │   new.txt    │               new2.txt               │
                                   │    sec/op    │    sec/op     vs base                │
GetManyNodes/GetNodesBatch-8         61.28m ± 40%   25.35m ± 33%  -58.64% (p=0.000 n=10)
GetManyNodes/GetManyNodeMetadata-8   718.4µ ± 27%   734.1µ ±  4%        ~ (p=0.315 n=10)
geomean                              6.635m         4.314m        -34.99%

                                   │   new.txt    │               new2.txt               │
                                   │     B/op     │     B/op      vs base                │
GetManyNodes/GetNodesBatch-8         3.342Mi ± 0%   2.733Mi ± 0%  -18.22% (p=0.000 n=10)
GetManyNodes/GetManyNodeMetadata-8   267.7Ki ± 0%   267.7Ki ± 0%        ~ (p=0.054 n=10)
geomean                              957.3Ki        865.7Ki        -9.57%

                                   │   new.txt   │               new2.txt                │
                                   │  allocs/op  │  allocs/op   vs base                  │
GetManyNodes/GetNodesBatch-8         53.54k ± 0%   39.52k ± 0%  -26.18% (p=0.000 n=10)
GetManyNodes/GetManyNodeMetadata-8   3.976k ± 0%   3.976k ± 0%        ~ (p=1.000 n=10) ¹
geomean                              14.59k        12.54k       -14.08%
¹ all samples are equal

```
