### PR TITLE
ROX-16877: Fix GQL hook to allow skip queries w invalid IDs

### DIFF
--- a/ui/apps/platform/src/hooks/useEntityName.js
+++ b/ui/apps/platform/src/hooks/useEntityName.js
@@ -9,12 +9,10 @@ function useEntityName(entityType, entityId, skip) {
     // Header query
     const entityNameQuery = entityNameQueryMap[entityType || entityTypes.CLUSTER];
     const nameQueryOptions = {
-        options: {
-            fetchPolicy: 'cache-first',
-            skip,
-        },
+        fetchPolicy: 'cache-first',
+        skip: skip || !entityId,
         variables: {
-            id: decodeURIComponent(entityId) || '',
+            id: entityId ? decodeURIComponent(entityId) : '',
         },
     };
     const { loading, error, data } = useQuery(entityNameQuery, nameQueryOptions);


### PR DESCRIPTION
## Description

Prevents invalid GraphQL queries being sent for entity names in ConfigManagement.

This PR fixes two issues:
- Queries with a `null` id should not be sent, as these will never result in a valid name response
- The `skip` parameter to avoid sending this query was nested at the wrong level

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the page described in the ticket and observe that a `null` id is no longer sent to `getClusterName`.
<img width="1496" height="990" alt="image" src="https://github.com/user-attachments/assets/df861c26-980b-46b9-95ce-be903876c5d2" />

