### PR TITLE
ROX-30858: Migrate scanner DB image from ubi9-minimal to ubi9-micro

### DIFF
--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -75,8 +75,8 @@ COPY init-bundles/db-init.dump.zst /db-init.dump.zst
 COPY scripts/docker-entrypoint.sh scripts/init-entrypoint.sh /usr/local/bin/
 
 RUN \
-    groupadd -g 70 postgres && \
-    useradd postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
+    groupmod -g 70 postgres && \
+    usermod -u 70 -g 70 postgres && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     mkdir -p /docker-entrypoint-initdb.d /var/run/postgresql && \
     chown postgres:postgres /var/run/postgresql && \


### PR DESCRIPTION
This commit migrates the scanner database (PostgreSQL) container image from ubi8-minimal to ubi8-micro, completing the migration of all scanner images.

- https://github.com/stackrox/stackrox/pull/17406
- https://github.com/stackrox/stackrox/pull/17430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
