### PR TITLE
ROX-31465: Delete React and sort named imports in Policies

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -781,7 +781,6 @@ module.exports = [
             'src/Containers/ConfigManagement/**',
             'src/Containers/MainPage/**',
             'src/Containers/NetworkGraph/**',
-            'src/Containers/Policies/**',
             'src/Containers/PolicyCategories/**',
             'src/Containers/SystemHealth/**',
             'src/Containers/Violations/**',
@@ -841,7 +840,6 @@ module.exports = [
             'src/Containers/Images/**',
             'src/Containers/Login/**',
             'src/Containers/MitreAttackVectors/**',
-            'src/Containers/Policies/**',
             'src/Containers/Search/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',

--- a/ui/apps/platform/src/Containers/Policies/Detail/ExcludedDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/ExcludedDeployment.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Detail/Notifier.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/Notifier.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyBehaviorSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyBehaviorSection.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import type { ReactElement } from 'react';
-import { DescriptionList, Card, CardBody } from '@patternfly/react-core';
+import { Card, CardBody, DescriptionList } from '@patternfly/react-core';
 
-import type { LifecycleStage, PolicyEventSource, EnforcementAction } from 'types/policy.proto';
+import type { EnforcementAction, LifecycleStage, PolicyEventSource } from 'types/policy.proto';
 import DescriptionListItem from 'Components/DescriptionListItem';
 import {
     formatEventSource,

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -7,16 +7,16 @@ import {
     AlertGroup,
     Breadcrumb,
     BreadcrumbItem,
+    Divider,
+    DropdownItem,
+    Flex,
+    FlexItem,
     Label,
+    PageSection,
     Title,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
-    Divider,
-    PageSection,
-    Flex,
-    FlexItem,
-    DropdownItem,
 } from '@patternfly/react-core';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetailContent.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetailContent.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Formik } from 'formik';
-import { Flex, Title, Divider, Grid } from '@patternfly/react-core';
+import { Divider, Flex, Grid, Title } from '@patternfly/react-core';
 
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
 import type { NotifierIntegration } from 'types/notifier.proto';

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Card,
     CardBody,
+    CardHeader,
     DescriptionList,
+    Divider,
     Grid,
     GridItem,
     Title,
-    Divider,
-    CardHeader,
 } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyScopeSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyScopeSection.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import type { ReactElement } from 'react';
-import { Title, Grid, GridItem, Card, CardBody, List, ListItem } from '@patternfly/react-core';
+import { Card, CardBody, Grid, GridItem, List, ListItem, Title } from '@patternfly/react-core';
 
 import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
-import type { PolicyScope, PolicyExclusion } from 'types/policy.proto';
+import type { PolicyExclusion, PolicyScope } from 'types/policy.proto';
 import Restriction from './Restriction';
 import ExcludedDeployment from './ExcludedDeployment';
 import { getExcludedDeployments, getExcludedImageNames } from '../policies.utils';

--- a/ui/apps/platform/src/Containers/Policies/Detail/Restriction.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/Restriction.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { DescriptionList } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/DuplicatePolicyForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import type { BaseSyntheticEvent, ReactElement } from 'react';
 import { Form, Radio } from '@patternfly/react-core';
 import { Field } from 'formik';

--- a/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 import capitalize from 'lodash/capitalize';
 

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModal.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Modal } from '@patternfly/react-core';
 
 import { importPolicies } from 'services/PoliciesService';
 import type { Policy } from 'types/policy.proto';
 import {
-    parsePolicyImportErrors,
-    getResolvedPolicies,
-    getErrorMessages,
     checkDupeOnlyErrors,
+    getErrorMessages,
+    getResolvedPolicies,
+    parsePolicyImportErrors,
 } from './PolicyImport.utils';
 import type { PolicyImportError, PolicyResolution } from './PolicyImport.utils';
 import ImportPolicyJSONSuccess from './ImportPolicyJSONSuccess';

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONModalError.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
 import type { ReactElement } from 'react';
