### PR TITLE
chore(AI): Remove reference to old repo from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,6 @@ This file provides guidance when working with code in this repository.
 ## Repository Information
 
 **Upstream Repository**: https://github.com/stackrox/stackrox
-**Legacy Upstream Repository**: https://github.com/stackrox/rox - archived, but may contain valuable past information
 
 ## Workflow
 


### PR DESCRIPTION
## Description

We should not point to the legacy repo, because it is still private. Agents would not be able to access it normally, and if someone who has access to that repo then gave their agent a token, it could leak references to old customers.

## User-facing documentation

- [x] [CHANGELOG.md] update is not needed
- [x] documentation  is not needed

## Testing and quality

- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

The UI e2e test failure is a flake. Not wasting compute resources to re-run.

### Automated testing

no test changes needed

### How I validated my change

PR review