### PR TITLE
ROX-31355: Use import type and delete React in Containers Risk

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -767,7 +767,6 @@ module.exports = [
             'src/Components/CompoundSearchFilter/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/Policies/**',
-            'src/Containers/Risk/**',
             'src/Containers/SystemConfig/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
@@ -811,7 +810,6 @@ module.exports = [
             'src/Containers/Policies/**',
             'src/Containers/PolicyCategories/**',
             'src/Containers/PolicyManagement/**',
-            'src/Containers/Risk/**',
             'src/Containers/Search/**',
             'src/Containers/SystemConfig/**',
             'src/Containers/SystemHealth/**',

--- a/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.jsx
+++ b/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import lowerCase from 'lodash/lowerCase';
 import capitalize from 'lodash/capitalize';

--- a/ui/apps/platform/src/Containers/Risk/CreatePolicyFromSearch.jsx
+++ b/ui/apps/platform/src/Containers/Risk/CreatePolicyFromSearch.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { connect } from 'react-redux';

--- a/ui/apps/platform/src/Containers/Risk/DeploymentDetails.jsx
+++ b/ui/apps/platform/src/Containers/Risk/DeploymentDetails.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Risk/EventTimeline/DeploymentEventTimeline/DeploymentEventTimeline.jsx
+++ b/ui/apps/platform/src/Containers/Risk/EventTimeline/DeploymentEventTimeline/DeploymentEventTimeline.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import { useQuery } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/Risk/EventTimeline/EventTimeline.jsx
+++ b/ui/apps/platform/src/Containers/Risk/EventTimeline/EventTimeline.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { selectOptionEventTypes, rootTypes } from 'constants/timelineTypes';

--- a/ui/apps/platform/src/Containers/Risk/EventTimeline/EventTimelineOverview/EventTimelineOverview.jsx
+++ b/ui/apps/platform/src/Containers/Risk/EventTimeline/EventTimelineOverview/EventTimelineOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { memo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import Raven from 'raven-js';
@@ -74,4 +74,4 @@ EventTimelineOverview.propTypes = {
     deploymentId: PropTypes.string.isRequired,
 };
 
-export default React.memo(EventTimelineOverview);
+export default memo(EventTimelineOverview);

--- a/ui/apps/platform/src/Containers/Risk/EventTimeline/EventTypeSelect.jsx
+++ b/ui/apps/platform/src/Containers/Risk/EventTimeline/EventTypeSelect.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { selectOptionEventTypes } from 'constants/timelineTypes';
 import Select from 'Components/ReactSelect';
 

--- a/ui/apps/platform/src/Containers/Risk/EventTimeline/PodEventTimeline/PodEventTimeline.jsx
+++ b/ui/apps/platform/src/Containers/Risk/EventTimeline/PodEventTimeline/PodEventTimeline.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { ArrowLeft } from 'react-feather';

--- a/ui/apps/platform/src/Containers/Risk/Indicators/RiskIndicators.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Indicators/RiskIndicators.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Alert } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Risk/KeyValuePairs.jsx
+++ b/ui/apps/platform/src/Containers/Risk/KeyValuePairs.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import isObject from 'lodash/isObject';

--- a/ui/apps/platform/src/Containers/Risk/Process/Binaries.jsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/Binaries.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import ProcessSignal from './Signal';

--- a/ui/apps/platform/src/Containers/Risk/Process/BinaryCollapsible.jsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/BinaryCollapsible.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
 

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { MinusIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineList.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, FlexItem, Switch, Tooltip } from '@patternfly/react-core';
 import { LockIcon, LockOpenIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscovery.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscovery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
 import uniqBy from 'lodash/uniqBy';
 

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscoveryCard.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscoveryCard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import CollapsibleCard from 'Components/CollapsibleCard';
 import type { ProcessNameAndContainerNameGroup } from 'services/ProcessService';
 

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscoveryCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscoveryCardHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
 import {
     AngleDownIcon,

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscoveryCards.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessDiscoveryCards.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import orderBy from 'lodash/orderBy';
 
 import type { ProcessNameAndContainerNameGroup } from 'services/ProcessService';

--- a/ui/apps/platform/src/Containers/Risk/Process/Signal.jsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/Signal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import Table, {

--- a/ui/apps/platform/src/Containers/Risk/Process/SpecificationBaselineList.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Process/SpecificationBaselineList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ProcessBaseline } from 'types/processBaseline.proto';
 
 import ProcessBaselineList from './ProcessBaselineList';

--- a/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Risk/RiskPageHeader.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskPageHeader.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import entityTypes, { searchCategories } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/Risk/RiskSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskSidePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
 
 import { fetchDeploymentWithRisk } from 'services/DeploymentsService';

--- a/ui/apps/platform/src/Containers/Risk/RiskSidePanelTabs.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskSidePanelTabs.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
-
 import Tabs from 'Components/Tabs';
 import Tab from 'Components/Tab';
 import usePermissions from 'hooks/usePermissions';
-import { Deployment } from 'types/deployment.proto';
+import type { Deployment } from 'types/deployment.proto';
 import type { Risk } from 'types/risk.proto';
 
 import DeploymentDetails from './DeploymentDetails';

--- a/ui/apps/platform/src/Containers/Risk/RiskTable.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTable.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import NoResultsMessage from 'Components/NoResultsMessage';

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useCallback } from 'react';
+import { useContext, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import useDeepCompareEffect from 'use-deep-compare-effect';

--- a/ui/apps/platform/src/Containers/Risk/SecurityContext.jsx
+++ b/ui/apps/platform/src/Containers/Risk/SecurityContext.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import CollapsibleCard from 'Components/CollapsibleCard';
 
 import KeyValuePairs from './KeyValuePairs';

--- a/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.jsx
+++ b/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import PropTypes from 'prop-types';
 import find from 'lodash/find';


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

We waited until after refactoring for role-based access control in #15936

Double up because only one missing `import type` statement.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.