### PR TITLE
ROX-31498: Sort named imports in Vulnerabilities part 1

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -782,7 +782,10 @@ module.exports = [
             'src/Containers/PolicyCategories/**',
             'src/Containers/SystemHealth/**',
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/**',
+            'src/Containers/Vulnerabilities/components/**',
+            'src/Containers/Vulnerabilities/VirtualMachineCves/**',
+            'src/Containers/Vulnerabilities/VulnerablityReporting/**',
+            'src/Containers/Vulnerabilities/WorkloadCves/**',
         ],
 
         // languageOptions from previous configuration object

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedDeferrals.tsx
@@ -14,13 +14,13 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import type { SearchFilter } from 'types/search';
 import { getTableUIState } from 'utils/getTableUIState';
 import {
+    RequestCreatedAt,
     RequestExpires,
     RequestIDLink,
+    RequestScope,
     RequestedAction,
     RequestedItems,
-    RequestCreatedAt,
     Requester,
-    RequestScope,
 } from './components/ExceptionRequestTableCells';
 
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ApprovedFalsePositives.tsx
@@ -15,12 +15,12 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import type { SearchFilter } from 'types/search';
 import { getTableUIState } from 'utils/getTableUIState';
 import {
+    RequestCreatedAt,
     RequestIDLink,
+    RequestScope,
     RequestedAction,
     RequestedItems,
-    RequestCreatedAt,
     Requester,
-    RequestScope,
 } from './components/ExceptionRequestTableCells';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/DeniedRequests.tsx
@@ -14,13 +14,13 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import type { SearchFilter } from 'types/search';
 import { getTableUIState } from 'utils/getTableUIState';
 import {
+    RequestCreatedAt,
     RequestExpires,
     RequestIDLink,
+    RequestScope,
     RequestedAction,
     RequestedItems,
-    RequestCreatedAt,
     Requester,
-    RequestScope,
 } from './components/ExceptionRequestTableCells';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/ExceptionRequestsPage.tsx
@@ -7,7 +7,7 @@ import {
     Tabs,
     Title,
 } from '@patternfly/react-core';
-import { Route, Routes, Navigate, useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import { exceptionManagementPath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/PendingRequests.tsx
@@ -14,13 +14,13 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import type { SearchFilter } from 'types/search';
 import { getTableUIState } from 'utils/getTableUIState';
 import {
+    RequestCreatedAt,
     RequestExpires,
     RequestIDLink,
+    RequestScope,
     RequestedAction,
     RequestedItems,
-    RequestCreatedAt,
     Requester,
-    RequestScope,
 } from './components/ExceptionRequestTableCells';
 import AdvancedFiltersToolbar from '../components/AdvancedFiltersToolbar';
 import { DEFAULT_VM_PAGE_SIZE } from '../constants';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/ExceptionRequestTableCells.test.tsx
@@ -2,7 +2,7 @@ import type {
     BaseVulnerabilityException,
     VulnerabilityException,
 } from 'services/VulnerabilityExceptionService';
-import { getShouldUseUpdatedRequest, getRequestedAction } from './ExceptionRequestTableCells';
+import { getRequestedAction, getShouldUseUpdatedRequest } from './ExceptionRequestTableCells';
 import type { RequestContext } from './ExceptionRequestTableCells';
 
 const baseException: BaseVulnerabilityException = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ExceptionManagement/components/RequestCVEsTable.tsx
@@ -32,10 +32,10 @@ import {
     aggregateByCreatedTime,
     aggregateByDistinctCount,
     getScoreVersionsForTopCVSS,
-    sortCveDistroList,
-    getWorkloadCveOverviewSortFields,
-    getWorkloadCveOverviewDefaultSortOption,
     getSeveritySortOptions,
+    getWorkloadCveOverviewDefaultSortOption,
+    getWorkloadCveOverviewSortFields,
+    sortCveDistroList,
 } from '../../utils/sortUtils';
 import { cveListQuery } from '../../WorkloadCves/Tables/WorkloadCVEOverviewTable';
 import type { CVEListQueryResult } from '../../WorkloadCves/Tables/WorkloadCVEOverviewTable';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { pluralize } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Td, ExpandableRowContent, Tbody } from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import CvssFormatted from 'Components/CvssFormatted';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
@@ -13,8 +13,8 @@ import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/Vulner
 import type { UseURLSortResult } from 'hooks/useURLSort';
 import ExpandRowTh from 'Components/ExpandRowTh';
 import {
-    getIsSomeVulnerabilityFixable,
     getHighestVulnerabilitySeverity,
+    getIsSomeVulnerabilityFixable,
 } from '../../utils/vulnerabilityUtils';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -1,12 +1,12 @@
 import { useParams } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 import {
-    PageSection,
     Breadcrumb,
-    Divider,
     BreadcrumbItem,
-    Skeleton,
     Bullseye,
+    Divider,
+    PageSection,
+    Skeleton,
     Tab,
     TabContent,
     Tabs,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePageHeader.tsx
@@ -1,4 +1,4 @@
-import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
+import { Flex, Label, LabelGroup, Title } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
 
 import { getDateTime } from 'utils/dateUtils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -1,5 +1,5 @@
 import { Truncate, pluralize } from '@patternfly/react-core';
-import { ExpandableRowContent, Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 import { Link } from 'react-router-dom-v5-compat';
 
@@ -22,9 +22,9 @@ import {
 } from '../../utils/sortFields';
 import { getNodeEntityPagePath } from '../../utils/searchUtils';
 import {
+    getHighestCvssScore,
     getHighestVulnerabilitySeverity,
     getIsSomeVulnerabilityFixable,
-    getHighestCvssScore,
 } from '../../utils/vulnerabilityUtils';
 
 import NodeComponentsTable, { nodeComponentFragment } from '../components/NodeComponentsTable';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/NodeCvePage.tsx
@@ -26,7 +26,7 @@ import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { NODE_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
-import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import {
     getHiddenSeverities,
     getOverviewPagePath,
@@ -35,9 +35,9 @@ import {
 } from '../../utils/searchUtils';
 import CvePageHeader from '../../components/CvePageHeader';
 import {
-    nodeSearchFilterConfig,
-    nodeComponentSearchFilterConfig,
     clusterSearchFilterConfig,
+    nodeComponentSearchFilterConfig,
+    nodeSearchFilterConfig,
 } from '../../searchFilterConfig';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import AffectedNodesTable, { defaultSortOption, sortFields } from './AffectedNodesTable';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -34,8 +34,8 @@ import { createFilterTracker } from 'utils/analyticsEventTracking';
 
 import {
     clusterSearchFilterConfig,
-    nodeComponentSearchFilterConfig,
     nodeCVESearchFilterConfig,
+    nodeComponentSearchFilterConfig,
     nodeSearchFilterConfig,
 } from '../../searchFilterConfig';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/CVEsTable.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { Text } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Td, ExpandableRowContent, Tbody } from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import CvssFormatted from 'Components/CvssFormatted';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -1,11 +1,11 @@
 import { useParams } from 'react-router-dom-v5-compat';
 import {
-    PageSection,
     Breadcrumb,
-    Divider,
     BreadcrumbItem,
-    Skeleton,
     Bullseye,
+    Divider,
+    PageSection,
+    Skeleton,
     Tab,
     TabContent,
     Tabs,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageHeader.tsx
@@ -1,4 +1,4 @@
-import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
+import { Flex, Label, LabelGroup, Title } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
 
 import { getDateTime } from 'utils/dateUtils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPageVulnerabilities.tsx
@@ -21,7 +21,7 @@ import useURLSort from 'hooks/useURLSort';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { PLATFORM_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import { platformCVESearchFilterConfig } from '../../searchFilterConfig';
-import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import { getHiddenStatuses, parseQuerySearchFilter } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByStatusSummaryCard.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client';
-import { Card, CardTitle, CardBody, Flex, Text, pluralize } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Flex, Text, pluralize } from '@patternfly/react-core';
 import { MinusIcon, WrenchIcon } from '@patternfly/react-icons';
 import type { FixableStatus } from '../../types';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/PlatformCvesByTypeSummaryCard.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client';
-import { Card, CardTitle, CardBody, Flex, FlexItem, Text, pluralize } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Flex, FlexItem, Text, pluralize } from '@patternfly/react-core';
 
 const statusDisplays = [
     {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/CVEsTable.tsx
@@ -4,11 +4,11 @@ import {
     ActionsColumn,
     ExpandableRowContent,
     Table,
-    Thead,
-    Tr,
-    Th,
     Tbody,
     Td,
+    Th,
+    Thead,
+    Tr,
 } from '@patternfly/react-table';
 import type { IAction } from '@patternfly/react-table';
 import { gql, useQuery } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/ClustersTable.tsx
@@ -1,5 +1,5 @@
 import { pluralize } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Td, Tbody } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Overview/PlatformCvesOverviewPage.tsx
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
 import {
-    PageSection,
-    Title,
-    Divider,
-    Flex,
-    FlexItem,
     Card,
     CardBody,
-    ToolbarItem,
+    Divider,
     DropdownItem,
+    Flex,
+    FlexItem,
+    PageSection,
+    Title,
+    ToolbarItem,
 } from '@patternfly/react-core';
 import { useApolloClient } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/AffectedClustersTable.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import { Truncate } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import type { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/ClustersByTypeSummaryCard.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client';
-import { Card, CardTitle, CardBody, Grid, GridItem } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
 
 export const clustersByTypeFragment = gql`
     fragment ClustersByType on PlatformCVECore {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/PlatformCve/PlatformCvePage.tsx
@@ -1,13 +1,13 @@
 import {
-    PageSection,
     Breadcrumb,
-    Divider,
     BreadcrumbItem,
-    Skeleton,
+    Divider,
     Flex,
     Label,
     LabelGroup,
+    PageSection,
     Pagination,
+    Skeleton,
     Split,
     SplitItem,
     Text,
@@ -31,7 +31,7 @@ import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { PLATFORM_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import { clusterSearchFilterConfig } from '../../searchFilterConfig';
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
-import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import {
     getOverviewPagePath,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -23,9 +23,9 @@ import { nodeCVEAttributes } from 'Components/CompoundSearchFilter/attributes/no
 import { nodeComponentAttributes } from 'Components/CompoundSearchFilter/attributes/nodeComponent';
 import { platformCVEAttributes } from 'Components/CompoundSearchFilter/attributes/platformCVE';
 import {
+    VirtualMachineCVEName,
     VirtualMachineComponentName,
     VirtualMachineComponentVersion,
-    VirtualMachineCVEName,
     VirtualMachineID,
     VirtualMachineName,
 } from 'Components/CompoundSearchFilter/attributes/virtualMachine';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/searchUtils.tsx
@@ -10,9 +10,9 @@ import type { VulnerabilitySeverity, VulnerabilityState } from 'types/cve.proto'
 import type { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
 import {
-    searchValueAsArray,
-    getRequestQueryStringForSearchFilter,
     applyRegexSearchModifiers,
+    getRequestQueryStringForSearchFilter,
+    searchValueAsArray,
 } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
@@ -1,10 +1,10 @@
 import type { NonEmptyArray } from 'utils/type.utils';
 import {
+    formatCveDiscoveredTime,
+    getEarliestDiscoveredAtTime,
+    getHighestCvssScore,
     getHighestVulnerabilitySeverity,
     getIsSomeVulnerabilityFixable,
-    getHighestCvssScore,
-    getEarliestDiscoveredAtTime,
-    formatCveDiscoveredTime,
 } from './vulnerabilityUtils';
 
 const CRITICAL = 'CRITICAL_VULNERABILITY_SEVERITY';


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.