### PR TITLE
ROX-31385: Delete React in SystemConfig

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -848,7 +848,6 @@ module.exports = [
             'src/Containers/MitreAttackVectors/**',
             'src/Containers/Policies/**',
             'src/Containers/Search/**',
-            'src/Containers/SystemConfig/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
             'src/Containers/Workflow/**', // deprecated

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PlatformComponentsConfigDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import pluralize from 'pluralize';

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigPrometheusMetricsDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigPrometheusMetricsDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import type { PrivateConfig, PrometheusMetricsCategory } from 'types/config.proto';

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import capitalize from 'lodash/capitalize';
 import {

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigLoginDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigLoginDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigTelemetryDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigTelemetryDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Card, CardBody, CardHeader, CardTitle, Divider, Label } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Button,

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/CustomPlatformComponentsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
     Button,
     Card,

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/PrometheusMetricsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/PrometheusMetricsCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Card,

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/components/RedHatLayeredProductsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
     Button,
     Card,

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/FormSelect.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/FormSelect.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import type { SelectOptionProps } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/PlatformComponentsConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/PlatformComponentsConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
     Alert,
     Button,

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/SystemConfigPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import {
     Alert,


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

### Procedure

Select folders that will not cause merge conflicts with feature work in progress.

**Michaël** has not needed to make any changes for Prometheus metrics during 4.10A sprint.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Run auto fix on command line to fix errors.
    Bonus: Delete orphan newline after comment that precedes deleted `import` statement.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.