### PR TITLE
chore(fixxer): use rhacs-bot email for fixxer commits

### DIFF
--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -65,7 +65,7 @@ jobs:
       run: |
         set -ex
         git config --global --add safe.directory "$(pwd)"
-        git config --global user.email "nobody@redhat.com"
+        git config --global user.email "rhacs-bot@redhat.com"
         git config --global user.name "StackRox PR Fixxxer"
 
     - run: ./scripts/fixxxer.sh


### PR DESCRIPTION
This PR adds a real email to fixxer commits so they will be properly handled during merge. Alternatively we can use github actions email https://github.com/orgs/community/discussions/26560 https://github.com/actions/checkout/pull/1707

```diff
- Co-authored-by: StackRox PR Fixxxer <nobody@redhat.com>
+ Co-authored-by: StackRox PR Fixxxer <rhacs-bot@redhat.com>
```