### PR TITLE
ROX-31379: Use import type in Containers Policies

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -772,7 +772,6 @@ module.exports = [
         files: ['src/*/**/*.{js,jsx,ts,tsx}'], // product files, except for unit tests (including test-utils folder)
         ignores: [
             'src/Containers/Compliance/**', // deprecated
-            'src/Containers/Policies/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
             'src/Containers/Workflow/**', // deprecated

--- a/ui/apps/platform/src/Containers/Policies/Detail/ExcludedDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/ExcludedDeployment.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { ClusterScopeObject } from 'services/RolesService';
-import { PolicyExcludedDeployment } from 'types/policy.proto';
+import type { ClusterScopeObject } from 'services/RolesService';
+import type { PolicyExcludedDeployment } from 'types/policy.proto';
 
 import { getClusterName } from '../policies.utils';
 

--- a/ui/apps/platform/src/Containers/Policies/Detail/Notifier.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/Notifier.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { NotifierIntegration } from 'types/notifier.proto';
+import type { NotifierIntegration } from 'types/notifier.proto';
 
 import { getNotifierTypeLabel } from '../policies.utils';
 

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyBehaviorSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyBehaviorSection.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList, Card, CardBody } from '@patternfly/react-core';
 
-import { LifecycleStage, PolicyEventSource, EnforcementAction } from 'types/policy.proto';
+import type { LifecycleStage, PolicyEventSource, EnforcementAction } from 'types/policy.proto';
 import DescriptionListItem from 'Components/DescriptionListItem';
 import {
     formatEventSource,
@@ -20,7 +21,7 @@ function PolicyBehaviorSection({
     lifecycleStages,
     eventSource,
     enforcementActions,
-}: PolicyBehaviorSectionProps): React.ReactElement {
+}: PolicyBehaviorSectionProps): ReactElement {
     const enforcementLifecycleStages = getEnforcementLifecycleStages(
         lifecycleStages,
         enforcementActions

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Alert,
@@ -21,11 +22,12 @@ import {
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
-import useToasts, { Toast } from 'hooks/patternfly/useToasts';
+import useToasts from 'hooks/patternfly/useToasts';
+import type { Toast } from 'hooks/patternfly/useToasts';
 import { policiesBasePath } from 'routePaths';
 import { deletePolicy, exportPolicies } from 'services/PoliciesService';
 import { savePoliciesAsCustomResource } from 'services/PolicyCustomResourceService';
-import { ClientPolicy } from 'types/policy.proto';
+import type { ClientPolicy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import PolicyDetailContent from './PolicyDetailContent';

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetailContent.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetailContent.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { Formik } from 'formik';
 import { Flex, Title, Divider, Grid } from '@patternfly/react-core';
 
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
-import { NotifierIntegration } from 'types/notifier.proto';
-import { BasePolicy } from 'types/policy.proto';
+import type { NotifierIntegration } from 'types/notifier.proto';
+import type { BasePolicy } from 'types/policy.proto';
 import PolicyOverview from './PolicyOverview';
 import BooleanPolicyLogicSection from '../Wizard/Step3/BooleanPolicyLogicSection';
 import PolicyScopeSection from './PolicyScopeSection';
@@ -15,10 +16,7 @@ type PolicyDetailContentProps = {
     isReview?: boolean;
 };
 
-function PolicyDetailContent({
-    policy,
-    isReview = false,
-}: PolicyDetailContentProps): React.ReactElement {
+function PolicyDetailContent({ policy, isReview = false }: PolicyDetailContentProps): ReactElement {
     const [notifiers, setNotifiers] = useState<NotifierIntegration[]>([]);
 
     useEffect(() => {

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Card,
     CardBody,
@@ -12,8 +13,8 @@ import {
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
-import { NotifierIntegration } from 'types/notifier.proto';
-import { BasePolicy } from 'types/policy.proto';
+import type { NotifierIntegration } from 'types/notifier.proto';
+import type { BasePolicy } from 'types/policy.proto';
 import MitreAttackVectorsViewContainer from 'Containers/MitreAttackVectors/MitreAttackVectorsViewContainer';
 
 import { formatCategories, getPolicyOriginLabel } from '../policies.utils';

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyScopeSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyScopeSection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import type { ReactElement } from 'react';
 import { Title, Grid, GridItem, Card, CardBody, List, ListItem } from '@patternfly/react-core';
 
 import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
-import { PolicyScope, PolicyExclusion } from 'types/policy.proto';
+import type { PolicyScope, PolicyExclusion } from 'types/policy.proto';
 import Restriction from './Restriction';
 import ExcludedDeployment from './ExcludedDeployment';
 import { getExcludedDeployments, getExcludedImageNames } from '../policies.utils';
@@ -12,7 +13,7 @@ type PolicyScopeSectionProps = {
     exclusions: PolicyExclusion[];
 };
 
-function PolicyScopeSection({ scope, exclusions }: PolicyScopeSectionProps): React.ReactElement {
+function PolicyScopeSection({ scope, exclusions }: PolicyScopeSectionProps): ReactElement {
     const { clusters } = useFetchClustersForPermissions(['Deployment']);
 
     const excludedDeploymentScopes = getExcludedDeployments(exclusions);

--- a/ui/apps/platform/src/Containers/Policies/Detail/Restriction.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/Restriction.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
-import { ClusterScopeObject } from 'services/RolesService';
-import { PolicyScope } from 'types/policy.proto';
+import type { ClusterScopeObject } from 'services/RolesService';
+import type { PolicyScope } from 'types/policy.proto';
 
 import { getClusterName } from '../policies.utils';
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, ReactElement, BaseSyntheticEvent } from 'react';
+import React, { useCallback } from 'react';
+import type { BaseSyntheticEvent, ReactElement } from 'react';
 import { Form, Radio } from '@patternfly/react-core';
 import { Field } from 'formik';
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
@@ -5,9 +5,9 @@ import capitalize from 'lodash/capitalize';
 
 import { enableDisableNotificationsForPolicies } from 'services/PoliciesService';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
-import { AlertVariantType } from 'hooks/patternfly/useToasts';
+import type { AlertVariantType } from 'hooks/patternfly/useToasts';
 import useTableSelection from 'hooks/useTableSelection';
-import { NotifierIntegration } from 'types/notifier.proto';
+import type { NotifierIntegration } from 'types/notifier.proto';
 
 export type EnableDisableType = 'enable' | 'disable';
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
@@ -1,16 +1,16 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { Modal } from '@patternfly/react-core';
 
 import { importPolicies } from 'services/PoliciesService';
-import { Policy } from 'types/policy.proto';
+import type { Policy } from 'types/policy.proto';
 import {
     parsePolicyImportErrors,
     getResolvedPolicies,
     getErrorMessages,
     checkDupeOnlyErrors,
-    PolicyImportError,
-    PolicyResolution,
 } from './PolicyImport.utils';
+import type { PolicyImportError, PolicyResolution } from './PolicyImport.utils';
 import ImportPolicyJSONSuccess from './ImportPolicyJSONSuccess';
 import ImportPolicyJSONModalError from './ImportPolicyJSONModalError';
 import ImportPolicyJSONUpload from './ImportPolicyJSONUpload';

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
@@ -1,17 +1,17 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Button, ModalBoxBody, ModalBoxFooter, Alert } from '@patternfly/react-core';
 import { Formik } from 'formik';
 import * as yup from 'yup';
 
-import { Policy } from 'types/policy.proto';
+import type { Policy } from 'types/policy.proto';
 import {
     MIN_POLICY_NAME_LENGTH,
     hasDuplicateIdOnly,
     policyOverwriteAllowed,
     checkForBlockedSubmit,
-    PolicyImportError,
-    PolicyResolution,
 } from './PolicyImport.utils';
+import type { PolicyImportError, PolicyResolution } from './PolicyImport.utils';
 import DuplicatePolicyForm from './DuplicatePolicyForm';
 
 const RESOLUTION = { resolution: '', newName: '' };

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONSuccess.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONSuccess.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Button, Flex, FlexItem, ModalBoxBody, ModalBoxFooter } from '@patternfly/react-core';
 
-import { ListPolicy } from 'types/policy.proto';
+import type { ListPolicy } from 'types/policy.proto';
 import { policiesBasePath } from 'routePaths';
 
 type ImportPolicyJSONSuccessProps = {

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONUpload.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONUpload.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 import {
     Button,
@@ -10,7 +11,7 @@ import {
     ModalBoxBody,
 } from '@patternfly/react-core';
 
-import { ListPolicy } from 'types/policy.proto';
+import type { ListPolicy } from 'types/policy.proto';
 
 type ImportPolicyJSONUploadProps = {
     cancelModal: () => void;

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
@@ -1,5 +1,5 @@
 // system under test (SUT)
-import { ImportPoliciesResponse, ImportPolicyError } from 'services/PoliciesService';
+import type { ImportPoliciesResponse, ImportPolicyError } from 'services/PoliciesService';
 import {
     parsePolicyImportErrors,
     isDuplicateResolved,
@@ -7,6 +7,8 @@ import {
     getErrorMessages,
     hasDuplicateIdOnly,
     checkForBlockedSubmit,
+} from './PolicyImport.utils';
+import type {
     PolicyResolutionType,
     PolicyImportErrorDuplicateName,
     PolicyImportErrorDuplicateId,

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.ts
@@ -1,5 +1,5 @@
-import { Policy } from 'types/policy.proto';
-import { ImportPolicyResponse } from 'services/PoliciesService';
+import type { Policy } from 'types/policy.proto';
+import type { ImportPolicyResponse } from 'services/PoliciesService';
 
 export const MIN_POLICY_NAME_LENGTH = 5;
 

--- a/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Bullseye, Spinner } from '@patternfly/react-core';
@@ -8,9 +9,9 @@ import { policiesBasePath } from 'routePaths';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import { getPolicy, updatePolicyDisabledState } from 'services/PoliciesService';
-import { ClientPolicy, Policy } from 'types/policy.proto';
+import type { ClientPolicy, Policy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { ExtendedPageAction } from 'utils/queryStringUtils';
+import type { ExtendedPageAction } from 'utils/queryStringUtils';
 
 import { getClientWizardPolicy, initialPolicy } from './policies.utils';
 import PolicyDetail from './Detail/PolicyDetail';

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import {
     Button,
@@ -17,7 +18,6 @@ import {
 import {
     ActionsColumn,
     ExpandableRowContent,
-    IAction,
     Table,
     Tbody,
     Td,
@@ -25,8 +25,9 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 
-import { ListPolicy } from 'types/policy.proto';
+import type { ListPolicy } from 'types/policy.proto';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import {
     makeFilterChipDescriptors,
@@ -39,25 +40,25 @@ import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverit
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 
-import EnableDisableNotificationModal, {
-    EnableDisableType,
-} from 'Containers/Policies/Modal/EnableDisableNotificationModal';
 import useTableSelection from 'hooks/useTableSelection';
 import useSet from 'hooks/useSet';
-import { AlertVariantType } from 'hooks/patternfly/useToasts';
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { AlertVariantType } from 'hooks/patternfly/useToasts';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import { policiesBasePath } from 'routePaths';
-import { NotifierIntegration } from 'types/notifier.proto';
-import { SearchFilter } from 'types/search';
-import { TableUIState } from 'utils/getTableUIState';
+import type { NotifierIntegration } from 'types/notifier.proto';
+import type { SearchFilter } from 'types/search';
+import type { TableUIState } from 'utils/getTableUIState';
+
+import EnableDisableNotificationModal from '../Modal/EnableDisableNotificationModal';
+import type { EnableDisableType } from '../Modal/EnableDisableNotificationModal';
 import {
-    LabelAndNotifierIdsForType,
     formatLifecycleStages,
     formatNotifierCountsWithLabelStrings,
     getLabelAndNotifierIdsForTypes,
     getPolicyOriginLabel,
     isExternalPolicy,
 } from '../policies.utils';
+import type { LabelAndNotifierIdsForType } from '../policies.utils';
 import { policySearchFilterConfig } from '../policiesSearchFilterConfig';
 
 import './PoliciesTable.css';
@@ -100,7 +101,7 @@ function PoliciesTable({
     onClickReassessPolicies,
     getSortParams,
     searchFilter,
-}: PoliciesTableProps): React.ReactElement {
+}: PoliciesTableProps): ReactElement {
     const expandedRowSet = useSet<string>();
     const navigate = useNavigate();
     const [labelAndNotifierIdsForTypes, setLabelAndNotifierIdsForTypes] = useState<

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
@@ -1,5 +1,5 @@
 import { sortSeverity, sortAsciiCaseInsensitive, sortValueByLength } from 'sorters/sorters';
-import { ListPolicy } from 'types/policy.proto';
+import type { ListPolicy } from 'types/policy.proto';
 import { getPolicyOriginLabel } from '../policies.utils';
 
 export const columns = [

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { AlertGroup, AlertActionCloseButton, Divider, Button, Alert } from '@patternfly/react-core';
 import pluralize from 'pluralize';
@@ -14,13 +15,14 @@ import {
     updatePoliciesDisabledState,
 } from 'services/PoliciesService';
 import { savePoliciesAsCustomResource } from 'services/PolicyCustomResourceService';
-import useToasts, { Toast } from 'hooks/patternfly/useToasts';
+import useToasts from 'hooks/patternfly/useToasts';
+import type { Toast } from 'hooks/patternfly/useToasts';
 import useURLSort from 'hooks/useURLSort';
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
-import { ListPolicy } from 'types/policy.proto';
-import { NotifierIntegration } from 'types/notifier.proto';
-import { ApiSortOption, SearchFilter } from 'types/search';
-import { SortOption } from 'types/table';
+import type { ListPolicy } from 'types/policy.proto';
+import type { NotifierIntegration } from 'types/notifier.proto';
+import type { ApiSortOption, SearchFilter } from 'types/search';
+import type { SortOption } from 'types/table';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { applyRegexSearchModifiers, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { getTableUIState } from 'utils/getTableUIState';
@@ -46,7 +48,7 @@ function PoliciesTablePage({
     hasWriteAccessForPolicy,
     handleChangeSearchFilter,
     searchFilter,
-}: PoliciesTablePageProps): React.ReactElement {
+}: PoliciesTablePageProps): ReactElement {
     const navigate = useNavigate();
     const { getSortParams, sortOption } = useURLSort({ defaultSortOption, sortFields });
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { FormikProvider, useFormik } from 'formik';
 import {
@@ -10,16 +11,16 @@ import {
     PageSection,
     Wizard,
     WizardStep,
-    WizardStepType,
 } from '@patternfly/react-core';
+import type { WizardStepType } from '@patternfly/react-core';
 
 import { createPolicy, savePolicy } from 'services/PoliciesService';
 import { fetchAlertCount } from 'services/AlertsService';
-import { ClientPolicy } from 'types/policy.proto';
+import type { ClientPolicy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { policiesBasePath } from 'routePaths';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import { ExtendedPageAction } from 'utils/queryStringUtils';
+import type { ExtendedPageAction } from 'utils/queryStringUtils';
 
 import {
     POLICY_BEHAVIOR_ACTIONS_ID,

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreAttackVectorsFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreAttackVectorsFormSection.tsx
@@ -1,11 +1,12 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Button, Flex } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import { useFormikContext } from 'formik';
 
 import { fetchMitreAttackVectors } from 'services/MitreService';
-import { MitreAttackVector } from 'types/mitre.proto';
-import { Policy } from 'types/policy.proto';
+import type { MitreAttackVector } from 'types/mitre.proto';
+import type { Policy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import MitreTacticSelect from './MitreTacticSelect';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTacticSelect.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTacticSelect.tsx
@@ -1,15 +1,16 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement, Ref } from 'react';
 import {
     Select,
     MenuToggle,
-    MenuToggleElement,
     SelectList,
     SelectOption,
     Flex,
     FlexItem,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
-import { MitreAttackVector } from 'types/mitre.proto';
+import type { MitreAttackVector } from 'types/mitre.proto';
 import useSelectToggleState from 'Components/SelectSingle/useSelectToggleState';
 
 type MitreTacticSelectProps = {
@@ -37,7 +38,7 @@ function MitreTacticSelect({
     const { isOpen, setIsOpen, onSelect, onToggle } = useSelectToggleState(handleSelectOption);
     const selectedTactic = mitreAttackVectors.find(({ tactic }) => tactic.id === tacticId);
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             ref={toggleRef}
             onClick={onToggle}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.test.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.test.tsx
@@ -1,4 +1,4 @@
-import { MitreTechnique } from 'types/mitre.proto';
+import type { MitreTechnique } from 'types/mitre.proto';
 
 import { formatTechniqueDisplayName, groupAndSortTechniques } from './MitreTechniqueSelect';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.tsx
@@ -1,8 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { Fragment } from 'react';
+import type { ReactElement, Ref } from 'react';
 import {
     Select,
     MenuToggle,
-    MenuToggleElement,
     SelectList,
     SelectOption,
     SelectGroup,
@@ -10,8 +10,9 @@ import {
     Flex,
     FlexItem,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
-import { MitreTechnique } from 'types/mitre.proto';
+import type { MitreTechnique } from 'types/mitre.proto';
 import useSelectToggleState from 'Components/SelectSingle/useSelectToggleState';
 
 type GroupedTechnique = {
@@ -92,7 +93,7 @@ function MitreTechniqueSelect({
     const groupedTechniques = groupAndSortTechniques(mitreTechniques);
     const selectedTechnique = mitreTechniques.find((technique) => technique.id === techniqueId);
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             ref={toggleRef}
             onClick={onToggle}
@@ -134,7 +135,7 @@ function MitreTechniqueSelect({
                     const isLastGroup = index === groupedTechniques.length - 1;
 
                     return (
-                        <React.Fragment key={baseId}>
+                        <Fragment key={baseId}>
                             <SelectGroup label={groupLabel}>
                                 {techniques.map(({ id, name }) => (
                                     <SelectOption
@@ -148,7 +149,7 @@ function MitreTechniqueSelect({
                                 ))}
                             </SelectGroup>
                             {!isLastGroup && <Divider component="li" />}
-                        </React.Fragment>
+                        </Fragment>
                     );
                 })}
             </SelectList>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, ReactElement } from 'react';
+import React, { useState, useEffect } from 'react';
+import type { FormEvent, MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
 import {
     FormGroup,
     FormHelperText,
@@ -8,7 +9,6 @@ import {
     SelectOption,
     SelectList,
     MenuToggle,
-    MenuToggleElement,
     TextInputGroup,
     TextInputGroupMain,
     TextInputGroupUtilities,
@@ -16,10 +16,11 @@ import {
     Chip,
     Button,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 import { useField } from 'formik';
 
 import { getPolicyCategories } from 'services/PolicyCategoriesService';
-import { PolicyCategory } from 'types/policy.proto';
+import type { PolicyCategory } from 'types/policy.proto';
 import { TimesIcon } from '@patternfly/react-icons';
 
 function PolicyCategoriesSelectField(): ReactElement {
@@ -37,7 +38,7 @@ function PolicyCategoriesSelectField(): ReactElement {
     };
 
     const onSelect = (
-        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
         value: string | number | undefined
     ) => {
         if (typeof value === 'string' && !selectedCategories.includes(value)) {
@@ -81,7 +82,7 @@ function PolicyCategoriesSelectField(): ReactElement {
             </SelectOption>
         ));
 
-    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    const toggle = (toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
             variant="typeahead"
             onClick={onToggle}
@@ -93,7 +94,7 @@ function PolicyCategoriesSelectField(): ReactElement {
                 <TextInputGroupMain
                     value={inputValue}
                     onClick={onToggle}
-                    onChange={(_event: React.FormEvent<HTMLInputElement>, value: string) =>
+                    onChange={(_event: FormEvent<HTMLInputElement>, value: string) =>
                         onInputChange(value)
                     }
                     autoComplete="off"
@@ -106,7 +107,7 @@ function PolicyCategoriesSelectField(): ReactElement {
                         {selectedCategories.map((category) => (
                             <Chip
                                 key={category}
-                                onClick={(event: React.MouseEvent) => {
+                                onClick={(event: ReactMouseEvent) => {
                                     event.stopPropagation();
                                     onRemoveChip(category);
                                 }}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Divider, Flex, Title } from '@patternfly/react-core';
 
 import MitreAttackVectorsViewContainer from 'Containers/MitreAttackVectors/MitreAttackVectorsViewContainer';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
@@ -1,9 +1,11 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Flex, TextInput, Radio, TextArea, Form } from '@patternfly/react-core';
-import { FormikContextType, useFormikContext } from 'formik';
+import { useFormikContext } from 'formik';
+import type { FormikContextType } from 'formik';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
-import { ClientPolicy } from 'types/policy.proto';
+import type { ClientPolicy } from 'types/policy.proto';
 
 import PolicyCategoriesSelectField from './PolicyCategoriesSelectField';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/mitreAttackVectors.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/mitreAttackVectors.utils.ts
@@ -1,5 +1,5 @@
-import { MitreAttackVector, MitreTechnique } from 'types/mitre.proto';
-import { PolicyMitreAttackVector } from 'types/policy.proto';
+import type { MitreAttackVector, MitreTechnique } from 'types/mitre.proto';
+import type { PolicyMitreAttackVector } from 'types/policy.proto';
 
 // MitreAttackVector
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -19,8 +19,7 @@ import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useMetadata from 'hooks/useMetadata';
-import { ClientPolicy } from 'types/policy.proto';
-import type { PolicyEventSource } from 'types/policy.proto';
+import type { ClientPolicy, PolicyEventSource } from 'types/policy.proto';
 import { getVersionedDocs } from 'utils/versioning';
 
 import {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/BooleanPolicyLogicSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/BooleanPolicyLogicSection.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Flex, GridItem } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 
-import { Policy } from 'types/policy.proto';
+import type { Policy } from 'types/policy.proto';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { getPolicyDescriptors } from 'Containers/Policies/policies.utils';
+import { getPolicyDescriptors } from '../../policies.utils';
 import PolicySection from './PolicySection';
 
 import './BooleanPolicyLogicSection.css';
@@ -28,7 +28,7 @@ function BooleanPolicyLogicSection({ readOnly = false }: BooleanPolicyLogicSecti
             {values.policySections?.map((_, sectionIndex) =>
                 readOnly ? (
                     // eslint-disable-next-line react/no-array-index-key
-                    <React.Fragment key={sectionIndex}>
+                    <Fragment key={sectionIndex}>
                         {/* this grid item takes up the default 5 columns specified in the Grid component in PolicyDetailContent */}
                         <GridItem>
                             <PolicySection
@@ -54,10 +54,10 @@ function BooleanPolicyLogicSection({ readOnly = false }: BooleanPolicyLogicSecti
                                 </Flex>
                             )}
                         </GridItem>
-                    </React.Fragment>
+                    </Fragment>
                 ) : (
                     // eslint-disable-next-line react/no-array-index-key
-                    <React.Fragment key={sectionIndex}>
+                    <Fragment key={sectionIndex}>
                         <PolicySection
                             sectionIndex={sectionIndex}
                             descriptors={filteredDescriptors}
@@ -77,7 +77,7 @@ function BooleanPolicyLogicSection({ readOnly = false }: BooleanPolicyLogicSecti
                                 <div className="or-divider" />
                             </Flex>
                         )}
-                    </React.Fragment>
+                    </Fragment>
                 )
             )}
         </>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { integrationsPath } from 'routePaths';
 import { fetchSignatureIntegrations } from 'services/SignatureIntegrationsService';
-import { SignatureIntegration } from 'types/signatureIntegration.proto';
+import type { SignatureIntegration } from 'types/signatureIntegration.proto';
 import tableColumnDescriptor from 'Containers/Integrations/utils/tableColumnDescriptor';
 import TableModal from './TableModal';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaCategory.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaCategory.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ExpandableSection } from '@patternfly/react-core';
 
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { Descriptor } from './policyCriteriaDescriptors';
 import PolicyCriteriaKey from './PolicyCriteriaKey';
 
 type PolicyCriteriaCategoryProps = {
@@ -15,7 +15,7 @@ function PolicyCriteriaCategory({
     keys,
     isOpenDefault = false,
 }: PolicyCriteriaCategoryProps) {
-    const [isExpanded, setIsExpanded] = React.useState(isOpenDefault);
+    const [isExpanded, setIsExpanded] = useState(isOpenDefault);
 
     function onToggle(expanded: boolean) {
         setIsExpanded(expanded);

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ReactElement } from 'react';
 import { useField } from 'formik';
 import {
     TextInput,
@@ -11,7 +12,7 @@ import {
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
 
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { Descriptor } from './policyCriteriaDescriptors';
 import PolicyCriteriaFieldSubInput from './PolicyCriteriaFieldSubInput';
 import TableModalFieldInput from './TableModalFieldInput';
 
@@ -25,7 +26,7 @@ function PolicyCriteriaFieldInput({
     descriptor,
     readOnly = false,
     name,
-}: PolicyCriteriaFieldInputProps): React.ReactElement {
+}: PolicyCriteriaFieldInputProps): ReactElement {
     const [field, , helper] = useField(name);
     const { value } = field;
     const { setValue } = helper;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import type { ReactElement } from 'react';
 import { useField } from 'formik';
 import { TextInput, FormGroup, SelectOption } from '@patternfly/react-core';
 
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
-import { SubComponent } from './policyCriteriaDescriptors';
+import type { SubComponent } from './policyCriteriaDescriptors';
 
 type PolicyCriteriaFieldSubInputProps = {
     subComponent: SubComponent;
@@ -15,7 +16,7 @@ function PolicyCriteriaFieldSubInput({
     subComponent,
     readOnly = false,
     name,
-}: PolicyCriteriaFieldSubInputProps): React.ReactElement {
+}: PolicyCriteriaFieldSubInputProps): ReactElement {
     const [field, , helper] = useField(name);
     const { value } = field;
     const { setValue } = helper;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldValue.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldValue.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Flex, Button } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { Descriptor } from './policyCriteriaDescriptors';
 import PolicyCriteriaFieldInput from './PolicyCriteriaFieldInput';
 
 type FieldValueProps = {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -4,9 +4,9 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { useFormikContext } from 'formik';
 
-import { ClientPolicy } from 'types/policy.proto';
+import type { ClientPolicy } from 'types/policy.proto';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { getPolicyDescriptors } from 'Containers/Policies/policies.utils';
+import { getPolicyDescriptors } from '../../policies.utils';
 import PolicyCriteriaKeys from './PolicyCriteriaKeys';
 import BooleanPolicyLogicSection from './BooleanPolicyLogicSection';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKeys.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKeys.tsx
@@ -6,7 +6,7 @@ import { policyCriteriaCategories } from 'messages/common';
 import type { PolicyCriteriaCategoryKey } from 'messages/common';
 
 import PolicyCriteriaCategory from './PolicyCriteriaCategory';
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { Descriptor } from './policyCriteriaDescriptors';
 
 type CriteriaDomain =
     | 'Image criteria'

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
@@ -10,13 +10,13 @@ import {
     ToolbarContent,
     ToolbarItem,
     TreeView,
-    TreeViewDataItem,
     TreeViewSearch,
 } from '@patternfly/react-core';
+import type { TreeViewDataItem } from '@patternfly/react-core';
 import { kebabCase } from 'lodash';
 
-import { PolicyGroup } from 'types/policy.proto';
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { PolicyGroup } from 'types/policy.proto';
+import type { Descriptor } from './policyCriteriaDescriptors';
 
 import './PolicyCriteriaModal.css';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
     Alert,
     Card,
@@ -16,8 +16,8 @@ import {
 import { TrashIcon, PlusIcon } from '@patternfly/react-icons';
 import { useFormikContext } from 'formik';
 
-import { Policy } from 'types/policy.proto';
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { Policy } from 'types/policy.proto';
+import type { Descriptor } from './policyCriteriaDescriptors';
 import PolicyCriteriaFieldValue from './PolicyCriteriaFieldValue';
 import AndOrOperatorField from './AndOrOperatorField';
 import './PolicyGroupCard.css';
@@ -150,7 +150,7 @@ function PolicyGroupCard({
                         const name = `policySections[${sectionIndex}].policyGroups[${groupIndex}].values[${valueIndex}]`;
                         const groupName = `policySections[${sectionIndex}].policyGroups[${groupIndex}]`;
                         return (
-                            <React.Fragment key={name}>
+                            <Fragment key={name}>
                                 <Flex
                                     direction={{ default: 'column' }}
                                     spaceItems={{ default: 'spaceItemsNone' }}
@@ -172,7 +172,7 @@ function PolicyGroupCard({
                                         </FlexItem>
                                     )}
                                 </Flex>
-                            </React.Fragment>
+                            </Fragment>
                         );
                     })}
                     {/* this is because there can't be multiple boolean values */}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useFormikContext } from 'formik';
 import {
     Card,
@@ -15,8 +15,8 @@ import { PencilAltIcon, TrashIcon, CheckIcon } from '@patternfly/react-icons';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useModal from 'hooks/useModal';
-import { Policy } from 'types/policy.proto';
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { Policy } from 'types/policy.proto';
+import type { Descriptor } from './policyCriteriaDescriptors';
 import PolicyGroupCard from './PolicyGroupCard';
 import PolicySectionDropTarget from './PolicySectionDropTarget';
 import PolicyCriteriaModal from './PolicyCriteriaModal';
@@ -30,7 +30,7 @@ type PolicySectionProps = {
 };
 
 function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySectionProps) {
-    const [isEditingName, setIsEditingName] = React.useState(false);
+    const [isEditingName, setIsEditingName] = useState(false);
     const { isModalOpen, openModal, closeModal } = useModal();
     const { values, setFieldValue, handleChange } = useFormikContext<Policy>();
     const { sectionName, policyGroups } = values.policySections[sectionIndex];

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySectionDropTarget.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySectionDropTarget.tsx
@@ -4,8 +4,8 @@ import { Flex } from '@patternfly/react-core';
 import { useDrop } from 'react-dnd';
 import { useFormikContext } from 'formik';
 
-import { Policy } from 'types/policy.proto';
-import { Descriptor } from './policyCriteriaDescriptors';
+import type { Policy } from 'types/policy.proto';
+import type { Descriptor } from './policyCriteriaDescriptors';
 import { getEmptyPolicyFieldCard } from '../../policies.utils';
 
 import './PolicySectionDropTarget.css';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import {
     Button,
@@ -13,10 +14,10 @@ import isEqual from 'lodash/isEqual';
 import pluralize from 'pluralize';
 
 import TableCellValue from 'Components/TableCellValue/TableCellValue';
-import { IntegrationTableColumnDescriptor } from 'Containers/Integrations/utils/tableColumnDescriptor';
+import type { IntegrationTableColumnDescriptor } from 'Containers/Integrations/utils/tableColumnDescriptor';
 import useTableSelection from 'hooks/useTableSelection';
-import { ClientPolicyValue } from 'types/policy.proto';
-import { SignatureIntegration } from 'types/signatureIntegration.proto';
+import type { ClientPolicyValue } from 'types/policy.proto';
+import type { SignatureIntegration } from 'types/signatureIntegration.proto';
 
 type TableModalProps = {
     setValue: (value: ClientPolicyValue) => void;
@@ -34,7 +35,7 @@ function TableModal({
     rows,
     columns,
     typeText,
-}: TableModalProps): React.ReactElement {
+}: TableModalProps): ReactElement {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     const isPreSelected = useCallback(

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModalFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModalFieldInput.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
+import type { ReactElement } from 'react';
 
 import ImageSigningTableModal from './ImageSigningTableModal';
 
-function TableModalFieldInput({
-    setValue,
-    value,
-    readOnly = false,
-    tableType,
-}): React.ReactElement {
+function TableModalFieldInput({ setValue, value, readOnly = false, tableType }): ReactElement {
     if (tableType === 'imageSigning') {
         return <ImageSigningTableModal setValue={setValue} value={value} readOnly={readOnly} />;
     }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -7,9 +7,10 @@ import {
     seccompProfileTypeLabels,
     severityRatings,
 } from 'messages/common';
-import { FeatureFlagEnvVar } from 'types/featureFlag';
-import ImageSigningTableModal from 'Containers/Policies/Wizard/Step3/ImageSigningTableModal';
-import { LifecycleStage } from 'types/policy.proto';
+import type { FeatureFlagEnvVar } from 'types/featureFlag';
+import type { LifecycleStage } from 'types/policy.proto';
+
+import ImageSigningTableModal from './ImageSigningTableModal';
 
 const equalityOptions: DescriptorOption[] = [
     { label: 'Is greater than', value: '>' },

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ReactElement } from 'react';
 import {
     Card,
     CardHeader,
@@ -15,9 +16,10 @@ import {
 import { TrashIcon } from '@patternfly/react-icons';
 import { useField } from 'formik';
 
-import TypeaheadSelect, { TypeaheadSelectOption } from 'Components/TypeaheadSelect/TypeaheadSelect';
-import { ClusterScopeObject } from 'services/RolesService';
-import { ListDeployment } from 'types/deployment.proto';
+import TypeaheadSelect from 'Components/TypeaheadSelect/TypeaheadSelect';
+import type { TypeaheadSelectOption } from 'Components/TypeaheadSelect/TypeaheadSelect';
+import type { ClusterScopeObject } from 'services/RolesService';
+import type { ListDeployment } from 'types/deployment.proto';
 
 type PolicyScopeCardProps = {
     type: 'exclusion' | 'inclusion';
@@ -35,7 +37,7 @@ function PolicyScopeCard({
     deployments = [],
     onDelete,
     hasAuditLogEventSource = false,
-}: PolicyScopeCardProps): React.ReactElement {
+}: PolicyScopeCardProps): ReactElement {
     const [field, , helper] = useField(name);
     const { value } = field;
     const { scope } = value || {};

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import type { MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
 import { useFormikContext } from 'formik';
 import {
     Flex,
@@ -16,28 +17,28 @@ import {
     SelectOption,
     SelectList,
     MenuToggle,
-    MenuToggleElement,
     TextInputGroup,
     TextInputGroupMain,
     TextInputGroupUtilities,
     ChipGroup,
     Chip,
 } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 
-import { ClientPolicy } from 'types/policy.proto';
-import { ListImage } from 'types/image.proto';
-import { ListDeployment } from 'types/deployment.proto';
+import type { ClientPolicy } from 'types/policy.proto';
+import type { ListImage } from 'types/image.proto';
+import type { ListDeployment } from 'types/deployment.proto';
 import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
 import { getImages } from 'services/imageService';
 import { fetchDeploymentsWithProcessInfoLegacy as fetchDeploymentsWithProcessInfo } from 'services/DeploymentsService';
 import PolicyScopeCard from './PolicyScopeCard';
 
-function PolicyScopeForm() {
-    const [isExcludeImagesOpen, setIsExcludeImagesOpen] = React.useState(false);
-    const [filterValue, setFilterValue] = React.useState('');
-    const [images, setImages] = React.useState<ListImage[]>([]);
-    const [deployments, setDeployments] = React.useState<ListDeployment[]>([]);
+function PolicyScopeForm(): ReactElement {
+    const [isExcludeImagesOpen, setIsExcludeImagesOpen] = useState(false);
+    const [filterValue, setFilterValue] = useState('');
+    const [images, setImages] = useState<ListImage[]>([]);
+    const [deployments, setDeployments] = useState<ListDeployment[]>([]);
     const { clusters } = useFetchClustersForPermissions(['Deployment']);
     const { values, setFieldValue } = useFormikContext<ClientPolicy>();
     const { scope, excludedDeploymentScopes, excludedImageNames } = values;
@@ -77,7 +78,7 @@ function PolicyScopeForm() {
     }
 
     function handleChangeMultiSelect(
-        _event: React.MouseEvent | undefined,
+        _event: ReactMouseEvent | undefined,
         selectedImage: string | number | undefined
     ) {
         if (!selectedImage || typeof selectedImage === 'number') {
@@ -93,7 +94,7 @@ function PolicyScopeForm() {
         setFilterValue('');
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
         getImages()
             .then((response) => {
                 setImages(response);
@@ -223,7 +224,7 @@ function PolicyScopeForm() {
                             selected={excludedImageNames}
                             onSelect={handleChangeMultiSelect}
                             onOpenChange={(nextOpen: boolean) => setIsExcludeImagesOpen(nextOpen)}
-                            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                            toggle={(toggleRef: Ref<MenuToggleElement>) => (
                                 <MenuToggle
                                     variant="typeahead"
                                     aria-label="Typeahead menu toggle"

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/DownloadCLIDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/DownloadCLIDropdown.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { DropdownItem } from '@patternfly/react-core';
 
 import downloadCLI from 'services/CLIService';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 
 function DownloadCLIDropdown({ hasBuild }) {
-    const [isCLIDownloading, setIsCLIDownloading] = React.useState(false);
+    const [isCLIDownloading, setIsCLIDownloading] = useState(false);
 
     // TODO: Show a success and error message
     async function handleDownloadCLI(_, value) {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Flex, FlexItem, Title, Divider, Form, FormGroup, Radio } from '@patternfly/react-core';
-import { FormikContextType, useFormikContext } from 'formik';
+import { useFormikContext } from 'formik';
+import type { FormikContextType } from 'formik';
 
-import { ClientPolicy } from 'types/policy.proto';
+import type { ClientPolicy } from 'types/policy.proto';
 
 import PolicyEnforcementForm from './PolicyEnforcementForm';
 import NotifiersForm from './NotifiersForm';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
@@ -18,7 +18,7 @@ import {
 } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 
-import { ClientPolicy, LifecycleStage } from 'types/policy.proto';
+import type { ClientPolicy, LifecycleStage } from 'types/policy.proto';
 
 import DownloadCLIDropdown from './DownloadCLIDropdown';
 import {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step6/PreviewViolations.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step6/PreviewViolations.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { List, ListItem, Title } from '@patternfly/react-core';
 
-import { DryRunAlert } from 'services/PoliciesService';
+import type { DryRunAlert } from 'services/PoliciesService';
 
 type PreviewViolationsProps = {
     alertsFromDryRun: DryRunAlert[];

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
@@ -1,9 +1,11 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Flex, FlexItem, Spinner, Title, Divider, Button } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 
-import { DryRunAlert, checkDryRun, startDryRun } from 'services/PoliciesService';
-import { ClientPolicy } from 'types/policy.proto';
+import { checkDryRun, startDryRun } from 'services/PoliciesService';
+import type { DryRunAlert } from 'services/PoliciesService';
+import type { ClientPolicy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import { getServerPolicy } from '../../policies.utils';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.test.ts
@@ -1,4 +1,5 @@
-import { WizardPolicyStep4, initialExcludedDeployment, initialScope } from '../policies.utils';
+import { initialExcludedDeployment, initialScope } from '../policies.utils';
+import type { WizardPolicyStep4 } from '../policies.utils';
 import { validationSchemaStep4 } from './policyValidationSchemas';
 
 // const options = { strict: true };

--- a/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 
-import { Policy } from 'types/policy.proto';
+import type { Policy } from 'types/policy.proto';
 
 import {
     POLICY_DEFINITION_DETAILS_ID,
@@ -8,7 +8,7 @@ import {
     POLICY_DEFINITION_RULES_ID,
     POLICY_BEHAVIOR_SCOPE_ID,
 } from '../policies.constants';
-import { WizardPolicyStep4, WizardScope } from '../policies.utils';
+import type { WizardPolicyStep4, WizardScope } from '../policies.utils';
 import {
     imageSigningCriteriaName,
     mountPropagationCriteriaName,

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
@@ -1,4 +1,4 @@
-import { ClientPolicy, Policy } from 'types/policy.proto';
+import type { ClientPolicy, Policy } from 'types/policy.proto';
 import {
     getClientWizardPolicy,
     getLifeCyclesUpdates,

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -1,19 +1,14 @@
 import pluralize from 'pluralize';
 import qs from 'qs';
 import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 
-import {
-    policyCriteriaDescriptors,
-    auditLogDescriptor,
-    imageSigningCriteriaName,
-    Descriptor,
-} from 'Containers/Policies/Wizard/Step3/policyCriteriaDescriptors';
 import { notifierIntegrationsDescriptors } from 'Containers/Integrations/utils/integrationsList';
 import { eventSourceLabels, lifecycleStageLabels } from 'messages/common';
-import { ClusterScopeObject } from 'services/RolesService';
-import { NotifierIntegration } from 'types/notifier.proto';
-import {
+import type { ClusterScopeObject } from 'services/RolesService';
+import type { NotifierIntegration } from 'types/notifier.proto';
+import type {
     EnforcementAction,
     LifecycleStage,
     PolicyEventSource,
@@ -28,11 +23,17 @@ import {
     PolicyImageExclusion,
     ListPolicy,
 } from 'types/policy.proto';
-import { SearchFilter } from 'types/search';
-import { ExtendedPageAction } from 'utils/queryStringUtils';
+import type { SearchFilter } from 'types/search';
+import type { ExtendedPageAction } from 'utils/queryStringUtils';
 import { checkArrayContainsArray } from 'utils/arrayUtils';
 import { allEnabled } from 'utils/featureFlagUtils';
-import isEqual from 'lodash/isEqual';
+
+import {
+    policyCriteriaDescriptors,
+    auditLogDescriptor,
+    imageSigningCriteriaName,
+} from './Wizard/Step3/policyCriteriaDescriptors';
+import type { Descriptor } from './Wizard/Step3/policyCriteriaDescriptors';
 
 function isValidAction(action: unknown): action is ExtendedPageAction {
     return action === 'clone' || action === 'create' || action === 'edit' || action === 'generate';


### PR DESCRIPTION
## Description

Toward Q3 AI goal: help AI to help us.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

**David** did make a change for backport during 4.10A sprint.

Better to do now as prerequisite to any changes in 4.10 release.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
    * Also move some `import` statements, although absence of errors gives more evidence that import/order rule does not distinguish paths in package dependencies from paths to application files.
    * Although it was tempting, I did not double up to delete `React` because it would cause merge conflict in eslint.config.js file with another contribution.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

By the way, separation of `import type` solves some problems with order of named imports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.