### PR TITLE
fix(VM): Increase relay vsock connection size limit to 16 MB

### DIFF
--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -1,9 +1,9 @@
 package env
 
 var (
-	// VirtualMachinesVsockConnMaxSizeKB defines the maximum size of incoming vsock connections. The 4 MB default
-	// allows connections carrying index reports with up to approximately 10000 packages.
-	VirtualMachinesVsockConnMaxSizeKB = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_VSOCK_CONN_MAX_SIZE_KB", 4096)
+	// VirtualMachinesVsockConnMaxSizeKB defines the maximum size of incoming vsock connections. The 16 MB default
+	// allows connections carrying index reports with up to approximately 6400 packages.
+	VirtualMachinesVsockConnMaxSizeKB = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_VSOCK_CONN_MAX_SIZE_KB", 16384)
 
 	// VirtualMachinesVsockPort defines the port where the virtual machine relay will listen for incoming vsock
 	// connections carrying virtual machine index reports.


### PR DESCRIPTION
## Description

The "relay" component of the Virtual Machines Vulnerability Management reads data from vsock connections, parses it as `v1.IndexReport` and forwards those to Sensor. The default maximum amount of bytes read from each vsock connection was set to 4 MB based on estimations that such size enables transferring reports with around 10000 packages. However this estimation is off, largely due to a ClairCore update which doubled the size of produced reports.

This PR sets the default limit to 16 MB, which fits reports with around 6400 packages. This is the default value, and it can be changed via the `ROX_VIRTUAL_MACHINES_VSOCK_CONN_MAX_SIZE_KB` environment variable.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Only a default value was changed. Tests covering the size limit logic override this value.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI