### PR TITLE
ROX-31331: Require Collector reporting all processes

### DIFF
--- a/tests/container_instances_test.go
+++ b/tests/container_instances_test.go
@@ -63,10 +63,7 @@ func TestContainerInstances(testT *testing.T) {
 		retryEventsT.Logf("Second container (%s) events: %+v", groupedContainers[1].Name, secondContainerEvents)
 
 		// Second container: ubuntu running a loop with date and sleep
-		// TODO(ROX-31331): Collector cannot reliably detect /bin/sh /bin/date or /bin/sleep in ubuntu image,
-		// thus not including it in the required processes.
-		// If this flakes again, see ROX-31331 and follow-up on the discussion in the ticket.
-		requiredSecondContainer := []string{"/bin/sh"}
+		requiredSecondContainer := []string{"/bin/sh", "/bin/date", "/bin/sleep"}
 		require.Subsetf(retryEventsT, secondContainerEvents, requiredSecondContainer,
 			"Second container: required processes: %v not found in events: %v", requiredSecondContainer, secondContainerEvents)
 

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -155,9 +155,7 @@ func TestPod(testT *testing.T) {
 		retryEventsT.Logf("Event names: %+v", eventNames)
 
 		// Required processes from both containers
-		// TODO(ROX-31331): Collector cannot reliably detect /bin/sh /bin/date or /bin/sleep in ubuntu image,
-		// thus not including it in the required processes.
-		requiredProcesses := []string{"/usr/sbin/nginx"}
+		requiredProcesses := []string{"/usr/sbin/nginx", "/bin/sh", "/bin/date", "/bin/sleep"}
 		require.Subsetf(retryEventsT, eventNames, requiredProcesses,
 			"Pod: required processes: %v not found in events: %v", requiredProcesses, eventNames)
 


### PR DESCRIPTION
## Description

Re-enable detection of `/bin/sh`, `/bin/date`, and `/bin/sleep` processes in `TestPod` and `TestContainerInstances` by removing TODO(ROX-31331) workarounds.

### Problem

Tests `TestPod` and `TestContainerInstances` were not checking for `/bin/sh`, `/bin/date`, and `/bin/sleep` processes from the Ubuntu container due to unreliable Collector process detection (ROX-31331). The tests had TODO comments indicating these processes should be re-enabled once the underlying issue was resolved.

### Why it was failing before

We created ROX-31331, because it was easy to say that if something is missing in Central, then most probably the Collector is not reporting something. The faith in Sensor was too strong, because it turned out that Sensor was loosing selected data in the test run because it was restarted shortly before the `TestPod` and `TestContainerInstances` were triggered.
The issue of Sensor not being ready for test was fixed in #17502.

### Changes

Removed TODO(ROX-31331) comments and re-enabled full process detection:

**`tests/container_instances_test.go`**:
- Changed `requiredSecondContainer` from `[]string{"/bin/sh"}` 
- To: `[]string{"/bin/sh", "/bin/date", "/bin/sleep"}`

**`tests/pods_test.go`**:
- Changed `requiredProcesses` from `[]string{"/usr/sbin/nginx"}`
- To: `[]string{"/usr/sbin/nginx", "/bin/sh", "/bin/date", "/bin/sleep"}`

### Before vs After

**Before**:
```go
// TODO(ROX-31331): Collector cannot reliably detect /bin/sh /bin/date or /bin/sleep
requiredProcesses := []string{"/usr/sbin/nginx"} // Only checking nginx
```

**After**:
```go
requiredProcesses := []string{"/usr/sbin/nginx", "/bin/sh", "/bin/date", "/bin/sleep"}
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- I run `gke-nongroovy-e2e-tests` and `ocp-4-19-nongroovy-e2e-tests` in CI 10 times each, and manually checked the results by making sure that `TestPod` and `TestContainerInstances` are not failing.

