### PR TITLE
chore: move image_prefetcher_prebuilt_await in nongroovy case

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -40,13 +40,6 @@ class PreSystemTests:
             check=True,
             timeout=PreSystemTests.START_PREFETCH_TIMEOUT,
         )
-        subprocess.run(
-            [
-                "scripts/ci/lib.sh", "image_prefetcher_prebuilt_await"
-            ],
-            check=True,
-            timeout=PreSystemTests.POLL_TIMEOUT,
-        )
         if self.run_poll_for_system_test_images:
             subprocess.run(
                 [

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -731,6 +731,11 @@ image_prefetcher_system_await() {
 
 _image_prefetcher_prebuilt_await() {
     case "$CI_JOB_NAME" in
+
+    # Note: when adding a case for a new test job below, add a image_prefetcher_prebuilt_await call
+    # at the last moment before any of the prebuilt images is used. (See other existing examples.)
+    # This way we save time since prefetching can happen in parallel with whatever other setup the test job needs.
+
     *qa-e2e-tests)
         image_prefetcher_await_set qa-e2e
         ;;

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -35,6 +35,8 @@ test_e2e() {
     "$ROOT/tests/complianceoperator/create.sh"
     kubectl get compliancecheckresults.compliance.openshift.io -n openshift-compliance
 
+    image_prefetcher_prebuilt_await
+
     # If deploy_optional_e2e_components is called after deploy_stackrox it causes an unnecessary Sensor restart
     deploy_optional_e2e_components
     deploy_stackrox


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Following up on #17327 to make sure awaiting happens:
- as late as possible, to increase parallelism
- only once per test job, to avoid duplication of prefetcher metrics

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI