### PR TITLE
ROX-31217: Remove datastore-level SAC checks in process baseline res

### DIFF
--- a/central/deployment/service/service_impl.go
+++ b/central/deployment/service/service_impl.go
@@ -116,6 +116,10 @@ func (s *serviceImpl) ListDeploymentsWithProcessInfo(ctx context.Context, rawQue
 			},
 		)
 	}
+	// The function below requires the caller to have read allowed the DeploymentExtension
+	// permission, and at least the same scope for it as for the Deployment permission.
+	// Otherwise, the endpoint will return an error for any deployment that is not in the
+	// intersection of scope for both permissions.
 	if err := s.fillBaselineResults(ctx, resp); err != nil {
 		return nil, err
 	}

--- a/central/processbaselineresults/datastore/datastore_sac_test.go
+++ b/central/processbaselineresults/datastore/datastore_sac_test.go
@@ -132,11 +132,17 @@ func (s *processBaselineResultsDatastoreSACSuite) TestDeleteBaselineResults() {
 
 			ctx := s.testContexts[c.ScopeKey]
 			err = s.datastore.DeleteBaselineResults(ctx, processBaselineResult.GetDeploymentId())
-			if c.ExpectError {
-				s.Require().Error(err)
-				s.ErrorIs(err, c.ExpectedError)
+			s.NoError(err)
+
+			fetchedResults, err := s.datastore.GetBaselineResults(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaselineResult.GetDeploymentId(),
+			)
+			s.NoError(err)
+			if c.ExpectedFound {
+				protoassert.Equal(s.T(), processBaselineResult, fetchedResults)
 			} else {
-				s.NoError(err)
+				s.Nil(fetchedResults)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

With the migration to postgres and later evolutions of the data access layers, basic scoped access control checks have been copied or moved from the datastore layer to the generated postgres store code and later to the postgres query generator code.

The SAC checks for the process baseline results datastore were left behind in these migrations, and are still present in the `processbaselineresults` datastore, where they can create confusion. The goal of this change is to remove these checks that are now unnecessary.

The removal of the SAC checks in the `UpsertBaselineResults` and `DeleteBaselineResults` datastore functions slightly change the behaviour of these functions:

- Instead of returning an `access to resource denied` if the requester does not have full scope for the `DeploymentExtension` permission, `UpsertBaselineResults` will only do so if the target process baseline results are not in the requester scope for the `DeploymentExtension` resource and `Write` action (regardless of whether the target process baseline results exist or not).
- Instead of returning an `access to resource denied` if the requester does not have full scope for the `DeploymentExtension` permission, `DeleteBaselineResults` will silently ignore the request and leave the target process baseline results in place if they do not belong to the requester scope for the `DeploymentExtension` permission and the `Write` action.

Note: the current call locations for the `UpsertBaselineResults` and `DeleteBaselineResults` functions were checked, and all of them currently call the functions with global write access for `DeploymentExtension`. This means that the behaviour change does not impact these code paths, as these would never have entered the access to resource denied error code path. These code locations are:

- process baseline evaluator (called from the sensor pipeline for reprocessing)
- deployment removal
- pruning


## User-facing documentation

- No change in behaviour is expected as a result of this code change.
- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
-->
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI run
