### PR TITLE
ROX-31388: Use import type and delete React in Vulnerabilities part 1

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -809,7 +809,10 @@ module.exports = [
         ignores: [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/**',
+            'src/Containers/Vulnerabilities/components/**',
+            'src/Containers/Vulnerabilities/VirtualMachineCves/**',
+            'src/Containers/Vulnerabilities/VulnerablityReporting/**',
+            'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
         ],
 
@@ -848,7 +851,10 @@ module.exports = [
             'src/Containers/Policies/**',
             'src/Containers/Search/**',
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/**',
+            'src/Containers/Vulnerabilities/components/**',
+            'src/Containers/Vulnerabilities/VirtualMachineCves/**',
+            'src/Containers/Vulnerabilities/VulnerablityReporting/**',
+            'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
             'src/Containers/*.{js,jsx,ts,tsx}',
             'src/constants/**',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionManagementPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import ExceptionRequestsPage from './ExceptionRequestsPage';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Flex,
     FlexItem,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { PageSection, Pagination, ToolbarItem } from '@patternfly/react-core';
 import { Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestApprovalButtonModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Alert, Button, Form, Modal, TextArea, pluralize } from '@patternfly/react-core';
 import * as yup from 'yup';
 import { useFormik } from 'formik';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Flex,
     PageSection,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCancelButtonModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
 
 import { cancelVulnerabilityException } from 'services/VulnerabilityExceptionService';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestDenialButtonModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Alert, Button, Flex, Form, Modal, Text, TextArea } from '@patternfly/react-core';
 import * as yup from 'yup';
 import { useFormik } from 'formik';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestOverview.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     DescriptionList,
     DescriptionListDescription,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestUpdateButtonModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestUpdateButtonModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button } from '@patternfly/react-core';
 
 import type { VulnerabilityException } from 'services/VulnerabilityExceptionService';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { pluralize } from '@patternfly/react-core';
@@ -7,27 +6,25 @@ import { Table, Thead, Tr, Th, Td, ExpandableRowContent, Tbody } from '@patternf
 import CvssFormatted from 'Components/CvssFormatted';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 import useSet from 'hooks/useSet';
 
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
-import { UseURLSortResult } from 'hooks/useURLSort';
-import {
-    CVE_SEVERITY_SORT_FIELD,
-    CVE_SORT_FIELD,
-    CVE_STATUS_SORT_FIELD,
-    CVSS_SORT_FIELD,
-} from 'Containers/Vulnerabilities/utils/sortFields';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import ExpandRowTh from 'Components/ExpandRowTh';
 import {
     getIsSomeVulnerabilityFixable,
     getHighestVulnerabilitySeverity,
 } from '../../utils/vulnerabilityUtils';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
-import NodeComponentsTable, {
-    NodeComponent,
-    nodeComponentFragment,
-} from '../components/NodeComponentsTable';
+import {
+    CVE_SEVERITY_SORT_FIELD,
+    CVE_SORT_FIELD,
+    CVE_STATUS_SORT_FIELD,
+    CVSS_SORT_FIELD,
+} from '../../utils/sortFields';
+import NodeComponentsTable, { nodeComponentFragment } from '../components/NodeComponentsTable';
+import type { NodeComponent } from '../components/NodeComponentsTable';
 
 export const sortFields = [
     CVE_SORT_FIELD,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 import {
@@ -23,7 +22,8 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { detailsTabValues } from '../../types';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 
-import NodePageHeader, { NodeMetadata, nodeMetadataFragment } from './NodePageHeader';
+import NodePageHeader, { nodeMetadataFragment } from './NodePageHeader';
+import type { NodeMetadata } from './NodePageHeader';
 import NodePageVulnerabilities from './NodePageVulnerabilities';
 import NodePageDetails from './NodePageDetails';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Bullseye,
     Card,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageVulnerabilities.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Divider,
     Flex,
@@ -18,14 +17,14 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { getTableUIState } from 'utils/getTableUIState';
 import { getHasSearchApplied } from 'utils/searchUtils';
-
-import BySeveritySummaryCard from 'Containers/Vulnerabilities/components/BySeveritySummaryCard';
 import useAnalytics, { NODE_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
+
+import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import {
     nodeCVESearchFilterConfig,
     nodeComponentSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
+} from '../../searchFilterConfig';
 
 import {
     getHiddenSeverities,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeSummaryData.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeSummaryData.tsx
@@ -1,9 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 
-import {
-    ResourceCountByCveSeverityAndStatus,
-    resourceCountByCveSeverityAndStatusFragment,
-} from '../../components/CvesByStatusSummaryCard';
+import { resourceCountByCveSeverityAndStatusFragment } from '../../components/CvesByStatusSummaryCard';
+import type { ResourceCountByCveSeverityAndStatus } from '../../components/CvesByStatusSummaryCard';
 
 const nodeSummaryDataQuery = gql`
     ${resourceCountByCveSeverityAndStatusFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/useNodeVulnerabilities.ts
@@ -1,8 +1,9 @@
 import { gql, useQuery } from '@apollo/client';
 
 import { getPaginationParams } from 'utils/searchUtils';
-import { ClientPagination, Pagination } from 'services/types';
-import { NodeVulnerability, nodeVulnerabilityFragment } from './CVEsTable';
+import type { ClientPagination, Pagination } from 'services/types';
+import { nodeVulnerabilityFragment } from './CVEsTable';
+import type { NodeVulnerability } from './CVEsTable';
 
 const nodeVulnerabilitiesQuery = gql`
     ${nodeVulnerabilityFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesSummaryCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, CardBody, CardTitle, Grid, GridItem, pluralize } from '@patternfly/react-core';
 
 export type AffectedNodesSummaryCardProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ComponentTestProvider from 'test-utils/ComponentTestProvider';
 import AffectedNodesTable from './AffectedNodesTable';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { Truncate, pluralize } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom-v5-compat';
 
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 
 import useSet from 'hooks/useSet';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -12,7 +11,7 @@ import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/Vulnera
 
 import CvssFormatted from 'Components/CvssFormatted';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import {
     CLUSTER_SORT_FIELD,
     CVE_SEVERITY_SORT_FIELD,
@@ -28,10 +27,8 @@ import {
     getHighestCvssScore,
 } from '../../utils/vulnerabilityUtils';
 
-import NodeComponentsTable, {
-    NodeComponent,
-    nodeComponentFragment,
-} from '../components/NodeComponentsTable';
+import NodeComponentsTable, { nodeComponentFragment } from '../components/NodeComponentsTable';
+import type { NodeComponent } from '../components/NodeComponentsTable';
 
 export const sortFields = [
     NODE_SORT_FIELD,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -22,15 +21,12 @@ import { getTableUIState } from 'utils/getTableUIState';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 
-import {
-    SummaryCardLayout,
-    SummaryCard,
-} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import useURLSort from 'hooks/useURLSort';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { NODE_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
+import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
 import {
     getHiddenSeverities,
     getOverviewPagePath,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useAffectedNodes.ts
@@ -1,7 +1,8 @@
 import { gql, useQuery } from '@apollo/client';
-import { ClientPagination, Pagination } from 'services/types';
+import type { ClientPagination, Pagination } from 'services/types';
 import { getPaginationParams } from 'utils/searchUtils';
-import { affectedNodeFragment, AffectedNode } from './AffectedNodesTable';
+import { affectedNodeFragment } from './AffectedNodesTable';
+import type { AffectedNode } from './AffectedNodesTable';
 
 const affectedNodesQuery = gql`
     ${affectedNodeFragment}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveMetadata.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveMetadata.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { CveMetadata } from '../../components/CvePageHeader';
+import type { CveMetadata } from '../../components/CvePageHeader';
 
 const metadataQuery = gql`
     query getNodeCVEMetadata($cve: String!) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveSummaryData.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/useNodeCveSummaryData.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { ResourceCountsByCveSeverity } from '../../components/BySeveritySummaryCard';
+import type { ResourceCountsByCveSeverity } from '../../components/BySeveritySummaryCard';
 
 const summaryDataQuery = gql`
     query getNodeCVESummaryData($cve: String!, $query: String!) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCvesPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/CVEsTable.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Text } from '@patternfly/react-core';
 import {
     ActionsColumn,
     ExpandableRowContent,
-    IAction,
     Table,
     Tbody,
     Td,
@@ -12,9 +10,10 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 
 import useSet from 'hooks/useSet';
-import useURLPagination from 'hooks/useURLPagination';
+import type useURLPagination from 'hooks/useURLPagination';
 import { getTableUIState } from 'utils/getTableUIState';
 
 import TooltipTh from 'Components/TooltipTh';
@@ -22,9 +21,9 @@ import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import useMap from 'hooks/useMap';
-import { UseURLSortResult } from 'hooks/useURLSort';
-import { ApiSortOption } from 'types/search';
+import type useMap from 'hooks/useMap';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { ApiSortOption } from 'types/search';
 
 import ExpandRowTh from 'Components/ExpandRowTh';
 import { vulnerabilitySeverityLabels } from 'messages/common';
@@ -44,7 +43,8 @@ import {
     sortCveDistroList,
 } from '../../utils/sortUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
-import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
+import { isVulnerabilitySeverityLabel } from '../../types';
+import type { QuerySearchFilter } from '../../types';
 import useNodeCves from './useNodeCves';
 import useTotalNodeCount from './useTotalNodeCount';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import {
     Alert,
     Card,
@@ -14,8 +14,11 @@ import {
 import { useApolloClient } from '@apollo/client';
 
 import PageTitle from 'Components/PageTitle';
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useMap from 'hooks/useMap';
+import useMetadata from 'hooks/useMetadata';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -26,25 +29,26 @@ import useAnalytics, {
     NODE_CVE_FILTER_APPLIED,
 } from 'hooks/useAnalytics';
 import { getHasSearchApplied } from 'utils/searchUtils';
-
-import { parseQuerySearchFilter } from 'Containers/Vulnerabilities/utils/searchUtils';
-import useSnoozedCveCount from 'Containers/Vulnerabilities/hooks/useSnoozedCveCount';
+import { getVersionedDocs } from 'utils/versioning';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
+
 import {
     clusterSearchFilterConfig,
     nodeComponentSearchFilterConfig,
     nodeCVESearchFilterConfig,
     nodeSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
+} from '../../searchFilterConfig';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import SnoozedCveToggleButton from '../../components/SnoozedCveToggleButton';
 import SnoozeCvesModal from '../../components/SnoozeCvesModal/SnoozeCvesModal';
 import useSnoozeCveModal from '../../components/SnoozeCvesModal/useSnoozeCveModal';
 import useHasLegacySnoozeAbility from '../../hooks/useHasLegacySnoozeAbility';
+import useSnoozedCveCount from '../../hooks/useSnoozedCveCount';
 import TableEntityToolbar from '../../components/TableEntityToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import { nodeEntityTabValues } from '../../types';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
+import { parseQuerySearchFilter } from '../../utils/searchUtils';
 
 import CVEsTable, {
     defaultSortOption as cveDefaultSortOption,
@@ -55,10 +59,6 @@ import NodesTable, {
     sortFields as nodeSortFields,
 } from './NodesTable';
 import { useNodeCveEntityCounts } from './useNodeCveEntityCounts';
-import ExternalLink from '../../../../Components/PatternFly/IconText/ExternalLink';
-import { getVersionedDocs } from '../../../../utils/versioning';
-import useMetadata from '../../../../hooks/useMetadata';
-import useFeatureFlags from '../../../../hooks/useFeatureFlags';
 
 const searchFilterConfig = [
     nodeSearchFilterConfig,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Truncate } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
@@ -6,9 +5,9 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import DateDistance from 'Components/DateDistance';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import { getTableUIState } from 'utils/getTableUIState';
-import useURLPagination from 'hooks/useURLPagination';
-import { UseURLSortResult } from 'hooks/useURLSort';
-import { ApiSortOption } from 'types/search';
+import type useURLPagination from 'hooks/useURLPagination';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { ApiSortOption } from 'types/search';
 
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
@@ -21,7 +20,8 @@ import {
 } from '../../utils/sortFields';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
-import { QuerySearchFilter, isVulnerabilitySeverityLabel } from '../../types';
+import { isVulnerabilitySeverityLabel } from '../../types';
+import type { QuerySearchFilter } from '../../types';
 import useNodes from './useNodes';
 
 export const sortFields = [

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCveEntityCounts.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCveEntityCounts.ts
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 
-import { QuerySearchFilter } from '../../types';
+import type { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
 const entityCountsQuery = gql`

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodeCves.ts
@@ -1,7 +1,7 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
-import { ClientPagination, Pagination } from 'services/types';
-import { QuerySearchFilter } from '../../types';
+import type { ClientPagination, Pagination } from 'services/types';
+import type { QuerySearchFilter } from '../../types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
 
 const cvesListQuery = gql`

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/useNodes.ts
@@ -1,8 +1,8 @@
 import { gql, useQuery } from '@apollo/client';
 import { getPaginationParams } from 'utils/searchUtils';
-import { ClientPagination } from 'services/types';
+import type { ClientPagination } from 'services/types';
 import { getRegexScopedQueryString } from '../../utils/searchUtils';
-import { QuerySearchFilter } from '../../types';
+import type { QuerySearchFilter } from '../../types';
 
 const nodeListQuery = gql`
     query getNodes($query: String, $pagination: Pagination) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.cy.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import NodeComponentsTable from './NodeComponentsTable';
 
 const mockData = [

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import sortBy from 'lodash/sortBy';
 
 import useTableSort from 'hooks/useTableSort';
-import { ApiSortOptionSingle } from 'types/search';
+import type { ApiSortOptionSingle } from 'types/search';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 
 function sortTableData(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { Text } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import {
     PageSection,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Bullseye,
     Card,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Divider,
     Flex,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 import { Card, CardTitle, CardBody, Flex, Text, pluralize } from '@patternfly/react-core';
 import { MinusIcon, WrenchIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByTypeSummaryCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 import { Card, CardTitle, CardBody, Flex, FlexItem, Text, pluralize } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Text } from '@patternfly/react-core';
 import {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { pluralize } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Td, Tbody } from '@patternfly/react-table';
 import { Link } from 'react-router-dom-v5-compat';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import {
     PageSection,
     Title,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersSummaryCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
 
 export type AffectedClustersSummaryCardProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { Truncate } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 import { Card, CardTitle, CardBody, Grid, GridItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     PageSection,
     Breadcrumb,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCvesPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/filterChipDescriptor.ts
@@ -5,10 +5,10 @@
  * add it to the viewBasedReportFilterChipDescriptors array at the bottom of this file.
  */
 
-import React from 'react';
+import type { ReactNode } from 'react';
 import type { FilterChipGroupDescriptor } from 'Components/PatternFly/SearchFilterChips';
 
-function renderFixableStatus(value: string): React.ReactNode {
+function renderFixableStatus(value: string): ReactNode {
     if (value === 'true') {
         return 'Fixable';
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useExceptionRequestModal.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useExceptionRequestModal.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { BaseVulnerabilityException } from 'services/VulnerabilityExceptionService';
-import { ExceptionRequestModalOptions } from '../components/ExceptionRequestModal/ExceptionRequestModal';
+import type { BaseVulnerabilityException } from 'services/VulnerabilityExceptionService';
+import type { ExceptionRequestModalOptions } from '../components/ExceptionRequestModal/ExceptionRequestModal';
 
 export type ShowExceptionModalAction =
     | {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useInvalidateVulnerabilityQueries.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/hooks/useInvalidateVulnerabilityQueries.ts
@@ -1,5 +1,6 @@
 import { useApolloClient } from '@apollo/client';
-import { DocumentNode, FieldNode, Kind, OperationDefinitionNode, OperationTypeNode } from 'graphql';
+import { Kind, OperationTypeNode } from 'graphql';
+import type { DocumentNode, FieldNode, OperationDefinitionNode } from 'graphql';
 import uniq from 'lodash/uniq';
 
 import { imageListQuery } from '../WorkloadCves/Tables/ImageOverviewTable';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/types.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 
-import { VulnerabilitySeverity } from 'types/cve.proto';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
 
 export const vulnerabilitySeverityLabels = [
     'Critical',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -1,16 +1,13 @@
-import qs from 'qs';
+import type { ParsedQs } from 'qs';
 
 import {
     vulnerabilitiesNodeCvesPath,
     vulnerabilitiesPlatformCvesPath,
     vulnerabilitiesVirtualMachineCvesPath,
 } from 'routePaths';
-import {
-    VulnerabilitySeverity,
-    VulnerabilityState,
-    vulnerabilitySeverities,
-} from 'types/cve.proto';
-import { SearchFilter } from 'types/search';
+import { vulnerabilitySeverities } from 'types/cve.proto';
+import type { VulnerabilitySeverity, VulnerabilityState } from 'types/cve.proto';
+import type { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
 import {
     searchValueAsArray,
@@ -21,7 +18,8 @@ import { ensureExhaustive } from 'utils/type.utils';
 
 import { ensureStringArray } from 'utils/ensure';
 
-import {
+import { isFixableStatus, isVulnerabilitySeverityLabel } from '../types';
+import type {
     FixableStatus,
     NodeEntityTab,
     PlatformEntityTab,
@@ -29,8 +27,6 @@ import {
     VirtualMachineEntityTab,
     VulnerabilitySeverityLabel,
     WorkloadEntityTab,
-    isFixableStatus,
-    isVulnerabilitySeverityLabel,
 } from '../types';
 
 export type OverviewPageSearch = {
@@ -64,7 +60,7 @@ export function getWorkloadEntityPagePath(
     workloadCveEntity: WorkloadEntityTab,
     id: string,
     vulnerabilityState: VulnerabilityState,
-    queryOptions?: qs.ParsedQs
+    queryOptions?: ParsedQs
 ): string {
     const queryString = getQueryString({ ...queryOptions, vulnerabilityState });
     switch (workloadCveEntity) {
@@ -82,7 +78,7 @@ export function getWorkloadEntityPagePath(
 export function getPlatformEntityPagePath(
     platformCveEntity: PlatformEntityTab,
     id: string,
-    queryOptions?: qs.ParsedQs
+    queryOptions?: ParsedQs
 ): string {
     const queryString = getQueryString(queryOptions);
     switch (platformCveEntity) {
@@ -99,7 +95,7 @@ export function getPlatformEntityPagePath(
 export function getNodeEntityPagePath(
     nodeCveEntity: NodeEntityTab,
     id: string,
-    queryOptions?: qs.ParsedQs
+    queryOptions?: ParsedQs
 ): string {
     const queryString = getQueryString(queryOptions);
     switch (nodeCveEntity) {
@@ -115,7 +111,7 @@ export function getNodeEntityPagePath(
 export function getVirtualMachineEntityPagePath(
     virtualMachineCveEntity: VirtualMachineEntityTab,
     id: string,
-    queryOptions?: qs.ParsedQs
+    queryOptions?: ParsedQs
 ): string {
     const queryString = getQueryString(queryOptions);
     switch (virtualMachineCveEntity) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortUtils.tsx
@@ -1,14 +1,12 @@
 import intersection from 'lodash/intersection';
 import sortBy from 'lodash/sortBy';
-import { ensureExhaustive, isNonEmptyArray, NonEmptyArray } from 'utils/type.utils';
-import { SortAggregate, SortOption } from 'types/table';
-import { FieldOption } from 'hooks/useURLSort';
-import { ApiSortOption, SearchFilter } from 'types/search';
-import {
-    vulnerabilitySeverityLabels,
-    VulnerabilitySeverityLabel,
-    WorkloadEntityTab,
-} from '../types';
+import { ensureExhaustive, isNonEmptyArray } from 'utils/type.utils';
+import type { NonEmptyArray } from 'utils/type.utils';
+import type { SortAggregate, SortOption } from 'types/table';
+import type { FieldOption } from 'hooks/useURLSort';
+import type { ApiSortOption, SearchFilter } from 'types/search';
+import { vulnerabilitySeverityLabels } from '../types';
+import type { VulnerabilitySeverityLabel, WorkloadEntityTab } from '../types';
 import { getAppliedSeverities } from './searchUtils';
 
 // ROX-27906 Image CVEs view cannot use search fields as sort options without providing aggregates

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
@@ -1,4 +1,4 @@
-import { NonEmptyArray } from 'utils/type.utils';
+import type { NonEmptyArray } from 'utils/type.utils';
 import {
     getHighestVulnerabilitySeverity,
     getIsSomeVulnerabilityFixable,


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

Double up to precede PatternFly 6 upgrade.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to replace folder in `ignores` array with subfolders.
    Typo in subfolder name temporarily got me again: VulnerablityReporting
2. Edit files to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.