### PR TITLE
ROX-31497: Sort named imports in NetworkGraph

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -778,7 +778,6 @@ module.exports = [
             'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/ConfigManagement/**',
-            'src/Containers/NetworkGraph/**',
             'src/Containers/PolicyCategories/**',
             'src/Containers/SystemHealth/**',
             'src/Containers/VulnMgmt/**', // deprecated

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -19,10 +19,10 @@ import { getNodeById } from './utils/networkGraphUtils';
 import type { EdgeState } from './components/EdgeStateSelect';
 import type { DisplayOption } from './components/DisplayOptionsSelect';
 import {
-    createExtraneousNodes,
     createExtraneousEdges,
-    graphModel,
+    createExtraneousNodes,
     getConnectedNodeIds,
+    graphModel,
 } from './utils/modelUtils';
 import {
     cidrBlockBadgeColor,

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -41,10 +41,10 @@ import type { DisplayOption } from './components/DisplayOptionsSelect';
 import TimeWindowSelector from './components/TimeWindowSelector';
 import { useScopeHierarchy } from './hooks/useScopeHierarchy';
 import {
-    transformPolicyData,
-    transformActiveData,
     createExtraneousFlowsModel,
     graphModel,
+    transformActiveData,
+    transformPolicyData,
 } from './utils/modelUtils';
 import { getPropertiesForAnalytics } from './utils/networkGraphURLUtils';
 import getSimulation from './utils/getSimulation';

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { Popover } from '@patternfly/react-core';
 import {
     SELECTION_EVENT,
-    useEventListener,
+    TopologyControlBar,
     TopologySideBar,
     TopologyView,
+    VisualizationSurface,
     createTopologyControlButtons,
     defaultControlButtonsOptions,
-    TopologyControlBar,
+    useEventListener,
     useVisualizationController,
-    VisualizationSurface,
 } from '@patternfly/react-topology';
 import type { SelectionEventListener } from '@patternfly/react-topology';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -7,11 +7,11 @@ import {
     Button,
     Divider,
     EmptyState,
+    EmptyStateHeader,
+    SelectOption,
     Spinner,
     Stack,
     StackItem,
-    EmptyStateHeader,
-    SelectOption,
 } from '@patternfly/react-core';
 
 import download from 'utils/download';

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRForm.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRForm.tsx
@@ -1,6 +1,6 @@
 import { FieldArray, useFormikContext } from 'formik';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { Flex, FlexItem, Form, Button } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Form } from '@patternfly/react-core';
 
 import CIDRFormRow from './CIDRFormRow';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormModal.tsx
@@ -1,20 +1,20 @@
 import { useEffect, useState } from 'react';
 import { FormikProvider, useFormik } from 'formik';
-import { Alert, Bullseye, Spinner, Modal, Button, Flex } from '@patternfly/react-core';
+import { Alert, Bullseye, Button, Flex, Modal, Spinner } from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import { isValidCidrBlock } from 'utils/urlUtils';
 import {
-    fetchCIDRBlocks,
     deleteCIDRBlock,
-    postCIDRBlock,
+    fetchCIDRBlocks,
     patchCIDRBlock,
+    postCIDRBlock,
 } from 'services/NetworkService';
 import useTimeout from 'hooks/useTimeout';
-import { getHasDuplicateCIDRNames, getHasDuplicateCIDRAddresses } from './cidrFormUtils';
+import { getHasDuplicateCIDRAddresses, getHasDuplicateCIDRNames } from './cidrFormUtils';
 import DefaultCIDRToggle from './DefaultCIDRToggle';
 import CIDRForm, { emptyCIDRBlockRow } from './CIDRForm';
-import type { CIDRBlockEntity, CIDRBlockEntities } from './CIDRForm';
+import type { CIDRBlockEntities, CIDRBlockEntity } from './CIDRForm';
 
 const validationSchema = yup.object().shape({
     entities: yup.array().of(

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
@@ -6,16 +6,16 @@ import { observer } from 'mobx-react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-topology/dist/js/css/topology-components';
 import {
-    Layer,
-    LabelPosition,
-    LabelBadge,
     Ellipse,
+    LabelBadge,
+    LabelPosition,
+    Layer,
     NodeLabel,
     createSvgIdUrl,
     useCombineRefs,
+    useDragNode,
     useHover,
     useSize,
-    useDragNode,
 } from '@patternfly/react-topology';
 
 const DefaultFakeGroup = ({

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -10,12 +10,12 @@ import {
     MenuContent,
     MenuFooter,
     MenuGroup,
-    MenuSearch,
     MenuItem,
     MenuList,
+    MenuSearch,
+    MenuSearchInput,
     MenuToggle,
     SearchInput,
-    MenuSearchInput,
     Select,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
@@ -1,4 +1,4 @@
-import { Split, SplitItem, SelectGroup, SelectOption } from '@patternfly/react-core';
+import { SelectGroup, SelectOption, Split, SplitItem } from '@patternfly/react-core';
 import { PficonNetworkRangeIcon } from '@patternfly/react-icons';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/FlowTable.tsx
@@ -1,5 +1,5 @@
-import { ToolbarContent, ToolbarItem, Pagination } from '@patternfly/react-core';
-import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn } from '@patternfly/react-table';
+import { Pagination, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import type { IAction } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/LegendContent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/LegendContent.tsx
@@ -1,8 +1,8 @@
 import { Flex, FlexItem, Title } from '@patternfly/react-core';
 import {
-    PficonNetworkRangeIcon,
     BuilderImageIcon,
     ExclamationCircleIcon,
+    PficonNetworkRangeIcon,
 } from '@patternfly/react-icons';
 
 import DescriptionListItem from 'Components/DescriptionListItem';

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -9,13 +9,13 @@ import {
     Menu,
     MenuContent,
     MenuFooter,
-    MenuSearch,
     MenuItem,
     MenuList,
-    SearchInput,
+    MenuSearch,
     MenuSearchInput,
-    Select,
     MenuToggle,
+    SearchInput,
+    Select,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import { useMemo } from 'react';
 import type { ComponentClass, FunctionComponent, PropsWithChildren, ReactNode } from 'react';
-import { observer, ScaleDetailsLevel } from '@patternfly/react-topology';
+import { ScaleDetailsLevel, observer } from '@patternfly/react-topology';
 import type {
     Node,
     ShapeProps,

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { ComponentClass, FunctionComponent, PropsWithChildren, ReactNode } from 'react';
-import { DefaultGroup, observer, ScaleDetailsLevel } from '@patternfly/react-topology';
+import { DefaultGroup, ScaleDetailsLevel, observer } from '@patternfly/react-topology';
 import type {
     Node,
     ShapeProps,

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
@@ -8,18 +8,18 @@ import type {
     ReactNode,
 } from 'react';
 import {
-    Decorator,
-    DEFAULT_DECORATOR_RADIUS,
     DEFAULT_DECORATOR_PADDING,
+    DEFAULT_DECORATOR_RADIUS,
     DEFAULT_LAYER,
+    Decorator,
     DefaultNode,
-    getDefaultShapeDecoratorCenter,
     Layer,
     NodeShape,
-    observer,
     ScaleDetailsLevel,
     TOP_LAYER,
     TopologyQuadrant,
+    getDefaultShapeDecoratorCenter,
+    observer,
     useHover,
 } from '@patternfly/react-topology';
 import type {
@@ -40,7 +40,7 @@ import EgressOnly from 'images/network-graph/egress-only.svg?react';
 import IngressOnly from 'images/network-graph/ingress-only.svg?react';
 import NoPolicyRules from 'images/network-graph/no-policy-rules.svg?react';
 import { ensureExhaustive } from 'utils/type.utils';
-import type { NetworkPolicyState, DeploymentData, NodeDataType } from '../types/topology.type';
+import type { DeploymentData, NetworkPolicyState, NodeDataType } from '../types/topology.type';
 
 const ICON_PADDING = 20;
 const CUSTOM_DECORATOR_PADDING = 2.5;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, PropsWithChildren } from 'react';
-import { GraphComponent, DefaultNode, DefaultEdge, DefaultGroup } from '@patternfly/react-topology';
+import { DefaultEdge, DefaultGroup, DefaultNode, GraphComponent } from '@patternfly/react-topology';
 import type { ComponentFactory, GraphElement } from '@patternfly/react-topology';
 
 enum CustomModelKind {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
-    withDragNode,
-    withSelection,
-    ModelKind,
-    withPanZoom,
     GraphComponent,
-    withDndDrop,
-    nodeDragSourceSpec,
-    graphDropTargetSpec,
+    ModelKind,
     NODE_DRAG_TYPE,
+    graphDropTargetSpec,
+    nodeDragSourceSpec,
+    withDndDrop,
+    withDragNode,
+    withPanZoom,
+    withSelection,
 } from '@patternfly/react-topology';
 import type { ComponentFactory } from '@patternfly/react-topology';
 import StyleNode from './StyleNode';

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -6,6 +6,7 @@ import {
     DescriptionListTerm,
     Divider,
     EmptyState,
+    EmptyStateHeader,
     ExpandableSection,
     Flex,
     FlexItem,
@@ -15,7 +16,6 @@ import {
     StackItem,
     TextContent,
     Title,
-    EmptyStateHeader,
 } from '@patternfly/react-core';
 
 import usePermissions from 'hooks/usePermissions';

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -10,8 +10,8 @@ import {
     StackItem,
     Tab,
     TabContent,
-    Tabs,
     TabTitleText,
+    Tabs,
     Text,
     Title,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/ExternalFlows.tsx
@@ -12,7 +12,7 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';

--- a/ui/apps/platform/src/Containers/NetworkGraph/layouts/defaultLayoutFactory.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/layouts/defaultLayoutFactory.ts
@@ -1,10 +1,10 @@
 import {
-    ForceLayout,
+    BreadthFirstLayout,
     ColaLayout,
     ConcentricLayout,
     DagreLayout,
+    ForceLayout,
     GridLayout,
-    BreadthFirstLayout,
 } from '@patternfly/react-topology';
 import type { Graph, Layout, LayoutFactory } from '@patternfly/react-topology';
 import { ColaGroupsLayout } from '@patternfly/react-topology/dist/esm/layouts/ColaGroupsLayout';

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -6,8 +6,8 @@ import {
     StackItem,
     Tab,
     TabContent,
-    Tabs,
     TabTitleText,
+    Tabs,
     Text,
     Title,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/DeploymentScopeModal.tsx
@@ -10,7 +10,7 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql, useQuery } from '@apollo/client';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ReactNode } from 'react';
 
-import { CodeBlockAction, Button } from '@patternfly/react-core';
+import { Button, CodeBlockAction } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 
 import CodeViewer from 'Components/CodeViewer';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -14,8 +14,8 @@ import {
     StackItem,
     Tab,
     TabContent,
-    Tabs,
     TabTitleText,
+    Tabs,
     Text,
     Title,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import {
     Bullseye,
     EmptyState,
-    Stack,
-    StackItem,
     EmptyStateHeader,
     SelectOption,
+    Stack,
+    StackItem,
 } from '@patternfly/react-core';
 import type { DropEvent } from '@patternfly/react-core';
 import type { NetworkPolicy } from 'types/networkPolicy.proto';

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -2,10 +2,10 @@ import uniq from 'lodash/uniq';
 
 import type { NetworkBaselinePeerStatus } from 'types/networkBaseline.proto';
 import type {
+    DeploymentNetworkEntityInfo,
     ExternalNetworkFlowProperties,
     L4Protocol,
     NetworkEntityInfoType as EntityType,
-    DeploymentNetworkEntityInfo,
 } from 'types/networkFlow.proto';
 import type { GroupedDiffFlows } from 'types/networkPolicyService';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -2,32 +2,32 @@ import { EdgeStyle, EdgeTerminalType, NodeShape } from '@patternfly/react-topolo
 
 import type {
     DeploymentNetworkEntityInfo,
+    EdgeProperties,
     ExternalSourceNetworkEntityInfo,
+    InternalNetworkEntitiesInfo,
     InternetNetworkEntityInfo,
+    L4Protocol,
     NetworkEntityInfo,
     Node,
     OutEdges,
-    L4Protocol,
-    EdgeProperties,
-    InternalNetworkEntitiesInfo,
 } from 'types/networkFlow.proto';
 import { ensureExhaustive } from 'utils/type.utils';
 import type {
-    CustomModel,
-    CustomNodeModel,
-    ExternalGroupNodeModel,
-    ExternalGroupData,
-    NamespaceData,
-    NamespaceNodeModel,
-    DeploymentNodeModel,
-    ExtraneousNodeModel,
-    NetworkPolicyState,
-    ExternalEntitiesNodeModel,
+    CIDRBlockData,
     CIDRBlockNodeModel,
     CustomEdgeModel,
+    CustomModel,
+    CustomNodeModel,
     DeploymentData,
-    CIDRBlockData,
+    DeploymentNodeModel,
+    ExternalEntitiesNodeModel,
+    ExternalGroupData,
+    ExternalGroupNodeModel,
+    ExtraneousNodeModel,
     InternalEntitiesNodeModel,
+    NamespaceData,
+    NamespaceNodeModel,
+    NetworkPolicyState,
 } from '../types/topology.type';
 import { protocolLabel } from './flowUtils';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphURLUtils.test.ts
@@ -1,4 +1,4 @@
-import { getURLLinkToDeployment, getPropertiesForAnalytics } from './networkGraphURLUtils';
+import { getPropertiesForAnalytics, getURLLinkToDeployment } from './networkGraphURLUtils';
 
 describe('networkGraphURLUtils', () => {
     describe('getURLLinkToDeployment', () => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/timeWindow.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/timeWindow.ts
@@ -1,4 +1,4 @@
-import { subHours, subWeeks, subMonths } from 'date-fns';
+import { subHours, subMonths, subWeeks } from 'date-fns';
 
 import type { TimeWindow } from 'constants/timeWindows';
 


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.