### PR TITLE
ROX-31307: Delete React in 5 Containers folders

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -815,13 +815,8 @@ module.exports = [
             'src/Containers/Login/**',
             'src/Containers/MitreAttackVectors/**',
             'src/Containers/Policies/**',
-            'src/Containers/PolicyCategories/**',
-            'src/Containers/PolicyManagement/**',
             'src/Containers/Search/**',
             'src/Containers/SystemConfig/**',
-            'src/Containers/SystemHealth/**',
-            'src/Containers/User/**',
-            'src/Containers/Violations/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
             'src/Containers/Workflow/**', // deprecated

--- a/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { FormEvent, ReactElement } from 'react';
 import * as yup from 'yup';
 import {

--- a/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
     Modal,
     ModalBoxBody,

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesFilterSelect.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesFilterSelect.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
 

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesList.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SimpleList, SimpleListItem } from '@patternfly/react-core';
 
 import type { PolicyCategory } from 'types/policy.proto';

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PageSection, Divider, Title, Flex, FlexItem, TextInput } from '@patternfly/react-core';
 
 import type { PolicyCategory } from 'types/policy.proto';

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import type { ReactElement } from 'react';
 import {
     PageSection,

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { FormEvent, ReactElement } from 'react';
 import { FormikProvider, useFormik } from 'formik';
 import {

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TabNavHeader from 'Components/TabNav/TabNavHeader';
 import { policiesBasePath, policyCategoriesPath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 
 import PoliciesPage from 'Containers/Policies/PoliciesPage';

--- a/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Icon, Spinner } from '@patternfly/react-core';
 import {

--- a/ui/apps/platform/src/Containers/SystemHealth/CentralDatabaseHealth/CentralDatabaseHealthCard.cy.jsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CentralDatabaseHealth/CentralDatabaseHealthCard.cy.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import CentralDatabaseHealthCard from './CentralDatabaseHealthCard';
 
 function patchDatabaseStatusResponse(overrides = {}) {

--- a/ui/apps/platform/src/Containers/SystemHealth/CentralDatabaseHealth/CentralDatabaseHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CentralDatabaseHealth/CentralDatabaseHealthCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import { Table, Tbody, Th, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { GridItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthTable.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import { Table, Tbody, Th, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import { Table, Tbody, Th, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/BackupIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/BackupIntegrationHealthWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import type { ReactElement } from 'react';
 
 import { fetchBackupIntegrationsHealth } from 'services/IntegrationHealthService';

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/ImageIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/ImageIntegrationHealthWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import { fetchImageIntegrationsHealth } from 'services/IntegrationHealthService';

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { getDateTime } from 'utils/dateUtils';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/NotifierIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/NotifierIntegrationHealthWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import type { ReactElement } from 'react';
 
 import { fetchNotifierIntegrationsHealth } from 'services/IntegrationHealthService';

--- a/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ChangeEvent, MouseEvent as ReactMouseEvent, FormEvent, ReactElement } from 'react';
 import {
     Form,

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/FilterByStartingTimeValidationMessage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Flex, FlexItem, Icon } from '@patternfly/react-core';
 import {

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/GenerateDiagnosticBundle.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { FormEvent, ReactElement } from 'react';
 import { Button, Flex, Popover, PopoverPosition } from '@patternfly/react-core';
 import { AngleDownIcon, AngleUpIcon, DownloadIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/SystemHealth/SystemHealthPage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/SystemHealthPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Flex, FlexItem, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import useCentralCapabilities from 'hooks/useCentralCapabilities';

--- a/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/AdministrationUsageForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/AdministrationUsageForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/UsageStatistics/ShowAdministrationUsage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Button, Modal, ModalBoxBody } from '@patternfly/react-core';
 import useModal from 'hooks/useModal';

--- a/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
+++ b/ui/apps/platform/src/Containers/User/RolesForResourceAccess.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, Icon } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/User/UserPage.jsx
+++ b/ui/apps/platform/src/Containers/User/UserPage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { NavLink, Route, Routes, useMatch, useParams } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/ui/apps/platform/src/Containers/User/UserPermissionsForRolesTable.tsx
+++ b/ui/apps/platform/src/Containers/User/UserPermissionsForRolesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties, ReactElement } from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfiguration.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
 
@@ -22,14 +22,14 @@ function ContainerConfiguration({ deployment }: ContainerConfigurationProps): Re
             'Container configurations are unavailable because the alert’s deployment no longer exists.';
     } else if (deployment.containers.length !== 0) {
         content = deployment.containers.map((container, i) => (
-            <React.Fragment key={container.id}>
+            <Fragment key={container.id}>
                 <Title headingLevel="h4" className="pf-v5-u-mb-md">{`containers[${i}]`}</Title>
                 <ContainerConfigurationDescriptionList
                     key={container.id}
                     container={container}
                     vulnMgmtBasePath={vulnMgmtBasePath}
                 />
-            </React.Fragment>
+            </Fragment>
         ));
     }
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerConfigurationDescriptionList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerImage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerResourcesDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerResourcesDescriptionList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerSecretDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerSecretDescriptionList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerVolumeDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/ContainerVolumeDescriptionList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentOverview.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { DescriptionList } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithReadAccessForDeployment.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Card, CardBody, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithoutReadAccessForDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/DeploymentTabWithoutReadAccessForDeployment.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/FlatObjectDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/FlatObjectDescriptionList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortConfiguration.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, Title } from '@patternfly/react-core';
 
@@ -19,10 +19,10 @@ function PortConfiguration({ deployment }: PortConfigurationProps): ReactElement
         content = deployment.ports.map((port, i) => {
             /* eslint-disable react/no-array-index-key */
             return (
-                <React.Fragment key={i}>
+                <Fragment key={i}>
                     <Title headingLevel="h4" className="pf-v5-u-mb-md">{`ports[${i}]`}</Title>
                     <PortDescriptionList port={port} />
-                </React.Fragment>
+                </Fragment>
             );
             /* eslint-enable react/no-array-index-key */
         });

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortDescriptionList.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/PortDescriptionList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Deployment/SecurityContext.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/DeploytimeMessages.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/DeploytimeMessages.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Card, CardBody } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Explanation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Divider } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/Enforcement/Header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';

--- a/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import uniqBy from 'lodash/uniqBy';
 import { Flex, FlexItem, Divider, Card } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import capitalize from 'lodash/capitalize';
 import {

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPoliciesTab.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPoliciesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Button, Card, CardBody, CardTitle, List, ListItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPolicyModal.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkPolicies/NetworkPolicyModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, Flex, Modal } from '@patternfly/react-core';
 
 import type { NetworkPolicy } from 'types/networkPolicy.proto';

--- a/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.jsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { getTime } from 'date-fns';
 import {

--- a/ui/apps/platform/src/Containers/Violations/Details/ProcessCardContent.jsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ProcessCardContent.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { DescriptionList, Flex, Divider } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/RuntimeMessages.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/RuntimeMessages.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import type { ProcessViolation, Violation } from 'types/alert.proto';

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Divider, Flex, FlexItem, Title } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import type { ReactElement } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import startCase from 'lodash/startCase';

--- a/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ExcludeConfirmation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Modals/ResolveConfirmation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 import { Button, Modal } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Violations/ViolationNotFoundPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationNotFoundPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import { violationsBasePath } from 'routePaths';

--- a/ui/apps/platform/src/Containers/Violations/ViolationsBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsBreadcrumbs.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Breadcrumb, BreadcrumbItem, Divider, PageSection } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement, Ref } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
 import type { SearchFilter } from 'types/search';

--- a/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationsTableColumnDescriptors.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

### Procedure

Select folders that will not cause merge conflicts with feature work in progress.

That is, wait until at least end of sprint to fix folders of features in 4.9 effort.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Run auto fix on command line to fix errors.
    Bonus: Delete orphan newline after comment that precedes deleted `import` statement.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

### Residue

1. Update `limited/no-qualified-name-react` rule to report as error: `React.Fragment`

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.