### PR TITLE
ROX-23025: Resets table page on listening endpoints table after search

### DIFF
--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -127,8 +127,13 @@ function ListeningEndpointsPage() {
         const newValue = oldValue.includes(value)
             ? oldValue.filter((f) => f !== value)
             : [...oldValue, value];
+        onSearchFilterChange({ ...searchFilter, [entity]: newValue });
+    }
+
+    function onSearchFilterChange(searchFilter: SearchFilter) {
+        setSearchFilter(searchFilter);
+        setPage(1);
         setSearchValue('');
-        setSearchFilter({ ...searchFilter, [entity]: newValue });
     }
 
     return (
@@ -214,7 +219,7 @@ function ListeningEndpointsPage() {
                         <ToolbarGroup className="pf-v5-u-w-100">
                             <SearchFilterChips
                                 searchFilter={searchFilter}
-                                onFilterChange={setSearchFilter}
+                                onFilterChange={onSearchFilterChange}
                                 filterChipGroupDescriptors={[
                                     { displayName: 'Deployment', searchFilterName: 'Deployment' },
                                     { displayName: 'Namespace', searchFilterName: 'Namespace' },


### PR DESCRIPTION
## Description

Resets the current table page for Listening Endpoints when a change is made to the search filter. This prevents situations where a user paginates beyond the first page, applies a search filter, and sees an empty table due to being on a page beyond the data that is available.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual test:
<img width="1246" height="746" alt="image" src="https://github.com/user-attachments/assets/707e4d36-5963-43a5-98ce-85d74268b880" />
<img width="1246" height="746" alt="image" src="https://github.com/user-attachments/assets/e4e05464-5f72-404d-b83c-b0d551ac1bdd" />
<img width="1246" height="746" alt="image" src="https://github.com/user-attachments/assets/a84c155d-1c5b-420c-ae85-62a1983b96f6" />
<img width="1246" height="746" alt="image" src="https://github.com/user-attachments/assets/fc03ce04-b14c-47ad-b83a-3b5baa579a22" />

