### PR TITLE
ROX-31217: Remove datastore-level SAC checks in process baselines

### DIFF
--- a/central/processbaseline/datastore/datastore_sac_test.go
+++ b/central/processbaseline/datastore/datastore_sac_test.go
@@ -5,18 +5,22 @@ package datastore
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/sac/testconsts"
 	"github.com/stackrox/rox/pkg/sac/testutils"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -252,6 +256,267 @@ func (s *processBaselineSACTestSuite) TestRemoveProcessBaselineByDeploymentOther
 			s.NoError(err)
 			s.True(found)
 			protoassert.Equal(s.T(), processBaseline, fetched)
+		})
+	}
+}
+
+func (s *processBaselineSACTestSuite) TestUserLockProcessBaselineLock() {
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), "lock")
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			processBaseline := fixtures.GetScopedProcessBaseline(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			id, err := keyToID(processBaseline.GetKey())
+			s.Require().NoError(err)
+			processBaseline.Id = id
+			ctx := s.testContexts[c.ScopeKey]
+			_, err = s.datastore.AddProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline,
+			)
+			defer s.deleteProcessBaseline(processBaseline.GetId())
+			expectedUnchanged := processBaseline.CloneVT()
+
+			_, err = s.datastore.UserLockProcessBaseline(ctx, processBaseline.GetKey(), true)
+			fetched, found, fetchErr := s.datastore.GetProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline.GetKey(),
+			)
+			s.NoError(fetchErr)
+			s.True(found)
+			if c.ExpectError {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.ExpectedError)
+
+				// Ensure the process baseline was not changed
+				protoassert.Equal(s.T(), expectedUnchanged, fetched)
+			} else {
+				s.NoError(err)
+
+				// Ensure the user lock timestamp was changed
+				assert.NotNil(s.T(), fetched.GetUserLockedTimestamp())
+				assert.Nil(s.T(), expectedUnchanged.GetUserLockedTimestamp())
+				// Ensure the last updated state was changed
+				assert.NotEqual(s.T(), expectedUnchanged.GetLastUpdate().GetNanos(), fetched.GetLastUpdate().GetNanos())
+				// Ensure the above two changes were the only changes
+				expectedUnchanged.LastUpdate = nil
+				expectedUnchanged.UserLockedTimestamp = nil
+				fetched.LastUpdate = nil
+				fetched.UserLockedTimestamp = nil
+				protoassert.Equal(s.T(), expectedUnchanged, fetched)
+			}
+		})
+	}
+}
+
+func (s *processBaselineSACTestSuite) TestUserLockProcessBaselineUnlock() {
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), "unlock")
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			processBaseline := fixtures.GetScopedProcessBaseline(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			id, err := keyToID(processBaseline.GetKey())
+			s.Require().NoError(err)
+			processBaseline.Id = id
+			userLockTS := time.Date(2022, 3, 4, 5, 6, 0, 0, time.UTC)
+			userLockProtoTS := protocompat.ConvertTimeToTimestampOrNil(&userLockTS)
+			s.Require().NotNil(userLockProtoTS)
+			processBaseline.UserLockedTimestamp = userLockProtoTS
+			ctx := s.testContexts[c.ScopeKey]
+			_, err = s.datastore.AddProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline,
+			)
+			defer s.deleteProcessBaseline(processBaseline.GetId())
+			expectedUnchanged := processBaseline.CloneVT()
+
+			_, err = s.datastore.UserLockProcessBaseline(ctx, processBaseline.GetKey(), false)
+			fetched, found, fetchErr := s.datastore.GetProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline.GetKey(),
+			)
+			s.NoError(fetchErr)
+			s.True(found)
+			if c.ExpectError {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.ExpectedError)
+
+				// Ensure the process baseline was not changed
+				protoassert.Equal(s.T(), expectedUnchanged, fetched)
+			} else {
+				s.NoError(err)
+
+				// Ensure the user lock timestamp was changed
+				assert.Nil(s.T(), fetched.GetUserLockedTimestamp())
+				assert.NotNil(s.T(), expectedUnchanged.GetUserLockedTimestamp())
+				// Ensure the last updated state was changed
+				assert.NotEqual(s.T(), expectedUnchanged.GetLastUpdate().GetNanos(), fetched.GetLastUpdate().GetNanos())
+				// Ensure the above two changes were the only changes
+				expectedUnchanged.LastUpdate = nil
+				expectedUnchanged.UserLockedTimestamp = nil
+				fetched.LastUpdate = nil
+				fetched.UserLockedTimestamp = nil
+				protoassert.Equal(s.T(), expectedUnchanged, fetched)
+			}
+		})
+	}
+}
+
+func (s *processBaselineSACTestSuite) TestCreateUnlockedProcessBaseline() {
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), "create")
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			processBaseline := fixtures.GetScopedProcessBaseline(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			id, err := keyToID(processBaseline.GetKey())
+			s.Require().NoError(err)
+			processBaseline.Id = id
+			processBaseline.Elements = []*storage.BaselineElement{}
+			ctx := s.testContexts[c.ScopeKey]
+			created, err := s.datastore.CreateUnlockedProcessBaseline(ctx, processBaseline.GetKey())
+			defer s.deleteProcessBaseline(processBaseline.GetId())
+
+			fetched, found, fetchErr := s.datastore.GetProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline.GetKey(),
+			)
+			s.NoError(fetchErr)
+			if c.ExpectError {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.ExpectedError)
+
+				s.False(found)
+				s.Nil(fetched)
+			} else {
+				s.NoError(err)
+
+				s.True(found)
+				s.NotNil(fetched.GetCreated())
+				s.NotNil(fetched.GetLastUpdate())
+				s.NotNil(fetched.GetStackRoxLockedTimestamp())
+				// Check the created baseline is empty
+				protoassert.Equal(s.T(), created, fetched)
+				fetched.Created = nil
+				fetched.LastUpdate = nil
+				fetched.StackRoxLockedTimestamp = nil
+				processBaseline.Created = nil
+				processBaseline.LastUpdate = nil
+				processBaseline.StackRoxLockedTimestamp = nil
+				protoassert.Equal(s.T(), processBaseline, fetched)
+			}
+		})
+	}
+}
+
+func (s *processBaselineSACTestSuite) TestRemoveProcessBaselinesByID() {
+	cases := testutils.GenericNamespaceSACDeleteTestCases(s.T())
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			processBaseline := fixtures.GetScopedProcessBaseline(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			id, err := keyToID(processBaseline.GetKey())
+			s.Require().NoError(err)
+			processBaseline.Id = id
+			ctx := s.testContexts[c.ScopeKey]
+			_, err = s.datastore.AddProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline,
+			)
+			s.Require().NoError(err)
+			defer s.deleteProcessBaseline(processBaseline.GetId())
+
+			err = s.datastore.RemoveProcessBaselinesByIDs(ctx, []string{id})
+			fetched, found, fetchErr := s.datastore.GetProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline.GetKey(),
+			)
+			s.NoError(fetchErr)
+			if c.ExpectError {
+				s.Require().Error(err)
+				s.ErrorIs(err, c.ExpectedError)
+
+				s.True(found)
+				protoassert.Equal(s.T(), processBaseline, fetched)
+			} else {
+				s.NoError(err)
+
+				s.False(found)
+				s.Nil(fetched)
+			}
+		})
+	}
+}
+
+func (s *processBaselineSACTestSuite) TestClearProcessBaselines() {
+	cases := testutils.GenericNamespaceSACUpsertTestCases(s.T(), "clear")
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			processBaseline := fixtures.GetScopedProcessBaseline(uuid.NewV4().String(), testconsts.Cluster2,
+				testconsts.NamespaceB)
+			id, err := keyToID(processBaseline.GetKey())
+			s.Require().NoError(err)
+			processBaseline.Id = id
+			processBaseline.Elements = []*storage.BaselineElement{}
+			processBaseline.ElementGraveyard = []*storage.BaselineElement{}
+			ctx := s.testContexts[c.ScopeKey]
+			_, err = s.datastore.AddProcessBaseline(s.testContexts[testutils.UnrestrictedReadWriteCtx], processBaseline)
+			s.Require().NoError(err)
+			defer s.deleteProcessBaseline(processBaseline.GetId())
+
+			err = s.datastore.ClearProcessBaselines(ctx, []string{id})
+			fetched, found, fetchErr := s.datastore.GetProcessBaseline(
+				s.testContexts[testutils.UnrestrictedReadWriteCtx],
+				processBaseline.GetKey(),
+			)
+			s.NoError(fetchErr)
+			s.True(found)
+			if c.ExpectError {
+				// Depending whether the requester has read access to the target object or not,
+				// the error behaviour of ClearProcessBaselines will be different
+				// - If read is granted, the user will get an `access to resource denied` error
+				// - otherwise, there will be no error
+				if sac.ForResource(resources.DeploymentExtension).
+					ScopeChecker(ctx, storage.Access_READ_ACCESS).
+					ForNamespaceScopedObject(processBaseline.GetKey()).IsAllowed() {
+					s.Error(err)
+					s.ErrorIs(err, sac.ErrResourceAccessDenied)
+				} else {
+					s.NoError(err)
+				}
+
+				// Ensure the baseline was not changed
+				protoassert.Equal(s.T(), processBaseline, fetched)
+			} else {
+				s.NoError(err)
+
+				// Ensure the following fields were changed
+				// - LastUpdate
+				// - StackRoxLockedTimestamp
+				// - Elements
+				// - ElementGraveyard
+				s.NotNil(fetched.GetLastUpdate())
+				s.NotEqual(processBaseline.GetLastUpdate().GetNanos(), fetched.GetLastUpdate().GetNanos())
+				s.NotNil(fetched.GetStackRoxLockedTimestamp())
+				s.NotEqual(processBaseline.GetStackRoxLockedTimestamp().GetNanos(), fetched.GetStackRoxLockedTimestamp().GetNanos())
+				s.Nil(fetched.GetElements())
+				s.NotNil(processBaseline.GetElements())
+				s.Nil(fetched.GetElementGraveyard())
+				s.NotNil(processBaseline.GetElementGraveyard())
+				// Ensure these changes were the only changes
+				processBaseline.LastUpdate = nil
+				fetched.LastUpdate = nil
+				processBaseline.StackRoxLockedTimestamp = nil
+				fetched.StackRoxLockedTimestamp = nil
+				processBaseline.Elements = nil
+				processBaseline.ElementGraveyard = nil
+				protoassert.Equal(s.T(), processBaseline, fetched)
+
+			}
 		})
 	}
 }

