### PR TITLE
JDK21, toolchain setup, allow gradle to download necessary jdk

### DIFF
--- a/qa-tests-backend/build.gradle.kts
+++ b/qa-tests-backend/build.gradle.kts
@@ -237,7 +237,8 @@ tasks.register<Test>("testDeploymentCheck") {
 allprojects {
     apply(plugin = "java")
     java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
     }
 }

--- a/qa-tests-backend/settings.gradle.kts
+++ b/qa-tests-backend/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenLocal()


### PR DESCRIPTION
## Description

This PR:
- defines JDK21 toolchain for this gradle project
- adds `foojay-resolver-convention` plugin so that gradle can download JDK required by the build itself

The update is necessary to update protobuf plugin that requires later jdk version