### PR TITLE
ROX-29424: Add scrollbar to stop layout thrashing

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/DashboardPage.tsx
@@ -78,6 +78,7 @@ function DashboardPage() {
             <Divider component="div" />
             <PageSection>
                 <Gallery
+                    id="main-dashboard-widget-gallery"
                     style={
                         {
                             // Ensure the grid has never grows large enough to show 4 columns

--- a/ui/apps/platform/src/css/acs.css
+++ b/ui/apps/platform/src/css/acs.css
@@ -74,3 +74,13 @@ a[href="/main/search"] {
 .chrome-picker label {
     color: var(--pf-v5-global--Color--100) !important; /* instead of #969696 */
 }
+
+
+/*
+ * Forces the main dashboard to display a scrollbar unconditionally. This is needed to prevent an infinite
+ * screen flicker at specific screen resolutions where the Victory chart resize observer triggers a resize event
+ * infinitely and shifts the grid layout between 2x3 and 3x2.
+ */
+#main-page-container > div:has(#main-dashboard-widget-gallery) {
+    overflow-y: scroll !important;
+}


### PR DESCRIPTION
## Description

Forces the scrollbar to be rendered on the main dashboard even if the content does not flow below the fold. This prevents an issue where the resizing of Victory chart SVG elements causes the cards to infinitely switch between a 2x3 and a 3x2 layout.

The main downside to this approach is the permanent display of the scrollbar on large screen sizes, which feels like a worthwhile tradeoff.
<img width="1653" height="1128" alt="image" src="https://github.com/user-attachments/assets/ef2c359b-2316-4ceb-9fb0-e8f4e9f03415" />


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Reproduced against staging with a 1916x1048 screen resolution specifically. By observation it is clear that the addition and removal of the scrollbar when the layout adjusts is the source of the infinite redraw. If the scrollbar never disappears, this cycle never begins.
