### PR TITLE
ROX-31374: Use import type in Containers SystemConfig

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -774,7 +774,6 @@ module.exports = [
             'src/Components/CompoundSearchFilter/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/Policies/**',
-            'src/Containers/SystemConfig/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
             'src/Containers/Workflow/**', // deprecated

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Card,
     CardBody,
@@ -11,7 +12,7 @@ import {
     Text,
 } from '@patternfly/react-core';
 
-import { PlatformComponentsConfig } from 'types/config.proto';
+import type { PlatformComponentsConfig } from 'types/config.proto';
 
 import './PlatformComponentsConfigDetails.css';
 import RedHatLayeredProductsCard from './components/RedHatLayeredProductsCard';

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';
 import {
@@ -13,12 +14,12 @@ import {
     Title,
     Tooltip,
 } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 
 import ClusterLabelsTable from 'Containers/Clusters/ClusterLabelsTable';
-import { PrivateConfig } from 'types/config.proto';
+import type { PrivateConfig } from 'types/config.proto';
 import { clustersBasePath } from 'routePaths';
 
-import { HelpIcon } from '@patternfly/react-icons';
 import { convertBetweenBytesAndMB } from '../SystemConfig.utils';
 
 type DataRetentionValueProps = {

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigPrometheusMetricsDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigPrometheusMetricsDetails.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
-import { PrivateConfig, PrometheusMetricsCategory } from 'types/config.proto';
+import type { PrivateConfig, PrometheusMetricsCategory } from 'types/config.proto';
 import { PrometheusMetricsCard } from './components/PrometheusMetricsCard';
 
 export type PrivateConfigPrometheusMetricsDetailsProps = {

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
@@ -1,8 +1,6 @@
-import React, { ReactElement } from 'react';
-
+import React from 'react';
+import type { ReactElement } from 'react';
 import capitalize from 'lodash/capitalize';
-import ColorPicker from 'Components/ColorPicker';
-import { PublicConfig } from 'types/config.proto';
 import {
     Card,
     CardTitle,
@@ -15,6 +13,9 @@ import {
     DescriptionListDescription,
     Divider,
 } from '@patternfly/react-core';
+
+import ColorPicker from 'Components/ColorPicker';
+import type { PublicConfig } from 'types/config.proto';
 
 type BannerType = 'header' | 'footer';
 

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigLoginDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigLoginDetails.tsx
@@ -1,6 +1,5 @@
-import React, { ReactElement } from 'react';
-
-import { PublicConfig } from 'types/config.proto';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Card,
     CardBody,
@@ -13,6 +12,8 @@ import {
     Divider,
     Label,
 } from '@patternfly/react-core';
+
+import type { PublicConfig } from 'types/config.proto';
 
 export type PublicConfigLoginDetailsProps = {
     publicConfig: PublicConfig | null;

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigTelemetryDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigTelemetryDetails.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
-
-import { PublicConfig } from 'types/config.proto';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Card, CardBody, CardHeader, CardTitle, Divider, Label } from '@patternfly/react-core';
+
+import type { PublicConfig } from 'types/config.proto';
 
 export type PublicConfigTelemetryDetailsProps = {
     publicConfig: PublicConfig | null;

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Button,
     Flex,
@@ -11,10 +12,10 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-import { SystemConfig } from 'types/config.proto';
-
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 import useTelemetryConfig from 'hooks/useTelemetryConfig';
+import type { SystemConfig } from 'types/config.proto';
+
 import PrivateConfigDataRetentionDetails from './PrivateConfigDataRetentionDetails';
 import PublicConfigBannerDetails from './PublicConfigBannerDetails';
 import PublicConfigLoginDetails from './PublicConfigLoginDetails';

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
@@ -14,7 +14,7 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import { PlatformComponentRule } from 'types/config.proto';
+import type { PlatformComponentRule } from 'types/config.proto';
 
 export type CustomPlatformComponentsCardProps = {
     customRules: PlatformComponentRule[];

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/PrometheusMetricsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/PrometheusMetricsCard.tsx
@@ -1,9 +1,5 @@
-import React, { ReactElement } from 'react';
-import {
-    PrometheusMetricsCategory,
-    PrivateConfig,
-    PrometheusMetricsLabels,
-} from 'types/config.proto';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Card,
     CardBody,
@@ -27,7 +23,13 @@ import {
 } from '@patternfly/react-core';
 import { Table, Tr, Td, Thead, Tbody, Th } from '@patternfly/react-table';
 import pluralize from 'pluralize';
-import { FormikErrors, FormikValues } from 'formik';
+import type { FormikErrors, FormikValues } from 'formik';
+
+import type {
+    PrometheusMetricsCategory,
+    PrivateConfig,
+    PrometheusMetricsLabels,
+} from 'types/config.proto';
 
 const metricPrefixes = {
     imageVulnerabilities: 'rox_central_image_vuln_',

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
@@ -12,7 +12,7 @@ import {
     Text,
 } from '@patternfly/react-core';
 
-import { PlatformComponentRule } from 'types/config.proto';
+import type { PlatformComponentRule } from 'types/config.proto';
 
 export type RedHatLayeredProductsCardProps = {
     rule: PlatformComponentRule | undefined;

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/FormSelect.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/FormSelect.tsx
@@ -1,5 +1,6 @@
-import React, { ReactElement } from 'react';
-import { SelectOptionProps } from '@patternfly/react-core';
+import React from 'react';
+import type { ReactElement } from 'react';
+import type { SelectOptionProps } from '@patternfly/react-core';
 
 import SelectSingle from 'Components/SelectSingle';
 

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/PlatformComponentsConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/PlatformComponentsConfigForm.tsx
@@ -24,8 +24,8 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { PlusCircleIcon, RedoAltIcon, TrashIcon } from '@patternfly/react-icons';
-import { FormikErrors } from 'formik';
-import { Values } from './formTypes';
+import type { FormikErrors } from 'formik';
+import type { Values } from './formTypes';
 
 export type PlatformComponentsConfigFormProps = {
     values: Values;

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import {
     Alert,
     Button,
@@ -32,7 +33,7 @@ import * as yup from 'yup';
 import ColorPicker from 'Components/ColorPicker';
 import ClusterLabelsTable from 'Containers/Clusters/ClusterLabelsTable';
 import { saveSystemConfig } from 'services/SystemConfigService';
-import { PlatformComponentsConfig, PublicConfig, SystemConfig } from 'types/config.proto';
+import type { PlatformComponentsConfig, PublicConfig, SystemConfig } from 'types/config.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { initializeAnalytics } from 'init/initializeAnalytics';
 import usePublicConfig from 'hooks/usePublicConfig';
@@ -40,8 +41,9 @@ import useTelemetryConfig from 'hooks/useTelemetryConfig';
 
 import FormSelect from './FormSelect';
 import { convertBetweenBytesAndMB } from '../SystemConfig.utils';
-import { getPlatformComponentsConfigRules, PlatformComponentsConfigRules } from '../configUtils';
-import { Values } from './formTypes';
+import { getPlatformComponentsConfigRules } from '../configUtils';
+import type { PlatformComponentsConfigRules } from '../configUtils';
+import type { Values } from './formTypes';
 import PlatformComponentsConfigForm from './PlatformComponentsConfigForm';
 import { PrometheusMetricsForm } from '../Details/components/PrometheusMetricsCard';
 

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/formTypes.ts
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/formTypes.ts
@@ -1,5 +1,5 @@
-import { PrivateConfig, PublicConfig } from 'types/config.proto';
-import { PlatformComponentsConfigRules } from '../configUtils';
+import type { PrivateConfig, PublicConfig } from 'types/config.proto';
+import type { PlatformComponentsConfigRules } from '../configUtils';
 
 export type Values = {
     privateConfig: PrivateConfig;

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     Alert,
     Bullseye,
@@ -20,7 +21,7 @@ import {
     fetchDefaultRedHatLayeredProductsRule,
     fetchSystemConfig,
 } from 'services/SystemConfigService';
-import { SystemConfig } from 'types/config.proto';
+import type { SystemConfig } from 'types/config.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import SystemConfigDetails from './Details/SystemConfigDetails';

--- a/ui/apps/platform/src/Containers/SystemConfig/configUtils.ts
+++ b/ui/apps/platform/src/Containers/SystemConfig/configUtils.ts
@@ -1,4 +1,4 @@
-import { PlatformComponentRule, PlatformComponentsConfig } from 'types/config.proto';
+import type { PlatformComponentRule, PlatformComponentsConfig } from 'types/config.proto';
 
 export type PlatformComponentsConfigRules = {
     coreSystemRule: PlatformComponentRule;


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

**Michaël** has not needed to make any changes for Prometheus metrics during 4.10A sprint.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
    * Also move some `import` statements, although absence of errors gives more evidence that import/order rule does not distinguish paths in package dependencies from paths to application files.
    * Although it was tempting, I did not double up to delete `React` because it would cause merge conflict in eslint.config.js file with another contribution.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.