### PR TITLE
ROX-31043: Bump timeout in CO integration tests

### DIFF
--- a/sensor/tests/complianceoperator/sync_test.go
+++ b/sensor/tests/complianceoperator/sync_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	helloMessageTimeout = 10 * time.Second
+	helloMessageTimeout = 20 * time.Second
 	coDeployment        = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "co-deployment.yaml", Name: "compliance-operator"}
 
 	testScanConfig = &central.ApplyComplianceScanConfigRequest{


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

A lot of failures since #17388 due to timeouts waiting for the hello message to later get the hello message a few seconds later.

Here's an example:

```bash
common/scannerdefinitions: 2025/10/23 08:32:00.458535 http_handler.go:47: Info: Component 'Scanner definitions handler' runs now in Offline mode
    sync_test.go:167: Wait for Hello message
common/scannerclient: 2025/10/23 08:32:00.458585 reset_notifiable.go:33: Info: Component runs now in Offline mode
common/sensor: 2025/10/23 08:32:00.458675 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 1s...
grpc_internal: 2025/10/23 08:32:00.459921 logging.go:39: Debug: [core][Channel #29 SubChannel #30] Subchannel Connectivity change to READY
grpc_internal: 2025/10/23 08:32:00.460110 logging.go:39: Debug: [core][Channel #29] Channel Connectivity change to READY
common/sensor: 2025/10/23 08:32:01.785094 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:01.785489 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 2s...
common/sensor: 2025/10/23 08:32:03.314555 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:03.314777 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 1s...
common/sensor: 2025/10/23 08:32:04.730668 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:04.730909 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 2s...
common/sensor: 2025/10/23 08:32:07.084167 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:07.084441 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 3s...
common/sensor: 2025/10/23 08:32:09.898547 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:09.898775 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 3s...
    helper.go:507: timeout (10s) reached waiting for hello event
    sync_test.go:133: Sending updated SyncScanConfigs message with multiple scan configs
    sync_test.go:136: Asserting updated resources exist
common/sensor: 2025/10/23 08:32:12.794882 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:12.795174 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 2s...
kubernetes/complianceoperator: 2025/10/23 08:32:14.694800 updater.go:181: Debug: Compliance Operator Info: {
  "version":  "1.4.0",
  "namespace":  "openshift-compliance",
  "totalDesiredPods":  1,
  "totalReadyPods":  1,
  "statusError":  "",
  "isInstalled":  true
}
common/sensor: 2025/10/23 08:32:15.224307 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:15.224526 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 2s...
common/sensor: 2025/10/23 08:32:16.920238 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:16.920598 sensor.go:475: Info: Central communication stopped: communication stopped. Retrying after 2s...
common/sensor: 2025/10/23 08:32:18.484066 sensor.go:417: Info: Attempting connection setup (client reconciliation = true)
common/sensor: 2025/10/23 08:32:18.484268 sensor.go:361: Info: Updating Sensor State to: central-reachable-HTTP
kubernetes/eventpipeline: 2025/10/23 08:32:18.484353 pipeline_impl.go:130: Info: Component 'Event Pipeline' has received the central-reachable-HTTP notification
common/networkflow/manager: 2025/10/23 08:32:18.484453 manager_impl.go:278: Info: Component 'NetworkFlowManager' has received the central-reachable-HTTP notification
common/networkflow/manager: 2025/10/23 08:32:18.484520 purger.go:111: Info: Component 'NetworkFlowPurger' has received the central-reachable-HTTP notification
kubernetes/clusterstatus: 2025/10/23 08:32:18.484602 updater.go:73: Info: Component has received the central-reachable-HTTP notification
kubernetes/clusterhealth: 2025/10/23 08:32:18.484673 updater.go:76: Info: Component has received the central-reachable-HTTP notification
kubernetes/clustermetrics: 2025/10/23 08:32:18.484744 cluster_metrics.go:99: Info: Component has received the central-reachable-HTTP notification
common/compliance: 2025/10/23 08:32:18.484806 command_handler_impl.go:57: Info: Component has received the central-reachable-HTTP notification
common/signal: 2025/10/23 08:32:18.484861 signal_service.go:86: Info: Component has received the central-reachable-HTTP notification
common/processsignal: 2025/10/23 08:32:18.484963 pipeline.go:91: Info: Component has received the central-reachable-HTTP notification
kubernetes/telemetry: 2025/10/23 08:32:18.485042 command_handler.go:102: Info: Component has received the central-reachable-HTTP notification
common/admissioncontroller: 2025/10/23 08:32:18.485099 alert_handler.go:48: Info: Component has received the central-reachable-HTTP notification
common/compliance: 2025/10/23 08:32:18.485159 auditlog_manager_impl.go:68: Info: Component has received the central-reachable-HTTP notification
common/image: 2025/10/23 08:32:18.485209 service_impl.go:157: Info: Component has received the central-reachable-HTTP notification
common/compliance: 2025/10/23 08:32:18.485264 service_impl.go:56: Info: Component has received the central-reachable-HTTP notification
common/compliance: 2025/10/23 08:32:18.485311 node_inventory_handler_impl.go:106: Info: Component has received the central-reachable-HTTP notification
kubernetes/complianceoperator: 2025/10/23 08:32:18.485368 updater.go:119: Info: Component has received the central-reachable-HTTP notification
common/detector: 2025/10/23 08:32:18.485440 detector.go:272: Info: Component has received the central-reachable-HTTP notification
common/sensor: 2025/10/23 08:32:18.485504 notifiable.go:26: Info: Component 'Kernel probe server handler' has received the central-reachable-HTTP notification
common/sensor: 2025/10/23 08:32:18.485553 notifiable.go:26: Info: Component 'Kernel object cache' has received the central-reachable-HTTP notification
common/scannerdefinitions: 2025/10/23 08:32:18.485614 http_handler.go:47: Info: Component 'Scanner definitions handler' has received the central-reachable-HTTP notification
common/scannerclient: 2025/10/23 08:32:18.485672 reset_notifiable.go:33: Info: Component has received the central-reachable-HTTP notification
common/clusterid: 2025/10/23 08:32:18.495109 cluster_id.go:68: Info: Received dynamic cluster ID "00000000-0000-4000-A000-000000000000"
```

☝️ it took 18s for sensor to reconnect to the fake central.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Sensor integration tests should pass