--- a/central/processbaseline/datastore/datastore_sac_test.go
+++ b/central/processbaseline/datastore/datastore_sac_test.go
@@ -288,6 +288,7 @@ func (s *processBaselineSACTestSuite) TestUserLockProcessBaselineLock() {
 				s.testContexts[testutils.UnrestrictedReadWriteCtx],
 				processBaseline,
 			)
+			s.Require().NoError(err)
 			defer s.deleteProcessBaseline(processBaseline.GetId())
 			expectedUnchanged := processBaseline.CloneVT()
 
@@ -344,6 +345,7 @@ func (s *processBaselineSACTestSuite) TestUserLockProcessBaselineUnlock() {
 				s.testContexts[testutils.UnrestrictedReadWriteCtx],
 				processBaseline,
 			)
+			s.Require().NoError(err)
 			defer s.deleteProcessBaseline(processBaseline.GetId())
 			expectedUnchanged := processBaseline.CloneVT()
 

--- a/central/processbaseline/service/service_impl_test.go
+++ b/central/processbaseline/service/service_impl_test.go
@@ -179,6 +179,11 @@ func (suite *ProcessBaselineServiceTestSuite) TestGetProcessBaseline() {
 			defer emptyDB(t, suite.datastore, c.baselines)
 			requestByKey := &v1.GetProcessBaselineRequest{Key: knownBaseline.GetKey()}
 			suite.deployments.EXPECT().GetDeployment(hasReadCtx, gomock.Any()).Return(nil, true, nil).AnyTimes()
+			if c.expectedResult == nil {
+				suite.indicatorMockStore.EXPECT().
+					SearchRawProcessIndicators(hasReadCtx, gomock.Any()).
+					Return(nil, nil)
+			}
 			baseline, err := suite.service.GetProcessBaseline(hasReadCtx, requestByKey)
 			if c.shouldFail {
 				assert.Error(t, err)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

With the migration to postgres and later evolutions of the data access layers, basic scoped access control checks have been copied or moved from the datastore layer to the generated postgres store code and later to the postgres query generator code.

The SAC checks for the processbaseline datastore were left behind in these migrations, and are still present in the processbaseline datastore, where they can create confusion. The goal of this change is to remove these checks that are now unnecessary.

The removal of the SAC checks in the `AddProcessBaseline`, `RemoveProcessBaseline`, `RemoveProcessBaselinesByDeployment`, `UpdateProcessBaselineElements`, `UpsertProcessBaseline`, `UserLockProcessBaseline`, `CreateUnlockedProcessBaseline`, `WalkAll`, `RemoveProcessBaselinesByIDs` and `ClearProcessBaselines` datastore functions slightly change the behaviour of these functions:
- Instead of returning an `access to resource denied` if the target baseline is not in the requester scope for  `Write` action on the `DeploymentExtension` permission, `RemoveProcessBaseline` will silently ignore the request and leave the target process baseline in place
- Instead of returning an `access to resource denied` if the requester does not have full `Write` access to the `DeploymentExtension` permission, `RemoveProcessBaselinesByDeployment` will silently ignore the request and leave the target process baseline in place if it is not in the requester scope for `Write` action on the `DeploymentExtension` permission.
- The existing and added tests should cover the remaining functions and did not highlight change of behaviour for these.

Note: the current call locations for the `RemoveProcessBaseline` and `RemoveProcessBaselinesByDeployment` functions were checked.

- `RemoveProcessBaseline` is called in the pruning flow, which works with full access context.
- `RemoveProcessBaselinesByDeployment` is called with elevated context upon deployment removal, so no change in behaviour will happen here.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
<!--
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Local postgres CI test of the altered datastore directory.
PR CI checks
