### PR TITLE
ROX-30425: Add retry to endpoints e2e test

### DIFF
--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/tlsutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -122,7 +123,7 @@ func (c *endpointsTestCase) endpoint() string {
 	return endpointForTargetPort(c.targetPort)
 }
 
-func (c *endpointsTestCase) Run(t *testing.T, testCtx *endpointsTestContext) {
+func (c *endpointsTestCase) Run(t testutils.T, testCtx *endpointsTestContext) {
 	c.runConnectionTest(t, testCtx)
 
 	if c.expectConnectFailure {
@@ -134,11 +135,11 @@ func (c *endpointsTestCase) Run(t *testing.T, testCtx *endpointsTestContext) {
 	c.runHTTPTest(t, testCtx, true)
 }
 
-func (c *endpointsTestCase) verifyDialResult(t *testing.T, conn *tls.Conn, err error) {
+func (c *endpointsTestCase) verifyDialResult(t testutils.T, conn *tls.Conn, err error) {
 	if conn != nil {
 		defer utils.IgnoreError(conn.Close)
 	} else {
-		t.Error("conn is nil")
+		t.Errorf("conn is nil")
 	}
 	if err == nil {
 		ctx, cancel := context.WithTimeoutCause(context.Background(), 2*time.Second, errors.New("TLS handshake timeout"))
@@ -158,7 +159,7 @@ func (c *endpointsTestCase) verifyDialResult(t *testing.T, conn *tls.Conn, err e
 	assert.EqualErrorf(t, err, "remote error: tls: certificate required", "expected a bad certificate error after handshake")
 }
 
-func (c *endpointsTestCase) runConnectionTest(t *testing.T, testCtx *endpointsTestContext) {
+func (c *endpointsTestCase) runConnectionTest(t testutils.T, testCtx *endpointsTestContext) {
 	if c.skipTLS {
 		if c.expectConnectFailure {
 			require.Fail(t, "malformed test spec: cannot expect connection failures in non-TLS mode")
@@ -216,7 +217,7 @@ func (c *endpointsTestCase) tlsDialWithRetry(tlsConf *tls.Config) (conn *tls.Con
 	return
 }
 
-func (c *endpointsTestCase) verifyAuthStatus(t *testing.T, _ *endpointsTestContext, authStatus *v1.AuthStatus) {
+func (c *endpointsTestCase) verifyAuthStatus(t testutils.T, _ *endpointsTestContext, authStatus *v1.AuthStatus) {
 	switch id := authStatus.GetId().(type) {
 	case *v1.AuthStatus_ServiceId:
 		assert.Equal(t, serviceAuth, c.expectAuth, "got service ID from auth status, expected this to be a service client")
@@ -229,7 +230,7 @@ func (c *endpointsTestCase) verifyAuthStatus(t *testing.T, _ *endpointsTestConte
 	}
 }
 
-func (c *endpointsTestCase) runGRPCTest(t *testing.T, testCtx *endpointsTestContext) {
+func (c *endpointsTestCase) runGRPCTest(t testutils.T, testCtx *endpointsTestContext) {
 	var creds credentials.TransportCredentials
 	if c.skipTLS {
 		creds = insecure.NewCredentials()
@@ -271,7 +272,7 @@ func (c *endpointsTestCase) runGRPCTest(t *testing.T, testCtx *endpointsTestCont
 	c.verifyAuthStatus(t, testCtx, authStatus)
 }
 
-func (c *endpointsTestCase) runHTTPTest(t *testing.T, testCtx *endpointsTestContext, useHTTP2 bool) {
+func (c *endpointsTestCase) runHTTPTest(t testutils.T, testCtx *endpointsTestContext, useHTTP2 bool) {
 	assert.True(t, c.skipTLS == (len(c.validServerNames) == 0), "invalid test case: either skipTLS is set or validServerNames are provided")
 
 	var scheme string
@@ -532,7 +533,9 @@ func TestEndpoints(t *testing.T) {
 
 	for desc, tc := range cases {
 		t.Run(desc, func(t *testing.T) {
-			tc.Run(t, testCtx)
+			testutils.Retry(t, 3, 100*time.Millisecond, func(t testutils.T) {
+				tc.Run(t, testCtx)
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Description

Based on CI failure investigation we have several tests executed that ping central API.

We can see rare situations where establishing of connection timeouts after 1 minute. It happens of different tests defined in the test set. Network can be unstable in some situations and best would be to just retry e2e test again.

This PR is adding 3 retries on sub-test level.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] Tested that retry logic works by adding assert.True(false) in subtest.
