### PR TITLE
ROX-33563: Migrate scanner image to ubi-micro

### DIFF
--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -50,7 +50,11 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
+    value: |
+      [
+        { "type": "gomod", "path": "." },
+        { "type": "rpm" }
+      ]
   - name: build-source-image
     value: 'true'
   - name: clone-depth

--- a/.tekton/scanner-v4-pipeline.yaml
+++ b/.tekton/scanner-v4-pipeline.yaml
@@ -256,6 +256,8 @@ spec:
       value: $(params.output-image-repo):konflux-$(params.revision).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.oci-artifact-expires-after)
+    - name: ACTIVATION_KEY
+      value: subscription-manager-activation-key-prod
     taskRef:
       params:
       - name: name

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -9,7 +9,7 @@ packages:
 - postgresql
 # builder stage in operator/konflux.bundle.Dockerfile
 - python3.12-pyyaml
-# package_installer stage in operator/konflux.Dockerfile and image/roxctl/konflux.Dockerfile
+# package_installer stage in operator/konflux.Dockerfile, image/roxctl/konflux.Dockerfile, and scanner/image/scanner/konflux.Dockerfile
 - ca-certificates
 - openssl
 moduleEnable:

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -43,6 +43,7 @@ LABEL name="scanner-v4" \
 
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
+COPY --from=package_installer /out/ /
 COPY scripts/entrypoint.sh \
      scripts/import-additional-cas \
      scripts/restore-all-dir-contents \
@@ -50,9 +51,8 @@ COPY scripts/entrypoint.sh \
 COPY bin/scanner /usr/local/bin/
 COPY THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 COPY --from=mappings /mappings/repository-to-cpe.json /mappings/container-name-repos-map.json /run/mappings/
+# Copy Delve debugger if built (empty dir when DEBUG_BUILD=no).
 COPY --from=debugger /output/go/ /go/
-
-COPY --from=package_installer /out/ /
 
 RUN \
     chown -R 65534:65534 /tmp && \

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -1,24 +1,32 @@
-ARG MAPPINGS_REGISTRY=registry.access.redhat.com
-ARG MAPPINGS_BASE_IMAGE=ubi9
-ARG MAPPINGS_BASE_TAG=latest
-ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi9-minimal
-ARG BASE_TAG=latest
-
-FROM ${MAPPINGS_REGISTRY}/${MAPPINGS_BASE_IMAGE}:${MAPPINGS_BASE_TAG} AS mappings
+FROM registry.access.redhat.com/ubi9/ubi:latest AS mappings
 
 COPY download-mappings.sh /download-mappings.sh
 RUN /download-mappings.sh /mappings
 
 # Build Delve debugger when DEBUG_BUILD=yes.
-FROM ${MAPPINGS_REGISTRY}/${MAPPINGS_BASE_IMAGE}:${MAPPINGS_BASE_TAG} AS debugger
+FROM registry.access.redhat.com/ubi9/ubi:latest AS debugger
 
 ARG DEBUG_BUILD=no
 
 COPY download-dlv.sh /download-dlv.sh
 RUN DEBUG_BUILD=${DEBUG_BUILD} /download-dlv.sh
 
-FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest AS ubi-micro-base
+
+FROM registry.access.redhat.com/ubi9/ubi:latest AS package_installer
+
+COPY --from=ubi-micro-base / /out/
+
+RUN dnf install -y \
+    --installroot=/out/ \
+    --releasever=9 \
+    --setopt=install_weak_deps=0 \
+    --nodocs \
+    ca-certificates && \
+    dnf clean all --installroot=/out/ && \
+    rm -rf /out/var/cache/dnf /out/var/cache/yum
+
+FROM ubi-micro-base
 
 ARG LABEL_VERSION
 ARG LABEL_RELEASE
@@ -42,14 +50,11 @@ COPY scripts/entrypoint.sh \
 COPY bin/scanner /usr/local/bin/
 COPY THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 COPY --from=mappings /mappings/repository-to-cpe.json /mappings/container-name-repos-map.json /run/mappings/
-# Copy Delve debugger if built (empty dir when DEBUG_BUILD=no).
 COPY --from=debugger /output/go/ /go/
 
