### PR TITLE
ROX-31359: Fix env vars not being passed

### DIFF
--- a/qa-tests-backend/build.gradle.kts
+++ b/qa-tests-backend/build.gradle.kts
@@ -121,6 +121,10 @@ tasks.withType<Test>().configureEach {
 
     timeout = Duration.ofMinutes(630)
 
+    // Pass all environment variables from parent process to test JVM.
+    // This is required for tests that depend on environment variables like UPGRADE_CLUSTER_ID.
+    environment(System.getenv())
+
     // This ensures that repeated invocations of tests actually run the tests.
     // Otherwise, if the tests pass, Gradle "caches" the result and doesn"t actually run the tests,
     // which is not the behaviour we expect of E2Es.


### PR DESCRIPTION
## Description

Fixes `UpgradesTest` failure introduced by PR #17390 (https://github.com/stackrox/stackrox/pull/17390) which migrated `protobuf.gradle` to Kotlin format.

**Problem:** When PR #17390 migrated the Gradle build files from Groovy to Kotlin (`.gradle` → `.gradle.kts`), the configuration to pass environment variables from the parent process to the test JVM was accidentally omitted. This caused upgrade tests to fail with:

```
java.lang.RuntimeException: No value assigned for required key UPGRADE_CLUSTER_ID
    at util.Env.mustGetInternal(Env.groovy:86)
    at UpgradesTest.<clinit>(UpgradesTest.groovy:24)
```

**Root Cause:** Gradle test tasks run in a separate JVM process and do not automatically inherit environment variables. The test tries to read `UPGRADE_CLUSTER_ID` (and potentially other CI-provided variables) during static initialization, but these variables were not available in the test JVM.

**Solution:** Added `environment(System.getenv())` to the `tasks.withType<Test>().configureEach` block in `qa-tests-backend/build.gradle.kts` to explicitly pass all environment variables from the parent process to test JVMs.

**Triaged issue:** https://issues.redhat.com/browse/ROX-31359

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added - this fixes the test infrastructure itself. The existing `UpgradesTest` will validate the fix when it runs successfully in CI with `UPGRADE_CLUSTER_ID` set.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

**Analysis approach:**
1. Identified PR #17390 as the first failing commit via web search of the issue
2. Compared the Groovy-to-Kotlin migration changes
3. Recognized that Gradle test tasks run in separate JVM processes and require explicit environment variable forwarding
4. Verified this is a standard Gradle configuration pattern for test tasks that depend on environment variables

**Validation:**
- Confirmed the fix syntax is correct (no linter errors)
- Verified that `environment(System.getenv())` is the standard Gradle Kotlin DSL method to pass environment variables to test JVMs
- The fix follows established Gradle best practices and is a single-line configuration change

**Expected CI validation:**
- The upgrade tests (`make upgrade-test` / `testUpgrade` task) should now pass when run with `UPGRADE_CLUSTER_ID` environment variable set
- All other test tasks will also have access to their required environment variables (e.g., `KUBECONFIG`, `CLUSTER`, `API_HOSTNAME`, etc.)

**AI Contribution Statement:**
- AI-generated: Root cause analysis via codebase search and triage, fix implementation, and PR description
- Human required: CI validation to confirm the fix resolves the failing upgrade tests

