### PR TITLE
fix: Enable enforcement on Helm upgrades if both previous options on

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-defaulting.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_admission-controller-defaulting.tpl
@@ -30,11 +30,12 @@
     {{/* In this upgrade scenario we will defeault to enforce=false, but will upgrade to enforce=true if at least one of the old enforceOn* settings is enabled. */}}
     {{- $_ := set $admissionControl "enforce" false -}}
 
-    {{- if and $admissionControl.dynamic.enforceOnCreates (not $admissionControl.dynamic.enforceOnUpdates) -}}
+    {{- if $admissionControl.dynamic.enforceOnCreates -}}
       {{- $note := "Detected upgrade from pre-4.9: Admission Controller enforcement will be generally turned on, because enforceOnCreates is enabled." -}}
       {{- include "srox.warn" (list $ $note) -}}
       {{- $_ := set $admissionControl "enforce" true -}}
-    {{- else if and (not $admissionControl.dynamic.enforceOnCreates) $admissionControl.dynamic.enforceOnUpdates -}}
+    {{- end -}}
+    {{- if $admissionControl.dynamic.enforceOnUpdates -}}
       {{- $note := "Detected upgrade from pre-4.9: Admission Controller enforcement will be generally turned on, because enforceOnUpdates is enabled." -}}
       {{- include "srox.warn" (list $ $note) -}}
       {{- $_ := set $admissionControl "enforce" true -}}

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
@@ -99,6 +99,10 @@ tests:
       set:
         admissionControl.dynamic.enforceOnUpdates: false
         admissionControl.dynamic.enforceOnCreates: true
+    - name: "if enforceOnCreates and enforceOnUpdates enabled"
+      set:
+        admissionControl.dynamic.enforceOnUpdates: true
+        admissionControl.dynamic.enforceOnCreates: true
 - name: "Warning is emitted when enforcement is disabled"
   expect:
     .notes | assertThat(contains("Admission Controller enforcement will be completely disabled, this is a bad idea"))


### PR DESCRIPTION
## Description

There's a logic error in the current Helm upgrade flow for the new admission controller config. It works as expected when either one of the old `enforceOn*` options is enabled in isolation. In these cases the new high-level enforcement toggle is correctly defauled to `true` as well. But it unfortunately fails if both of the old settings are enabled.

This PR changes fixes the logic and contributes a test for this case.

## User-facing documentation

CHANGELOG is already correct.
Doc PR is currently WIP.

## Testing and quality

- [x] the change is production ready
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Unit test.