-import { Button, ModalBoxBody, ModalBoxFooter, Alert } from '@patternfly/react-core';
+import { Alert, Button, ModalBoxBody, ModalBoxFooter } from '@patternfly/react-core';
 import { Formik } from 'formik';
 import * as yup from 'yup';
 
 import type { Policy } from 'types/policy.proto';
 import {
     MIN_POLICY_NAME_LENGTH,
+    checkForBlockedSubmit,
     hasDuplicateIdOnly,
     policyOverwriteAllowed,
-    checkForBlockedSubmit,
 } from './PolicyImport.utils';
 import type { PolicyImportError, PolicyResolution } from './PolicyImport.utils';
 import DuplicatePolicyForm from './DuplicatePolicyForm';

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONSuccess.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONSuccess.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Button, Flex, FlexItem, ModalBoxBody, ModalBoxFooter } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONUpload.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/ImportPolicyJSONUpload.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 import {
     Button,
     FileUpload,
-    Title,
     Flex,
     FlexItem,
-    ModalBoxFooter,
     ModalBoxBody,
+    ModalBoxFooter,
+    Title,
 } from '@patternfly/react-core';
 
 import type { ListPolicy } from 'types/policy.proto';

--- a/ui/apps/platform/src/Containers/Policies/Modal/KeepBothSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/KeepBothSection.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'formik';
 import { Radio } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
@@ -1,18 +1,18 @@
 // system under test (SUT)
 import type { ImportPoliciesResponse, ImportPolicyError } from 'services/PoliciesService';
 import {
-    parsePolicyImportErrors,
-    isDuplicateResolved,
-    getResolvedPolicies,
-    getErrorMessages,
-    hasDuplicateIdOnly,
     checkForBlockedSubmit,
+    getErrorMessages,
+    getResolvedPolicies,
+    hasDuplicateIdOnly,
+    isDuplicateResolved,
+    parsePolicyImportErrors,
 } from './PolicyImport.utils';
 import type {
-    PolicyResolutionType,
-    PolicyImportErrorDuplicateName,
     PolicyImportErrorDuplicateId,
+    PolicyImportErrorDuplicateName,
     PolicyImportErrorInvalidPolicy,
+    PolicyResolutionType,
 } from './PolicyImport.utils';
 
 describe('PolicyImport.utils', () => {

--- a/ui/apps/platform/src/Containers/Policies/Modal/RenamePolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/RenamePolicySection.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     FormGroup,
     FormHelperText,

--- a/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PoliciesPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import usePermissions from 'hooks/usePermissions';

--- a/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import {

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
@@ -1,4 +1,4 @@
-import { sortSeverity, sortAsciiCaseInsensitive, sortValueByLength } from 'sorters/sorters';
+import { sortAsciiCaseInsensitive, sortSeverity, sortValueByLength } from 'sorters/sorters';
 import type { ListPolicy } from 'types/policy.proto';
 import { getPolicyOriginLabel } from '../policies.utils';
 

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -1,17 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { AlertGroup, AlertActionCloseButton, Divider, Button, Alert } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertGroup, Button, Divider } from '@patternfly/react-core';
 import pluralize from 'pluralize';
 import orderBy from 'lodash/orderBy';
 
 import { policiesBasePath } from 'routePaths';
 import TabNavSubHeader from 'Components/TabNav/TabNavSubHeader';
 import {
-    getPolicies,
-    reassessPolicies,
     deletePolicies,
     exportPolicies,
+    getPolicies,
+    reassessPolicies,
     updatePoliciesDisabledState,
 } from 'services/PoliciesService';
 import { savePoliciesAsCustomResource } from 'services/PolicyCustomResourceService';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { FormikProvider, useFormik } from 'formik';
 import {
     Alert,
     Breadcrumb,
-    Title,
     BreadcrumbItem,
     Divider,
     PageSection,
+    Title,
     Wizard,
     WizardStep,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreAttackVectorsFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreAttackVectorsFormSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Button, Flex } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTacticSelect.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTacticSelect.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
 import type { ReactElement, Ref } from 'react';
 import {
-    Select,
-    MenuToggle,
-    SelectList,
-    SelectOption,
     Flex,
     FlexItem,
+    MenuToggle,
+    Select,
+    SelectList,
+    SelectOption,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/MitreTechniqueSelect.tsx
@@ -1,14 +1,14 @@
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import type { ReactElement, Ref } from 'react';
 import {
-    Select,
-    MenuToggle,
-    SelectList,
-    SelectOption,
-    SelectGroup,
     Divider,
     Flex,
     FlexItem,
+    MenuToggle,
+    Select,
+    SelectGroup,
+    SelectList,
+    SelectOption,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
@@ -1,20 +1,20 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { FormEvent, MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
 import {
+    Button,
+    Chip,
+    ChipGroup,
     FormGroup,
     FormHelperText,
     HelperText,
     HelperTextItem,
-    Select,
-    SelectOption,
-    SelectList,
     MenuToggle,
+    Select,
+    SelectList,
+    SelectOption,
     TextInputGroup,
     TextInputGroupMain,
     TextInputGroupUtilities,
-    ChipGroup,
-    Chip,
-    Button,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
 import { useField } from 'formik';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyDetailsForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Divider, Flex, Title } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import type { ReactElement } from 'react';
-import { Flex, TextInput, Radio, TextArea, Form } from '@patternfly/react-core';
+import { Flex, Form, Radio, TextArea, TextInput } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import type { FormikContextType } from 'formik';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -1,15 +1,15 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
     Alert,
     Divider,
     Flex,
     Form,
     FormGroup,
-    Radio,
-    Title,
     FormHelperText,
     HelperText,
     HelperTextItem,
+    Radio,
+    Title,
 } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import cloneDeep from 'lodash/cloneDeep';
@@ -25,10 +25,10 @@ import { getVersionedDocs } from 'utils/versioning';
 import {
     getLifeCyclesUpdates,
     initialPolicy,
-    isRuntimePolicy,
-    isBuildPolicy,
     isBuildAndDeployPolicy,
+    isBuildPolicy,
     isDeployPolicy,
+    isRuntimePolicy,
 } from '../../policies.utils';
 import type { ValidPolicyLifeCycle } from '../../policies.utils';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/AndOrOperatorField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/AndOrOperatorField.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useField } from 'formik';
 import { Button } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/BooleanPolicyLogicSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/BooleanPolicyLogicSection.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import { Flex, GridItem } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/ImageSigningTableModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { integrationsPath } from 'routePaths';
 import { fetchSignatureIntegrations } from 'services/SignatureIntegrationsService';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaCategory.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaCategory.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ExpandableSection } from '@patternfly/react-core';
 
 import type { Descriptor } from './policyCriteriaDescriptors';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useField } from 'formik';
 import {
+    FormGroup,
+    SelectOption,
     TextInput,
     ToggleGroup,
     ToggleGroupItem,
-    FormGroup,
-    SelectOption,
 } from '@patternfly/react-core';
 
 import SelectSingle from 'Components/SelectSingle/SelectSingle';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldSubInput.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useField } from 'formik';
