### PR TITLE
ROX-31506: Delete React in ConsolePlugin

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -826,7 +826,6 @@ module.exports = [
     {
         files: ['**/*.{js,jsx,ts,tsx}'],
         ignores: [
-            'src/ConsolePlugin/**',
             'src/Containers/Audit/**',
             'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated

--- a/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/AdministrationNamespaceSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/AdministrationNamespaceSecurityTab.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
 
 import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';

--- a/ui/apps/platform/src/ConsolePlugin/Components/VulnerabilitiesOverviewContainer.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/Components/VulnerabilitiesOverviewContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import noop from 'lodash/noop';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 

--- a/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { NamespaceBar, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 import useURLSearch from 'hooks/useURLSearch';

--- a/ui/apps/platform/src/ConsolePlugin/ImageDetailPage/ImageDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/ImageDetailPage/ImageDetailPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { NamespaceBar, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 import { ALL_NAMESPACES_KEY } from 'ConsolePlugin/constants';

--- a/ui/apps/platform/src/ConsolePlugin/PluginContent.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginContent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import usePermissions from 'hooks/usePermissions';
 import LoadingSection from 'Components/PatternFly/LoadingSection';

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { ApolloProvider } from '@apollo/client';
 

--- a/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
 
 import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { PageSection, Title } from '@patternfly/react-core';
 import { DocumentTitle, NamespaceBar } from '@openshift-console/dynamic-plugin-sdk';
 

--- a/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import { Spinner } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

### Procedure

Select folders that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Run auto fix on command line to fix errors.
    Bonus: Delete orphan newline after comment that precedes deleted `import` statement.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.