### PR TITLE
ROX-31322: Fix no-qualified-name-react to match MemberExpression

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginLimited.js
+++ b/ui/apps/platform/eslint-plugins/pluginLimited.js
@@ -216,8 +216,18 @@ const rules = {
         },
         create(context) {
             return {
+                MemberExpression(node) {
+                    // For example, React.Fragment or React.useState
+                    if (node.object?.name === 'React' && typeof node.property?.name === 'string') {
+                        context.report({
+                            node,
+                            message: `Replace React qualified name with named import: ${node.property.name}`,
+                        });
+                    }
+                },
                 TSQualifiedName(node) {
-                    if (node?.left?.name === 'React' && typeof node?.right?.name === 'string') {
+                    // For example, React.ReactElement
+                    if (node.left?.name === 'React' && typeof node.right?.name === 'string') {
                         context.report({
                             node,
                             message: `Replace React qualified name with named import: ${node.right.name}`,

--- a/ui/apps/platform/src/Components/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/CheckboxSelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, ReactElement, ReactNode, Ref } from 'react';
 import { Select, MenuToggle, Badge, Flex, FlexItem } from '@patternfly/react-core';
 import type { MenuToggleElement, SelectOption } from '@patternfly/react-core';
@@ -24,7 +24,7 @@ function CheckboxSelect({
     toggleLabel,
     toggleIcon,
 }: CheckboxSelectProps) {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
         setIsOpen(!isOpen);

--- a/ui/apps/platform/src/Components/KeyValueListModal.tsx
+++ b/ui/apps/platform/src/Components/KeyValueListModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Bullseye,
     Button,
@@ -39,7 +39,7 @@ function filterKeyValuesBySearchValue(keyValues: KeyValue[], searchValue: string
 
 function KeyValueListModal({ type, keyValues }: KeyValueListModalProps) {
     const { isModalOpen, openModal, closeModal } = useModal();
-    const [searchValue, setSearchValue] = React.useState('');
+    const [searchValue, setSearchValue] = useState('');
 
     const onChange = (value: string) => {
         setSearchValue(value);

--- a/ui/apps/platform/src/Components/Labeled/Labeled.jsx
+++ b/ui/apps/platform/src/Components/Labeled/Labeled.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 
 /*
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
  * Not recommeded for input element as children because component does not render label with htmlFor prop.
  */
 function Labeled({ label, children }) {
-    if (!React.Children.count(children)) {
+    if (!Children.count(children)) {
         return null;
     } // don't render w/o children
     return (

--- a/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo } from 'react';
+import React, { Children, cloneElement, isValidElement, useMemo, useRef, useState } from 'react';
 import type {
     FocusEvent,
     FocusEventHandler,
@@ -25,12 +25,12 @@ import type {
 
 // Enhance children to automatically inject hasCheckbox and isSelected props
 function enhanceSelectOptions(children: ReactNode, selectionsSet: Set<string>): ReactNode {
-    return React.Children.map(children, (child) => {
-        if (React.isValidElement(child)) {
+    return Children.map(children, (child) => {
+        if (isValidElement(child)) {
             if (child.type === SelectOption) {
                 const { value } = child.props;
                 if (value !== null && value !== undefined) {
-                    return React.cloneElement(child, {
+                    return cloneElement(child, {
                         hasCheckbox: true,
                         isSelected: selectionsSet.has(value as string),
                         ...child.props, // Allow explicit overrides if needed
@@ -42,7 +42,7 @@ function enhanceSelectOptions(children: ReactNode, selectionsSet: Set<string>): 
                     child.props.children,
                     selectionsSet
                 );
-                return React.cloneElement(child, {
+                return cloneElement(child, {
                     ...child.props,
                     children: enhancedGroupChildren,
                 });

--- a/ui/apps/platform/src/Components/ReportJob/PartialReportModal.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/PartialReportModal.tsx
@@ -20,7 +20,7 @@ export type PartialReportModalProps = {
 };
 
 function PartialReportModal({ failedClusters = [], onDownload }: PartialReportModalProps) {
-    const [isModalOpen, setIsModalOpen] = React.useState(false);
+    const [isModalOpen, setIsModalOpen] = useState(false);
     const [page, setPage] = useState(1);
     const [perPage, setPerPage] = useState(20);
 

--- a/ui/apps/platform/src/Components/Tabs.jsx
+++ b/ui/apps/platform/src/Components/Tabs.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Children, Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Tab from 'Components/Tab';
@@ -28,7 +28,7 @@ class Tabs extends Component {
         children: (props, propName, componentName) => {
             const prop = props[propName];
             let error = null;
-            React.Children.forEach(prop, (child) => {
+            Children.forEach(prop, (child) => {
                 if (child.type !== Tab) {
                     error = new Error(
                         `'${componentName}' children should be of type ${Tab.name}, but got '${child.type}'.`
@@ -105,7 +105,7 @@ class Tabs extends Component {
     };
 
     renderChildren() {
-        const children = React.Children.toArray(this.props.children);
+        const children = Children.toArray(this.props.children);
         return children[this.state.activeIndex];
     }
 

--- a/ui/apps/platform/src/Components/TimelineGraph/ClusteredEventsVisibilityContext.js
+++ b/ui/apps/platform/src/Components/TimelineGraph/ClusteredEventsVisibilityContext.js
@@ -1,5 +1,5 @@
-import React from 'react';
+import { createContext } from 'react';
 
-const ClusteredEventsVisibilityContext = React.createContext(false);
+const ClusteredEventsVisibilityContext = createContext(false);
 
 export default ClusteredEventsVisibilityContext;

--- a/ui/apps/platform/src/Components/Widget/Widget.jsx
+++ b/ui/apps/platform/src/Components/Widget/Widget.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Children, cloneElement, useState } from 'react';
 import PropTypes from 'prop-types';
 import { PagerButtonGroup } from 'Components/PagerControls';
 
@@ -51,11 +51,7 @@ function Widget({
 
     const childrenWithPageProp =
         pages && pages > 1 ? (
-            <>
-                {React.Children.map(children, (child) =>
-                    React.cloneElement(child, { currentPage })
-                )}
-            </>
+            <>{Children.map(children, (child) => cloneElement(child, { currentPage }))}</>
         ) : (
             children
         );

--- a/ui/apps/platform/src/Components/visuals/Sunburst.jsx
+++ b/ui/apps/platform/src/Components/visuals/Sunburst.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Sunburst as SunburstReactVis, DiscreteColorLegend, LabelSeries } from 'react-vis';
 import PropTypes from 'prop-types';
 import merge from 'deepmerge';
@@ -34,7 +34,7 @@ const LABEL_STYLE = {
     fill: 'var(--primary-800)',
 };
 
-class Sunburst extends React.Component {
+class Sunburst extends Component {
     static propTypes = {
         data: PropTypes.arrayOf(
             PropTypes.shape({

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ProfileDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { MouseEvent } from 'react';
 import {
     ExpandableSection,
@@ -24,7 +24,7 @@ function ProfileDetailsHeader({
     profileDetails,
     profileName,
 }: ProfileDetailsHeaderProps) {
-    const [isExpanded, setIsExpanded] = React.useState(false);
+    const [isExpanded, setIsExpanded] = useState(false);
 
     function onToggleDescription(_event: MouseEvent, isExpanded: boolean) {
         setIsExpanded(isExpanded);

--- a/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 import PageNotFound from 'Components/PageNotFound';
@@ -44,4 +44,4 @@ const ConfigManagementRoutes = () => (
     </searchContext.Provider>
 );
 
-export default React.memo(ConfigManagementRoutes, isEqual);
+export default memo(ConfigManagementRoutes, isEqual);

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { gql, useQuery } from '@apollo/client';
 
@@ -63,12 +63,10 @@ function MitreAttackVectorsViewContainer({
         },
     });
 
-    const [allMitreAttackVectors, setAllMitreAttackVectors] = React.useState<MitreAttackVector[]>(
-        []
-    );
-    const [mitreAttackVectorsError, setMitreAttackVectorsError] = React.useState('');
+    const [allMitreAttackVectors, setAllMitreAttackVectors] = useState<MitreAttackVector[]>([]);
+    const [mitreAttackVectorsError, setMitreAttackVectorsError] = useState('');
 
-    React.useEffect(() => {
+    useEffect(() => {
         fetchMitreAttackVectors()
             .then((mitreAttackVectors) => {
                 setAllMitreAttackVectors(mitreAttackVectors);

--- a/ui/apps/platform/src/Containers/configMgmtPaginationContext.js
+++ b/ui/apps/platform/src/Containers/configMgmtPaginationContext.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import { createContext } from 'react';
 
 import { pagingParams, sortParams } from 'constants/searchParams';
 
-const configMgmtPaginationContext = React.createContext();
+const configMgmtPaginationContext = createContext();
 
 export default configMgmtPaginationContext;
 

--- a/ui/apps/platform/src/Containers/searchContext.js
+++ b/ui/apps/platform/src/Containers/searchContext.js
@@ -1,5 +1,5 @@
-import React from 'react';
+import { createContext } from 'react';
 
-const searchContext = React.createContext();
+const searchContext = createContext();
 
 export default searchContext;

--- a/ui/apps/platform/src/hooks/useTabs.js
+++ b/ui/apps/platform/src/hooks/useTabs.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { Children, useState } from 'react';
 
 import Tab from 'Components/Tab';
 
@@ -14,7 +14,7 @@ import Tab from 'Components/Tab';
 function useTabs(children) {
     const [activeTabIndex, selectActiveTabIndex] = useState(0);
 
-    const tabHeaders = React.Children.toArray(children).map((child, i) => {
+    const tabHeaders = Children.toArray(children).map((child, i) => {
         const {
             type,
             props: { title, dataTestId },
@@ -39,7 +39,7 @@ function useTabs(children) {
         return { title, isActive, onSelectTab, dataTestId };
     });
 
-    const activeTabContent = React.Children.toArray(children)[activeTabIndex];
+    const activeTabContent = Children.toArray(children)[activeTabIndex];
 
     return { tabHeaders, activeTabContent };
 }


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

**Residue** in #17335

Delete `import React from 'react';` but it has a reference: `React.Fragment`

### Analysis

I though only of type like `React.ReactElement` but not:
* `<React.Fragment>` for rendered content
* nor `React.useState` and so on for function call

Use typescript-eslint playground to learn that nodes for `React.Fragment` and `React.useState` have properties:
* `type: 'MemberExpression'`
* `object` for React
* `property` for Fragment or useState

https://typescript-eslint.io/play/#ts=5.9.3&showAST=es&fileType=.tsx

### Solution

1. Add function to match other relevant node.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] fixed lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.