### PR TITLE
ROX-31217: Remove datastore-level SAC checks in k8s roles

### DIFF
--- a/central/rbac/k8srole/datastore/datastore_impl.go
+++ b/central/rbac/k8srole/datastore/datastore_impl.go
@@ -7,13 +7,7 @@ import (
 	"github.com/stackrox/rox/central/rbac/k8srole/internal/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/sac"
-	"github.com/stackrox/rox/pkg/sac/resources"
 	searchPkg "github.com/stackrox/rox/pkg/search"
-)
-
-var (
-	k8sRolesSAC = sac.ForResource(resources.K8sRole)
 )
 
 type datastoreImpl struct {
@@ -26,9 +20,6 @@ func (d *datastoreImpl) GetRole(ctx context.Context, id string) (*storage.K8SRol
 		return nil, false, err
 	}
 
-	if !k8sRolesSAC.ScopeChecker(ctx, storage.Access_READ_ACCESS).ForNamespaceScopedObject(role).IsAllowed() {
-		return nil, false, nil
-	}
 	return role, true, nil
 }
 
@@ -56,22 +47,10 @@ func (d *datastoreImpl) SearchRawRoles(ctx context.Context, request *v1.Query) (
 }
 
 func (d *datastoreImpl) UpsertRole(ctx context.Context, request *storage.K8SRole) error {
-	if ok, err := k8sRolesSAC.WriteAllowed(ctx); err != nil {
-		return err
-	} else if !ok {
-		return sac.ErrResourceAccessDenied
-	}
-
 	return d.storage.Upsert(ctx, request)
 }
 
 func (d *datastoreImpl) RemoveRole(ctx context.Context, id string) error {
-	if ok, err := k8sRolesSAC.WriteAllowed(ctx); err != nil {
-		return err
-	} else if !ok {
-		return sac.ErrResourceAccessDenied
-	}
-
 	return d.storage.Delete(ctx, id)
 }
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

With the migration to postgres and later evolutions of the data access layers, basic scoped access control checks have been copied or moved from the datastore layer to the generated postgres store code and later to the postgres query generator code.

The SAC checks for the kubernetes roles datastore were left behind in these migrations, and are still present in the `rbac/k8sroles` datastore, where they can create confusion. The goal of this change is to remove these checks that are now unnecessary.

The removal of the SAC checks in the `UpsertRole` and `RemoveRole` datastore functions slightly change the behaviour of these functions:
- Instead of returning an `access to resource denied` if the requester does not have full scope for the `K8sRole` permission, `UpsertRole` will only do so if the target role is not in the requester scope for the `K8sRole` resource and `Write` action (regardless of whether the target role exists or not).
- Instead of returning an `access to resource denied` if the requester does not have full scope for the `K8sRole` permission, `RemoveRole` will silently ignore the request and leave the target role in place if it does not belong to the requester scope for the `K8sRole` permission and the `Write` action.

Note: the current call locations for the `UpsertRole` and `RemoveRole` functions were checked, and all of them currently call the functions with global write access for `K8sRole`. This means that the behaviour change does not impact these code paths, as these would never have entered the `access to resource denied` error code path. These code locations are:
- sensor pipeline for k8s roles
- removal of cluster-related resources upon cluster removal
- pruning

## User-facing documentation

- No change in behaviour is expected as a result of this code change.
- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
-->
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI run
