### PR TITLE
ROX-31508: Delete React in Containers small subfolders

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -832,12 +832,6 @@ module.exports = [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/ComplianceEnhanced/**',
             'src/Containers/ConfigManagement/**',
-            'src/Containers/Docs/**',
-            'src/Containers/ExceptionConfiguration/**',
-            'src/Containers/Images/**',
-            'src/Containers/Login/**',
-            'src/Containers/MitreAttackVectors/**',
-            'src/Containers/Search/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',
             'src/Containers/Vulnerabilities/VirtualMachineCves/**',

--- a/ui/apps/platform/src/Containers/Docs/ApiPage.jsx
+++ b/ui/apps/platform/src/Containers/Docs/ApiPage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import SwaggerBrowser from './SwaggerBrowser';
 
 function ApiPage() {

--- a/ui/apps/platform/src/Containers/Docs/ApiPageV2.jsx
+++ b/ui/apps/platform/src/Containers/Docs/ApiPageV2.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import SwaggerBrowser from './SwaggerBrowser';
 
 function ApiPageV2() {

--- a/ui/apps/platform/src/Containers/Docs/SwaggerBrowser.jsx
+++ b/ui/apps/platform/src/Containers/Docs/SwaggerBrowser.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { RedocStandalone } from 'redoc';
 import Raven from 'raven-js';
 

--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/ExceptionConfigurationPage.tsx
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/ExceptionConfigurationPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Bullseye, PageSection, Spinner, Tab, Tabs, Title } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ExceptionConfiguration/VulnerabilitiesConfiguration.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
     Alert,
     AlertActionCloseButton,

--- a/ui/apps/platform/src/Containers/Images/CVETable.jsx
+++ b/ui/apps/platform/src/Containers/Images/CVETable.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Table, { defaultHeaderClassName } from 'Components/Table';
 import { Tooltip } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Images/VulnsTable.jsx
+++ b/ui/apps/platform/src/Containers/Images/VulnsTable.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Login/LoginNotice.tsx
+++ b/ui/apps/platform/src/Containers/Login/LoginNotice.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import usePublicConfig from 'hooks/usePublicConfig';
 
 export default function LoginNotice() {

--- a/ui/apps/platform/src/Containers/Login/LoginPage.jsx
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
 import { connect } from 'react-redux';

--- a/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.jsx
+++ b/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackLink.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackLink.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsView.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Flex, FlexItem, Spinner, TreeView } from '@patternfly/react-core';
 import type { TreeViewDataItem } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { gql, useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
+++ b/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 function NotApplicable(): ReactElement {

--- a/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchNavAndTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem, Nav, NavItem, NavList, Split, SplitItem } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex, FlexItem } from '@patternfly/react-core';


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

### Procedure

Select folders that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Run auto fix on command line to fix errors.
    Bonus: Delete orphan newline after comment that precedes deleted `import` statement.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.