-RUN microdnf upgrade -y --nobest && \
-    microdnf clean all && \
-    # (Optional) Remove line below to keep package management utilities
-    rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
-    rm -rf /var/cache/dnf /var/cache/yum && \
+COPY --from=package_installer /out/ /
+
+RUN \
     chown -R 65534:65534 /tmp && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -55,6 +55,8 @@ LABEL \
     # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
     release="1"
 
+COPY --from=package_installer /out/ /
+
 COPY --from=builder \
     /src/scanner/image/scanner/scripts/entrypoint.sh \
     /src/scanner/image/scanner/scripts/import-additional-cas \
@@ -69,8 +71,6 @@ COPY --from=builder \
 # (Note that the file is downloaded from Central after initial seeding.)
 
 COPY .konflux/scanner-data/repository-to-cpe.json .konflux/scanner-data/container-name-repos-map.json /run/mappings/
-
-COPY --from=package_installer /out/ /
 
 RUN \
     chown -R 65534:65534 /tmp && \

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -16,8 +16,23 @@ WORKDIR /src
 
 RUN make -C scanner NODEPS=1 CGO_ENABLED=1 image/scanner/bin/scanner copy-scripts
 
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest@sha256:093a704be0eaef9bb52d9bc0219c67ee9db13c2e797da400ddb5d5ae6849fa10 AS ubi-micro-base
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:69f5c9886ecb19b23e88275a5cd904c47dd982dfa370fbbd0c356d7b1047ef68
+FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:6ed9f6f637fe731d93ec60c065dbced79273f1e0b5f512951f2c0b0baedb16ad AS package_installer
+
+COPY --from=ubi-micro-base / /out/
+
+RUN dnf install -y \
+    --installroot=/out/ \
+    --releasever=9 \
+    --setopt=install_weak_deps=0 \
+    --setopt=reposdir=/etc/yum.repos.d \
+    --nodocs \
+    ca-certificates openssl && \
+    dnf clean all --installroot=/out/ && \
+    rm -rf /out/var/cache/dnf /out/var/cache/yum
+
+FROM ubi-micro-base
 
 ARG BUILD_TAG
 
@@ -55,10 +70,9 @@ COPY --from=builder \
 
 COPY .konflux/scanner-data/repository-to-cpe.json .konflux/scanner-data/container-name-repos-map.json /run/mappings/
 
-RUN microdnf clean all && \
-    # (Optional) Remove line below to keep package management utilities
-    rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
-    rm -rf /var/cache/dnf /var/cache/yum && \
+COPY --from=package_installer /out/ /
+
+RUN \
     chown -R 65534:65534 /tmp && \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
     # by the script `save-dir-contents` during the image build. The directory


### PR DESCRIPTION
Migrate scanner images from ubi8-minimal to ubi8-micro following the same best practices used for collector migration.

- https://github.com/stackrox/collector/pull/3021/
- https://github.com/stackrox/stackrox/pull/19379
- https://github.com/stackrox/stackrox/pull/19378
- https://github.com/stackrox/stackrox/pull/17406
- https://github.com/stackrox/stackrox/pull/17430

Tested:

```
  export KUBECONFIG=/tmp/tests/kubeconfig
  kubectl -n stackrox set image deployment/central \
    central=quay.io/rhacs-eng/release-main:4.11.0-484-g90cc136570-fast
  kubectl -n stackrox set image deployment/scanner-v4-indexer \
    indexer=quay.io/rhacs-eng/release-scanner-v4:4.11.0-517-g99d643f394-fast

  kubectl -n stackrox set image deployment/scanner-v4-matcher \
    matcher=quay.io/rhacs-eng/release-scanner-v4:4.11.0-631-g9762630fef-fast

  kubectl -n stackrox rollout status deployment/central --timeout=5m
  kubectl -n stackrox rollout status deployment/scanner-v4-indexer --timeout=5m
  kubectl -n stackrox rollout status deployment/scanner-v4-matcher --timeout=5m
  ```
  
  Then check in UI if everything is healthy and followed and check if scanner is working
  ```
# roxctl --insecure-skip-tls-verify -e https://tj0331aparttheeblank.demos.rox.systems:443 image scan --image=nginx:latest --output=table
Scan results for image: nginx:latest
(TOTAL-COMPONENTS: 57, TOTAL-VULNERABILITIES: 107, LOW: 87, MODERATE: 10, IMPORTANT: 9, CRITICAL: 1)
```