-import { TextInput, FormGroup, SelectOption } from '@patternfly/react-core';
+import { FormGroup, SelectOption, TextInput } from '@patternfly/react-core';
 
 import SelectSingle from 'Components/SelectSingle/SelectSingle';
 import type { SubComponent } from './policyCriteriaDescriptors';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldValue.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldValue.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Flex, Button } from '@patternfly/react-core';
+import { Button, Flex } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 
 import type { Descriptor } from './policyCriteriaDescriptors';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Alert, Button, Divider, Flex, FlexItem, Title } from '@patternfly/react-core';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKey.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKey.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDrag } from 'react-dnd';
 import { Flex } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKeys.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaKeys.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { groupBy } from 'lodash';
 import { Divider, Flex, Title } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
     Button,
     Flex,

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyGroupCard.tsx
@@ -1,19 +1,19 @@
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import {
     Alert,
+    Button,
     Card,
+    CardBody,
     CardHeader,
     CardTitle,
-    CardBody,
+    Checkbox,
     Divider,
     Flex,
     FlexItem,
-    Button,
-    Checkbox,
     Stack,
     StackItem,
 } from '@patternfly/react-core';
-import { TrashIcon, PlusIcon } from '@patternfly/react-icons';
+import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
 import { useFormikContext } from 'formik';
 
 import type { Policy } from 'types/policy.proto';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -1,17 +1,17 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useFormikContext } from 'formik';
 import {
+    Button,
     Card,
+    CardBody,
     CardHeader,
     CardTitle,
-    CardBody,
-    Button,
     Divider,
     Flex,
     FlexItem,
     TextInput,
 } from '@patternfly/react-core';
