### PR TITLE
chore(CI): only use quay.io/stackrox-io/apollo-ci images for CI

### DIFF
--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.4.9
+            image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.4.9
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash


### PR DESCRIPTION
## Description

Updating the last mention of quay.io/rhacs-eng/apollo-ci to quay.io/stackrox-io/apollo-ci as a small cleanup, as I intend to stop publishing new quay.io/rhacs-eng/apollo-ci images in https://github.com/stackrox/rox-ci-image/pull/232.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/17563/pull-ci-stackrox-stackrox-master-gke-scale-tests/1983846375074304000 passes.
