### PR TITLE
ROX-31217: Remove datastore-level SAC checks in pod

### DIFF
--- a/central/pod/datastore/datastore_impl_test.go
+++ b/central/pod/datastore/datastore_impl_test.go
@@ -62,9 +62,9 @@ func (suite *PodDataStoreTestSuite) TestNoAccessAllowed() {
 	_, ok, _ := suite.datastore.GetPod(ctx, expectedPod.GetId())
 	suite.False(ok)
 
-	suite.Error(suite.datastore.UpsertPod(ctx, expectedPod), "permission denied")
-
-	suite.Error(suite.datastore.RemovePod(ctx, expectedPod.GetId()), "permission denied")
+	// The datastore delegates the access control checks to the storage layer
+	// for UpsertPod and RemovePod.  The "end-to-end" behaviour of the datastore
+	// for these functions is now tested in datastore_sac_test.go
 }
 
 func (suite *PodDataStoreTestSuite) TestGetPod() {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

With the migration to postgres and later evolutions of the data access layers, basic scoped access control checks have been copied or moved from the datastore layer to the generated postgres store code and later to the postgres query generator code.

The SAC checks for the pod datastore were left behind in these migrations, and are still present in the pod datastore, where they can create confusion. The goal of this change is to remove these checks that are now unnecessary.

The removal of the SAC checks in the `UpsertPod` and `RemovePod` datastore functions slightly change the behaviour of these functions:
- Instead of returning an access to resource denied if the requester does not have full `Write` access to the `Deployment` permission, `RemovePod` will silently ignore the request and leave the target pod in place if it is not in the requester scope for `Write` action on the `Deployment` permission.
- `UpsertPod` should have the same behaviour from the end-user perspective.

Note: the current call locations for the`UpsertPod` and `RemovePod` functions were checked.

- `UpsertPod` is called in the dedicated sensor pipeline flow, which works with full access context (sensor service identity).
- `RemovePod` is called with elevated context upon cluster removal and pruning, or with full access context in the dedicated sensor pipeline, so no change in behaviour will happen here.


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

<!--
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
-->
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual postgres unit test run in the altered datastore directory
PR CI run
