### PR TITLE
chore(CI): Add go tools retry

### DIFF
--- a/make/gotools.mk
+++ b/make/gotools.mk
@@ -50,17 +50,18 @@ GOTOOLS_ROOT ?= $(GOTOOLS_PROJECT_ROOT)/.gotools
 GOTOOLS_BIN ?= $(GOTOOLS_ROOT)/bin
 
 # RUN_WITH_RETRY_FN provides a shell function wrapper for retrying commands.
-# The function retries up to 5 times with exponential backoff (1s, 4s, 9s, 16s).
+# The function retries up to 8 times with exponential backoff.
 #
 # Note on escaping: $$$$ is used instead of $$ because this variable is expanded twice:
 # - First by Make when defining the recipe ($$$$i becomes $$i)
 # - Then by the shell when executing the recipe ($$i becomes $i)
 # Without the quadruple $, the shell would receive empty variables.
 RUN_WITH_RETRY_FN = run_with_retry() { \
-	for i in $$$$(seq 5); do \
+	attempts=8; \
+	for i in $$$$(seq $$$$attempts); do \
 		"$$$$@" && return 0; \
-		[[ $$$$i -eq 5 ]] && return 1; \
-		echo "Retry $$$$i/5 failed. Retrying after $$$$((i**2)) seconds..."; \
+		[[ $$$$i -eq $$$$attempts ]] && return 1; \
+		echo "Retry $$$$i/$$$$attempts failed. Retrying after $$$$((i**2)) seconds..."; \
 		sleep "$$$$((i**2))"; \
 	done \
 }


### PR DESCRIPTION
## Description

This PR is adding retry for `go-tools`.

We had a situation in `ROX-31293` where test failed because "downloading" of go-tool failed.

Assisted-by: Claude Code

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added tests utility

### How I validated my change

Tested locally:

Failures (changed package to `v6`):
```
❯ make yq               
+ yq
no required module provides package github.com/mikefarah/yq/v6; to add it:
        go get github.com/mikefarah/yq/v6
Retry 1/5 failed. Retrying after 1 seconds...
no required module provides package github.com/mikefarah/yq/v6; to add it:
        go get github.com/mikefarah/yq/v6
Retry 2/5 failed. Retrying after 4 seconds...
no required module provides package github.com/mikefarah/yq/v6; to add it:
        go get github.com/mikefarah/yq/v6
Retry 3/5 failed. Retrying after 9 seconds...
no required module provides package github.com/mikefarah/yq/v6; to add it:
        go get github.com/mikefarah/yq/v6
Retry 4/5 failed. Retrying after 16 seconds...
no required module provides package github.com/mikefarah/yq/v6; to add it:
        go get github.com/mikefarah/yq/v6
make: *** [/Users/mtodorov/devel/stackrox/operator/.gotools/bin/yq] Error 1
```

Success:
```
❯ make yq
+ yq
```