-import { PencilAltIcon, TrashIcon, CheckIcon } from '@patternfly/react-icons';
+import { CheckIcon, PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useModal from 'hooks/useModal';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySectionDropTarget.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySectionDropTarget.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import keyBy from 'lodash/keyBy';
 import { Flex } from '@patternfly/react-core';
 import { useDrop } from 'react-dnd';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModalFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModalFieldInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import ImageSigningTableModal from './ImageSigningTableModal';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -1,9 +1,9 @@
 import {
-    portExposureLabels,
     envVarSrcLabels,
-    rbacPermissionLabels,
-    policyCriteriaCategories,
     mountPropagationLabels,
+    policyCriteriaCategories,
+    portExposureLabels,
+    rbacPermissionLabels,
     seccompProfileTypeLabels,
     severityRatings,
 } from 'messages/common';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
@@ -1,17 +1,16 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
+    Button,
     Card,
+    CardBody,
     CardHeader,
     CardTitle,
-    CardBody,
     Divider,
-    Button,
-    TextInput,
     Flex,
     FlexItem,
     Form,
     FormGroup,
+    TextInput,
 } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import { useField } from 'formik';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -1,27 +1,27 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
 import { useFormikContext } from 'formik';
 import {
+    Button,
+    Chip,
+    ChipGroup,
+    Divider,
     Flex,
     FlexItem,
-    Title,
-    Button,
-    Divider,
-    Grid,
-    GridItem,
     FormGroup,
     FormHelperText,
+    Grid,
+    GridItem,
     HelperText,
     HelperTextItem,
-    Select,
-    SelectOption,
-    SelectList,
     MenuToggle,
+    Select,
+    SelectList,
+    SelectOption,
     TextInputGroup,
     TextInputGroupMain,
     TextInputGroupUtilities,
-    ChipGroup,
-    Chip,
+    Title,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/DownloadCLIDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/DownloadCLIDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { DropdownItem } from '@patternfly/react-core';
 
 import downloadCLI from 'services/CLIService';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Form } from '@patternfly/react-core';
 import { useField } from 'formik';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Flex, FlexItem, Title, Divider, Form, FormGroup, Radio } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem, Form, FormGroup, Radio, Title } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import type { FormikContextType } from 'formik';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
     Card,
     CardBody,
@@ -7,14 +7,14 @@ import {
     Flex,
     Form,
     FormGroup,
+    FormHelperText,
     Grid,
     GridItem,
+    HelperText,
+    HelperTextItem,
     Radio,
     Switch,
     Title,
-    FormHelperText,
-    HelperText,
-    HelperTextItem,
 } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step6/PreviewViolations.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step6/PreviewViolations.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { List, ListItem, Title } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
-import { Alert, Flex, FlexItem, Spinner, Title, Divider, Button } from '@patternfly/react-core';
+import { Alert, Button, Divider, Flex, FlexItem, Spinner, Title } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 
 import { checkDryRun, startDryRun } from 'services/PoliciesService';

--- a/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
@@ -3,10 +3,10 @@ import * as yup from 'yup';
 import type { Policy } from 'types/policy.proto';
 
 import {
+    POLICY_BEHAVIOR_SCOPE_ID,
     POLICY_DEFINITION_DETAILS_ID,
     POLICY_DEFINITION_LIFECYCLE_ID,
     POLICY_DEFINITION_RULES_ID,
-    POLICY_BEHAVIOR_SCOPE_ID,
 } from '../policies.constants';
 import type { WizardPolicyStep4, WizardScope } from '../policies.utils';
 import {

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -9,19 +9,19 @@ import { eventSourceLabels, lifecycleStageLabels } from 'messages/common';
 import type { ClusterScopeObject } from 'services/RolesService';
 import type { NotifierIntegration } from 'types/notifier.proto';
 import type {
+    ClientPolicy,
     EnforcementAction,
     LifecycleStage,
+    ListPolicy,
+    Policy,
+    PolicyDeploymentExclusion,
     PolicyEventSource,
     PolicyExcludedDeployment,
     PolicyExclusion,
-    Policy,
-    ClientPolicy,
-    ValueObj,
-    PolicyScope,
     PolicyGroup,
-    PolicyDeploymentExclusion,
     PolicyImageExclusion,
-    ListPolicy,
+    PolicyScope,
+    ValueObj,
 } from 'types/policy.proto';
 import type { SearchFilter } from 'types/search';
 import type { ExtendedPageAction } from 'utils/queryStringUtils';
@@ -29,9 +29,9 @@ import { checkArrayContainsArray } from 'utils/arrayUtils';
 import { allEnabled } from 'utils/featureFlagUtils';
 
 import {
-    policyCriteriaDescriptors,
     auditLogDescriptor,
     imageSigningCriteriaName,
+    policyCriteriaDescriptors,
 } from './Wizard/Step3/policyCriteriaDescriptors';
 import type { Descriptor } from './Wizard/Step3/policyCriteriaDescriptors';
 


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

Double up to merge ahead of PatternFly 6.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.