### PR TITLE
fix(pg): do not batch with copyFrom

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -144,12 +143,18 @@ func copyFromActiveComponents(ctx context.Context, s pgSearch.Deleter, tx *postg
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -158,39 +163,29 @@ func copyFromActiveComponents(ctx context.Context, s pgSearch.Deleter, tx *postg
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				pgutils.NilOrUUID(obj.GetDeploymentId()),
-				obj.GetComponentId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			pgutils.NilOrUUID(obj.GetDeploymentId()),
+			obj.GetComponentId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"active_components"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"active_components"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -206,8 +201,6 @@ func copyFromActiveComponentsActiveContextsSlices(ctx context.Context, s pgSearc
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"active_components_id",
@@ -217,27 +210,23 @@ func copyFromActiveComponentsActiveContextsSlices(ctx context.Context, s pgSearc
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				activeComponentID,
-				idx,
-				obj.GetContainerName(),
-				obj.GetImageId(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			activeComponentID,
+			idx,
+			obj.GetContainerName(),
+			obj.GetImageId(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"active_components_active_contexts_slices"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"active_components_active_contexts_slices"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/administration/events/datastore/internal/store/postgres/store.go
+++ b/central/administration/events/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -124,12 +123,18 @@ func copyFromAdministrationEvents(ctx context.Context, s pgSearch.Deleter, tx *p
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -143,44 +148,34 @@ func copyFromAdministrationEvents(ctx context.Context, s pgSearch.Deleter, tx *p
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetType(),
-				obj.GetLevel(),
-				obj.GetDomain(),
-				obj.GetResource().GetType(),
-				obj.GetNumOccurrences(),
-				protocompat.NilOrTime(obj.GetLastOccurredAt()),
-				protocompat.NilOrTime(obj.GetCreatedAt()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetType(),
+			obj.GetLevel(),
+			obj.GetDomain(),
+			obj.GetResource().GetType(),
+			obj.GetNumOccurrences(),
+			protocompat.NilOrTime(obj.GetLastOccurredAt()),
+			protocompat.NilOrTime(obj.GetCreatedAt()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"administration_events"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"administration_events"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/administration/usage/store/postgres/store.go
+++ b/central/administration/usage/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -120,12 +119,18 @@ func copyFromSecuredUnits(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -135,40 +140,30 @@ func copyFromSecuredUnits(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				protocompat.NilOrTime(obj.GetTimestamp()),
-				obj.GetNumNodes(),
-				obj.GetNumCpuUnits(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			protocompat.NilOrTime(obj.GetTimestamp()),
+			obj.GetNumNodes(),
+			obj.GetNumCpuUnits(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secured_units"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secured_units"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -172,12 +171,18 @@ func copyFromAlerts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -218,71 +223,61 @@ func copyFromAlerts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetPolicy().GetId(),
-				obj.GetPolicy().GetName(),
-				obj.GetPolicy().GetDescription(),
-				obj.GetPolicy().GetDisabled(),
-				obj.GetPolicy().GetCategories(),
-				obj.GetPolicy().GetSeverity(),
-				obj.GetPolicy().GetEnforcementActions(),
-				protocompat.NilOrTime(obj.GetPolicy().GetLastUpdated()),
-				obj.GetPolicy().GetSORTName(),
-				obj.GetPolicy().GetSORTLifecycleStage(),
-				obj.GetPolicy().GetSORTEnforcement(),
-				obj.GetLifecycleStage(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetClusterName(),
-				obj.GetNamespace(),
-				pgutils.NilOrUUID(obj.GetNamespaceId()),
-				pgutils.NilOrUUID(obj.GetDeployment().GetId()),
-				obj.GetDeployment().GetName(),
-				obj.GetDeployment().GetInactive(),
-				obj.GetImage().GetId(),
-				obj.GetImage().GetName().GetRegistry(),
-				obj.GetImage().GetName().GetRemote(),
-				obj.GetImage().GetName().GetTag(),
-				obj.GetImage().GetName().GetFullName(),
-				obj.GetImage().GetIdV2(),
-				obj.GetNode().GetId(),
-				obj.GetNode().GetName(),
-				obj.GetResource().GetResourceType(),
-				obj.GetResource().GetName(),
-				obj.GetEnforcement().GetAction(),
-				protocompat.NilOrTime(obj.GetTime()),
-				obj.GetState(),
-				obj.GetPlatformComponent(),
-				obj.GetEntityType(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetPolicy().GetId(),
+			obj.GetPolicy().GetName(),
+			obj.GetPolicy().GetDescription(),
+			obj.GetPolicy().GetDisabled(),
+			obj.GetPolicy().GetCategories(),
+			obj.GetPolicy().GetSeverity(),
+			obj.GetPolicy().GetEnforcementActions(),
+			protocompat.NilOrTime(obj.GetPolicy().GetLastUpdated()),
+			obj.GetPolicy().GetSORTName(),
+			obj.GetPolicy().GetSORTLifecycleStage(),
+			obj.GetPolicy().GetSORTEnforcement(),
+			obj.GetLifecycleStage(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetClusterName(),
+			obj.GetNamespace(),
+			pgutils.NilOrUUID(obj.GetNamespaceId()),
+			pgutils.NilOrUUID(obj.GetDeployment().GetId()),
+			obj.GetDeployment().GetName(),
+			obj.GetDeployment().GetInactive(),
+			obj.GetImage().GetId(),
+			obj.GetImage().GetName().GetRegistry(),
+			obj.GetImage().GetName().GetRemote(),
+			obj.GetImage().GetName().GetTag(),
+			obj.GetImage().GetName().GetFullName(),
+			obj.GetImage().GetIdV2(),
+			obj.GetNode().GetId(),
+			obj.GetNode().GetName(),
+			obj.GetResource().GetResourceType(),
+			obj.GetResource().GetName(),
+			obj.GetEnforcement().GetAction(),
+			protocompat.NilOrTime(obj.GetTime()),
+			obj.GetState(),
+			obj.GetPlatformComponent(),
+			obj.GetEntityType(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"alerts"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"alerts"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -118,12 +117,18 @@ func copyFromAPITokens(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -132,39 +137,29 @@ func copyFromAPITokens(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				protocompat.NilOrTime(obj.GetExpiration()),
-				obj.GetRevoked(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			protocompat.NilOrTime(obj.GetExpiration()),
+			obj.GetRevoked(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"api_tokens"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"api_tokens"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/auth/store/postgres/store.go
+++ b/central/auth/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -139,12 +138,18 @@ func copyFromAuthMachineToMachineConfigs(ctx context.Context, s pgSearch.Deleter
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -152,38 +157,28 @@ func copyFromAuthMachineToMachineConfigs(ctx context.Context, s pgSearch.Deleter
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetIssuer(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetIssuer(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -199,8 +194,6 @@ func copyFromAuthMachineToMachineConfigsMappings(ctx context.Context, s pgSearch
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"auth_machine_to_machine_configs_id",
@@ -209,26 +202,22 @@ func copyFromAuthMachineToMachineConfigsMappings(ctx context.Context, s pgSearch
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(authMachineToMachineConfigID),
-				idx,
-				obj.GetRole(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(authMachineToMachineConfigID),
+			idx,
+			obj.GetRole(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs_mappings"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs_mappings"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -116,12 +115,18 @@ func copyFromAuthProviders(ctx context.Context, s pgSearch.Deleter, tx *postgres
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -129,38 +134,28 @@ func copyFromAuthProviders(ctx context.Context, s pgSearch.Deleter, tx *postgres
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_providers"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_providers"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -118,12 +117,18 @@ func copyFromBlobs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetName())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"name",
@@ -132,39 +137,29 @@ func copyFromBlobs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetName(),
-				obj.GetLength(),
-				protocompat.NilOrTime(obj.GetModifiedTime()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetName())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetName(),
+			obj.GetLength(),
+			protocompat.NilOrTime(obj.GetModifiedTime()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"blobs"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"blobs"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -126,12 +125,18 @@ func copyFromCloudSources(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -140,39 +145,29 @@ func copyFromCloudSources(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				obj.GetType(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			obj.GetType(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cloud_sources"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cloud_sources"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -123,12 +122,18 @@ func copyFromClusterHealthStatuses(ctx context.Context, s pgSearch.Deleter, tx *
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -141,43 +146,33 @@ func copyFromClusterHealthStatuses(ctx context.Context, s pgSearch.Deleter, tx *
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetSensorHealthStatus(),
-				obj.GetCollectorHealthStatus(),
-				obj.GetOverallHealthStatus(),
-				obj.GetAdmissionControlHealthStatus(),
-				obj.GetScannerHealthStatus(),
-				protocompat.NilOrTime(obj.GetLastContact()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetSensorHealthStatus(),
+			obj.GetCollectorHealthStatus(),
+			obj.GetOverallHealthStatus(),
+			obj.GetAdmissionControlHealthStatus(),
+			obj.GetScannerHealthStatus(),
+			protocompat.NilOrTime(obj.GetLastContact()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_health_statuses"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_health_statuses"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -120,49 +119,45 @@ func copyFromClusterInitBundles(ctx context.Context, s pgSearch.Deleter, tx *pos
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_init_bundles"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_init_bundles"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromComplianceConfigs(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetStandardId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"standardid",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetStandardId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetStandardId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetStandardId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_configs"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_configs"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -115,49 +114,45 @@ func copyFromComplianceDomains(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_domains"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_domains"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -141,12 +140,18 @@ func copyFromComplianceRunResults(ctx context.Context, s pgSearch.Deleter, tx *p
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetRunMetadata().GetRunId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"runmetadata_runid",
@@ -156,40 +161,30 @@ func copyFromComplianceRunResults(ctx context.Context, s pgSearch.Deleter, tx *p
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetRunMetadata().GetRunId(),
-				obj.GetRunMetadata().GetStandardId(),
-				pgutils.NilOrUUID(obj.GetRunMetadata().GetClusterId()),
-				protocompat.NilOrTime(obj.GetRunMetadata().GetFinishTimestamp()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetRunMetadata().GetRunId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetRunMetadata().GetRunId(),
+			obj.GetRunMetadata().GetStandardId(),
+			pgutils.NilOrUUID(obj.GetRunMetadata().GetClusterId()),
+			protocompat.NilOrTime(obj.GetRunMetadata().GetFinishTimestamp()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_run_results"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_run_results"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromComplianceStrings(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_strings"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_strings"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromComplianceOperatorCheckResults(ctx context.Context, s pgSearch.Dele
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_results"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_results"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromComplianceOperatorProfiles(ctx context.Context, s pgSearch.Deleter,
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profiles"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profiles"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromComplianceOperatorRules(ctx context.Context, s pgSearch.Deleter, tx
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rules"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rules"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromComplianceOperatorScans(ctx context.Context, s pgSearch.Deleter, tx
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scans"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scans"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromComplianceOperatorScanSettingBindings(ctx context.Context, s pgSear
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_bindings"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_bindings"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -145,12 +144,18 @@ func copyFromComplianceOperatorBenchmarkV2(ctx context.Context, s pgSearch.Delet
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -160,40 +165,30 @@ func copyFromComplianceOperatorBenchmarkV2(ctx context.Context, s pgSearch.Delet
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				obj.GetVersion(),
-				obj.GetShortName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			obj.GetVersion(),
+			obj.GetShortName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -209,8 +204,6 @@ func copyFromComplianceOperatorBenchmarkV2Profiles(ctx context.Context, s pgSear
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"compliance_operator_benchmark_v2_id",
@@ -220,27 +213,23 @@ func copyFromComplianceOperatorBenchmarkV2Profiles(ctx context.Context, s pgSear
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(complianceOperatorBenchmarkV2ID),
-				idx,
-				obj.GetProfileName(),
-				obj.GetProfileVersion(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(complianceOperatorBenchmarkV2ID),
+			idx,
+			obj.GetProfileName(),
+			obj.GetProfileVersion(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2_profiles"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2_profiles"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -149,12 +148,18 @@ func copyFromComplianceOperatorCheckResultV2(ctx context.Context, s pgSearch.Del
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -172,48 +177,38 @@ func copyFromComplianceOperatorCheckResultV2(ctx context.Context, s pgSearch.Del
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetCheckId(),
-				obj.GetCheckName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetStatus(),
-				obj.GetSeverity(),
-				protocompat.NilOrTime(obj.GetCreatedTime()),
-				obj.GetScanConfigName(),
-				obj.GetRationale(),
-				pgutils.NilOrUUID(obj.GetScanRefId()),
-				pgutils.NilOrUUID(obj.GetRuleRefId()),
-				protocompat.NilOrTime(obj.GetLastStartedTime()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetCheckId(),
+			obj.GetCheckName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetStatus(),
+			obj.GetSeverity(),
+			protocompat.NilOrTime(obj.GetCreatedTime()),
+			obj.GetScanConfigName(),
+			obj.GetRationale(),
+			pgutils.NilOrUUID(obj.GetScanRefId()),
+			pgutils.NilOrUUID(obj.GetRuleRefId()),
+			protocompat.NilOrTime(obj.GetLastStartedTime()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_result_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_result_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/integration/store/postgres/store.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -141,12 +140,18 @@ func copyFromComplianceIntegrations(ctx context.Context, s pgSearch.Deleter, tx 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -157,41 +162,31 @@ func copyFromComplianceIntegrations(ctx context.Context, s pgSearch.Deleter, tx 
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetVersion(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetOperatorInstalled(),
-				obj.GetOperatorStatus(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetVersion(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetOperatorInstalled(),
+			obj.GetOperatorStatus(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_integrations"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_integrations"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -169,12 +168,18 @@ func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -188,44 +193,34 @@ func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetProfileId(),
-				obj.GetName(),
-				obj.GetProfileVersion(),
-				obj.GetProductType(),
-				obj.GetStandard(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				pgutils.NilOrUUID(obj.GetProfileRefId()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetProfileId(),
+			obj.GetName(),
+			obj.GetProfileVersion(),
+			obj.GetProductType(),
+			obj.GetStandard(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			pgutils.NilOrUUID(obj.GetProfileRefId()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -241,8 +236,6 @@ func copyFromComplianceOperatorProfileV2Rules(ctx context.Context, s pgSearch.De
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"compliance_operator_profile_v2_id",
@@ -251,26 +244,22 @@ func copyFromComplianceOperatorProfileV2Rules(ctx context.Context, s pgSearch.De
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				complianceOperatorProfileV2ID,
-				idx,
-				obj.GetRuleName(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			complianceOperatorProfileV2ID,
+			idx,
+			obj.GetRuleName(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2_rules"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2_rules"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/remediations/store/postgres/store.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -140,12 +139,18 @@ func copyFromComplianceOperatorRemediationV2(ctx context.Context, s pgSearch.Del
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -155,40 +160,30 @@ func copyFromComplianceOperatorRemediationV2(ctx context.Context, s pgSearch.Del
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				obj.GetComplianceCheckResultName(),
-				obj.GetClusterId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			obj.GetComplianceCheckResultName(),
+			obj.GetClusterId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_remediation_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_remediation_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -141,12 +140,18 @@ func copyFromComplianceOperatorClusterScanConfigStatuses(ctx context.Context, s 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -156,40 +161,30 @@ func copyFromComplianceOperatorClusterScanConfigStatuses(ctx context.Context, s 
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				pgutils.NilOrUUID(obj.GetScanConfigId()),
-				protocompat.NilOrTime(obj.GetLastUpdatedTime()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			pgutils.NilOrUUID(obj.GetScanConfigId()),
+			protocompat.NilOrTime(obj.GetLastUpdatedTime()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_cluster_scan_config_statuses"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_cluster_scan_config_statuses"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -189,12 +188,18 @@ func copyFromComplianceOperatorScanConfigurationV2(ctx context.Context, s pgSear
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -203,39 +208,29 @@ func copyFromComplianceOperatorScanConfigurationV2(ctx context.Context, s pgSear
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetScanConfigName(),
-				obj.GetModifiedBy().GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetScanConfigName(),
+			obj.GetModifiedBy().GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -257,8 +252,6 @@ func copyFromComplianceOperatorScanConfigurationV2Profiles(ctx context.Context, 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"compliance_operator_scan_configuration_v2_id",
@@ -267,26 +260,22 @@ func copyFromComplianceOperatorScanConfigurationV2Profiles(ctx context.Context, 
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(complianceOperatorScanConfigurationV2ID),
-				idx,
-				obj.GetProfileName(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(complianceOperatorScanConfigurationV2ID),
+			idx,
+			obj.GetProfileName(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_profiles"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_profiles"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil
@@ -296,8 +285,6 @@ func copyFromComplianceOperatorScanConfigurationV2Clusters(ctx context.Context, 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"compliance_operator_scan_configuration_v2_id",
@@ -306,26 +293,22 @@ func copyFromComplianceOperatorScanConfigurationV2Clusters(ctx context.Context, 
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(complianceOperatorScanConfigurationV2ID),
-				idx,
-				pgutils.NilOrUUID(obj.GetClusterId()),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(complianceOperatorScanConfigurationV2ID),
+			idx,
+			pgutils.NilOrUUID(obj.GetClusterId()),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_clusters"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_clusters"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil
@@ -335,8 +318,6 @@ func copyFromComplianceOperatorScanConfigurationV2Notifiers(ctx context.Context,
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"compliance_operator_scan_configuration_v2_id",
@@ -345,26 +326,22 @@ func copyFromComplianceOperatorScanConfigurationV2Notifiers(ctx context.Context,
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(complianceOperatorScanConfigurationV2ID),
-				idx,
-				obj.GetId(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(complianceOperatorScanConfigurationV2ID),
+			idx,
+			obj.GetId(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_notifiers"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_notifiers"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -146,12 +145,18 @@ func copyFromComplianceOperatorScanV2(ctx context.Context, s pgSearch.Deleter, t
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -166,45 +171,35 @@ func copyFromComplianceOperatorScanV2(ctx context.Context, s pgSearch.Deleter, t
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetScanConfigName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				pgutils.NilOrUUID(obj.GetProfile().GetProfileRefId()),
-				obj.GetStatus().GetResult(),
-				protocompat.NilOrTime(obj.GetLastExecutedTime()),
-				obj.GetScanName(),
-				pgutils.NilOrUUID(obj.GetScanRefId()),
-				protocompat.NilOrTime(obj.GetLastStartedTime()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetScanConfigName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			pgutils.NilOrUUID(obj.GetProfile().GetProfileRefId()),
+			obj.GetStatus().GetResult(),
+			protocompat.NilOrTime(obj.GetLastExecutedTime()),
+			obj.GetScanName(),
+			pgutils.NilOrUUID(obj.GetScanRefId()),
+			protocompat.NilOrTime(obj.GetLastStartedTime()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -140,12 +139,18 @@ func copyFromComplianceOperatorScanSettingBindingV2(ctx context.Context, s pgSea
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -155,40 +160,30 @@ func copyFromComplianceOperatorScanSettingBindingV2(ctx context.Context, s pgSea
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetScanSettingName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetScanSettingName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_binding_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_binding_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/complianceoperator/v2/suites/store/postgres/store.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -139,12 +138,18 @@ func copyFromComplianceOperatorSuiteV2(ctx context.Context, s pgSearch.Deleter, 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -153,39 +158,29 @@ func copyFromComplianceOperatorSuiteV2(ctx context.Context, s pgSearch.Deleter, 
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_suite_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_suite_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -126,12 +125,18 @@ func copyFromClusterCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -148,47 +153,37 @@ func copyFromClusterCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetCveBaseInfo().GetCve(),
-				protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
-				protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
-				obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
-				obj.GetCvss(),
-				obj.GetSeverity(),
-				obj.GetImpactScore(),
-				obj.GetSnoozed(),
-				protocompat.NilOrTime(obj.GetSnoozeExpiry()),
-				obj.GetType(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetCveBaseInfo().GetCve(),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
+			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetCvss(),
+			obj.GetSeverity(),
+			obj.GetImpactScore(),
+			obj.GetSnoozed(),
+			protocompat.NilOrTime(obj.GetSnoozeExpiry()),
+			obj.GetType(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_cves"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_cves"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -127,12 +126,18 @@ func copyFromImageCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -150,48 +155,38 @@ func copyFromImageCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetCveBaseInfo().GetCve(),
-				protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
-				protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
-				obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
-				obj.GetOperatingSystem(),
-				obj.GetCvss(),
-				obj.GetSeverity(),
-				obj.GetImpactScore(),
-				obj.GetSnoozed(),
-				protocompat.NilOrTime(obj.GetSnoozeExpiry()),
-				obj.GetNvdcvss(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetCveBaseInfo().GetCve(),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
+			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetOperatingSystem(),
+			obj.GetCvss(),
+			obj.GetSeverity(),
+			obj.GetImpactScore(),
+			obj.GetSnoozed(),
+			protocompat.NilOrTime(obj.GetSnoozeExpiry()),
+			obj.GetNvdcvss(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_cves"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_cves"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -128,12 +127,18 @@ func copyFromNodeCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -152,49 +157,39 @@ func copyFromNodeCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetCveBaseInfo().GetCve(),
-				protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
-				protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
-				obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
-				obj.GetOperatingSystem(),
-				obj.GetCvss(),
-				obj.GetSeverity(),
-				obj.GetImpactScore(),
-				obj.GetSnoozed(),
-				protocompat.NilOrTime(obj.GetSnoozeExpiry()),
-				obj.GetOrphaned(),
-				protocompat.NilOrTime(obj.GetOrphanedTime()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetCveBaseInfo().GetCve(),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
+			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
+			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetOperatingSystem(),
+			obj.GetCvss(),
+			obj.GetSeverity(),
+			obj.GetImpactScore(),
+			obj.GetSnoozed(),
+			protocompat.NilOrTime(obj.GetSnoozeExpiry()),
+			obj.GetOrphaned(),
+			protocompat.NilOrTime(obj.GetOrphanedTime()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_cves"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_cves"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -113,49 +112,45 @@ func copyFromDeclarativeConfigHealths(ctx context.Context, s pgSearch.Deleter, t
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"declarative_config_healths"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"declarative_config_healths"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/discoveredclusters/datastore/internal/store/postgres/store.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -123,12 +122,18 @@ func copyFromDiscoveredClusters(ctx context.Context, s pgSearch.Deleter, tx *pos
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -141,43 +146,33 @@ func copyFromDiscoveredClusters(ctx context.Context, s pgSearch.Deleter, tx *pos
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetMetadata().GetName(),
-				obj.GetMetadata().GetType(),
-				protocompat.NilOrTime(obj.GetMetadata().GetFirstDiscoveredAt()),
-				obj.GetStatus(),
-				pgutils.NilOrUUID(obj.GetSourceId()),
-				protocompat.NilOrTime(obj.GetLastUpdatedAt()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetMetadata().GetName(),
+			obj.GetMetadata().GetType(),
+			protocompat.NilOrTime(obj.GetMetadata().GetFirstDiscoveredAt()),
+			obj.GetStatus(),
+			pgutils.NilOrUUID(obj.GetSourceId()),
+			protocompat.NilOrTime(obj.GetLastUpdatedAt()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"discovered_clusters"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"discovered_clusters"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromExternalBackups(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"external_backups"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"external_backups"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -116,12 +115,18 @@ func copyFromGroups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetProps().GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"props_id",
@@ -132,41 +137,31 @@ func copyFromGroups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetProps().GetId(),
-				obj.GetProps().GetAuthProviderId(),
-				obj.GetProps().GetKey(),
-				obj.GetProps().GetValue(),
-				obj.GetRoleName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetProps().GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetProps().GetId(),
+			obj.GetProps().GetAuthProviderId(),
+			obj.GetProps().GetKey(),
+			obj.GetProps().GetValue(),
+			obj.GetRoleName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"groups"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"groups"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromHashes(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetClusterId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"clusterid",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetClusterId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetClusterId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetClusterId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"hashes"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"hashes"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -122,12 +121,18 @@ func copyFromImageComponents(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -141,44 +146,34 @@ func copyFromImageComponents(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				obj.GetVersion(),
-				obj.GetPriority(),
-				obj.GetSource(),
-				obj.GetRiskScore(),
-				obj.GetTopCvss(),
-				obj.GetOperatingSystem(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			obj.GetVersion(),
+			obj.GetPriority(),
+			obj.GetSource(),
+			obj.GetRiskScore(),
+			obj.GetTopCvss(),
+			obj.GetOperatingSystem(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_components"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_components"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/imagecomponent/v2/datastore/store/postgres/store.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -126,12 +125,18 @@ func copyFromImageComponentV2(ctx context.Context, s pgSearch.Deleter, tx *postg
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -148,47 +153,37 @@ func copyFromImageComponentV2(ctx context.Context, s pgSearch.Deleter, tx *postg
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				obj.GetVersion(),
-				obj.GetPriority(),
-				obj.GetSource(),
-				obj.GetRiskScore(),
-				obj.GetTopCvss(),
-				obj.GetOperatingSystem(),
-				obj.GetImageId(),
-				obj.GetLocation(),
-				pgutils.NilOrString(obj.GetImageIdV2()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			obj.GetVersion(),
+			obj.GetPriority(),
+			obj.GetSource(),
+			obj.GetRiskScore(),
+			obj.GetTopCvss(),
+			obj.GetOperatingSystem(),
+			obj.GetImageId(),
+			obj.GetLocation(),
+			pgutils.NilOrString(obj.GetImageIdV2()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_component_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_component_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -126,12 +125,18 @@ func copyFromImageIntegrations(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -140,39 +145,29 @@ func copyFromImageIntegrations(ctx context.Context, s pgSearch.Deleter, tx *post
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_integrations"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_integrations"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromIntegrationHealths(ctx context.Context, s pgSearch.Deleter, tx *pos
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"integration_healths"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"integration_healths"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -114,12 +113,18 @@ func copyFromLogImbues(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -127,38 +132,28 @@ func copyFromLogImbues(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				protocompat.NilOrTime(obj.GetTimestamp()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			protocompat.NilOrTime(obj.GetTimestamp()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"log_imbues"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"log_imbues"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/namespace/datastore/internal/store/postgres/store.go
+++ b/central/namespace/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -153,12 +152,18 @@ func copyFromNamespaces(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -170,42 +175,32 @@ func copyFromNamespaces(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetClusterName(),
-				pgutils.EmptyOrMap(obj.GetLabels()),
-				pgutils.EmptyOrMap(obj.GetAnnotations()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetClusterName(),
+			pgutils.EmptyOrMap(obj.GetLabels()),
+			pgutils.EmptyOrMap(obj.GetAnnotations()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"namespaces"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"namespaces"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -139,12 +138,18 @@ func copyFromNetworkBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetDeploymentId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"deploymentid",
@@ -153,39 +158,29 @@ func copyFromNetworkBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetDeploymentId()),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetNamespace(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetDeploymentId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetDeploymentId()),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetNamespace(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_baselines"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_baselines"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromNetworkGraphConfigs(ctx context.Context, s pgSearch.Deleter, tx *po
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_graph_configs"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_graph_configs"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -119,12 +118,18 @@ func copyFromNetworkEntities(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetInfo().GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"info_id",
@@ -134,40 +139,30 @@ func copyFromNetworkEntities(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetInfo().GetId(),
-				pgutils.NilOrCIDR(obj.GetInfo().GetExternalSource().GetCidr()),
-				obj.GetInfo().GetExternalSource().GetDefault(),
-				obj.GetInfo().GetExternalSource().GetDiscovered(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetInfo().GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetInfo().GetId(),
+			pgutils.NilOrCIDR(obj.GetInfo().GetExternalSource().GetCidr()),
+			obj.GetInfo().GetExternalSource().GetDefault(),
+			obj.GetInfo().GetExternalSource().GetDiscovered(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_entities"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_entities"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -139,12 +138,18 @@ func copyFromNetworkpolicies(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -153,39 +158,29 @@ func copyFromNetworkpolicies(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetNamespace(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetNamespace(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicies"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicies"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -113,49 +112,45 @@ func copyFromNetworkpoliciesundodeployments(ctx context.Context, s pgSearch.Dele
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetDeploymentId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"deploymentid",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetDeploymentId()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetDeploymentId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetDeploymentId()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpoliciesundodeployments"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpoliciesundodeployments"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -113,49 +112,45 @@ func copyFromNetworkpolicyapplicationundorecords(ctx context.Context, s pgSearch
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetClusterId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"clusterid",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetClusterId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicyapplicationundorecords"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicyapplicationundorecords"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -121,12 +120,18 @@ func copyFromNodeComponents(ctx context.Context, s pgSearch.Deleter, tx *postgre
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -139,43 +144,33 @@ func copyFromNodeComponents(ctx context.Context, s pgSearch.Deleter, tx *postgre
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				obj.GetVersion(),
-				obj.GetPriority(),
-				obj.GetRiskScore(),
-				obj.GetTopCvss(),
-				obj.GetOperatingSystem(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			obj.GetVersion(),
+			obj.GetPriority(),
+			obj.GetRiskScore(),
+			obj.GetTopCvss(),
+			obj.GetOperatingSystem(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_components"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_components"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -113,12 +112,18 @@ func copyFromNotifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -126,38 +131,28 @@ func copyFromNotifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"notifiers"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"notifiers"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -127,12 +126,18 @@ func copyFromPolicies(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -150,48 +155,38 @@ func copyFromPolicies(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				obj.GetDescription(),
-				obj.GetDisabled(),
-				obj.GetCategories(),
-				obj.GetLifecycleStages(),
-				obj.GetSeverity(),
-				obj.GetEnforcementActions(),
-				protocompat.NilOrTime(obj.GetLastUpdated()),
-				obj.GetSORTName(),
-				obj.GetSORTLifecycleStage(),
-				obj.GetSORTEnforcement(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			obj.GetDescription(),
+			obj.GetDisabled(),
+			obj.GetCategories(),
+			obj.GetLifecycleStages(),
+			obj.GetSeverity(),
+			obj.GetEnforcementActions(),
+			protocompat.NilOrTime(obj.GetLastUpdated()),
+			obj.GetSORTName(),
+			obj.GetSORTLifecycleStage(),
+			obj.GetSORTEnforcement(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policies"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policies"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -116,12 +115,18 @@ func copyFromPolicyCategories(ctx context.Context, s pgSearch.Deleter, tx *postg
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -129,38 +134,28 @@ func copyFromPolicyCategories(ctx context.Context, s pgSearch.Deleter, tx *postg
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_categories"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_categories"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -117,12 +116,18 @@ func copyFromPolicyCategoryEdges(ctx context.Context, s pgSearch.Deleter, tx *po
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -131,39 +136,29 @@ func copyFromPolicyCategoryEdges(ctx context.Context, s pgSearch.Deleter, tx *po
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetPolicyId(),
-				obj.GetCategoryId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetPolicyId(),
+			obj.GetCategoryId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_category_edges"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_category_edges"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -149,12 +148,18 @@ func copyFromProcessBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -164,40 +169,30 @@ func copyFromProcessBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				pgutils.NilOrUUID(obj.GetKey().GetDeploymentId()),
-				pgutils.NilOrUUID(obj.GetKey().GetClusterId()),
-				obj.GetKey().GetNamespace(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			pgutils.NilOrUUID(obj.GetKey().GetDeploymentId()),
+			pgutils.NilOrUUID(obj.GetKey().GetClusterId()),
+			obj.GetKey().GetNamespace(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baselines"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baselines"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -139,12 +138,18 @@ func copyFromProcessBaselineResults(ctx context.Context, s pgSearch.Deleter, tx 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetDeploymentId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"deploymentid",
@@ -153,39 +158,29 @@ func copyFromProcessBaselineResults(ctx context.Context, s pgSearch.Deleter, tx 
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetDeploymentId()),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetNamespace(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetDeploymentId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetDeploymentId()),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetNamespace(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baseline_results"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baseline_results"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -151,12 +150,18 @@ func copyFromProcessIndicators(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -176,50 +181,40 @@ func copyFromProcessIndicators(ctx context.Context, s pgSearch.Deleter, tx *post
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				pgutils.NilOrUUID(obj.GetDeploymentId()),
-				obj.GetContainerName(),
-				obj.GetPodId(),
-				pgutils.NilOrUUID(obj.GetPodUid()),
-				obj.GetSignal().GetContainerId(),
-				protocompat.NilOrTime(obj.GetSignal().GetTime()),
-				obj.GetSignal().GetName(),
-				obj.GetSignal().GetArgs(),
-				obj.GetSignal().GetExecFilePath(),
-				obj.GetSignal().GetUid(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetNamespace(),
-				protocompat.NilOrTime(obj.GetContainerStartTime()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			pgutils.NilOrUUID(obj.GetDeploymentId()),
+			obj.GetContainerName(),
+			obj.GetPodId(),
+			pgutils.NilOrUUID(obj.GetPodUid()),
+			obj.GetSignal().GetContainerId(),
+			protocompat.NilOrTime(obj.GetSignal().GetTime()),
+			obj.GetSignal().GetName(),
+			obj.GetSignal().GetArgs(),
+			obj.GetSignal().GetExecFilePath(),
+			obj.GetSignal().GetUid(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetNamespace(),
+			protocompat.NilOrTime(obj.GetContainerStartTime()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_indicators"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_indicators"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -147,12 +146,18 @@ func copyFromListeningEndpoints(ctx context.Context, s pgSearch.Deleter, tx *pos
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -168,46 +173,36 @@ func copyFromListeningEndpoints(ctx context.Context, s pgSearch.Deleter, tx *pos
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetPort(),
-				obj.GetProtocol(),
-				protocompat.NilOrTime(obj.GetCloseTimestamp()),
-				pgutils.NilOrUUID(obj.GetProcessIndicatorId()),
-				obj.GetClosed(),
-				pgutils.NilOrUUID(obj.GetDeploymentId()),
-				pgutils.NilOrUUID(obj.GetPodUid()),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetNamespace(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetPort(),
+			obj.GetProtocol(),
+			protocompat.NilOrTime(obj.GetCloseTimestamp()),
+			pgutils.NilOrUUID(obj.GetProcessIndicatorId()),
+			obj.GetClosed(),
+			pgutils.NilOrUUID(obj.GetDeploymentId()),
+			pgutils.NilOrUUID(obj.GetPodUid()),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetNamespace(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"listening_endpoints"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"listening_endpoints"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -144,12 +143,18 @@ func copyFromK8sRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -163,44 +168,34 @@ func copyFromK8sRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				obj.GetNamespace(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetClusterName(),
-				obj.GetClusterRole(),
-				pgutils.EmptyOrMap(obj.GetLabels()),
-				pgutils.EmptyOrMap(obj.GetAnnotations()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			obj.GetNamespace(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetClusterName(),
+			obj.GetClusterRole(),
+			pgutils.EmptyOrMap(obj.GetLabels()),
+			pgutils.EmptyOrMap(obj.GetAnnotations()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"k8s_roles"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"k8s_roles"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -171,12 +170,18 @@ func copyFromRoleBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -191,45 +196,35 @@ func copyFromRoleBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				obj.GetNamespace(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetClusterName(),
-				obj.GetClusterRole(),
-				pgutils.EmptyOrMap(obj.GetLabels()),
-				pgutils.EmptyOrMap(obj.GetAnnotations()),
-				pgutils.NilOrUUID(obj.GetRoleId()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			obj.GetNamespace(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetClusterName(),
+			obj.GetClusterRole(),
+			pgutils.EmptyOrMap(obj.GetLabels()),
+			pgutils.EmptyOrMap(obj.GetAnnotations()),
+			pgutils.NilOrUUID(obj.GetRoleId()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -245,8 +240,6 @@ func copyFromRoleBindingsSubjects(ctx context.Context, s pgSearch.Deleter, tx *p
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"role_bindings_id",
@@ -256,27 +249,23 @@ func copyFromRoleBindingsSubjects(ctx context.Context, s pgSearch.Deleter, tx *p
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(roleBindingID),
-				idx,
-				obj.GetKind(),
-				obj.GetName(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(roleBindingID),
+			idx,
+			obj.GetKind(),
+			obj.GetName(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings_subjects"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings_subjects"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -127,12 +126,18 @@ func copyFromReportSnapshots(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetReportId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"reportid",
@@ -149,47 +154,37 @@ func copyFromReportSnapshots(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetReportId()),
-				pgutils.NilOrString(obj.GetReportConfigurationId()),
-				obj.GetName(),
-				obj.GetReportStatus().GetRunState(),
-				protocompat.NilOrTime(obj.GetReportStatus().GetQueuedAt()),
-				protocompat.NilOrTime(obj.GetReportStatus().GetCompletedAt()),
-				obj.GetReportStatus().GetReportRequestType(),
-				obj.GetReportStatus().GetReportNotificationMethod(),
-				obj.GetRequester().GetId(),
-				obj.GetRequester().GetName(),
-				obj.GetAreaOfConcern(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetReportId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetReportId()),
+			pgutils.NilOrString(obj.GetReportConfigurationId()),
+			obj.GetName(),
+			obj.GetReportStatus().GetRunState(),
+			protocompat.NilOrTime(obj.GetReportStatus().GetQueuedAt()),
+			protocompat.NilOrTime(obj.GetReportStatus().GetCompletedAt()),
+			obj.GetReportStatus().GetReportRequestType(),
+			obj.GetReportStatus().GetReportNotificationMethod(),
+			obj.GetRequester().GetId(),
+			obj.GetRequester().GetName(),
+			obj.GetAreaOfConcern(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_snapshots"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_snapshots"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -143,12 +142,18 @@ func copyFromCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -158,40 +163,30 @@ func copyFromCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				obj.GetCreatedBy().GetName(),
-				obj.GetUpdatedBy().GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			obj.GetCreatedBy().GetName(),
+			obj.GetUpdatedBy().GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -207,8 +202,6 @@ func copyFromCollectionsEmbeddedCollections(ctx context.Context, s pgSearch.Dele
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"collections_id",
@@ -217,26 +210,22 @@ func copyFromCollectionsEmbeddedCollections(ctx context.Context, s pgSearch.Dele
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				collectionID,
-				idx,
-				obj.GetId(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			collectionID,
+			idx,
+			obj.GetId(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections_embedded_collections"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections_embedded_collections"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -141,12 +140,18 @@ func copyFromRisks(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -157,41 +162,31 @@ func copyFromRisks(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetSubject().GetNamespace(),
-				pgutils.NilOrUUID(obj.GetSubject().GetClusterId()),
-				obj.GetSubject().GetType(),
-				obj.GetScore(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetSubject().GetNamespace(),
+			pgutils.NilOrUUID(obj.GetSubject().GetClusterId()),
+			obj.GetSubject().GetType(),
+			obj.GetScore(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"risks"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"risks"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -114,12 +113,18 @@ func copyFromPermissionSets(ctx context.Context, s pgSearch.Deleter, tx *postgre
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -127,38 +132,28 @@ func copyFromPermissionSets(ctx context.Context, s pgSearch.Deleter, tx *postgre
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"permission_sets"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"permission_sets"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetName())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"name",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetName())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"roles"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"roles"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -114,12 +113,18 @@ func copyFromSimpleAccessScopes(ctx context.Context, s pgSearch.Deleter, tx *pos
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -127,38 +132,28 @@ func copyFromSimpleAccessScopes(ctx context.Context, s pgSearch.Deleter, tx *pos
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"simple_access_scopes"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"simple_access_scopes"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -195,12 +194,18 @@ func copyFromSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, o
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -212,42 +217,32 @@ func copyFromSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, o
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetClusterName(),
-				obj.GetNamespace(),
-				protocompat.NilOrTime(obj.GetCreatedAt()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetClusterName(),
+			obj.GetNamespace(),
+			protocompat.NilOrTime(obj.GetCreatedAt()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -263,8 +258,6 @@ func copyFromSecretsFiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"secrets_id",
@@ -274,30 +267,26 @@ func copyFromSecretsFiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(secretID),
-				idx,
-				obj.GetType(),
-				protocompat.NilOrTime(obj.GetCert().GetEndDate()),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(secretID),
+			idx,
+			obj.GetType(),
+			protocompat.NilOrTime(obj.GetCert().GetEndDate()),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
-	for idx, obj := range objs {
+	for _, obj := range objs {
 		if err := copyFromSecretsFilesRegistries(ctx, s, tx, secretID, idx, obj.GetImagePullSecret().GetRegistries()...); err != nil {
 			return err
 		}
@@ -310,8 +299,6 @@ func copyFromSecretsFilesRegistries(ctx context.Context, s pgSearch.Deleter, tx 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"secrets_id",
@@ -321,27 +308,23 @@ func copyFromSecretsFilesRegistries(ctx context.Context, s pgSearch.Deleter, tx 
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(secretID),
-				secretFileIdx,
-				idx,
-				obj.GetName(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(secretID),
+			secretFileIdx,
+			idx,
+			obj.GetName(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files_registries"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files_registries"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -143,12 +142,18 @@ func copyFromServiceAccounts(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -161,43 +166,33 @@ func copyFromServiceAccounts(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetName(),
-				obj.GetNamespace(),
-				obj.GetClusterName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				pgutils.EmptyOrMap(obj.GetLabels()),
-				pgutils.EmptyOrMap(obj.GetAnnotations()),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetName(),
+			obj.GetNamespace(),
+			obj.GetClusterName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			pgutils.EmptyOrMap(obj.GetLabels()),
+			pgutils.EmptyOrMap(obj.GetAnnotations()),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_accounts"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_accounts"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromServiceIdentities(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetSerialStr())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"serialstr",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetSerialStr(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetSerialStr())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetSerialStr(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_identities"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_identities"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -121,12 +120,18 @@ func copyFromSignatureIntegrations(ctx context.Context, s pgSearch.Deleter, tx *
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -134,38 +139,28 @@ func copyFromSignatureIntegrations(ctx context.Context, s pgSearch.Deleter, tx *
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"signature_integrations"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"signature_integrations"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/virtualmachine/datastore/internal/store/postgres/store.go
+++ b/central/virtualmachine/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"time"
 
@@ -141,12 +140,18 @@ func copyFromVirtualMachines(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -157,41 +162,31 @@ func copyFromVirtualMachines(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetNamespace(),
-				obj.GetName(),
-				pgutils.NilOrUUID(obj.GetClusterId()),
-				obj.GetClusterName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetNamespace(),
+			obj.GetName(),
+			pgutils.NilOrUUID(obj.GetClusterId()),
+			obj.GetClusterName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"virtual_machines"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"virtual_machines"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -206,12 +205,18 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -236,55 +241,45 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetName(),
-				obj.GetTargetState(),
-				obj.GetStatus(),
-				obj.GetExpired(),
-				obj.GetRequestor().GetName(),
-				protocompat.NilOrTime(obj.GetCreatedAt()),
-				protocompat.NilOrTime(obj.GetLastUpdated()),
-				obj.GetScope().GetImageScope().GetRegistry(),
-				obj.GetScope().GetImageScope().GetRemote(),
-				obj.GetScope().GetImageScope().GetTag(),
-				obj.GetRequesterV2().GetId(),
-				obj.GetRequesterV2().GetName(),
-				protocompat.NilOrTime(obj.GetDeferralReq().GetExpiry().GetExpiresOn()),
-				obj.GetDeferralReq().GetExpiry().GetExpiresWhenFixed(),
-				obj.GetDeferralReq().GetExpiry().GetExpiryType(),
-				obj.GetCves().GetCves(),
-				obj.GetDeferralUpdate().GetCVEs(),
-				obj.GetFalsePositiveUpdate().GetCVEs(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetName(),
+			obj.GetTargetState(),
+			obj.GetStatus(),
+			obj.GetExpired(),
+			obj.GetRequestor().GetName(),
+			protocompat.NilOrTime(obj.GetCreatedAt()),
+			protocompat.NilOrTime(obj.GetLastUpdated()),
+			obj.GetScope().GetImageScope().GetRegistry(),
+			obj.GetScope().GetImageScope().GetRemote(),
+			obj.GetScope().GetImageScope().GetTag(),
+			obj.GetRequesterV2().GetId(),
+			obj.GetRequesterV2().GetName(),
+			protocompat.NilOrTime(obj.GetDeferralReq().GetExpiry().GetExpiresOn()),
+			obj.GetDeferralReq().GetExpiry().GetExpiresWhenFixed(),
+			obj.GetDeferralReq().GetExpiry().GetExpiryType(),
+			obj.GetCves().GetCves(),
+			obj.GetDeferralUpdate().GetCVEs(),
+			obj.GetFalsePositiveUpdate().GetCVEs(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -306,8 +301,6 @@ func copyFromVulnerabilityRequestsApprovers(ctx context.Context, s pgSearch.Dele
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"vulnerability_requests_id",
@@ -316,26 +309,22 @@ func copyFromVulnerabilityRequestsApprovers(ctx context.Context, s pgSearch.Dele
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				vulnerabilityRequestID,
-				idx,
-				obj.GetName(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			vulnerabilityRequestID,
+			idx,
+			obj.GetName(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil
@@ -345,8 +334,6 @@ func copyFromVulnerabilityRequestsComments(ctx context.Context, s pgSearch.Delet
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"vulnerability_requests_id",
@@ -355,26 +342,22 @@ func copyFromVulnerabilityRequestsComments(ctx context.Context, s pgSearch.Delet
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				vulnerabilityRequestID,
-				idx,
-				obj.GetUser().GetName(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			vulnerabilityRequestID,
+			idx,
+			obj.GetUser().GetName(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_comments"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_comments"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil
@@ -384,8 +367,6 @@ func copyFromVulnerabilityRequestsApproversV2(ctx context.Context, s pgSearch.De
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"vulnerability_requests_id",
@@ -395,27 +376,23 @@ func copyFromVulnerabilityRequestsApproversV2(ctx context.Context, s pgSearch.De
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				vulnerabilityRequestID,
-				idx,
-				obj.GetId(),
-				obj.GetName(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			vulnerabilityRequestID,
+			idx,
+			obj.GetId(),
+			obj.GetName(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers_v2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers_v2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,49 +111,45 @@ func copyFromWatchedImages(ctx context.Context, s pgSearch.Deleter, tx *postgres
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetName())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"name",
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetName(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetName())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetName(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"watched_images"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"watched_images"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -160,12 +159,18 @@ func copyFromTestStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetKey1())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"key1",
@@ -185,50 +190,40 @@ func copyFromTestStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetKey1(),
-				obj.GetKey2(),
-				obj.GetStringSlice(),
-				obj.GetBool(),
-				obj.GetUint64(),
-				obj.GetInt64(),
-				obj.GetFloat(),
-				pgutils.EmptyOrMap(obj.GetLabels()),
-				protocompat.NilOrTime(obj.GetTimestamp()),
-				obj.GetEnum(),
-				obj.GetEnums(),
-				obj.GetString_(),
-				obj.GetInt32Slice(),
-				obj.GetOneofnested().GetNested(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetKey1())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetKey1(),
+			obj.GetKey2(),
+			obj.GetStringSlice(),
+			obj.GetBool(),
+			obj.GetUint64(),
+			obj.GetInt64(),
+			obj.GetFloat(),
+			pgutils.EmptyOrMap(obj.GetLabels()),
+			protocompat.NilOrTime(obj.GetTimestamp()),
+			obj.GetEnum(),
+			obj.GetEnums(),
+			obj.GetString_(),
+			obj.GetInt32Slice(),
+			obj.GetOneofnested().GetNested(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -244,8 +239,6 @@ func copyFromTestStructsNesteds(ctx context.Context, s pgSearch.Deleter, tx *pos
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"test_structs_key1",
@@ -259,31 +252,27 @@ func copyFromTestStructsNesteds(ctx context.Context, s pgSearch.Deleter, tx *pos
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				testStructKey1,
-				idx,
-				obj.GetNested(),
-				obj.GetIsNested(),
-				obj.GetInt64(),
-				obj.GetNested2().GetNested2(),
-				obj.GetNested2().GetIsNested(),
-				obj.GetNested2().GetInt64(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			testStructKey1,
+			idx,
+			obj.GetNested(),
+			obj.GetIsNested(),
+			obj.GetInt64(),
+			obj.GetNested2().GetNested2(),
+			obj.GetNested2().GetIsNested(),
+			obj.GetNested2().GetInt64(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs_nesteds"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs_nesteds"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -259,16 +259,23 @@ func {{ template "insertFunctionName" $schema }}(batch *pgx.Batch, obj {{$schema
 
 {{- define "copyObject"}}
 {{- $schema := .schema }}
+{{- $singlePK := index $schema.PrimaryKeys 0 }}
 func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, {{ range $index, $field := $schema.FieldsReferringToParent }} {{$field.Name}} {{$field.Type}},{{end}} objs ...{{$schema.Type}}) error {
     if len(objs) == 0 {
         return nil
     }
-    batchSize := min(len(objs), pgSearch.MaxBatchSize)
-    inputRows := make([][]interface{}, 0, batchSize)
     {{if not $schema.Parent }}
-    // This is a copy so first we must delete the rows and re-add them
-    // Which is essentially the desired behaviour of an upsert.
-    deletes := make([]string, 0, batchSize)
+    {
+        // CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+        // Parent deletion cascades to children, so only the top-level parent needs deletion.
+        deletes := make([]string, 0, len(objs))
+        for _, obj := range objs {
+            deletes = append(deletes, {{ $singlePK.Getter "obj" }})
+        }
+        if err := s.DeleteMany(ctx, deletes); err != nil {
+            return err
+        }
+    }
     {{end}}
 
     copyCols := []string {
@@ -277,47 +284,32 @@ func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.D
     {{- end }}
     }
 
-    {{ $idx := false }}{{ range $field := $schema.DBColumnFields }}{{if eq "idx" ($field.Getter "obj") -}}{{ $idx = true }}{{end}}{{ end -}}
-    {{ if $idx }}idx := 0{{ end }}
-    for objBatch := range slices.Chunk(objs, batchSize) {
-        for _, obj := range objBatch {
-            {{/* If embedded, the top-level has the full serialized object */}}
-            {{if not $schema.Parent }}
-            serialized, marshalErr := obj.MarshalVT()
-            if marshalErr != nil {
-                return marshalErr
-            }
-            {{end}}
-
-            inputRows = append(inputRows, []interface{}{
-                {{- template "insertValues" $schema }}
-            })
-
-            {{ if not $schema.Parent }}
-            // Add the ID to be deleted.
-            deletes = append(deletes, {{ range $field := $schema.PrimaryKeys }}{{$field.Getter "obj"}}, {{end}})
-            {{end}}
-            {{- if $idx }}idx++{{ end -}}
+    idx := 0
+    inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+        if idx >= len(objs) {
+            return nil, nil
         }
+        obj := objs[idx]
+        idx++
 
-        // copy does not upsert so have to delete first.  parent deletion cascades so only need to
-        // delete for the top level parent
         {{if not $schema.Parent }}
-        if err := s.DeleteMany(ctx, deletes); err != nil {
-            return err
+        serialized, marshalErr := obj.MarshalVT()
+        if marshalErr != nil {
+            return nil, marshalErr
         }
-        // clear the inserts and vals for the next batch
-        deletes = deletes[:0]
         {{end}}
-        if _, err := tx.CopyFrom(ctx, pgx.Identifier{"{{$schema.Table|lowerCase}}"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
+
+        return []interface{}{
+            {{- template "insertValues" $schema }}
+        }, nil
+    })
+
+    if _, err := tx.CopyFrom(ctx, pgx.Identifier{"{{$schema.Table|lowerCase}}"}, copyCols, inputRows); err != nil {
             return err
-        }
-        // clear the input rows for the next batch
-        inputRows = inputRows[:0]
     }
 
     {{if $schema.Children }}
-    for {{ if $idx }}idx{{else}}_{{ end }}, obj := range objs {
+    for _, obj := range objs {
         {{- range $child := $schema.Children }}
         if err := {{ template "copyFunctionName" $child }}(ctx, s, tx{{ range $index, $field := $schema.PrimaryKeys }}, {{$field.Getter "obj"}}{{end}}, obj.{{$child.ObjectGetter}}...); err != nil {
             return err

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -127,12 +126,18 @@ func copyFromTestSingleKeyStructs(ctx context.Context, s pgSearch.Deleter, tx *p
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetKey())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"key",
@@ -149,47 +154,37 @@ func copyFromTestSingleKeyStructs(ctx context.Context, s pgSearch.Deleter, tx *p
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetKey(),
-				obj.GetName(),
-				obj.GetStringSlice(),
-				obj.GetBool(),
-				obj.GetUint64(),
-				obj.GetInt64(),
-				obj.GetFloat(),
-				pgutils.EmptyOrMap(obj.GetLabels()),
-				protocompat.NilOrTime(obj.GetTimestamp()),
-				obj.GetEnum(),
-				obj.GetEnums(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetKey())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetKey(),
+			obj.GetName(),
+			obj.GetStringSlice(),
+			obj.GetBool(),
+			obj.GetUint64(),
+			obj.GetInt64(),
+			obj.GetFloat(),
+			pgutils.EmptyOrMap(obj.GetLabels()),
+			protocompat.NilOrTime(obj.GetTimestamp()),
+			obj.GetEnum(),
+			obj.GetEnums(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_key_structs"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_key_structs"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -116,12 +115,18 @@ func copyFromTestChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -129,38 +134,28 @@ func copyFromTestChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -118,12 +117,18 @@ func copyFromTestChild1P4(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -132,39 +137,29 @@ func copyFromTestChild1P4(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				pgutils.NilOrUUID(obj.GetParentId()),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			pgutils.NilOrUUID(obj.GetParentId()),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1_p4"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1_p4"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -119,12 +118,18 @@ func copyFromTestChild2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -134,40 +139,30 @@ func copyFromTestChild2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetParentId(),
-				obj.GetGrandparentId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetParentId(),
+			obj.GetGrandparentId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -118,12 +117,18 @@ func copyFromTestG2GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -133,40 +138,30 @@ func copyFromTestG2GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetParentId(),
-				obj.GetChildId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetParentId(),
+			obj.GetChildId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g2_grand_child1"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g2_grand_child1"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -116,12 +115,18 @@ func copyFromTestG3GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -129,38 +134,28 @@ func copyFromTestG3GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g3_grand_child1"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g3_grand_child1"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -116,12 +115,18 @@ func copyFromTestGGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postg
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -129,38 +134,28 @@ func copyFromTestGGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postg
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g_grand_child1"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g_grand_child1"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -118,12 +117,18 @@ func copyFromTestGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgr
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -133,40 +138,30 @@ func copyFromTestGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetParentId(),
-				obj.GetChildId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetParentId(),
+			obj.GetChildId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grand_child1"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grand_child1"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -169,12 +168,18 @@ func copyFromTestGrandparents(ctx context.Context, s pgSearch.Deleter, tx *postg
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -184,40 +189,30 @@ func copyFromTestGrandparents(ctx context.Context, s pgSearch.Deleter, tx *postg
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetVal(),
-				obj.GetPriority(),
-				obj.GetRiskScore(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetVal(),
+			obj.GetPriority(),
+			obj.GetRiskScore(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -233,8 +228,6 @@ func copyFromTestGrandparentsEmbeddeds(ctx context.Context, s pgSearch.Deleter, 
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"test_grandparents_id",
@@ -243,29 +236,25 @@ func copyFromTestGrandparentsEmbeddeds(ctx context.Context, s pgSearch.Deleter, 
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				testGrandparentID,
-				idx,
-				obj.GetVal(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			testGrandparentID,
+			idx,
+			obj.GetVal(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
-	for idx, obj := range objs {
+	for _, obj := range objs {
 		if err := copyFromTestGrandparentsEmbeddedsEmbedded2(ctx, s, tx, testGrandparentID, idx, obj.GetEmbedded2()...); err != nil {
 			return err
 		}
@@ -278,8 +267,6 @@ func copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, s pgSearch.
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"test_grandparents_id",
@@ -289,27 +276,23 @@ func copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, s pgSearch.
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				testGrandparentID,
-				testGrandparentEmbeddedIdx,
-				idx,
-				obj.GetVal(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			testGrandparentID,
+			testGrandparentEmbeddedIdx,
+			idx,
+			obj.GetVal(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds_embedded2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds_embedded2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -143,12 +142,18 @@ func copyFromTestParent1(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -158,40 +163,30 @@ func copyFromTestParent1(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetParentId(),
-				obj.GetVal(),
-				obj.GetStringSlice(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetParentId(),
+			obj.GetVal(),
+			obj.GetStringSlice(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	for _, obj := range objs {
@@ -207,8 +202,6 @@ func copyFromTestParent1Childrens(ctx context.Context, s pgSearch.Deleter, tx *p
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
 	copyCols := []string{
 		"test_parent1_id",
@@ -217,26 +210,22 @@ func copyFromTestParent1Childrens(ctx context.Context, s pgSearch.Deleter, tx *p
 	}
 
 	idx := 0
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
-
-			inputRows = append(inputRows, []interface{}{
-				testParent1ID,
-				idx,
-				obj.GetChildId(),
-			})
-
-			idx++
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
 		}
+		obj := objs[idx]
+		idx++
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			testParent1ID,
+			idx,
+			obj.GetChildId(),
+		}, nil
+	})
 
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1_childrens"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1_childrens"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -118,12 +117,18 @@ func copyFromTestParent2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -132,39 +137,29 @@ func copyFromTestParent2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetParentId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetParentId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent2"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent2"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -117,12 +116,18 @@ func copyFromTestParent3(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -131,39 +136,29 @@ func copyFromTestParent3(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetParentId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetParentId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent3"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent3"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -118,12 +117,18 @@ func copyFromTestParent4(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -132,39 +137,29 @@ func copyFromTestParent4(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetId()),
-				obj.GetParentId(),
-				obj.GetVal(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetId()),
+			obj.GetParentId(),
+			obj.GetVal(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent4"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent4"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -117,12 +116,18 @@ func copyFromTestShortCircuits(ctx context.Context, s pgSearch.Deleter, tx *post
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetId())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"id",
@@ -131,39 +136,29 @@ func copyFromTestShortCircuits(ctx context.Context, s pgSearch.Deleter, tx *post
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				obj.GetId(),
-				obj.GetChildId(),
-				obj.GetG2GrandchildId(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetId())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			obj.GetId(),
+			obj.GetChildId(),
+			obj.GetG2GrandchildId(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_short_circuits"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_short_circuits"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -127,12 +126,18 @@ func copyFromTestSingleUUIDKeyStructs(ctx context.Context, s pgSearch.Deleter, t
 	if len(objs) == 0 {
 		return nil
 	}
-	batchSize := min(len(objs), pgSearch.MaxBatchSize)
-	inputRows := make([][]interface{}, 0, batchSize)
 
-	// This is a copy so first we must delete the rows and re-add them
-	// Which is essentially the desired behaviour of an upsert.
-	deletes := make([]string, 0, batchSize)
+	{
+		// CopyFrom does not upsert, so delete existing rows first to achieve upsert behavior.
+		// Parent deletion cascades to children, so only the top-level parent needs deletion.
+		deletes := make([]string, 0, len(objs))
+		for _, obj := range objs {
+			deletes = append(deletes, obj.GetKey())
+		}
+		if err := s.DeleteMany(ctx, deletes); err != nil {
+			return err
+		}
+	}
 
 	copyCols := []string{
 		"key",
@@ -149,47 +154,37 @@ func copyFromTestSingleUUIDKeyStructs(ctx context.Context, s pgSearch.Deleter, t
 		"serialized",
 	}
 
-	for objBatch := range slices.Chunk(objs, batchSize) {
-		for _, obj := range objBatch {
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
 
-			serialized, marshalErr := obj.MarshalVT()
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			inputRows = append(inputRows, []interface{}{
-				pgutils.NilOrUUID(obj.GetKey()),
-				obj.GetName(),
-				obj.GetStringSlice(),
-				obj.GetBool(),
-				obj.GetUint64(),
-				obj.GetInt64(),
-				obj.GetFloat(),
-				pgutils.EmptyOrMap(obj.GetLabels()),
-				protocompat.NilOrTime(obj.GetTimestamp()),
-				obj.GetEnum(),
-				obj.GetEnums(),
-				serialized,
-			})
-
-			// Add the ID to be deleted.
-			deletes = append(deletes, obj.GetKey())
+		serialized, marshalErr := obj.MarshalVT()
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
 
-		// copy does not upsert so have to delete first.  parent deletion cascades so only need to
-		// delete for the top level parent
+		return []interface{}{
+			pgutils.NilOrUUID(obj.GetKey()),
+			obj.GetName(),
+			obj.GetStringSlice(),
+			obj.GetBool(),
+			obj.GetUint64(),
+			obj.GetInt64(),
+			obj.GetFloat(),
+			pgutils.EmptyOrMap(obj.GetLabels()),
+			protocompat.NilOrTime(obj.GetTimestamp()),
+			obj.GetEnum(),
+			obj.GetEnums(),
+			serialized,
+		}, nil
+	})
 
-		if err := s.DeleteMany(ctx, deletes); err != nil {
-			return err
-		}
-		// clear the inserts and vals for the next batch
-		deletes = deletes[:0]
-
-		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_uuid_key_structs"}, copyCols, pgx.CopyFromRows(inputRows)); err != nil {
-			return err
-		}
-		// clear the input rows for the next batch
-		inputRows = inputRows[:0]
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_uuid_key_structs"}, copyCols, inputRows); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Refactored the generated `copyFrom` functions to use `pgx.CopyFromFunc` with an iterator pattern instead of pre-building row slices. This  improves memory efficiency for bulk insert operations.

I run benchmark from 
- https://github.com/stackrox/stackrox/pull/17564

```
                          │  master1.txt   │               new1.txt                │
                          │ max_heap_bytes │ max_heap_bytes  vs base               │
Many/upsert_128_alerts-8      1.826M ± 24%     1.291M ± 34%  -29.34% (p=0.002 n=6)
Many/upsert_256_alerts-8      3.176M ±  2%     2.096M ±  1%  -33.99% (p=0.002 n=6)
Many/upsert_512_alerts-8      5.413M ± 14%     2.915M ±  4%  -46.14% (p=0.002 n=6)
Many/upsert_1024_alerts-8     8.834M ±  6%     3.287M ± 10%  -62.80% (p=0.002 n=6)
Many/upsert_2048_alerts-8    14.597M ± 16%     3.564M ± 59%  -75.59% (p=0.002 n=6)
Many/upsert_4096_alerts-8    19.687M ± 15%     4.050M ± 15%  -79.43% (p=0.002 n=6)
Many/upsert_8192_alerts-8    38.786M ±  4%     4.660M ± 13%  -87.98% (p=0.002 n=6)
geomean                       4.628M           2.509M        -45.80%

                          │   master1.txt    │                new1.txt                 │
                          │ max_heap_objects │ max_heap_objects  vs base               │
Many/upsert_128_alerts-8        1.826M ± 24%       1.291M ± 34%  -29.34% (p=0.002 n=6)
Many/upsert_256_alerts-8        3.176M ±  2%       2.096M ±  1%  -33.99% (p=0.002 n=6)
Many/upsert_512_alerts-8        5.413M ± 14%       2.915M ±  4%  -46.14% (p=0.002 n=6)
Many/upsert_1024_alerts-8       8.834M ±  6%       3.287M ± 10%  -62.80% (p=0.002 n=6)
Many/upsert_2048_alerts-8      14.597M ± 16%       3.564M ± 59%  -75.59% (p=0.002 n=6)
Many/upsert_4096_alerts-8      19.687M ± 15%       4.050M ± 15%  -79.43% (p=0.002 n=6)
Many/upsert_8192_alerts-8      38.786M ±  4%       4.660M ± 13%  -87.98% (p=0.002 n=6)
geomean                         4.628M             2.509M        -45.80%
```

Refs: 
- https://github.com/jackc/pgx/pull/1776

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
