### PR TITLE
fix(qa-tests): update VulnMgmtTest GraphQL schema

### DIFF
--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -28,8 +28,8 @@ class VulnMgmtTest extends BaseSpecification {
     query getImage(\$id: ID!, \$query: String) {
       result: fullImage(id: \$id) {
         scan {
-          components(query: \$query) {
-            vulns(query: \$query) {
+          imageComponents(query: \$query) {
+            imageVulnerabilities(query: \$query) {
               ...cveFields
             }
           }
@@ -37,7 +37,7 @@ class VulnMgmtTest extends BaseSpecification {
       }
     }
 
-fragment cveFields on EmbeddedVulnerability {
+fragment cveFields on ImageVulnerability {
   cve
   cvss
   severity
@@ -168,7 +168,7 @@ fragment cveFields on ImageVulnerability {
             assert embeddedImageRes.getErrors().size() == 0
         }
 
-        def embeddedImageResVuln = embeddedImageRes.value.result.scan.components[0].vulns[0]
+        def embeddedImageResVuln = embeddedImageRes.value.result.scan.imageComponents[0].imageVulnerabilities[0]
 
         def topLevelImageRes = gqlService.Call(getTopLevelImageQuery(),
                 [id: imageDigest, query: query])


### PR DESCRIPTION
## Description

VulnMgmtTest was using deprecated GraphQL field names that no longer exist in the current schema. Updated the test to use current field names:
- `components` → `imageComponents`
- `vulns` → `imageVulnerabilities`
- `EmbeddedVulnerability` → `ImageVulnerability`

The GraphQL API evolved and the test query was causing errors like: `Cannot query field "components" on type "ImageScan". Did you mean "imageComponents"?`

Note: Test still fails due to outdated test data expectations (CVE CVSS scores don't match current database values). This is tracked in ROX-29222.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran VulnMgmtTest locally against a running StackRox cluster:
- Verified GraphQL queries execute without schema errors
- Confirmed query returns data when available in database
- Validated remaining failures are due to data mismatches (CVE CVSS scores), not schema issues

This is a test infrastructure fix, not a production code change.