### PR TITLE
fix(ui): Remove unneeded "K8s API verb" from runtime

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -1390,17 +1390,6 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         lifecycleStages: ['RUNTIME'],
     },
     {
-        label: 'Kubernetes API verb',
-        name: 'Kubernetes API Verb',
-        shortName: 'Kubernetes API verb',
-        category: policyCriteriaCategories.USER_ISSUED_CONTAINER_COMMANDS,
-        type: 'select',
-        placeholder: 'Select an API verb',
-        options: [{ label: 'CREATE', value: 'CREATE' }],
-        canBooleanLogic: false,
-        lifecycleStages: ['RUNTIME'],
-    },
-    {
         label: 'Kubernetes user name',
         name: 'Kubernetes User Name',
         shortName: 'Kubernetes user name',


### PR DESCRIPTION
## Description

This criteria was added in 4.9, but deeper investigation found that it is **not** needed at all, and does not have an impact on a created policy. Since it is not useful, it is being removed to prevent confusion.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Removed from Runtime -> Deployment criteria
<img width="1252" height="921" alt="image" src="https://github.com/user-attachments/assets/ba19c5eb-3283-4595-8df2-f330952fc4ce" />

Still exists in Runtime -> Audit Log criteria
<img width="1252" height="921" alt="image" src="https://github.com/user-attachments/assets/48383d83-ec83-4923-93a1-13ce294b4290" />

