### PR TITLE
ROX-28255: Fix broken form navigation when add/remove delivery dest.

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -17,6 +17,7 @@ npm-debug.log*
 
 # misc
 .DS_Store
+/apps/platform/.eslintcache
 
 # AI rules
 # we want to ignore all AI rules while we are experimenting with them

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -47,11 +47,15 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPro
 
     function onDeleteLastNotifierConfiguration() {
         // Update only the schedule because spread ...formik.values overwrites deletion of last notifier.
-        formik.setFieldValue('schedule', {
-            intervalType: null,
-            daysOfWeek: [],
-            daysOfMonth: [],
-        });
+        formik
+            .setFieldValue('schedule', {
+                intervalType: null,
+                daysOfWeek: [],
+                daysOfMonth: [],
+            })
+            // Revalidate form after schedule change completes to update dependent fields
+            // @ts-expect-error Formik's types incorrectly declare setFieldValue as void, but it returns a Promise
+            .then(() => formik.validateForm());
     }
 
     function onScheduledRepeatChange(_id, selection) {


### PR DESCRIPTION
## Description

Fixes an issue where adding and then deleting a delivery destination during report creation locks the report wizard and makes it impossible to navigation beyond step 2. The "Next" button remains disabled even though the form is valid.

There is shaky evidence that this is a bug with formik array validation but I am not 100% convinced this is the exact issue. https://github.com/jaredpalmer/formik/issues/2083

Regardless, the fix is a single line that runs an additional validation after the formik field is updated, which is low risk and explained by a comment.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1250" height="980" alt="image" src="https://github.com/user-attachments/assets/26b274fd-9ba2-4bfa-8489-54d22ada6a64" />
<img width="1250" height="980" alt="image" src="https://github.com/user-attachments/assets/a838f36a-625d-479a-bdae-a3ff50596a2d" />
<img width="1250" height="980" alt="image" src="https://github.com/user-attachments/assets/c3ca54a0-dc79-4274-a526-9dae2602821a" />

