### PR TITLE
ROX-31292: Remove Pending Exception links in Console plugin labels

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
@@ -21,6 +21,7 @@ export type WorkloadCveView = {
             },
             vulnerabilityState: VulnerabilityState
         ) => string;
+        exceptionDetails?: (cve: string) => string;
     };
     baseSearchFilter: QuerySearchFilter;
     pageTitle: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -6,6 +6,7 @@ import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 
 import {
+    exceptionManagementPath,
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesImagesWithoutCvesPath,
     vulnerabilitiesInactiveImagesPath,
@@ -15,6 +16,7 @@ import {
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
 import useFeatureFlags, { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { NonEmptyArray } from 'utils/type.utils';
 import type { VulnerabilityState } from 'types/cve.proto';
 
@@ -96,6 +98,10 @@ function getUrlBuilder(viewId: string): WorkloadCveView['urlBuilder'] {
             getAbsoluteUrl(
                 getWorkloadEntityPagePath('Deployment', workload.id, vulnerabilityState)
             ),
+        exceptionDetails: (cve: string) => {
+            const query = getUrlQueryStringForSearchFilter({ CVE: [cve] });
+            return `${exceptionManagementPath}/pending-requests?${query}`;
+        },
     };
 }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/PendingExceptionLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/PendingExceptionLabel.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import { Link } from 'react-router-dom-v5-compat';
-import { Label } from '@patternfly/react-core';
+import { Label, Popover } from '@patternfly/react-core';
 import { OutlinedClockIcon } from '@patternfly/react-icons';
 
+import { getProductBranding } from 'constants/productBranding';
+import PopoverBodyContent from 'Components/PopoverBodyContent';
 import type { VulnerabilityState } from 'types/cve.proto';
-import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
-import { exceptionManagementPath } from 'routePaths';
+import useWorkloadCveViewContext from '../WorkloadCves/hooks/useWorkloadCveViewContext';
 
 export type PendingExceptionLabelProps = {
     cve: string;
@@ -15,25 +16,57 @@ export type PendingExceptionLabelProps = {
 };
 
 /**
- * ‘Pending exception’ label layout for use in tables. Conditionally renders a label
+ * 'Pending exception' label layout for use in tables. Conditionally renders a label
  * with a link to the exception request page if the vulnerability has a pending exception.
+ * In the ConsolePlugin context (when exceptionDetails URL is not available), renders a
+ * popover instead with information about vulnerability exceptions.
  *
- * @param children - The table cell contents to render before the label
- * @param hasPendingException - Whether the vulnerability has a pending exception
  * @param cve - The CVE ID of the vulnerability
+ * @param isCompact - Whether to render the label in compact mode (true for tables)
  * @param vulnerabilityState - The vulnerability state
  */
 function PendingExceptionLabel({ cve, isCompact, vulnerabilityState }: PendingExceptionLabelProps) {
-    const query = getUrlQueryStringForSearchFilter({ CVE: [cve] });
-    const url = `${exceptionManagementPath}/pending-requests?${query}`;
+    const { urlBuilder } = useWorkloadCveViewContext();
+    const labelText = vulnerabilityState === 'OBSERVED' ? 'Pending exception' : 'Pending update';
 
-    return (
-        <Label color="blue" isCompact={isCompact} icon={<OutlinedClockIcon />} variant="outline">
-            <Link to={url}>
-                {vulnerabilityState === 'OBSERVED' ? 'Pending exception' : 'Pending update'}
-            </Link>
+    const { shortName } = getProductBranding();
+
+    const label = (
+        <Label
+            color="blue"
+            isCompact={isCompact}
+            icon={<OutlinedClockIcon />}
+            variant="outline"
+            style={!urlBuilder.exceptionDetails ? { cursor: 'pointer' } : undefined}
+        >
+            {urlBuilder.exceptionDetails ? (
+                <Link to={urlBuilder.exceptionDetails(cve)}>{labelText}</Link>
+            ) : (
+                labelText
+            )}
         </Label>
     );
+
+    // In ConsolePlugin context, wrap with a popover since there's no detail page
+    if (!urlBuilder.exceptionDetails) {
+        return (
+            <Popover
+                aria-label="Pending exception information"
+                bodyContent={
+                    <PopoverBodyContent
+                        headerContent={labelText}
+                        bodyContent={`This vulnerability has a pending exception request. Exception management is available in the standalone ${shortName} interface.`}
+                    />
+                }
+                enableFlip
+                position="top"
+            >
+                {label}
+            </Popover>
+        );
+    }
+
+    return label;
 }
 
 export default PendingExceptionLabel;


### PR DESCRIPTION
## Description

**Pending Exception** labels are shown for CVEs in both the standalone UI as well as the console plugin. These labels typically link to the detail page for individual exception requests, but these pages do not exist in the MVP of the console plugin.

This change updates the click action on these labels to display a popover with information in the case that a valid URL is not available.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the console plugin, and click a Pending exception label.
<img width="1255" height="1124" alt="image" src="https://github.com/user-attachments/assets/4613718c-6d59-4a83-9ce2-8dd3405ebfe8" />

