### PR TITLE
ROX-31507: Delete React in miscellaneous folders

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -844,13 +844,6 @@ module.exports = [
             'src/Containers/Vulnerabilities/VulnerablityReporting/**',
             'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
-            'src/Containers/*.{js,jsx,ts,tsx}',
-            'src/constants/**',
-            'src/hooks/**',
-            'src/providers/**',
-            'src/test-utils/**',
-            'src/utils/**',
-            'src/*.{js,jsx,ts,tsx}',
         ],
 
         // After deprecated folders have been deleted:

--- a/ui/apps/platform/src/Containers/AppPage.tsx
+++ b/ui/apps/platform/src/Containers/AppPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/AppPageFavicon.tsx
+++ b/ui/apps/platform/src/Containers/AppPageFavicon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Helmet } from 'react-helmet';
 import { getProductBranding } from 'constants/productBranding';

--- a/ui/apps/platform/src/Containers/AppPageTitle.tsx
+++ b/ui/apps/platform/src/Containers/AppPageTitle.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import type { Location } from 'react-router-dom-v5-compat';

--- a/ui/apps/platform/src/Containers/ExportMenu.tsx
+++ b/ui/apps/platform/src/Containers/ExportMenu.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FileText, List } from 'react-feather';
 
 import exportPDF from 'services/PDFExportService';

--- a/ui/apps/platform/src/Containers/ReduxUserPermissionProvider.tsx
+++ b/ui/apps/platform/src/Containers/ReduxUserPermissionProvider.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 import type { Access } from 'types/role.proto';

--- a/ui/apps/platform/src/constants/listColumns.jsx
+++ b/ui/apps/platform/src/constants/listColumns.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { defaultColumnClassName, defaultHeaderClassName, wrapClassName } from 'Components/Table';
 import entityTypes, { resourceTypes } from 'constants/entityTypes';
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';

--- a/ui/apps/platform/src/hooks/useMetadata.test.tsx
+++ b/ui/apps/platform/src/hooks/useMetadata.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { renderHook } from '@testing-library/react';
 

--- a/ui/apps/platform/src/hooks/useTabs.test.jsx
+++ b/ui/apps/platform/src/hooks/useTabs.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render, renderHook, screen } from '@testing-library/react';
 
 import Tab from 'Components/Tab';

--- a/ui/apps/platform/src/hooks/useURLPagination.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLPagination.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 // import { createMemoryHistory } from 'history';
 import { MemoryRouter as Router, Route } from 'react-router-dom';

--- a/ui/apps/platform/src/hooks/useURLParameter.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLParameter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 // import { createMemoryHistory } from 'history';
 import { MemoryRouter as Router, Route } from 'react-router-dom';

--- a/ui/apps/platform/src/hooks/useURLSort.test.jsx
+++ b/ui/apps/platform/src/hooks/useURLSort.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom-v5-compat';
 import cloneDeep from 'lodash/cloneDeep';

--- a/ui/apps/platform/src/hooks/useURLStringUnion.test.tsx
+++ b/ui/apps/platform/src/hooks/useURLStringUnion.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryRouter, useLocation } from 'react-router-dom-v5-compat';
 import { renderHook } from '@testing-library/react';
 import actAndFlushTaskQueue from 'test-utils/flushTaskQueue';

--- a/ui/apps/platform/src/hooks/useWidgetConfig.test.tsx
+++ b/ui/apps/platform/src/hooks/useWidgetConfig.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import React from 'react';
 import { act, render, renderHook } from '@testing-library/react';
 import useWidgetConfig, { defaultStorageKey } from 'hooks/useWidgetConfig';
 

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -3,7 +3,6 @@
  * The rest of the files can be either TypeScript (.ts or .tsx) or JavaScript (.js).
  */
 
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 

--- a/ui/apps/platform/src/providers/FeatureFlagProvider.tsx
+++ b/ui/apps/platform/src/providers/FeatureFlagProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 
 import { FeatureFlagsContext } from 'hooks/useFeatureFlags';

--- a/ui/apps/platform/src/providers/MetadataProvider.tsx
+++ b/ui/apps/platform/src/providers/MetadataProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import type { ReactNode } from 'react';
 import isEqual from 'lodash/isEqual';
 

--- a/ui/apps/platform/src/providers/PublicConfigProvider.tsx
+++ b/ui/apps/platform/src/providers/PublicConfigProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 
 import { PublicConfigContext } from 'hooks/usePublicConfig';

--- a/ui/apps/platform/src/providers/TelemetryConfigProvider.tsx
+++ b/ui/apps/platform/src/providers/TelemetryConfigProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { ReactNode } from 'react';
 
 import useRestQuery from 'hooks/useRestQuery';

--- a/ui/apps/platform/src/providers/UserPermissionProvider.tsx
+++ b/ui/apps/platform/src/providers/UserPermissionProvider.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { UserPermissionContext } from 'hooks/usePermissions';
 

--- a/ui/apps/platform/src/test-utils/ComponentTestProvider.tsx
+++ b/ui/apps/platform/src/test-utils/ComponentTestProvider.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { createStore } from 'redux';
 import type { Store } from 'redux';

--- a/ui/apps/platform/src/test-utils/renderWithRedux.jsx
+++ b/ui/apps/platform/src/test-utils/renderWithRedux.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as rtlRender } from '@testing-library/react';
 import { Provider } from 'react-redux';
 

--- a/ui/apps/platform/src/test-utils/renderWithRouter.jsx
+++ b/ui/apps/platform/src/test-utils/renderWithRouter.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom-v5-compat';
 import { render } from '@testing-library/react';
 

--- a/ui/apps/platform/src/utils/vulnerabilityUtils.jsx
+++ b/ui/apps/platform/src/utils/vulnerabilityUtils.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import pluralize from 'pluralize';
 import reduce from 'lodash/reduce';
 


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

### Procedure

Select folders that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Run auto fix on command line to fix errors.
    Bonus: Delete orphan newline after comment that precedes deleted `import` statement.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.