### PR TITLE
ROX-31375: Use import type in Components CompoundSearchFilter

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -771,7 +771,6 @@ module.exports = [
     {
         files: ['src/*/**/*.{js,jsx,ts,tsx}'], // product files, except for unit tests (including test-utils folder)
         ignores: [
-            'src/Components/CompoundSearchFilter/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/Policies/**',
             'src/Containers/SystemConfig/**',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/alert.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "alertAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const ViolationTime: CompoundSearchFilterAttribute = {
     displayName: 'Violation time',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/complianceScan.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/complianceScan.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "complianceScanAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const ConfigID: CompoundSearchFilterAttribute = {
     displayName: 'Config ID',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/deployment.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/deployment.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "deploymentAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const ID: CompoundSearchFilterAttribute = {
     displayName: 'ID',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/epssProbability.ts
@@ -1,5 +1,5 @@
-import { ConditionTextFilterAttribute } from '../types';
-import { ConditionEntries } from '../components/ConditionText';
+import type { ConditionTextFilterAttribute } from '../types';
+import type { ConditionEntries } from '../components/ConditionText';
 
 const conditionEntries: ConditionEntries = [
     ['>', 'Is greater than'],

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/image.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/image.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "imageAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "imageCVEAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 import { EPSSProbability } from './epssProbability';
 
 export const Name: CompoundSearchFilterAttribute = {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
@@ -1,7 +1,7 @@
 // If you're adding a new attribute, make sure to add it to "imageComponentAttributes" as well
 
 import { sourceTypeLabels, sourceTypes } from 'types/image.proto';
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/namespace.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/namespace.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "namespaceAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const ID: CompoundSearchFilterAttribute = {
     displayName: 'ID',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/node.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/node.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "nodeAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/nodeCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/nodeCVE.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "nodeCVEAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/nodeComponent.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/nodeComponent.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "nodeComponentAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/platformCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/platformCVE.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "platformCVEAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
@@ -1,7 +1,7 @@
 // If you're adding a new attribute, make sure to add it to "policyAttributes" as well
 
 import { severityLabels } from 'messages/common';
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/profileCheck.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/profileCheck.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "profileCheckAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/resource.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/resource.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "resourceAttributes" as well
 
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/virtualMachine.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/virtualMachine.ts
@@ -1,4 +1,4 @@
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const VirtualMachineCVEName: CompoundSearchFilterAttribute = {
     displayName: 'Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/vulnerabilityRequests.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/vulnerabilityRequests.ts
@@ -1,4 +1,4 @@
-import { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute } from '../types';
 
 export const RequestName: CompoundSearchFilterAttribute = {
     displayName: 'Request Name',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
@@ -4,8 +4,8 @@ import { SelectOption } from '@patternfly/react-core';
 import { getEntityAttributes } from 'Components/CompoundSearchFilter/utils/utils';
 
 import SimpleSelect from './SimpleSelect';
-import { SelectedEntity } from './EntitySelector';
-import { CompoundSearchFilterConfig } from '../types';
+import type { SelectedEntity } from './EntitySelector';
+import type { CompoundSearchFilterConfig } from '../types';
 
 export type SelectedAttribute = string | undefined;
 export type AttributeSelectorOnChange = (value: string | number | undefined) => void;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -1,14 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { Flex } from '@patternfly/react-core';
 
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { ensureString } from 'utils/ensure';
-import { CompoundSearchFilterConfig, OnSearchPayload } from '../types';
+import type { CompoundSearchFilterConfig, OnSearchPayload } from '../types';
 import { getDefaultAttributeName, getDefaultEntityName } from '../utils/utils';
 
-import EntitySelector, { SelectedEntity } from './EntitySelector';
-import AttributeSelector, { SelectedAttribute } from './AttributeSelector';
-import CompoundSearchFilterInputField, { InputFieldValue } from './CompoundSearchFilterInputField';
+import EntitySelector from './EntitySelector';
+import type { SelectedEntity } from './EntitySelector';
+import AttributeSelector from './AttributeSelector';
+import type { SelectedAttribute } from './AttributeSelector';
+import CompoundSearchFilterInputField from './CompoundSearchFilterInputField';
+import type { InputFieldValue } from './CompoundSearchFilterInputField';
 
 export type CompoundSearchFilterProps = {
     config: CompoundSearchFilterConfig;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
     Divider,
     SearchInput,
@@ -7,12 +7,12 @@ import {
     SelectOption,
 } from '@patternfly/react-core';
 
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import CheckboxSelect from 'Components/CheckboxSelect';
 import { ensureString, ensureStringArray } from 'utils/ensure';
-import { SelectedEntity } from './EntitySelector';
-import { SelectedAttribute } from './AttributeSelector';
-import { CompoundSearchFilterConfig, OnSearchPayload } from '../types';
+import type { SelectedEntity } from './EntitySelector';
+import type { SelectedAttribute } from './AttributeSelector';
+import type { CompoundSearchFilterConfig, OnSearchPayload } from '../types';
 import {
     conditionMap,
     dateConditionMap,
@@ -187,7 +187,7 @@ function CompoundSearchFilterInputField({
         ) {
             content = attribute.inputProps.groupOptions.map(({ name, options }, index) => {
                 return (
-                    <React.Fragment key={name}>
+                    <Fragment key={name}>
                         <SelectGroup label={name}>
                             <SelectList>
                                 {options.map((option) => (
@@ -203,7 +203,7 @@ function CompoundSearchFilterInputField({
                             </SelectList>
                         </SelectGroup>
                         {index !== options.length - 1 && <Divider component="div" />}
-                    </React.Fragment>
+                    </Fragment>
                 );
             });
         } else if (

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionNumber.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { FormEvent } from 'react';
 import { Button, NumberInput, SelectOption } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
 import clamp from 'lodash/clamp';
@@ -70,14 +71,14 @@ function ConditionNumber({ value, onChange, onSearch }: ConditionNumberProps) {
                 value={value.number || minValue}
                 min={0}
                 max={10}
-                onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                onChange={(event: FormEvent<HTMLInputElement>) => {
                     const { value: newNumber } = event.target as HTMLInputElement;
                     onChange({
                         ...value,
                         number: Number(newNumber),
                     });
                 }}
-                onBlur={(event: React.FormEvent<HTMLInputElement>) => {
+                onBlur={(event: FormEvent<HTMLInputElement>) => {
                     const target = event.target as HTMLInputElement;
                     const normalizedNumber = clamp(
                         Number.isNaN(+target.value)

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/ConditionText.tsx
@@ -1,16 +1,17 @@
 import React, { useState } from 'react';
+import type { FormEvent, MouseEvent as ReactMouseEvent, Ref } from 'react';
 import {
     Button,
     MenuToggle,
-    MenuToggleElement,
     Select,
     SelectList,
     SelectOption,
     TextInput,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 import { ArrowRightIcon } from '@patternfly/react-icons';
 
-import { NonEmptyArray } from 'utils/type.utils';
+import type { NonEmptyArray } from 'utils/type.utils';
 
 import './ConditionText.css';
 
@@ -87,14 +88,14 @@ function ConditionText({ inputProps, onSearch }: ConditionTextProps) {
     const [externalText, setExternalText] = useState(externalTextDefault);
 
     // Adapt SimpleSelect because its MenuToggle renders conditionKey instead of conditionText.
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
         setIsOpen(!isOpen);
     };
 
     const onSelect = (
-        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
         value: string | number | undefined
     ) => {
         setConditionKey(value as string);
@@ -106,7 +107,7 @@ function ConditionText({ inputProps, onSearch }: ConditionTextProps) {
     const conditionSelected =
         conditionEntries.find((condition) => condition[0] === conditionKey) ?? conditionEntries[0];
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             className="pf-v5-u-flex-shrink-0"
             aria-label="Condition selector toggle"
@@ -139,7 +140,7 @@ function ConditionText({ inputProps, onSearch }: ConditionTextProps) {
             <TextInput
                 aria-label="Condition value input"
                 className="ConditionTextInput"
-                onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                onChange={(event: FormEvent<HTMLInputElement>) => {
                     const { value: changedText } = event.target as HTMLInputElement;
                     setExternalText(changedText);
                 }}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
@@ -4,7 +4,7 @@ import { SelectOption } from '@patternfly/react-core';
 import { getEntity } from 'Components/CompoundSearchFilter/utils/utils';
 
 import SimpleSelect from './SimpleSelect';
-import { CompoundSearchFilterConfig } from '../types';
+import type { CompoundSearchFilterConfig } from '../types';
 
 export type SelectedEntity = string | undefined;
 export type EntitySelectorOnChange = (value: string | number | undefined) => void;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -1,11 +1,10 @@
 import React, { useMemo, useRef, useState } from 'react';
+import type { FormEvent, KeyboardEvent, MouseEvent as ReactMouseEvent, Ref } from 'react';
 import {
     Select,
     SelectOption,
     SelectList,
-    SelectOptionProps,
     MenuToggle,
-    MenuToggleElement,
     TextInputGroup,
     TextInputGroupMain,
     TextInputGroupUtilities,
@@ -14,13 +13,13 @@ import {
     Flex,
     debounce,
 } from '@patternfly/react-core';
+import type { MenuToggleElement, SelectOptionProps } from '@patternfly/react-core';
 import { ArrowRightIcon, SearchIcon, TimesIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
-import SEARCH_AUTOCOMPLETE_QUERY, {
-    SearchAutocompleteQueryResponse,
-} from 'queries/searchAutocomplete';
+import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
+import type { SearchAutocompleteQueryResponse } from 'queries/searchAutocomplete';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { ensureString } from 'utils/ensure';
 
 type SearchFilterAutocompleteProps = {
@@ -160,7 +159,7 @@ function SearchFilterAutocomplete({
     };
 
     const onSelect = (
-        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
         value: string | number | undefined
     ) => {
         if (value) {
@@ -172,7 +171,7 @@ function SearchFilterAutocomplete({
         setActiveItem(null);
     };
 
-    const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    const onTextInputChange = (_event: FormEvent<HTMLInputElement>, value: string) => {
         onChange(value);
         if (!isOpen) {
             setIsOpen(true);
@@ -211,7 +210,7 @@ function SearchFilterAutocomplete({
         }
     };
 
-    const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const onInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
         const enabledMenuItems = selectOptions.filter((option) => !option.isDisabled);
         const [firstMenuItem] = enabledMenuItems;
         const focusedItem = focusedItemIndex ? enabledMenuItems[focusedItemIndex] : firstMenuItem;
@@ -245,7 +244,7 @@ function SearchFilterAutocomplete({
         }
     };
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             ref={toggleRef}
             variant="typeahead"

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
@@ -1,11 +1,7 @@
-import React, { ReactElement } from 'react';
-import {
-    Select,
-    SelectOption,
-    SelectList,
-    MenuToggle,
-    MenuToggleElement,
-} from '@patternfly/react-core';
+import React, { useState } from 'react';
+import type { MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
+import { Select, SelectList, MenuToggle } from '@patternfly/react-core';
+import type { MenuToggleElement, SelectOption } from '@patternfly/react-core';
 
 export type SimpleSelectProps = {
     value: string | number | undefined;
@@ -26,21 +22,21 @@ function SimpleSelect({
     ariaLabelToggle,
     menuToggleClassName,
 }: SimpleSelectProps) {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
         setIsOpen(!isOpen);
     };
 
     const onSelect = (
-        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
         newValue: string | number | undefined
     ) => {
         onChange(newValue);
         setIsOpen(false);
     };
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             className={menuToggleClassName}
             aria-label={ariaLabelToggle}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -1,6 +1,6 @@
-import { SearchCategory } from 'services/SearchService';
-import { FeatureFlagEnvVar } from 'types/featureFlag';
-import { ConditionTextInputProps } from './components/ConditionText';
+import type { SearchCategory } from 'services/SearchService';
+import type { FeatureFlagEnvVar } from 'types/featureFlag';
+import type { ConditionTextInputProps } from './components/ConditionText';
 
 // Compound search filter types
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -8,7 +8,7 @@ import {
     getSearchFilterConfigWithFeatureFlagDependency,
     makeFilterChipDescriptors,
 } from './utils';
-import { CompoundSearchFilterEntity } from '../types';
+import type { CompoundSearchFilterEntity } from '../types';
 
 const imageSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Image',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { FilterChip, FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
-import { SearchFilter } from 'types/search';
-import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
-import { SetSearchFilter } from 'hooks/useURLSearch';
-import {
+import { FilterChip } from 'Components/PatternFly/SearchFilterChips';
+import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
+import type { SearchFilter } from 'types/search';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import type { SetSearchFilter } from 'hooks/useURLSearch';
+import type {
     CompoundSearchFilterAttribute,
     CompoundSearchFilterConfig,
     CompoundSearchFilterEntity,


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

**Saif** has not needed to make any changes during 4.10A sprint.

Better to do now as prerequisite to my work for CISA KEV in 4.10 release.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
    Bonus: Fix some false negatives of `React.Whatever` that I will fix in an update to limited/no-qualified-name-react rule.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.