### PR TITLE
ROX-31349: Helm should set FACT_URL and FACT_CERT

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -126,7 +126,7 @@ spec:
         - name: FACT_LOGLEVEL
           value: 'debug'
         - name: FACT_URL
-          value: "https://sensor.stackrox.svc:443"
+          value: "https://{{ ._rox.sensor.endpoint }}"
         - name: FACT_CERTS
           value: "/var/run/secrets/stackrox.io/certs/"
         {{- include "srox.envVars" (list . "daemonset" "fact" "fact") | nindent 8 }}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Fact can be deployed in the collector daemonset if the helm charts are instantiated with the `ROX_SENSITY_FILE_ACTIVITY` feature flag enabled. However, it does not communicate with sensor. To fix this the `FACT_URL` and `FACT_CERT` env vars are set in the helm charts.

This PR is built on top of https://github.com/stackrox/stackrox/pull/17267 which introduces a service for sensitive file activity.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

ocp-4-12-operator-e2e-tests failed with operator-e2e-tests-ocp-4-create container test. I don't believe this failure is related to the changes here.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deployed ACS with the feature flag enabled. Checked the fact container in the collector daemonset. Saw the following

```
        - name: FACT_URL
          value: https://sensor.stackrox.svc:443
        - name: FACT_CERTS
          value: /var/run/secrets/stackrox.io/certs/
```

Checked the sensor logs and saw the following

```
common/detector/filesystem/service: 2025/10/16 18:42:48.771733 service_impl.go:83: Info: Starting file system stream server
common/detector/filesystem/service: 2025/10/16 18:42:48.999958 service_impl.go:90: Debug: Got file activity: timestamp:{seconds:1760640168  nanos:998103221}  process:{id:"c5959a2d-0975-40a4-927d-13fa620b57df"  container_id:"505faf79ba72"  name:"trust"  args:"/usr/bin/trust extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"  exec_file_path:"/usr/bin/trust"  pid:2723224  lineage_info:{parent_exec_file_path:"/usr/bin/bash"}  lineage_info:{parent_exec_file_path:"/usr/bin/bash"}  login_uid:4294967295  username:"root"}  open:{activity:{path:"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem.fES0O0"  host_path:"/var/lib/kubelet/pods/daf17a9c-e6e2-425a-a60d-e225f3b2438d/volumes/kubernetes.io~empty-dir/etc-pki-volume/extracted/pem/tls-ca-bundle.pem.fES0O0"  3:1}}
common/detector/filesystem/service: 2025/10/16 18:42:49.052598 service_impl.go:90: Debug: Got file activity: timestamp:{seconds:1760640169  nanos:51805220}  process:{id:"26bc74eb-64a9-4ce0-b424-92be6e1bd72d"  container_id:"474eefa29edd"  name:"flb-pipeline"  args:"/fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf"  exec_file_path:"/fluent-bit/bin/fluent-bit"  pid:8860  lineage_info:{parent_exec_file_path:"/usr/bin/containerd-shim-runc-v2"}  lineage_info:{parent_exec_file_path:"/usr/lib/systemd/systemd"}  login_uid:4294967295  username:"root"}  open:{activity:{path:"/var/lib/google-fluentbit/pos-files/kubelet.db-journal"  host_path:"/var/lib/google-fluentbit/pos-files/kubelet.db-journal"  3:1}}
common/detector/filesystem/service: 2025/10/16 18:42:49.061191 service_impl.go:90: Debug: Got file activity: timestamp:{seconds:1760640169  nanos:60349688}  process:{id:"b77c3c64-6959-4d61-bc5a-fdd6526cbf4c"  container_id:"474eefa29edd"  name:"flb-pipeline"  args:"/fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf"  exec_file_path:"/fluent-bit/bin/fluent-bit"  pid:8860  lineage_info:{parent_exec_file_path:"/usr/bin/containerd-shim-runc-v2"}  lineage_info:{parent_exec_file_path:"/usr/lib/systemd/systemd"}  login_uid:4294967295  username:"root"}  open:{activity:{path:"/var/lib/google-fluentbit/pos-files/container-runtime.db-journal"  host_path:"/var/lib/google-fluentbit/pos-files/container-runtime.db-journal"  3:1}}
```
