### PR TITLE
ROX-31463: Sort named imports in AccessControl

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -775,7 +775,6 @@ module.exports = [
         ignores: [
             'cypress/integration/**',
             'src/Components/**',
-            'src/Containers/AccessControl/**',
             'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/ConfigManagement/**',

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
-import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Alert, Button, Modal, PageSection, Title, pluralize } from '@patternfly/react-core';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import usePermissions from 'hooks/usePermissions';
 import type { AccessScope } from 'services/AccessScopesService';

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import type { CSSProperties, ReactElement } from 'react';
 import { Badge, Button, Flex, FlexItem, Switch, TextInput } from '@patternfly/react-core';
 import { AngleDownIcon, AngleUpIcon } from '@patternfly/react-icons';
-import { Table, Tbody, Td, Thead, Th, Tr, TreeRowWrapper } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr, TreeRowWrapper } from '@patternfly/react-table';
 
 import type {
     EffectiveAccessScopeCluster,

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelInclusion.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelInclusion.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Badge, Tab, TabContent, Tabs, TabTitleText } from '@patternfly/react-core';
+import { Badge, Tab, TabContent, TabTitleText, Tabs } from '@patternfly/react-core';
 
 import type { LabelSelector, LabelSelectorsKey } from 'services/AccessScopesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/RequirementRow.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/RequirementRow.tsx
@@ -4,8 +4,8 @@ import { Button, Icon, TextInput, Tooltip, ValidatedOptions } from '@patternfly/
 import {
     CheckCircleIcon,
     MinusCircleIcon,
-    PlusCircleIcon,
     PencilAltIcon,
+    PlusCircleIcon,
     TimesCircleIcon,
 } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/accessScopes.utils.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/accessScopes.utils.ts
@@ -1,8 +1,8 @@
 import type {
     LabelSelector,
-    LabelSelectorsKey,
     LabelSelectorOperator,
     LabelSelectorRequirement,
+    LabelSelectorsKey,
     SimpleAccessScopeRules,
 } from 'services/AccessScopesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/no-array-index-key */
 import type { FormEvent, ReactElement } from 'react';
 import { Link, useNavigate } from 'react-router-dom-v5-compat';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import { useFormik, FormikProvider, FieldArray } from 'formik';
+import { FieldArray, FormikProvider, useFormik } from 'formik';
 import * as yup from 'yup';
 import {
     Alert,
@@ -43,12 +43,12 @@ import ConfigurationFormFields from './ConfigurationFormFields';
 import RuleGroups from './RuleGroups';
 import type { RuleGroupErrors } from './RuleGroups';
 import {
+    getDefaultRoleByAuthProviderId,
+    getGroupsByAuthProviderId,
     getInitialAuthProviderValues,
+    isDefaultGroupModifiable,
     transformInitialValues,
     transformValuesBeforeSaving,
-    getGroupsByAuthProviderId,
-    getDefaultRoleByAuthProviderId,
-    isDefaultGroupModifiable,
 } from './authProviders.utils';
 import type { AccessControlQueryAction } from '../accessControlPaths';
 

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { selectors } from 'reducers';
-import { useLocation, useNavigate, useParams, Link } from 'react-router-dom-v5-compat';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import {
     Alert,
@@ -14,9 +14,9 @@ import {
     ExpandableSection,
     Flex,
     PageSection,
-    pluralize,
     Spinner,
     Title,
+    pluralize,
 } from '@patternfly/react-core';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { Button, Modal } from '@patternfly/react-core';
-import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { selectors } from 'reducers';
 import { actions as authActions } from 'reducers/auth';

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -30,7 +30,7 @@ import { getEntityPath, getQueryObject } from '../accessControlPaths';
 
 import PermissionSetForm from './PermissionSetForm';
 import PermissionSetsList from './PermissionSetsList';
-import { getNewPermissionSet, getCompletePermissionSet } from './permissionSets.utils';
+import { getCompletePermissionSet, getNewPermissionSet } from './permissionSets.utils';
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
 import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeading from '../AccessControlHeading';

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
-import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Alert, Button, Modal, PageSection, Title, pluralize } from '@patternfly/react-core';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import usePermissions from 'hooks/usePermissions';
 import type { PermissionSet, Role } from 'services/RolesService';

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
@@ -1,13 +1,13 @@
 import type { ReactElement } from 'react';
 import { Badge, SelectOption } from '@patternfly/react-core';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import SelectSingle from 'Components/SelectSingle';
 import {
+    deprecatedResourceRowStyle,
     replacedResourceMapping,
     resourceRemovalReleaseVersions,
     resourceSubstitutions,
-    deprecatedResourceRowStyle,
 } from 'constants/accessControl';
 import { accessControl as accessTypeLabels } from 'messages/common';
 import type { PermissionsMap } from 'services/RolesService';

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/permissionSets.utils.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/permissionSets.utils.ts
@@ -1,5 +1,5 @@
 import { defaultMinimalReadAccessResources } from 'constants/accessControl';
-import type { AccessLevel, PermissionsMap, PermissionSet } from 'services/RolesService';
+import type { AccessLevel, PermissionSet, PermissionsMap } from 'services/RolesService';
 
 /*
  * Return a new permission set with default minimal read access.

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/AccessScopesTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/AccessScopesTable.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEventHandler, ReactElement } from 'react';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import type { AccessScope } from 'services/AccessScopesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/PermissionSetsTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/PermissionSetsTable.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEventHandler, ReactElement } from 'react';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import type { PermissionSet } from 'services/RolesService';
 

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -13,7 +13,7 @@ import {
 
 import NotFoundMessage from 'Components/NotFoundMessage';
 import usePermissions from 'hooks/usePermissions';
-import { fetchAccessScopes, defaultAccessScopeIds } from 'services/AccessScopesService';
+import { defaultAccessScopeIds, fetchAccessScopes } from 'services/AccessScopesService';
 import type { AccessScope } from 'services/AccessScopesService';
 import { fetchAuthProviders } from 'services/AuthService';
 import type { Group } from 'services/AuthService';

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Alert, Button, Modal, PageSection, pluralize, Title } from '@patternfly/react-core';
-import { ActionsColumn, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Alert, Button, Modal, PageSection, Title, pluralize } from '@patternfly/react-core';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import usePermissions from 'hooks/usePermissions';
 import type { AccessScope } from 'services/AccessScopesService';


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

Especially because part-time contributors have made changes in this folder.

### Problem

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.