### PR TITLE
chore(alert): fix upsert bench test

### DIFF
--- a/central/alert/datastore/internal/store/postgres/bench_test.go
+++ b/central/alert/datastore/internal/store/postgres/bench_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkMany(b *testing.B) {
@@ -62,8 +61,12 @@ func BenchmarkMany(b *testing.B) {
 					count++
 					return nil
 				})
-				assert.NoError(b, err)
-				assert.Equal(b, alertsNum, count)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if alertsNum != count {
+					b.Fatalf("Expected %d alerts, got %d", alertsNum, count)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This PR fixes alert bench tests that was running only once instead of N times. It also uses `b.Loop` instead indexed for loop introduced in Go 1.24 https://go.dev/blog/testing-b-loop

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
