### PR TITLE
ROX-31467: Sort named imports in Violations

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -784,7 +784,6 @@ module.exports = [
             'src/Containers/Policies/**',
             'src/Containers/PolicyCategories/**',
             'src/Containers/SystemHealth/**',
-            'src/Containers/Violations/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/**',
         ],

--- a/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/EnforcementDetails.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import uniqBy from 'lodash/uniqBy';
-import { Flex, FlexItem, Divider, Card } from '@patternfly/react-core';
+import { Card, Divider, Flex, FlexItem } from '@patternfly/react-core';
 
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';

--- a/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
@@ -3,10 +3,10 @@ import type { ReactElement } from 'react';
 import capitalize from 'lodash/capitalize';
 import {
     Card,
+    CardBody,
+    CardExpandableContent,
     CardHeader,
     CardTitle,
-    CardExpandableContent,
-    CardBody,
     DescriptionList,
 } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Card,
+    CardBody,
+    CardExpandableContent,
     CardHeader,
     CardTitle,
-    CardExpandableContent,
-    CardBody,
     DescriptionList,
 } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.jsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ProcessCard.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { getTime } from 'date-fns';
 import {
     Card,
-    CardHeader,
     CardBody,
     CardExpandableContent,
+    CardHeader,
     DescriptionList,
 } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Violations/Details/ProcessCardContent.jsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ProcessCardContent.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { DescriptionList, Flex, Divider } from '@patternfly/react-core';
+import { DescriptionList, Divider, Flex } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 import KeyValue from 'Components/KeyValue';

--- a/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/ViolationDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import startCase from 'lodash/startCase';

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePage.tsx
@@ -8,15 +8,15 @@ import {
     PageSection,
     Popover,
     Spinner,
-    Title,
-    Tabs,
     Tab,
     TabTitleText,
+    Tabs,
     Text,
+    Title,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-import { fetchAlerts, fetchAlertCount } from 'services/AlertsService';
+import { fetchAlertCount, fetchAlerts } from 'services/AlertsService';
 import { CancelledPromiseError } from 'services/cancellationUtils';
 import useEntitiesByIdsCache from 'hooks/useEntitiesByIdsCache';
 import LIFECYCLE_STAGES from 'constants/lifecycleStages';

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -5,20 +5,20 @@ import {
     AlertActionCloseButton,
     AlertGroup,
     Divider,
-    Title,
+    MenuToggle,
     PageSection,
     Pagination,
-    pluralize,
+    Select,
+    SelectList,
+    SelectOption,
+    Title,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
-    Select,
-    SelectOption,
-    SelectList,
-    MenuToggle,
+    pluralize,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
-import { ActionsColumn, Table, Tbody, Thead, Td, Th, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { ENFORCEMENT_ACTIONS } from 'constants/enforcementActions';
 import { VIOLATION_STATES } from 'constants/violationStates';

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -1,4 +1,4 @@
-import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 
 import type { SearchFilter } from 'types/search';
 import useAnalytics from 'hooks/useAnalytics';
@@ -13,31 +13,31 @@ import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import {
     Category as PolicyCategory,
-    Name as PolicyName,
     LifecycleStage as PolicyLifecycleStage,
+    Name as PolicyName,
     Severity as PolicySeverity,
 } from 'Components/CompoundSearchFilter/attributes/policy';
 import {
-    ViolationTime as AlertViolationTime,
     EntityType as AlertEntityType,
+    ViolationTime as AlertViolationTime,
 } from 'Components/CompoundSearchFilter/attributes/alert';
 import {
-    clusterNameAttribute,
     clusterIdAttribute,
     clusterLabelAttribute,
+    clusterNameAttribute,
 } from 'Components/CompoundSearchFilter/attributes/cluster';
 import {
-    ID as NamespaceID,
-    Name as NamespaceName,
-    Label as NamespaceLabel,
     Annotation as NamespaceAnnotation,
+    ID as NamespaceID,
+    Label as NamespaceLabel,
+    Name as NamespaceName,
 } from 'Components/CompoundSearchFilter/attributes/namespace';
 import {
+    Annotation as DeploymentAnnotation,
     ID as DeploymentID,
-    Name as DeploymentName,
     Inactive as DeploymentInactive,
     Label as DeploymentLabel,
-    Annotation as DeploymentAnnotation,
+    Name as DeploymentName,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
 import { Name as ResourceName } from 'Components/CompoundSearchFilter/attributes/resource';
 


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.