### PR TITLE
refactor(perf): do not generate copyFrom columns on each large upsert

### DIFF
--- a/central/administration/events/datastore/internal/store/postgres/store.go
+++ b/central/administration/events/datastore/internal/store/postgres/store.go
@@ -118,6 +118,18 @@ func insertIntoAdministrationEvents(batch *pgx.Batch, obj *storage.Administratio
 	return nil
 }
 
+var copyColsAdministrationEvents = []string{
+	"id",
+	"type",
+	"level",
+	"domain",
+	"resource_type",
+	"numoccurrences",
+	"lastoccurredat",
+	"createdat",
+	"serialized",
+}
+
 func copyFromAdministrationEvents(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.AdministrationEvent) error {
 	if len(objs) == 0 {
 		return nil
@@ -133,18 +145,6 @@ func copyFromAdministrationEvents(ctx context.Context, s pgSearch.Deleter, tx *p
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"type",
-		"level",
-		"domain",
-		"resource_type",
-		"numoccurrences",
-		"lastoccurredat",
-		"createdat",
-		"serialized",
 	}
 
 	idx := 0
@@ -173,7 +173,7 @@ func copyFromAdministrationEvents(ctx context.Context, s pgSearch.Deleter, tx *p
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"administration_events"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"administration_events"}, copyColsAdministrationEvents, inputRows); err != nil {
 		return err
 	}
 

--- a/central/administration/usage/store/postgres/store.go
+++ b/central/administration/usage/store/postgres/store.go
@@ -114,6 +114,14 @@ func insertIntoSecuredUnits(batch *pgx.Batch, obj *storage.SecuredUnits) error {
 	return nil
 }
 
+var copyColsSecuredUnits = []string{
+	"id",
+	"timestamp",
+	"numnodes",
+	"numcpuunits",
+	"serialized",
+}
+
 func copyFromSecuredUnits(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.SecuredUnits) error {
 	if len(objs) == 0 {
 		return nil
@@ -129,14 +137,6 @@ func copyFromSecuredUnits(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"timestamp",
-		"numnodes",
-		"numcpuunits",
-		"serialized",
 	}
 
 	idx := 0
@@ -161,7 +161,7 @@ func copyFromSecuredUnits(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secured_units"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secured_units"}, copyColsSecuredUnits, inputRows); err != nil {
 		return err
 	}
 

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -166,6 +166,45 @@ func insertIntoAlerts(batch *pgx.Batch, obj *storage.Alert) error {
 	return nil
 }
 
+var copyColsAlerts = []string{
+	"id",
+	"policy_id",
+	"policy_name",
+	"policy_description",
+	"policy_disabled",
+	"policy_categories",
+	"policy_severity",
+	"policy_enforcementactions",
+	"policy_lastupdated",
+	"policy_sortname",
+	"policy_sortlifecyclestage",
+	"policy_sortenforcement",
+	"lifecyclestage",
+	"clusterid",
+	"clustername",
+	"namespace",
+	"namespaceid",
+	"deployment_id",
+	"deployment_name",
+	"deployment_inactive",
+	"image_id",
+	"image_name_registry",
+	"image_name_remote",
+	"image_name_tag",
+	"image_name_fullname",
+	"image_idv2",
+	"node_id",
+	"node_name",
+	"resource_resourcetype",
+	"resource_name",
+	"enforcement_action",
+	"time",
+	"state",
+	"platformcomponent",
+	"entitytype",
+	"serialized",
+}
+
 func copyFromAlerts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Alert) error {
 	if len(objs) == 0 {
 		return nil
@@ -181,45 +220,6 @@ func copyFromAlerts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"policy_id",
-		"policy_name",
-		"policy_description",
-		"policy_disabled",
-		"policy_categories",
-		"policy_severity",
-		"policy_enforcementactions",
-		"policy_lastupdated",
-		"policy_sortname",
-		"policy_sortlifecyclestage",
-		"policy_sortenforcement",
-		"lifecyclestage",
-		"clusterid",
-		"clustername",
-		"namespace",
-		"namespaceid",
-		"deployment_id",
-		"deployment_name",
-		"deployment_inactive",
-		"image_id",
-		"image_name_registry",
-		"image_name_remote",
-		"image_name_tag",
-		"image_name_fullname",
-		"image_idv2",
-		"node_id",
-		"node_name",
-		"resource_resourcetype",
-		"resource_name",
-		"enforcement_action",
-		"time",
-		"state",
-		"platformcomponent",
-		"entitytype",
-		"serialized",
 	}
 
 	idx := 0
@@ -275,7 +275,7 @@ func copyFromAlerts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"alerts"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"alerts"}, copyColsAlerts, inputRows); err != nil {
 		return err
 	}
 

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -112,6 +112,13 @@ func insertIntoAPITokens(batch *pgx.Batch, obj *storage.TokenMetadata) error {
 	return nil
 }
 
+var copyColsAPITokens = []string{
+	"id",
+	"expiration",
+	"revoked",
+	"serialized",
+}
+
 func copyFromAPITokens(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TokenMetadata) error {
 	if len(objs) == 0 {
 		return nil
@@ -127,13 +134,6 @@ func copyFromAPITokens(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"expiration",
-		"revoked",
-		"serialized",
 	}
 
 	idx := 0
@@ -157,7 +157,7 @@ func copyFromAPITokens(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"api_tokens"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"api_tokens"}, copyColsAPITokens, inputRows); err != nil {
 		return err
 	}
 

--- a/central/auth/store/postgres/store.go
+++ b/central/auth/store/postgres/store.go
@@ -133,6 +133,12 @@ func insertIntoAuthMachineToMachineConfigsMappings(batch *pgx.Batch, obj *storag
 	return nil
 }
 
+var copyColsAuthMachineToMachineConfigs = []string{
+	"id",
+	"issuer",
+	"serialized",
+}
+
 func copyFromAuthMachineToMachineConfigs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.AuthMachineToMachineConfig) error {
 	if len(objs) == 0 {
 		return nil
@@ -148,12 +154,6 @@ func copyFromAuthMachineToMachineConfigs(ctx context.Context, s pgSearch.Deleter
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"issuer",
-		"serialized",
 	}
 
 	idx := 0
@@ -176,7 +176,7 @@ func copyFromAuthMachineToMachineConfigs(ctx context.Context, s pgSearch.Deleter
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs"}, copyColsAuthMachineToMachineConfigs, inputRows); err != nil {
 		return err
 	}
 
@@ -189,15 +189,15 @@ func copyFromAuthMachineToMachineConfigs(ctx context.Context, s pgSearch.Deleter
 	return nil
 }
 
+var copyColsAuthMachineToMachineConfigsMappings = []string{
+	"auth_machine_to_machine_configs_id",
+	"idx",
+	"role",
+}
+
 func copyFromAuthMachineToMachineConfigsMappings(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, authMachineToMachineConfigID string, objs ...*storage.AuthMachineToMachineConfig_Mapping) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"auth_machine_to_machine_configs_id",
-		"idx",
-		"role",
 	}
 
 	idx := 0
@@ -215,7 +215,7 @@ func copyFromAuthMachineToMachineConfigsMappings(ctx context.Context, s pgSearch
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs_mappings"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_machine_to_machine_configs_mappings"}, copyColsAuthMachineToMachineConfigsMappings, inputRows); err != nil {
 		return err
 	}
 

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -110,6 +110,12 @@ func insertIntoAuthProviders(batch *pgx.Batch, obj *storage.AuthProvider) error 
 	return nil
 }
 
+var copyColsAuthProviders = []string{
+	"id",
+	"name",
+	"serialized",
+}
+
 func copyFromAuthProviders(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.AuthProvider) error {
 	if len(objs) == 0 {
 		return nil
@@ -125,12 +131,6 @@ func copyFromAuthProviders(ctx context.Context, s pgSearch.Deleter, tx *postgres
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -153,7 +153,7 @@ func copyFromAuthProviders(ctx context.Context, s pgSearch.Deleter, tx *postgres
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_providers"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"auth_providers"}, copyColsAuthProviders, inputRows); err != nil {
 		return err
 	}
 

--- a/central/baseimage/store/postgres/store.go
+++ b/central/baseimage/store/postgres/store.go
@@ -118,6 +118,18 @@ func insertIntoBaseImages(batch *pgx.Batch, obj *storage.BaseImage) error {
 	return nil
 }
 
+var copyColsBaseImages = []string{
+	"id",
+	"baseimagerepositoryid",
+	"repository",
+	"tag",
+	"manifestdigest",
+	"discoveredat",
+	"active",
+	"firstlayerdigest",
+	"serialized",
+}
+
 func copyFromBaseImages(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.BaseImage) error {
 	if len(objs) == 0 {
 		return nil
@@ -133,18 +145,6 @@ func copyFromBaseImages(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"baseimagerepositoryid",
-		"repository",
-		"tag",
-		"manifestdigest",
-		"discoveredat",
-		"active",
-		"firstlayerdigest",
-		"serialized",
 	}
 
 	idx := 0
@@ -173,7 +173,7 @@ func copyFromBaseImages(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_images"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_images"}, copyColsBaseImages, inputRows); err != nil {
 		return err
 	}
 

--- a/central/baseimage/store/repository/postgres/store.go
+++ b/central/baseimage/store/repository/postgres/store.go
@@ -108,6 +108,12 @@ func insertIntoBaseImageRepositories(batch *pgx.Batch, obj *storage.BaseImageRep
 	return nil
 }
 
+var copyColsBaseImageRepositories = []string{
+	"id",
+	"repositorypath",
+	"serialized",
+}
+
 func copyFromBaseImageRepositories(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.BaseImageRepository) error {
 	if len(objs) == 0 {
 		return nil
@@ -123,12 +129,6 @@ func copyFromBaseImageRepositories(ctx context.Context, s pgSearch.Deleter, tx *
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"repositorypath",
-		"serialized",
 	}
 
 	idx := 0
@@ -151,7 +151,7 @@ func copyFromBaseImageRepositories(ctx context.Context, s pgSearch.Deleter, tx *
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_image_repositories"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_image_repositories"}, copyColsBaseImageRepositories, inputRows); err != nil {
 		return err
 	}
 

--- a/central/baseimage/store/tag/postgres/store.go
+++ b/central/baseimage/store/tag/postgres/store.go
@@ -109,6 +109,13 @@ func insertIntoBaseImageTags(batch *pgx.Batch, obj *storage.BaseImageTag) error 
 	return nil
 }
 
+var copyColsBaseImageTags = []string{
+	"id",
+	"baseimagerepositoryid",
+	"tag",
+	"serialized",
+}
+
 func copyFromBaseImageTags(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.BaseImageTag) error {
 	if len(objs) == 0 {
 		return nil
@@ -124,13 +131,6 @@ func copyFromBaseImageTags(ctx context.Context, s pgSearch.Deleter, tx *postgres
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"baseimagerepositoryid",
-		"tag",
-		"serialized",
 	}
 
 	idx := 0
@@ -154,7 +154,7 @@ func copyFromBaseImageTags(ctx context.Context, s pgSearch.Deleter, tx *postgres
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_image_tags"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_image_tags"}, copyColsBaseImageTags, inputRows); err != nil {
 		return err
 	}
 

--- a/central/baseimagelayer/store/postgres/store.go
+++ b/central/baseimagelayer/store/postgres/store.go
@@ -113,6 +113,14 @@ func insertIntoBaseImageLayers(batch *pgx.Batch, obj *storage.BaseImageLayer) er
 	return nil
 }
 
+var copyColsBaseImageLayers = []string{
+	"id",
+	"baseimageid",
+	"layerdigest",
+	"index",
+	"serialized",
+}
+
 func copyFromBaseImageLayers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.BaseImageLayer) error {
 	if len(objs) == 0 {
 		return nil
@@ -128,14 +136,6 @@ func copyFromBaseImageLayers(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"baseimageid",
-		"layerdigest",
-		"index",
-		"serialized",
 	}
 
 	idx := 0
@@ -160,7 +160,7 @@ func copyFromBaseImageLayers(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_image_layers"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"base_image_layers"}, copyColsBaseImageLayers, inputRows); err != nil {
 		return err
 	}
 

--- a/central/blob/datastore/store/postgres/store.go
+++ b/central/blob/datastore/store/postgres/store.go
@@ -112,6 +112,13 @@ func insertIntoBlobs(batch *pgx.Batch, obj *storage.Blob) error {
 	return nil
 }
 
+var copyColsBlobs = []string{
+	"name",
+	"length",
+	"modifiedtime",
+	"serialized",
+}
+
 func copyFromBlobs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Blob) error {
 	if len(objs) == 0 {
 		return nil
@@ -127,13 +134,6 @@ func copyFromBlobs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"name",
-		"length",
-		"modifiedtime",
-		"serialized",
 	}
 
 	idx := 0
@@ -157,7 +157,7 @@ func copyFromBlobs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"blobs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"blobs"}, copyColsBlobs, inputRows); err != nil {
 		return err
 	}
 

--- a/central/cloudsources/datastore/internal/store/postgres/store.go
+++ b/central/cloudsources/datastore/internal/store/postgres/store.go
@@ -120,6 +120,13 @@ func insertIntoCloudSources(batch *pgx.Batch, obj *storage.CloudSource) error {
 	return nil
 }
 
+var copyColsCloudSources = []string{
+	"id",
+	"name",
+	"type",
+	"serialized",
+}
+
 func copyFromCloudSources(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.CloudSource) error {
 	if len(objs) == 0 {
 		return nil
@@ -135,13 +142,6 @@ func copyFromCloudSources(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"type",
-		"serialized",
 	}
 
 	idx := 0
@@ -165,7 +165,7 @@ func copyFromCloudSources(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cloud_sources"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cloud_sources"}, copyColsCloudSources, inputRows); err != nil {
 		return err
 	}
 

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -117,6 +117,17 @@ func insertIntoClusterHealthStatuses(batch *pgx.Batch, obj *storage.ClusterHealt
 	return nil
 }
 
+var copyColsClusterHealthStatuses = []string{
+	"id",
+	"sensorhealthstatus",
+	"collectorhealthstatus",
+	"overallhealthstatus",
+	"admissioncontrolhealthstatus",
+	"scannerhealthstatus",
+	"lastcontact",
+	"serialized",
+}
+
 func copyFromClusterHealthStatuses(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ClusterHealthStatus) error {
 	if len(objs) == 0 {
 		return nil
@@ -132,17 +143,6 @@ func copyFromClusterHealthStatuses(ctx context.Context, s pgSearch.Deleter, tx *
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"sensorhealthstatus",
-		"collectorhealthstatus",
-		"overallhealthstatus",
-		"admissioncontrolhealthstatus",
-		"scannerhealthstatus",
-		"lastcontact",
-		"serialized",
 	}
 
 	idx := 0
@@ -170,7 +170,7 @@ func copyFromClusterHealthStatuses(ctx context.Context, s pgSearch.Deleter, tx *
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_health_statuses"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_health_statuses"}, copyColsClusterHealthStatuses, inputRows); err != nil {
 		return err
 	}
 

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -114,6 +114,11 @@ func insertIntoClusterInitBundles(batch *pgx.Batch, obj *storage.InitBundleMeta)
 	return nil
 }
 
+var copyColsClusterInitBundles = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromClusterInitBundles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.InitBundleMeta) error {
 	if len(objs) == 0 {
 		return nil
@@ -129,11 +134,6 @@ func copyFromClusterInitBundles(ctx context.Context, s pgSearch.Deleter, tx *pos
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -155,7 +155,7 @@ func copyFromClusterInitBundles(ctx context.Context, s pgSearch.Deleter, tx *pos
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_init_bundles"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_init_bundles"}, copyColsClusterInitBundles, inputRows); err != nil {
 		return err
 	}
 

--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store.go
@@ -106,6 +106,11 @@ func insertIntoComplianceConfigs(batch *pgx.Batch, obj *storage.ComplianceConfig
 	return nil
 }
 
+var copyColsComplianceConfigs = []string{
+	"standardid",
+	"serialized",
+}
+
 func copyFromComplianceConfigs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceConfig) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromComplianceConfigs(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"standardid",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromComplianceConfigs(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_configs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_configs"}, copyColsComplianceConfigs, inputRows); err != nil {
 		return err
 	}
 

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -109,6 +109,11 @@ func insertIntoComplianceDomains(batch *pgx.Batch, obj *storage.ComplianceDomain
 	return nil
 }
 
+var copyColsComplianceDomains = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromComplianceDomains(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceDomain) error {
 	if len(objs) == 0 {
 		return nil
@@ -124,11 +129,6 @@ func copyFromComplianceDomains(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -150,7 +150,7 @@ func copyFromComplianceDomains(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_domains"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_domains"}, copyColsComplianceDomains, inputRows); err != nil {
 		return err
 	}
 

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -135,6 +135,14 @@ func insertIntoComplianceRunMetadata(batch *pgx.Batch, obj *storage.ComplianceRu
 	return nil
 }
 
+var copyColsComplianceRunMetadata = []string{
+	"runid",
+	"standardid",
+	"clusterid",
+	"finishtimestamp",
+	"serialized",
+}
+
 func copyFromComplianceRunMetadata(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceRunMetadata) error {
 	if len(objs) == 0 {
 		return nil
@@ -150,14 +158,6 @@ func copyFromComplianceRunMetadata(ctx context.Context, s pgSearch.Deleter, tx *
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"runid",
-		"standardid",
-		"clusterid",
-		"finishtimestamp",
-		"serialized",
 	}
 
 	idx := 0
@@ -182,7 +182,7 @@ func copyFromComplianceRunMetadata(ctx context.Context, s pgSearch.Deleter, tx *
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_run_metadata"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_run_metadata"}, copyColsComplianceRunMetadata, inputRows); err != nil {
 		return err
 	}
 

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -135,6 +135,14 @@ func insertIntoComplianceRunResults(batch *pgx.Batch, obj *storage.ComplianceRun
 	return nil
 }
 
+var copyColsComplianceRunResults = []string{
+	"runmetadata_runid",
+	"runmetadata_standardid",
+	"runmetadata_clusterid",
+	"runmetadata_finishtimestamp",
+	"serialized",
+}
+
 func copyFromComplianceRunResults(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceRunResults) error {
 	if len(objs) == 0 {
 		return nil
@@ -150,14 +158,6 @@ func copyFromComplianceRunResults(ctx context.Context, s pgSearch.Deleter, tx *p
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"runmetadata_runid",
-		"runmetadata_standardid",
-		"runmetadata_clusterid",
-		"runmetadata_finishtimestamp",
-		"serialized",
 	}
 
 	idx := 0
@@ -182,7 +182,7 @@ func copyFromComplianceRunResults(ctx context.Context, s pgSearch.Deleter, tx *p
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_run_results"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_run_results"}, copyColsComplianceRunResults, inputRows); err != nil {
 		return err
 	}
 

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -106,6 +106,11 @@ func insertIntoComplianceStrings(batch *pgx.Batch, obj *storage.ComplianceString
 	return nil
 }
 
+var copyColsComplianceStrings = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromComplianceStrings(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceStrings) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromComplianceStrings(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromComplianceStrings(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_strings"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_strings"}, copyColsComplianceStrings, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoComplianceOperatorCheckResults(batch *pgx.Batch, obj *storage.Com
 	return nil
 }
 
+var copyColsComplianceOperatorCheckResults = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromComplianceOperatorCheckResults(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorCheckResult) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromComplianceOperatorCheckResults(ctx context.Context, s pgSearch.Dele
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromComplianceOperatorCheckResults(ctx context.Context, s pgSearch.Dele
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_results"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_results"}, copyColsComplianceOperatorCheckResults, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoComplianceOperatorProfiles(batch *pgx.Batch, obj *storage.Complia
 	return nil
 }
 
+var copyColsComplianceOperatorProfiles = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromComplianceOperatorProfiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorProfile) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromComplianceOperatorProfiles(ctx context.Context, s pgSearch.Deleter,
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromComplianceOperatorProfiles(ctx context.Context, s pgSearch.Deleter,
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profiles"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profiles"}, copyColsComplianceOperatorProfiles, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoComplianceOperatorRules(batch *pgx.Batch, obj *storage.Compliance
 	return nil
 }
 
+var copyColsComplianceOperatorRules = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromComplianceOperatorRules(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorRule) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromComplianceOperatorRules(ctx context.Context, s pgSearch.Deleter, tx
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromComplianceOperatorRules(ctx context.Context, s pgSearch.Deleter, tx
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rules"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rules"}, copyColsComplianceOperatorRules, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoComplianceOperatorScans(batch *pgx.Batch, obj *storage.Compliance
 	return nil
 }
 
+var copyColsComplianceOperatorScans = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromComplianceOperatorScans(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorScan) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromComplianceOperatorScans(ctx context.Context, s pgSearch.Deleter, tx
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromComplianceOperatorScans(ctx context.Context, s pgSearch.Deleter, tx
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scans"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scans"}, copyColsComplianceOperatorScans, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoComplianceOperatorScanSettingBindings(batch *pgx.Batch, obj *stor
 	return nil
 }
 
+var copyColsComplianceOperatorScanSettingBindings = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromComplianceOperatorScanSettingBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorScanSettingBinding) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromComplianceOperatorScanSettingBindings(ctx context.Context, s pgSear
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromComplianceOperatorScanSettingBindings(ctx context.Context, s pgSear
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_bindings"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_bindings"}, copyColsComplianceOperatorScanSettingBindings, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/benchmarks/store/postgres/store.go
+++ b/central/complianceoperator/v2/benchmarks/store/postgres/store.go
@@ -139,6 +139,14 @@ func insertIntoComplianceOperatorBenchmarkV2Profiles(batch *pgx.Batch, obj *stor
 	return nil
 }
 
+var copyColsComplianceOperatorBenchmarkV2 = []string{
+	"id",
+	"name",
+	"version",
+	"shortname",
+	"serialized",
+}
+
 func copyFromComplianceOperatorBenchmarkV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorBenchmarkV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -154,14 +162,6 @@ func copyFromComplianceOperatorBenchmarkV2(ctx context.Context, s pgSearch.Delet
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"version",
-		"shortname",
-		"serialized",
 	}
 
 	idx := 0
@@ -186,7 +186,7 @@ func copyFromComplianceOperatorBenchmarkV2(ctx context.Context, s pgSearch.Delet
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2"}, copyColsComplianceOperatorBenchmarkV2, inputRows); err != nil {
 		return err
 	}
 
@@ -199,16 +199,16 @@ func copyFromComplianceOperatorBenchmarkV2(ctx context.Context, s pgSearch.Delet
 	return nil
 }
 
+var copyColsComplianceOperatorBenchmarkV2Profiles = []string{
+	"compliance_operator_benchmark_v2_id",
+	"idx",
+	"profilename",
+	"profileversion",
+}
+
 func copyFromComplianceOperatorBenchmarkV2Profiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, complianceOperatorBenchmarkV2ID string, objs ...*storage.ComplianceOperatorBenchmarkV2_Profile) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"compliance_operator_benchmark_v2_id",
-		"idx",
-		"profilename",
-		"profileversion",
 	}
 
 	idx := 0
@@ -227,7 +227,7 @@ func copyFromComplianceOperatorBenchmarkV2Profiles(ctx context.Context, s pgSear
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2_profiles"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_benchmark_v2_profiles"}, copyColsComplianceOperatorBenchmarkV2Profiles, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/v2/checkresults/store/postgres/store.go
@@ -143,6 +143,22 @@ func insertIntoComplianceOperatorCheckResultV2(batch *pgx.Batch, obj *storage.Co
 	return nil
 }
 
+var copyColsComplianceOperatorCheckResultV2 = []string{
+	"id",
+	"checkid",
+	"checkname",
+	"clusterid",
+	"status",
+	"severity",
+	"createdtime",
+	"scanconfigname",
+	"rationale",
+	"scanrefid",
+	"rulerefid",
+	"laststartedtime",
+	"serialized",
+}
+
 func copyFromComplianceOperatorCheckResultV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorCheckResultV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -158,22 +174,6 @@ func copyFromComplianceOperatorCheckResultV2(ctx context.Context, s pgSearch.Del
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"checkid",
-		"checkname",
-		"clusterid",
-		"status",
-		"severity",
-		"createdtime",
-		"scanconfigname",
-		"rationale",
-		"scanrefid",
-		"rulerefid",
-		"laststartedtime",
-		"serialized",
 	}
 
 	idx := 0
@@ -206,7 +206,7 @@ func copyFromComplianceOperatorCheckResultV2(ctx context.Context, s pgSearch.Del
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_result_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_check_result_v2"}, copyColsComplianceOperatorCheckResultV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/integration/store/postgres/store.go
+++ b/central/complianceoperator/v2/integration/store/postgres/store.go
@@ -135,6 +135,15 @@ func insertIntoComplianceIntegrations(batch *pgx.Batch, obj *storage.ComplianceI
 	return nil
 }
 
+var copyColsComplianceIntegrations = []string{
+	"id",
+	"version",
+	"clusterid",
+	"operatorinstalled",
+	"operatorstatus",
+	"serialized",
+}
+
 func copyFromComplianceIntegrations(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceIntegration) error {
 	if len(objs) == 0 {
 		return nil
@@ -150,15 +159,6 @@ func copyFromComplianceIntegrations(ctx context.Context, s pgSearch.Deleter, tx 
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"version",
-		"clusterid",
-		"operatorinstalled",
-		"operatorstatus",
-		"serialized",
 	}
 
 	idx := 0
@@ -184,7 +184,7 @@ func copyFromComplianceIntegrations(ctx context.Context, s pgSearch.Deleter, tx 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_integrations"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_integrations"}, copyColsComplianceIntegrations, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/profiles/store/postgres/store.go
+++ b/central/complianceoperator/v2/profiles/store/postgres/store.go
@@ -163,6 +163,18 @@ func insertIntoComplianceOperatorProfileV2Rules(batch *pgx.Batch, obj *storage.C
 	return nil
 }
 
+var copyColsComplianceOperatorProfileV2 = []string{
+	"id",
+	"profileid",
+	"name",
+	"profileversion",
+	"producttype",
+	"standard",
+	"clusterid",
+	"profilerefid",
+	"serialized",
+}
+
 func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorProfileV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -178,18 +190,6 @@ func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"profileid",
-		"name",
-		"profileversion",
-		"producttype",
-		"standard",
-		"clusterid",
-		"profilerefid",
-		"serialized",
 	}
 
 	idx := 0
@@ -218,7 +218,7 @@ func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2"}, copyColsComplianceOperatorProfileV2, inputRows); err != nil {
 		return err
 	}
 
@@ -231,15 +231,15 @@ func copyFromComplianceOperatorProfileV2(ctx context.Context, s pgSearch.Deleter
 	return nil
 }
 
+var copyColsComplianceOperatorProfileV2Rules = []string{
+	"compliance_operator_profile_v2_id",
+	"idx",
+	"rulename",
+}
+
 func copyFromComplianceOperatorProfileV2Rules(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, complianceOperatorProfileV2ID string, objs ...*storage.ComplianceOperatorProfileV2_Rule) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"compliance_operator_profile_v2_id",
-		"idx",
-		"rulename",
 	}
 
 	idx := 0
@@ -257,7 +257,7 @@ func copyFromComplianceOperatorProfileV2Rules(ctx context.Context, s pgSearch.De
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2_rules"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_profile_v2_rules"}, copyColsComplianceOperatorProfileV2Rules, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/remediations/store/postgres/store.go
+++ b/central/complianceoperator/v2/remediations/store/postgres/store.go
@@ -134,6 +134,14 @@ func insertIntoComplianceOperatorRemediationV2(batch *pgx.Batch, obj *storage.Co
 	return nil
 }
 
+var copyColsComplianceOperatorRemediationV2 = []string{
+	"id",
+	"name",
+	"compliancecheckresultname",
+	"clusterid",
+	"serialized",
+}
+
 func copyFromComplianceOperatorRemediationV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorRemediationV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -149,14 +157,6 @@ func copyFromComplianceOperatorRemediationV2(ctx context.Context, s pgSearch.Del
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"compliancecheckresultname",
-		"clusterid",
-		"serialized",
 	}
 
 	idx := 0
@@ -181,7 +181,7 @@ func copyFromComplianceOperatorRemediationV2(ctx context.Context, s pgSearch.Del
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_remediation_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_remediation_v2"}, copyColsComplianceOperatorRemediationV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/report/store/postgres/store.go
+++ b/central/complianceoperator/v2/report/store/postgres/store.go
@@ -146,6 +146,20 @@ func insertIntoComplianceOperatorReportSnapshotV2Scans(batch *pgx.Batch, obj *st
 	return nil
 }
 
+var copyColsComplianceOperatorReportSnapshotV2 = []string{
+	"reportid",
+	"scanconfigurationid",
+	"name",
+	"reportstatus_runstate",
+	"reportstatus_startedat",
+	"reportstatus_completedat",
+	"reportstatus_reportrequesttype",
+	"reportstatus_reportnotificationmethod",
+	"user_id",
+	"user_name",
+	"serialized",
+}
+
 func copyFromComplianceOperatorReportSnapshotV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorReportSnapshotV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -161,20 +175,6 @@ func copyFromComplianceOperatorReportSnapshotV2(ctx context.Context, s pgSearch.
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"reportid",
-		"scanconfigurationid",
-		"name",
-		"reportstatus_runstate",
-		"reportstatus_startedat",
-		"reportstatus_completedat",
-		"reportstatus_reportrequesttype",
-		"reportstatus_reportnotificationmethod",
-		"user_id",
-		"user_name",
-		"serialized",
 	}
 
 	idx := 0
@@ -205,7 +205,7 @@ func copyFromComplianceOperatorReportSnapshotV2(ctx context.Context, s pgSearch.
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_report_snapshot_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_report_snapshot_v2"}, copyColsComplianceOperatorReportSnapshotV2, inputRows); err != nil {
 		return err
 	}
 
@@ -218,16 +218,16 @@ func copyFromComplianceOperatorReportSnapshotV2(ctx context.Context, s pgSearch.
 	return nil
 }
 
+var copyColsComplianceOperatorReportSnapshotV2Scans = []string{
+	"compliance_operator_report_snapshot_v2_reportid",
+	"idx",
+	"scanrefid",
+	"laststartedtime",
+}
+
 func copyFromComplianceOperatorReportSnapshotV2Scans(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, complianceOperatorReportSnapshotV2ReportId string, objs ...*storage.ComplianceOperatorReportSnapshotV2_Scan) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"compliance_operator_report_snapshot_v2_reportid",
-		"idx",
-		"scanrefid",
-		"laststartedtime",
 	}
 
 	idx := 0
@@ -246,7 +246,7 @@ func copyFromComplianceOperatorReportSnapshotV2Scans(ctx context.Context, s pgSe
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_report_snapshot_v2_scans"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_report_snapshot_v2_scans"}, copyColsComplianceOperatorReportSnapshotV2Scans, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/rules/store/postgres/store.go
+++ b/central/complianceoperator/v2/rules/store/postgres/store.go
@@ -162,6 +162,16 @@ func insertIntoComplianceOperatorRuleV2Controls(batch *pgx.Batch, obj *storage.R
 	return nil
 }
 
+var copyColsComplianceOperatorRuleV2 = []string{
+	"id",
+	"name",
+	"ruletype",
+	"severity",
+	"clusterid",
+	"rulerefid",
+	"serialized",
+}
+
 func copyFromComplianceOperatorRuleV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorRuleV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -177,16 +187,6 @@ func copyFromComplianceOperatorRuleV2(ctx context.Context, s pgSearch.Deleter, t
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"ruletype",
-		"severity",
-		"clusterid",
-		"rulerefid",
-		"serialized",
 	}
 
 	idx := 0
@@ -213,7 +213,7 @@ func copyFromComplianceOperatorRuleV2(ctx context.Context, s pgSearch.Deleter, t
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rule_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rule_v2"}, copyColsComplianceOperatorRuleV2, inputRows); err != nil {
 		return err
 	}
 
@@ -226,16 +226,16 @@ func copyFromComplianceOperatorRuleV2(ctx context.Context, s pgSearch.Deleter, t
 	return nil
 }
 
+var copyColsComplianceOperatorRuleV2Controls = []string{
+	"compliance_operator_rule_v2_id",
+	"idx",
+	"standard",
+	"control",
+}
+
 func copyFromComplianceOperatorRuleV2Controls(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, complianceOperatorRuleV2ID string, objs ...*storage.RuleControls) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"compliance_operator_rule_v2_id",
-		"idx",
-		"standard",
-		"control",
 	}
 
 	idx := 0
@@ -254,7 +254,7 @@ func copyFromComplianceOperatorRuleV2Controls(ctx context.Context, s pgSearch.De
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rule_v2_controls"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_rule_v2_controls"}, copyColsComplianceOperatorRuleV2Controls, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/scanconfigstatus/store/postgres/store.go
@@ -135,6 +135,14 @@ func insertIntoComplianceOperatorClusterScanConfigStatuses(batch *pgx.Batch, obj
 	return nil
 }
 
+var copyColsComplianceOperatorClusterScanConfigStatuses = []string{
+	"id",
+	"clusterid",
+	"scanconfigid",
+	"lastupdatedtime",
+	"serialized",
+}
+
 func copyFromComplianceOperatorClusterScanConfigStatuses(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorClusterScanConfigStatus) error {
 	if len(objs) == 0 {
 		return nil
@@ -150,14 +158,6 @@ func copyFromComplianceOperatorClusterScanConfigStatuses(ctx context.Context, s 
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"clusterid",
-		"scanconfigid",
-		"lastupdatedtime",
-		"serialized",
 	}
 
 	idx := 0
@@ -182,7 +182,7 @@ func copyFromComplianceOperatorClusterScanConfigStatuses(ctx context.Context, s 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_cluster_scan_config_statuses"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_cluster_scan_config_statuses"}, copyColsComplianceOperatorClusterScanConfigStatuses, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
+++ b/central/complianceoperator/v2/scanconfigurations/store/postgres/store.go
@@ -183,6 +183,13 @@ func insertIntoComplianceOperatorScanConfigurationV2Notifiers(batch *pgx.Batch, 
 	return nil
 }
 
+var copyColsComplianceOperatorScanConfigurationV2 = []string{
+	"id",
+	"scanconfigname",
+	"modifiedby_name",
+	"serialized",
+}
+
 func copyFromComplianceOperatorScanConfigurationV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorScanConfigurationV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -198,13 +205,6 @@ func copyFromComplianceOperatorScanConfigurationV2(ctx context.Context, s pgSear
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"scanconfigname",
-		"modifiedby_name",
-		"serialized",
 	}
 
 	idx := 0
@@ -228,7 +228,7 @@ func copyFromComplianceOperatorScanConfigurationV2(ctx context.Context, s pgSear
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2"}, copyColsComplianceOperatorScanConfigurationV2, inputRows); err != nil {
 		return err
 	}
 
@@ -247,15 +247,15 @@ func copyFromComplianceOperatorScanConfigurationV2(ctx context.Context, s pgSear
 	return nil
 }
 
+var copyColsComplianceOperatorScanConfigurationV2Profiles = []string{
+	"compliance_operator_scan_configuration_v2_id",
+	"idx",
+	"profilename",
+}
+
 func copyFromComplianceOperatorScanConfigurationV2Profiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, complianceOperatorScanConfigurationV2ID string, objs ...*storage.ComplianceOperatorScanConfigurationV2_ProfileName) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"compliance_operator_scan_configuration_v2_id",
-		"idx",
-		"profilename",
 	}
 
 	idx := 0
@@ -273,22 +273,22 @@ func copyFromComplianceOperatorScanConfigurationV2Profiles(ctx context.Context, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_profiles"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_profiles"}, copyColsComplianceOperatorScanConfigurationV2Profiles, inputRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+var copyColsComplianceOperatorScanConfigurationV2Clusters = []string{
+	"compliance_operator_scan_configuration_v2_id",
+	"idx",
+	"clusterid",
+}
+
 func copyFromComplianceOperatorScanConfigurationV2Clusters(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, complianceOperatorScanConfigurationV2ID string, objs ...*storage.ComplianceOperatorScanConfigurationV2_Cluster) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"compliance_operator_scan_configuration_v2_id",
-		"idx",
-		"clusterid",
 	}
 
 	idx := 0
@@ -306,22 +306,22 @@ func copyFromComplianceOperatorScanConfigurationV2Clusters(ctx context.Context, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_clusters"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_clusters"}, copyColsComplianceOperatorScanConfigurationV2Clusters, inputRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+var copyColsComplianceOperatorScanConfigurationV2Notifiers = []string{
+	"compliance_operator_scan_configuration_v2_id",
+	"idx",
+	"id",
+}
+
 func copyFromComplianceOperatorScanConfigurationV2Notifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, complianceOperatorScanConfigurationV2ID string, objs ...*storage.NotifierConfiguration) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"compliance_operator_scan_configuration_v2_id",
-		"idx",
-		"id",
 	}
 
 	idx := 0
@@ -339,7 +339,7 @@ func copyFromComplianceOperatorScanConfigurationV2Notifiers(ctx context.Context,
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_notifiers"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_configuration_v2_notifiers"}, copyColsComplianceOperatorScanConfigurationV2Notifiers, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/scans/store/postgres/store.go
+++ b/central/complianceoperator/v2/scans/store/postgres/store.go
@@ -140,6 +140,19 @@ func insertIntoComplianceOperatorScanV2(batch *pgx.Batch, obj *storage.Complianc
 	return nil
 }
 
+var copyColsComplianceOperatorScanV2 = []string{
+	"id",
+	"scanconfigname",
+	"clusterid",
+	"profile_profilerefid",
+	"status_result",
+	"lastexecutedtime",
+	"scanname",
+	"scanrefid",
+	"laststartedtime",
+	"serialized",
+}
+
 func copyFromComplianceOperatorScanV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorScanV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -155,19 +168,6 @@ func copyFromComplianceOperatorScanV2(ctx context.Context, s pgSearch.Deleter, t
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"scanconfigname",
-		"clusterid",
-		"profile_profilerefid",
-		"status_result",
-		"lastexecutedtime",
-		"scanname",
-		"scanrefid",
-		"laststartedtime",
-		"serialized",
 	}
 
 	idx := 0
@@ -197,7 +197,7 @@ func copyFromComplianceOperatorScanV2(ctx context.Context, s pgSearch.Deleter, t
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_v2"}, copyColsComplianceOperatorScanV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
+++ b/central/complianceoperator/v2/scansettingbindings/store/postgres/store.go
@@ -134,6 +134,14 @@ func insertIntoComplianceOperatorScanSettingBindingV2(batch *pgx.Batch, obj *sto
 	return nil
 }
 
+var copyColsComplianceOperatorScanSettingBindingV2 = []string{
+	"id",
+	"name",
+	"clusterid",
+	"scansettingname",
+	"serialized",
+}
+
 func copyFromComplianceOperatorScanSettingBindingV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorScanSettingBindingV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -149,14 +157,6 @@ func copyFromComplianceOperatorScanSettingBindingV2(ctx context.Context, s pgSea
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"clusterid",
-		"scansettingname",
-		"serialized",
 	}
 
 	idx := 0
@@ -181,7 +181,7 @@ func copyFromComplianceOperatorScanSettingBindingV2(ctx context.Context, s pgSea
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_binding_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_scan_setting_binding_v2"}, copyColsComplianceOperatorScanSettingBindingV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/complianceoperator/v2/suites/store/postgres/store.go
+++ b/central/complianceoperator/v2/suites/store/postgres/store.go
@@ -133,6 +133,13 @@ func insertIntoComplianceOperatorSuiteV2(batch *pgx.Batch, obj *storage.Complian
 	return nil
 }
 
+var copyColsComplianceOperatorSuiteV2 = []string{
+	"id",
+	"name",
+	"clusterid",
+	"serialized",
+}
+
 func copyFromComplianceOperatorSuiteV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ComplianceOperatorSuiteV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -148,13 +155,6 @@ func copyFromComplianceOperatorSuiteV2(ctx context.Context, s pgSearch.Deleter, 
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"clusterid",
-		"serialized",
 	}
 
 	idx := 0
@@ -178,7 +178,7 @@ func copyFromComplianceOperatorSuiteV2(ctx context.Context, s pgSearch.Deleter, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_suite_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"compliance_operator_suite_v2"}, copyColsComplianceOperatorSuiteV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -120,6 +120,21 @@ func insertIntoClusterCves(batch *pgx.Batch, obj *storage.ClusterCVE) error {
 	return nil
 }
 
+var copyColsClusterCves = []string{
+	"id",
+	"cvebaseinfo_cve",
+	"cvebaseinfo_publishedon",
+	"cvebaseinfo_createdat",
+	"cvebaseinfo_epss_epssprobability",
+	"cvss",
+	"severity",
+	"impactscore",
+	"snoozed",
+	"snoozeexpiry",
+	"type",
+	"serialized",
+}
+
 func copyFromClusterCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ClusterCVE) error {
 	if len(objs) == 0 {
 		return nil
@@ -135,21 +150,6 @@ func copyFromClusterCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"cvebaseinfo_cve",
-		"cvebaseinfo_publishedon",
-		"cvebaseinfo_createdat",
-		"cvebaseinfo_epss_epssprobability",
-		"cvss",
-		"severity",
-		"impactscore",
-		"snoozed",
-		"snoozeexpiry",
-		"type",
-		"serialized",
 	}
 
 	idx := 0
@@ -181,7 +181,7 @@ func copyFromClusterCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_cves"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"cluster_cves"}, copyColsClusterCves, inputRows); err != nil {
 		return err
 	}
 

--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -128,6 +128,28 @@ func insertIntoImageCvesV2(batch *pgx.Batch, obj *storage.ImageCVEV2) error {
 	return nil
 }
 
+var copyColsImageCvesV2 = []string{
+	"id",
+	"imageid",
+	"cvebaseinfo_cve",
+	"cvebaseinfo_publishedon",
+	"cvebaseinfo_createdat",
+	"cvebaseinfo_epss_epssprobability",
+	"cvss",
+	"severity",
+	"impactscore",
+	"nvdcvss",
+	"firstimageoccurrence",
+	"state",
+	"isfixable",
+	"fixedby",
+	"componentid",
+	"advisory_name",
+	"advisory_link",
+	"imageidv2",
+	"serialized",
+}
+
 func copyFromImageCvesV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ImageCVEV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -143,28 +165,6 @@ func copyFromImageCvesV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"imageid",
-		"cvebaseinfo_cve",
-		"cvebaseinfo_publishedon",
-		"cvebaseinfo_createdat",
-		"cvebaseinfo_epss_epssprobability",
-		"cvss",
-		"severity",
-		"impactscore",
-		"nvdcvss",
-		"firstimageoccurrence",
-		"state",
-		"isfixable",
-		"fixedby",
-		"componentid",
-		"advisory_name",
-		"advisory_link",
-		"imageidv2",
-		"serialized",
 	}
 
 	idx := 0
@@ -203,7 +203,7 @@ func copyFromImageCvesV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_cves_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_cves_v2"}, copyColsImageCvesV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -122,6 +122,23 @@ func insertIntoNodeCves(batch *pgx.Batch, obj *storage.NodeCVE) error {
 	return nil
 }
 
+var copyColsNodeCves = []string{
+	"id",
+	"cvebaseinfo_cve",
+	"cvebaseinfo_publishedon",
+	"cvebaseinfo_createdat",
+	"cvebaseinfo_epss_epssprobability",
+	"operatingsystem",
+	"cvss",
+	"severity",
+	"impactscore",
+	"snoozed",
+	"snoozeexpiry",
+	"orphaned",
+	"orphanedtime",
+	"serialized",
+}
+
 func copyFromNodeCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NodeCVE) error {
 	if len(objs) == 0 {
 		return nil
@@ -137,23 +154,6 @@ func copyFromNodeCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"cvebaseinfo_cve",
-		"cvebaseinfo_publishedon",
-		"cvebaseinfo_createdat",
-		"cvebaseinfo_epss_epssprobability",
-		"operatingsystem",
-		"cvss",
-		"severity",
-		"impactscore",
-		"snoozed",
-		"snoozeexpiry",
-		"orphaned",
-		"orphanedtime",
-		"serialized",
 	}
 
 	idx := 0
@@ -187,7 +187,7 @@ func copyFromNodeCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_cves"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_cves"}, copyColsNodeCves, inputRows); err != nil {
 		return err
 	}
 

--- a/central/declarativeconfig/health/datastore/store/postgres/store.go
+++ b/central/declarativeconfig/health/datastore/store/postgres/store.go
@@ -107,6 +107,11 @@ func insertIntoDeclarativeConfigHealths(batch *pgx.Batch, obj *storage.Declarati
 	return nil
 }
 
+var copyColsDeclarativeConfigHealths = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromDeclarativeConfigHealths(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.DeclarativeConfigHealth) error {
 	if len(objs) == 0 {
 		return nil
@@ -122,11 +127,6 @@ func copyFromDeclarativeConfigHealths(ctx context.Context, s pgSearch.Deleter, t
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -148,7 +148,7 @@ func copyFromDeclarativeConfigHealths(ctx context.Context, s pgSearch.Deleter, t
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"declarative_config_healths"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"declarative_config_healths"}, copyColsDeclarativeConfigHealths, inputRows); err != nil {
 		return err
 	}
 

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -333,6 +333,28 @@ func insertIntoDeploymentsPortsExposureInfos(batch *pgx.Batch, obj *storage.Port
 	return nil
 }
 
+var copyColsDeployments = []string{
+	"id",
+	"name",
+	"type",
+	"namespace",
+	"namespaceid",
+	"orchestratorcomponent",
+	"labels",
+	"podlabels",
+	"created",
+	"clusterid",
+	"clustername",
+	"annotations",
+	"priority",
+	"imagepullsecrets",
+	"serviceaccount",
+	"serviceaccountpermissionlevel",
+	"riskscore",
+	"platformcomponent",
+	"serialized",
+}
+
 func copyFromDeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Deployment) error {
 	if len(objs) == 0 {
 		return nil
@@ -348,28 +370,6 @@ func copyFromDeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"type",
-		"namespace",
-		"namespaceid",
-		"orchestratorcomponent",
-		"labels",
-		"podlabels",
-		"created",
-		"clusterid",
-		"clustername",
-		"annotations",
-		"priority",
-		"imagepullsecrets",
-		"serviceaccount",
-		"serviceaccountpermissionlevel",
-		"riskscore",
-		"platformcomponent",
-		"serialized",
 	}
 
 	idx := 0
@@ -408,7 +408,7 @@ func copyFromDeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments"}, copyColsDeployments, inputRows); err != nil {
 		return err
 	}
 
@@ -424,28 +424,28 @@ func copyFromDeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	return nil
 }
 
+var copyColsDeploymentsContainers = []string{
+	"deployments_id",
+	"idx",
+	"image_id",
+	"image_name_registry",
+	"image_name_remote",
+	"image_name_tag",
+	"image_name_fullname",
+	"image_idv2",
+	"securitycontext_privileged",
+	"securitycontext_dropcapabilities",
+	"securitycontext_addcapabilities",
+	"securitycontext_readonlyrootfilesystem",
+	"resources_cpucoresrequest",
+	"resources_cpucoreslimit",
+	"resources_memorymbrequest",
+	"resources_memorymblimit",
+}
+
 func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, objs ...*storage.Container) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"deployments_id",
-		"idx",
-		"image_id",
-		"image_name_registry",
-		"image_name_remote",
-		"image_name_tag",
-		"image_name_fullname",
-		"image_idv2",
-		"securitycontext_privileged",
-		"securitycontext_dropcapabilities",
-		"securitycontext_addcapabilities",
-		"securitycontext_readonlyrootfilesystem",
-		"resources_cpucoresrequest",
-		"resources_cpucoreslimit",
-		"resources_memorymbrequest",
-		"resources_memorymblimit",
 	}
 
 	idx := 0
@@ -476,7 +476,7 @@ func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers"}, copyColsDeploymentsContainers, inputRows); err != nil {
 		return err
 	}
 
@@ -495,18 +495,18 @@ func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *
 	return nil
 }
 
+var copyColsDeploymentsContainersEnvs = []string{
+	"deployments_id",
+	"deployments_containers_idx",
+	"idx",
+	"key",
+	"value",
+	"envvarsource",
+}
+
 func copyFromDeploymentsContainersEnvs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, deploymentContainerIdx int, objs ...*storage.ContainerConfig_EnvironmentConfig) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"deployments_id",
-		"deployments_containers_idx",
-		"idx",
-		"key",
-		"value",
-		"envvarsource",
 	}
 
 	idx := 0
@@ -527,27 +527,27 @@ func copyFromDeploymentsContainersEnvs(ctx context.Context, s pgSearch.Deleter, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers_envs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers_envs"}, copyColsDeploymentsContainersEnvs, inputRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+var copyColsDeploymentsContainersVolumes = []string{
+	"deployments_id",
+	"deployments_containers_idx",
+	"idx",
+	"name",
+	"source",
+	"destination",
+	"readonly",
+	"type",
+}
+
 func copyFromDeploymentsContainersVolumes(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, deploymentContainerIdx int, objs ...*storage.Volume) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"deployments_id",
-		"deployments_containers_idx",
-		"idx",
-		"name",
-		"source",
-		"destination",
-		"readonly",
-		"type",
 	}
 
 	idx := 0
@@ -570,24 +570,24 @@ func copyFromDeploymentsContainersVolumes(ctx context.Context, s pgSearch.Delete
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers_volumes"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers_volumes"}, copyColsDeploymentsContainersVolumes, inputRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+var copyColsDeploymentsContainersSecrets = []string{
+	"deployments_id",
+	"deployments_containers_idx",
+	"idx",
+	"name",
+	"path",
+}
+
 func copyFromDeploymentsContainersSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, deploymentContainerIdx int, objs ...*storage.EmbeddedSecret) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"deployments_id",
-		"deployments_containers_idx",
-		"idx",
-		"name",
-		"path",
 	}
 
 	idx := 0
@@ -607,24 +607,24 @@ func copyFromDeploymentsContainersSecrets(ctx context.Context, s pgSearch.Delete
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers_secrets"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_containers_secrets"}, copyColsDeploymentsContainersSecrets, inputRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+var copyColsDeploymentsPorts = []string{
+	"deployments_id",
+	"idx",
+	"containerport",
+	"protocol",
+	"exposure",
+}
+
 func copyFromDeploymentsPorts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, objs ...*storage.PortConfig) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"deployments_id",
-		"idx",
-		"containerport",
-		"protocol",
-		"exposure",
 	}
 
 	idx := 0
@@ -644,7 +644,7 @@ func copyFromDeploymentsPorts(ctx context.Context, s pgSearch.Deleter, tx *postg
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_ports"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_ports"}, copyColsDeploymentsPorts, inputRows); err != nil {
 		return err
 	}
 
@@ -657,21 +657,21 @@ func copyFromDeploymentsPorts(ctx context.Context, s pgSearch.Deleter, tx *postg
 	return nil
 }
 
+var copyColsDeploymentsPortsExposureInfos = []string{
+	"deployments_id",
+	"deployments_ports_idx",
+	"idx",
+	"level",
+	"servicename",
+	"serviceport",
+	"nodeport",
+	"externalips",
+	"externalhostnames",
+}
+
 func copyFromDeploymentsPortsExposureInfos(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, deploymentPortIdx int, objs ...*storage.PortConfig_ExposureInfo) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"deployments_id",
-		"deployments_ports_idx",
-		"idx",
-		"level",
-		"servicename",
-		"serviceport",
-		"nodeport",
-		"externalips",
-		"externalhostnames",
 	}
 
 	idx := 0
@@ -695,7 +695,7 @@ func copyFromDeploymentsPortsExposureInfos(ctx context.Context, s pgSearch.Delet
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_ports_exposure_infos"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"deployments_ports_exposure_infos"}, copyColsDeploymentsPortsExposureInfos, inputRows); err != nil {
 		return err
 	}
 

--- a/central/discoveredclusters/datastore/internal/store/postgres/store.go
+++ b/central/discoveredclusters/datastore/internal/store/postgres/store.go
@@ -117,6 +117,17 @@ func insertIntoDiscoveredClusters(batch *pgx.Batch, obj *storage.DiscoveredClust
 	return nil
 }
 
+var copyColsDiscoveredClusters = []string{
+	"id",
+	"metadata_name",
+	"metadata_type",
+	"metadata_firstdiscoveredat",
+	"status",
+	"sourceid",
+	"lastupdatedat",
+	"serialized",
+}
+
 func copyFromDiscoveredClusters(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.DiscoveredCluster) error {
 	if len(objs) == 0 {
 		return nil
@@ -132,17 +143,6 @@ func copyFromDiscoveredClusters(ctx context.Context, s pgSearch.Deleter, tx *pos
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"metadata_name",
-		"metadata_type",
-		"metadata_firstdiscoveredat",
-		"status",
-		"sourceid",
-		"lastupdatedat",
-		"serialized",
 	}
 
 	idx := 0
@@ -170,7 +170,7 @@ func copyFromDiscoveredClusters(ctx context.Context, s pgSearch.Deleter, tx *pos
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"discovered_clusters"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"discovered_clusters"}, copyColsDiscoveredClusters, inputRows); err != nil {
 		return err
 	}
 

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoExternalBackups(batch *pgx.Batch, obj *storage.ExternalBackup) er
 	return nil
 }
 
+var copyColsExternalBackups = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromExternalBackups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ExternalBackup) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromExternalBackups(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromExternalBackups(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"external_backups"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"external_backups"}, copyColsExternalBackups, inputRows); err != nil {
 		return err
 	}
 

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -110,6 +110,15 @@ func insertIntoGroups(batch *pgx.Batch, obj *storage.Group) error {
 	return nil
 }
 
+var copyColsGroups = []string{
+	"props_id",
+	"props_authproviderid",
+	"props_key",
+	"props_value",
+	"rolename",
+	"serialized",
+}
+
 func copyFromGroups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Group) error {
 	if len(objs) == 0 {
 		return nil
@@ -125,15 +134,6 @@ func copyFromGroups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"props_id",
-		"props_authproviderid",
-		"props_key",
-		"props_value",
-		"rolename",
-		"serialized",
 	}
 
 	idx := 0
@@ -159,7 +159,7 @@ func copyFromGroups(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"groups"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"groups"}, copyColsGroups, inputRows); err != nil {
 		return err
 	}
 

--- a/central/hash/datastore/store/postgres/store.go
+++ b/central/hash/datastore/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoHashes(batch *pgx.Batch, obj *storage.Hash) error {
 	return nil
 }
 
+var copyColsHashes = []string{
+	"clusterid",
+	"serialized",
+}
+
 func copyFromHashes(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Hash) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromHashes(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"clusterid",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromHashes(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"hashes"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"hashes"}, copyColsHashes, inputRows); err != nil {
 		return err
 	}
 

--- a/central/imagecomponent/v2/datastore/store/postgres/store.go
+++ b/central/imagecomponent/v2/datastore/store/postgres/store.go
@@ -121,6 +121,22 @@ func insertIntoImageComponentV2(batch *pgx.Batch, obj *storage.ImageComponentV2)
 	return nil
 }
 
+var copyColsImageComponentV2 = []string{
+	"id",
+	"name",
+	"version",
+	"priority",
+	"source",
+	"riskscore",
+	"topcvss",
+	"operatingsystem",
+	"imageid",
+	"location",
+	"imageidv2",
+	"frombaseimage",
+	"serialized",
+}
+
 func copyFromImageComponentV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ImageComponentV2) error {
 	if len(objs) == 0 {
 		return nil
@@ -136,22 +152,6 @@ func copyFromImageComponentV2(ctx context.Context, s pgSearch.Deleter, tx *postg
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"version",
-		"priority",
-		"source",
-		"riskscore",
-		"topcvss",
-		"operatingsystem",
-		"imageid",
-		"location",
-		"imageidv2",
-		"frombaseimage",
-		"serialized",
 	}
 
 	idx := 0
@@ -184,7 +184,7 @@ func copyFromImageComponentV2(ctx context.Context, s pgSearch.Deleter, tx *postg
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_component_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_component_v2"}, copyColsImageComponentV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -120,6 +120,13 @@ func insertIntoImageIntegrations(batch *pgx.Batch, obj *storage.ImageIntegration
 	return nil
 }
 
+var copyColsImageIntegrations = []string{
+	"id",
+	"name",
+	"clusterid",
+	"serialized",
+}
+
 func copyFromImageIntegrations(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ImageIntegration) error {
 	if len(objs) == 0 {
 		return nil
@@ -135,13 +142,6 @@ func copyFromImageIntegrations(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"clusterid",
-		"serialized",
 	}
 
 	idx := 0
@@ -165,7 +165,7 @@ func copyFromImageIntegrations(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_integrations"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"image_integrations"}, copyColsImageIntegrations, inputRows); err != nil {
 		return err
 	}
 

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoIntegrationHealths(batch *pgx.Batch, obj *storage.IntegrationHeal
 	return nil
 }
 
+var copyColsIntegrationHealths = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromIntegrationHealths(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.IntegrationHealth) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromIntegrationHealths(ctx context.Context, s pgSearch.Deleter, tx *pos
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromIntegrationHealths(ctx context.Context, s pgSearch.Deleter, tx *pos
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"integration_healths"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"integration_healths"}, copyColsIntegrationHealths, inputRows); err != nil {
 		return err
 	}
 

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -108,6 +108,12 @@ func insertIntoLogImbues(batch *pgx.Batch, obj *storage.LogImbue) error {
 	return nil
 }
 
+var copyColsLogImbues = []string{
+	"id",
+	"timestamp",
+	"serialized",
+}
+
 func copyFromLogImbues(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.LogImbue) error {
 	if len(objs) == 0 {
 		return nil
@@ -123,12 +129,6 @@ func copyFromLogImbues(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"timestamp",
-		"serialized",
 	}
 
 	idx := 0
@@ -151,7 +151,7 @@ func copyFromLogImbues(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"log_imbues"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"log_imbues"}, copyColsLogImbues, inputRows); err != nil {
 		return err
 	}
 

--- a/central/namespace/datastore/internal/store/postgres/store.go
+++ b/central/namespace/datastore/internal/store/postgres/store.go
@@ -147,6 +147,16 @@ func insertIntoNamespaces(batch *pgx.Batch, obj *storage.NamespaceMetadata) erro
 	return nil
 }
 
+var copyColsNamespaces = []string{
+	"id",
+	"name",
+	"clusterid",
+	"clustername",
+	"labels",
+	"annotations",
+	"serialized",
+}
+
 func copyFromNamespaces(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NamespaceMetadata) error {
 	if len(objs) == 0 {
 		return nil
@@ -162,16 +172,6 @@ func copyFromNamespaces(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"clusterid",
-		"clustername",
-		"labels",
-		"annotations",
-		"serialized",
 	}
 
 	idx := 0
@@ -198,7 +198,7 @@ func copyFromNamespaces(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"namespaces"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"namespaces"}, copyColsNamespaces, inputRows); err != nil {
 		return err
 	}
 

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -133,6 +133,13 @@ func insertIntoNetworkBaselines(batch *pgx.Batch, obj *storage.NetworkBaseline) 
 	return nil
 }
 
+var copyColsNetworkBaselines = []string{
+	"deploymentid",
+	"clusterid",
+	"namespace",
+	"serialized",
+}
+
 func copyFromNetworkBaselines(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NetworkBaseline) error {
 	if len(objs) == 0 {
 		return nil
@@ -148,13 +155,6 @@ func copyFromNetworkBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"deploymentid",
-		"clusterid",
-		"namespace",
-		"serialized",
 	}
 
 	idx := 0
@@ -178,7 +178,7 @@ func copyFromNetworkBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_baselines"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_baselines"}, copyColsNetworkBaselines, inputRows); err != nil {
 		return err
 	}
 

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoNetworkGraphConfigs(batch *pgx.Batch, obj *storage.NetworkGraphCo
 	return nil
 }
 
+var copyColsNetworkGraphConfigs = []string{
+	"id",
+	"serialized",
+}
+
 func copyFromNetworkGraphConfigs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NetworkGraphConfig) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromNetworkGraphConfigs(ctx context.Context, s pgSearch.Deleter, tx *po
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromNetworkGraphConfigs(ctx context.Context, s pgSearch.Deleter, tx *po
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_graph_configs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_graph_configs"}, copyColsNetworkGraphConfigs, inputRows); err != nil {
 		return err
 	}
 

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -113,6 +113,14 @@ func insertIntoNetworkEntities(batch *pgx.Batch, obj *storage.NetworkEntity) err
 	return nil
 }
 
+var copyColsNetworkEntities = []string{
+	"info_id",
+	"info_externalsource_cidr",
+	"info_externalsource_default",
+	"info_externalsource_discovered",
+	"serialized",
+}
+
 func copyFromNetworkEntities(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NetworkEntity) error {
 	if len(objs) == 0 {
 		return nil
@@ -128,14 +136,6 @@ func copyFromNetworkEntities(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"info_id",
-		"info_externalsource_cidr",
-		"info_externalsource_default",
-		"info_externalsource_discovered",
-		"serialized",
 	}
 
 	idx := 0
@@ -160,7 +160,7 @@ func copyFromNetworkEntities(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_entities"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"network_entities"}, copyColsNetworkEntities, inputRows); err != nil {
 		return err
 	}
 

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -133,6 +133,13 @@ func insertIntoNetworkpolicies(batch *pgx.Batch, obj *storage.NetworkPolicy) err
 	return nil
 }
 
+var copyColsNetworkpolicies = []string{
+	"id",
+	"clusterid",
+	"namespace",
+	"serialized",
+}
+
 func copyFromNetworkpolicies(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NetworkPolicy) error {
 	if len(objs) == 0 {
 		return nil
@@ -148,13 +155,6 @@ func copyFromNetworkpolicies(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"clusterid",
-		"namespace",
-		"serialized",
 	}
 
 	idx := 0
@@ -178,7 +178,7 @@ func copyFromNetworkpolicies(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicies"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicies"}, copyColsNetworkpolicies, inputRows); err != nil {
 		return err
 	}
 

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -107,6 +107,11 @@ func insertIntoNetworkpoliciesundodeployments(batch *pgx.Batch, obj *storage.Net
 	return nil
 }
 
+var copyColsNetworkpoliciesundodeployments = []string{
+	"deploymentid",
+	"serialized",
+}
+
 func copyFromNetworkpoliciesundodeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NetworkPolicyApplicationUndoDeploymentRecord) error {
 	if len(objs) == 0 {
 		return nil
@@ -122,11 +127,6 @@ func copyFromNetworkpoliciesundodeployments(ctx context.Context, s pgSearch.Dele
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"deploymentid",
-		"serialized",
 	}
 
 	idx := 0
@@ -148,7 +148,7 @@ func copyFromNetworkpoliciesundodeployments(ctx context.Context, s pgSearch.Dele
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpoliciesundodeployments"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpoliciesundodeployments"}, copyColsNetworkpoliciesundodeployments, inputRows); err != nil {
 		return err
 	}
 

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -107,6 +107,11 @@ func insertIntoNetworkpolicyapplicationundorecords(batch *pgx.Batch, obj *storag
 	return nil
 }
 
+var copyColsNetworkpolicyapplicationundorecords = []string{
+	"clusterid",
+	"serialized",
+}
+
 func copyFromNetworkpolicyapplicationundorecords(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NetworkPolicyApplicationUndoRecord) error {
 	if len(objs) == 0 {
 		return nil
@@ -122,11 +127,6 @@ func copyFromNetworkpolicyapplicationundorecords(ctx context.Context, s pgSearch
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"clusterid",
-		"serialized",
 	}
 
 	idx := 0
@@ -148,7 +148,7 @@ func copyFromNetworkpolicyapplicationundorecords(ctx context.Context, s pgSearch
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicyapplicationundorecords"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"networkpolicyapplicationundorecords"}, copyColsNetworkpolicyapplicationundorecords, inputRows); err != nil {
 		return err
 	}
 

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -115,6 +115,17 @@ func insertIntoNodeComponents(batch *pgx.Batch, obj *storage.NodeComponent) erro
 	return nil
 }
 
+var copyColsNodeComponents = []string{
+	"id",
+	"name",
+	"version",
+	"priority",
+	"riskscore",
+	"topcvss",
+	"operatingsystem",
+	"serialized",
+}
+
 func copyFromNodeComponents(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.NodeComponent) error {
 	if len(objs) == 0 {
 		return nil
@@ -130,17 +141,6 @@ func copyFromNodeComponents(ctx context.Context, s pgSearch.Deleter, tx *postgre
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"version",
-		"priority",
-		"riskscore",
-		"topcvss",
-		"operatingsystem",
-		"serialized",
 	}
 
 	idx := 0
@@ -168,7 +168,7 @@ func copyFromNodeComponents(ctx context.Context, s pgSearch.Deleter, tx *postgre
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_components"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"node_components"}, copyColsNodeComponents, inputRows); err != nil {
 		return err
 	}
 

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -107,6 +107,12 @@ func insertIntoNotifiers(batch *pgx.Batch, obj *storage.Notifier) error {
 	return nil
 }
 
+var copyColsNotifiers = []string{
+	"id",
+	"name",
+	"serialized",
+}
+
 func copyFromNotifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Notifier) error {
 	if len(objs) == 0 {
 		return nil
@@ -122,12 +128,6 @@ func copyFromNotifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -150,7 +150,7 @@ func copyFromNotifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx,
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"notifiers"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"notifiers"}, copyColsNotifiers, inputRows); err != nil {
 		return err
 	}
 

--- a/central/pod/datastore/internal/store/postgres/store.go
+++ b/central/pod/datastore/internal/store/postgres/store.go
@@ -169,6 +169,15 @@ func insertIntoPodsLiveInstances(batch *pgx.Batch, obj *storage.ContainerInstanc
 	return nil
 }
 
+var copyColsPods = []string{
+	"id",
+	"name",
+	"deploymentid",
+	"namespace",
+	"clusterid",
+	"serialized",
+}
+
 func copyFromPods(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Pod) error {
 	if len(objs) == 0 {
 		return nil
@@ -184,15 +193,6 @@ func copyFromPods(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"deploymentid",
-		"namespace",
-		"clusterid",
-		"serialized",
 	}
 
 	idx := 0
@@ -218,7 +218,7 @@ func copyFromPods(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"pods"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"pods"}, copyColsPods, inputRows); err != nil {
 		return err
 	}
 
@@ -231,15 +231,15 @@ func copyFromPods(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs
 	return nil
 }
 
+var copyColsPodsLiveInstances = []string{
+	"pods_id",
+	"idx",
+	"imagedigest",
+}
+
 func copyFromPodsLiveInstances(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, podID string, objs ...*storage.ContainerInstance) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"pods_id",
-		"idx",
-		"imagedigest",
 	}
 
 	idx := 0
@@ -257,7 +257,7 @@ func copyFromPodsLiveInstances(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"pods_live_instances"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"pods_live_instances"}, copyColsPodsLiveInstances, inputRows); err != nil {
 		return err
 	}
 

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -121,6 +121,22 @@ func insertIntoPolicies(batch *pgx.Batch, obj *storage.Policy) error {
 	return nil
 }
 
+var copyColsPolicies = []string{
+	"id",
+	"name",
+	"description",
+	"disabled",
+	"categories",
+	"lifecyclestages",
+	"severity",
+	"enforcementactions",
+	"lastupdated",
+	"sortname",
+	"sortlifecyclestage",
+	"sortenforcement",
+	"serialized",
+}
+
 func copyFromPolicies(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Policy) error {
 	if len(objs) == 0 {
 		return nil
@@ -136,22 +152,6 @@ func copyFromPolicies(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"description",
-		"disabled",
-		"categories",
-		"lifecyclestages",
-		"severity",
-		"enforcementactions",
-		"lastupdated",
-		"sortname",
-		"sortlifecyclestage",
-		"sortenforcement",
-		"serialized",
 	}
 
 	idx := 0
@@ -184,7 +184,7 @@ func copyFromPolicies(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policies"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policies"}, copyColsPolicies, inputRows); err != nil {
 		return err
 	}
 

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -110,6 +110,12 @@ func insertIntoPolicyCategories(batch *pgx.Batch, obj *storage.PolicyCategory) e
 	return nil
 }
 
+var copyColsPolicyCategories = []string{
+	"id",
+	"name",
+	"serialized",
+}
+
 func copyFromPolicyCategories(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.PolicyCategory) error {
 	if len(objs) == 0 {
 		return nil
@@ -125,12 +131,6 @@ func copyFromPolicyCategories(ctx context.Context, s pgSearch.Deleter, tx *postg
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -153,7 +153,7 @@ func copyFromPolicyCategories(ctx context.Context, s pgSearch.Deleter, tx *postg
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_categories"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_categories"}, copyColsPolicyCategories, inputRows); err != nil {
 		return err
 	}
 

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -111,6 +111,13 @@ func insertIntoPolicyCategoryEdges(batch *pgx.Batch, obj *storage.PolicyCategory
 	return nil
 }
 
+var copyColsPolicyCategoryEdges = []string{
+	"id",
+	"policyid",
+	"categoryid",
+	"serialized",
+}
+
 func copyFromPolicyCategoryEdges(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.PolicyCategoryEdge) error {
 	if len(objs) == 0 {
 		return nil
@@ -126,13 +133,6 @@ func copyFromPolicyCategoryEdges(ctx context.Context, s pgSearch.Deleter, tx *po
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"policyid",
-		"categoryid",
-		"serialized",
 	}
 
 	idx := 0
@@ -156,7 +156,7 @@ func copyFromPolicyCategoryEdges(ctx context.Context, s pgSearch.Deleter, tx *po
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_category_edges"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"policy_category_edges"}, copyColsPolicyCategoryEdges, inputRows); err != nil {
 		return err
 	}
 

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -143,6 +143,14 @@ func insertIntoProcessBaselines(batch *pgx.Batch, obj *storage.ProcessBaseline) 
 	return nil
 }
 
+var copyColsProcessBaselines = []string{
+	"id",
+	"key_deploymentid",
+	"key_clusterid",
+	"key_namespace",
+	"serialized",
+}
+
 func copyFromProcessBaselines(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ProcessBaseline) error {
 	if len(objs) == 0 {
 		return nil
@@ -158,14 +166,6 @@ func copyFromProcessBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"key_deploymentid",
-		"key_clusterid",
-		"key_namespace",
-		"serialized",
 	}
 
 	idx := 0
@@ -190,7 +190,7 @@ func copyFromProcessBaselines(ctx context.Context, s pgSearch.Deleter, tx *postg
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baselines"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baselines"}, copyColsProcessBaselines, inputRows); err != nil {
 		return err
 	}
 

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -133,6 +133,13 @@ func insertIntoProcessBaselineResults(batch *pgx.Batch, obj *storage.ProcessBase
 	return nil
 }
 
+var copyColsProcessBaselineResults = []string{
+	"deploymentid",
+	"clusterid",
+	"namespace",
+	"serialized",
+}
+
 func copyFromProcessBaselineResults(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ProcessBaselineResults) error {
 	if len(objs) == 0 {
 		return nil
@@ -148,13 +155,6 @@ func copyFromProcessBaselineResults(ctx context.Context, s pgSearch.Deleter, tx 
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"deploymentid",
-		"clusterid",
-		"namespace",
-		"serialized",
 	}
 
 	idx := 0
@@ -178,7 +178,7 @@ func copyFromProcessBaselineResults(ctx context.Context, s pgSearch.Deleter, tx 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baseline_results"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_baseline_results"}, copyColsProcessBaselineResults, inputRows); err != nil {
 		return err
 	}
 

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -145,6 +145,24 @@ func insertIntoProcessIndicators(batch *pgx.Batch, obj *storage.ProcessIndicator
 	return nil
 }
 
+var copyColsProcessIndicators = []string{
+	"id",
+	"deploymentid",
+	"containername",
+	"podid",
+	"poduid",
+	"signal_containerid",
+	"signal_time",
+	"signal_name",
+	"signal_args",
+	"signal_execfilepath",
+	"signal_uid",
+	"clusterid",
+	"namespace",
+	"containerstarttime",
+	"serialized",
+}
+
 func copyFromProcessIndicators(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ProcessIndicator) error {
 	if len(objs) == 0 {
 		return nil
@@ -160,24 +178,6 @@ func copyFromProcessIndicators(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"deploymentid",
-		"containername",
-		"podid",
-		"poduid",
-		"signal_containerid",
-		"signal_time",
-		"signal_name",
-		"signal_args",
-		"signal_execfilepath",
-		"signal_uid",
-		"clusterid",
-		"namespace",
-		"containerstarttime",
-		"serialized",
 	}
 
 	idx := 0
@@ -212,7 +212,7 @@ func copyFromProcessIndicators(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_indicators"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"process_indicators"}, copyColsProcessIndicators, inputRows); err != nil {
 		return err
 	}
 

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -141,6 +141,20 @@ func insertIntoListeningEndpoints(batch *pgx.Batch, obj *storage.ProcessListenin
 	return nil
 }
 
+var copyColsListeningEndpoints = []string{
+	"id",
+	"port",
+	"protocol",
+	"closetimestamp",
+	"processindicatorid",
+	"closed",
+	"deploymentid",
+	"poduid",
+	"clusterid",
+	"namespace",
+	"serialized",
+}
+
 func copyFromListeningEndpoints(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ProcessListeningOnPortStorage) error {
 	if len(objs) == 0 {
 		return nil
@@ -156,20 +170,6 @@ func copyFromListeningEndpoints(ctx context.Context, s pgSearch.Deleter, tx *pos
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"port",
-		"protocol",
-		"closetimestamp",
-		"processindicatorid",
-		"closed",
-		"deploymentid",
-		"poduid",
-		"clusterid",
-		"namespace",
-		"serialized",
 	}
 
 	idx := 0
@@ -200,7 +200,7 @@ func copyFromListeningEndpoints(ctx context.Context, s pgSearch.Deleter, tx *pos
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"listening_endpoints"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"listening_endpoints"}, copyColsListeningEndpoints, inputRows); err != nil {
 		return err
 	}
 

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -138,6 +138,18 @@ func insertIntoK8sRoles(batch *pgx.Batch, obj *storage.K8SRole) error {
 	return nil
 }
 
+var copyColsK8sRoles = []string{
+	"id",
+	"name",
+	"namespace",
+	"clusterid",
+	"clustername",
+	"clusterrole",
+	"labels",
+	"annotations",
+	"serialized",
+}
+
 func copyFromK8sRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.K8SRole) error {
 	if len(objs) == 0 {
 		return nil
@@ -153,18 +165,6 @@ func copyFromK8sRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"namespace",
-		"clusterid",
-		"clustername",
-		"clusterrole",
-		"labels",
-		"annotations",
-		"serialized",
 	}
 
 	idx := 0
@@ -193,7 +193,7 @@ func copyFromK8sRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"k8s_roles"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"k8s_roles"}, copyColsK8sRoles, inputRows); err != nil {
 		return err
 	}
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -165,6 +165,19 @@ func insertIntoRoleBindingsSubjects(batch *pgx.Batch, obj *storage.Subject, role
 	return nil
 }
 
+var copyColsRoleBindings = []string{
+	"id",
+	"name",
+	"namespace",
+	"clusterid",
+	"clustername",
+	"clusterrole",
+	"labels",
+	"annotations",
+	"roleid",
+	"serialized",
+}
+
 func copyFromRoleBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.K8SRoleBinding) error {
 	if len(objs) == 0 {
 		return nil
@@ -180,19 +193,6 @@ func copyFromRoleBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"namespace",
-		"clusterid",
-		"clustername",
-		"clusterrole",
-		"labels",
-		"annotations",
-		"roleid",
-		"serialized",
 	}
 
 	idx := 0
@@ -222,7 +222,7 @@ func copyFromRoleBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings"}, copyColsRoleBindings, inputRows); err != nil {
 		return err
 	}
 
@@ -235,16 +235,16 @@ func copyFromRoleBindings(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	return nil
 }
 
+var copyColsRoleBindingsSubjects = []string{
+	"role_bindings_id",
+	"idx",
+	"kind",
+	"name",
+}
+
 func copyFromRoleBindingsSubjects(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, roleBindingID string, objs ...*storage.Subject) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"role_bindings_id",
-		"idx",
-		"kind",
-		"name",
 	}
 
 	idx := 0
@@ -263,7 +263,7 @@ func copyFromRoleBindingsSubjects(ctx context.Context, s pgSearch.Deleter, tx *p
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings_subjects"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"role_bindings_subjects"}, copyColsRoleBindingsSubjects, inputRows); err != nil {
 		return err
 	}
 

--- a/central/reports/config/store/postgres/store.go
+++ b/central/reports/config/store/postgres/store.go
@@ -139,6 +139,16 @@ func insertIntoReportConfigurationsNotifiers(batch *pgx.Batch, obj *storage.Noti
 	return nil
 }
 
+var copyColsReportConfigurations = []string{
+	"id",
+	"name",
+	"type",
+	"scopeid",
+	"resourcescope_collectionid",
+	"creator_name",
+	"serialized",
+}
+
 func copyFromReportConfigurations(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ReportConfiguration) error {
 	if len(objs) == 0 {
 		return nil
@@ -154,16 +164,6 @@ func copyFromReportConfigurations(ctx context.Context, s pgSearch.Deleter, tx *p
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"type",
-		"scopeid",
-		"resourcescope_collectionid",
-		"creator_name",
-		"serialized",
 	}
 
 	idx := 0
@@ -190,7 +190,7 @@ func copyFromReportConfigurations(ctx context.Context, s pgSearch.Deleter, tx *p
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_configurations"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_configurations"}, copyColsReportConfigurations, inputRows); err != nil {
 		return err
 	}
 
@@ -203,15 +203,15 @@ func copyFromReportConfigurations(ctx context.Context, s pgSearch.Deleter, tx *p
 	return nil
 }
 
+var copyColsReportConfigurationsNotifiers = []string{
+	"report_configurations_id",
+	"idx",
+	"id",
+}
+
 func copyFromReportConfigurationsNotifiers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, reportConfigurationID string, objs ...*storage.NotifierConfiguration) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"report_configurations_id",
-		"idx",
-		"id",
 	}
 
 	idx := 0
@@ -229,7 +229,7 @@ func copyFromReportConfigurationsNotifiers(ctx context.Context, s pgSearch.Delet
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_configurations_notifiers"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_configurations_notifiers"}, copyColsReportConfigurationsNotifiers, inputRows); err != nil {
 		return err
 	}
 

--- a/central/reports/snapshot/datastore/store/postgres/store.go
+++ b/central/reports/snapshot/datastore/store/postgres/store.go
@@ -121,6 +121,21 @@ func insertIntoReportSnapshots(batch *pgx.Batch, obj *storage.ReportSnapshot) er
 	return nil
 }
 
+var copyColsReportSnapshots = []string{
+	"reportid",
+	"reportconfigurationid",
+	"name",
+	"reportstatus_runstate",
+	"reportstatus_queuedat",
+	"reportstatus_completedat",
+	"reportstatus_reportrequesttype",
+	"reportstatus_reportnotificationmethod",
+	"requester_id",
+	"requester_name",
+	"areaofconcern",
+	"serialized",
+}
+
 func copyFromReportSnapshots(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ReportSnapshot) error {
 	if len(objs) == 0 {
 		return nil
@@ -136,21 +151,6 @@ func copyFromReportSnapshots(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"reportid",
-		"reportconfigurationid",
-		"name",
-		"reportstatus_runstate",
-		"reportstatus_queuedat",
-		"reportstatus_completedat",
-		"reportstatus_reportrequesttype",
-		"reportstatus_reportnotificationmethod",
-		"requester_id",
-		"requester_name",
-		"areaofconcern",
-		"serialized",
 	}
 
 	idx := 0
@@ -182,7 +182,7 @@ func copyFromReportSnapshots(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_snapshots"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"report_snapshots"}, copyColsReportSnapshots, inputRows); err != nil {
 		return err
 	}
 

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -137,6 +137,14 @@ func insertIntoCollectionsEmbeddedCollections(batch *pgx.Batch, obj *storage.Res
 	return nil
 }
 
+var copyColsCollections = []string{
+	"id",
+	"name",
+	"createdby_name",
+	"updatedby_name",
+	"serialized",
+}
+
 func copyFromCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ResourceCollection) error {
 	if len(objs) == 0 {
 		return nil
@@ -152,14 +160,6 @@ func copyFromCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"createdby_name",
-		"updatedby_name",
-		"serialized",
 	}
 
 	idx := 0
@@ -184,7 +184,7 @@ func copyFromCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections"}, copyColsCollections, inputRows); err != nil {
 		return err
 	}
 
@@ -197,15 +197,15 @@ func copyFromCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	return nil
 }
 
+var copyColsCollectionsEmbeddedCollections = []string{
+	"collections_id",
+	"idx",
+	"id",
+}
+
 func copyFromCollectionsEmbeddedCollections(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, collectionID string, objs ...*storage.ResourceCollection_EmbeddedResourceCollection) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"collections_id",
-		"idx",
-		"id",
 	}
 
 	idx := 0
@@ -223,7 +223,7 @@ func copyFromCollectionsEmbeddedCollections(ctx context.Context, s pgSearch.Dele
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections_embedded_collections"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"collections_embedded_collections"}, copyColsCollectionsEmbeddedCollections, inputRows); err != nil {
 		return err
 	}
 

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -135,6 +135,15 @@ func insertIntoRisks(batch *pgx.Batch, obj *storage.Risk) error {
 	return nil
 }
 
+var copyColsRisks = []string{
+	"id",
+	"subject_namespace",
+	"subject_clusterid",
+	"subject_type",
+	"score",
+	"serialized",
+}
+
 func copyFromRisks(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Risk) error {
 	if len(objs) == 0 {
 		return nil
@@ -150,15 +159,6 @@ func copyFromRisks(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"subject_namespace",
-		"subject_clusterid",
-		"subject_type",
-		"score",
-		"serialized",
 	}
 
 	idx := 0
@@ -184,7 +184,7 @@ func copyFromRisks(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"risks"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"risks"}, copyColsRisks, inputRows); err != nil {
 		return err
 	}
 

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -108,6 +108,12 @@ func insertIntoPermissionSets(batch *pgx.Batch, obj *storage.PermissionSet) erro
 	return nil
 }
 
+var copyColsPermissionSets = []string{
+	"id",
+	"name",
+	"serialized",
+}
+
 func copyFromPermissionSets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.PermissionSet) error {
 	if len(objs) == 0 {
 		return nil
@@ -123,12 +129,6 @@ func copyFromPermissionSets(ctx context.Context, s pgSearch.Deleter, tx *postgre
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -151,7 +151,7 @@ func copyFromPermissionSets(ctx context.Context, s pgSearch.Deleter, tx *postgre
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"permission_sets"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"permission_sets"}, copyColsPermissionSets, inputRows); err != nil {
 		return err
 	}
 

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoRoles(batch *pgx.Batch, obj *storage.Role) error {
 	return nil
 }
 
+var copyColsRoles = []string{
+	"name",
+	"serialized",
+}
+
 func copyFromRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Role) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromRoles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, obj
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"roles"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"roles"}, copyColsRoles, inputRows); err != nil {
 		return err
 	}
 

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -108,6 +108,12 @@ func insertIntoSimpleAccessScopes(batch *pgx.Batch, obj *storage.SimpleAccessSco
 	return nil
 }
 
+var copyColsSimpleAccessScopes = []string{
+	"id",
+	"name",
+	"serialized",
+}
+
 func copyFromSimpleAccessScopes(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.SimpleAccessScope) error {
 	if len(objs) == 0 {
 		return nil
@@ -123,12 +129,6 @@ func copyFromSimpleAccessScopes(ctx context.Context, s pgSearch.Deleter, tx *pos
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -151,7 +151,7 @@ func copyFromSimpleAccessScopes(ctx context.Context, s pgSearch.Deleter, tx *pos
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"simple_access_scopes"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"simple_access_scopes"}, copyColsSimpleAccessScopes, inputRows); err != nil {
 		return err
 	}
 

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -189,6 +189,16 @@ func insertIntoSecretsFilesRegistries(batch *pgx.Batch, obj *storage.ImagePullSe
 	return nil
 }
 
+var copyColsSecrets = []string{
+	"id",
+	"name",
+	"clusterid",
+	"clustername",
+	"namespace",
+	"createdat",
+	"serialized",
+}
+
 func copyFromSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Secret) error {
 	if len(objs) == 0 {
 		return nil
@@ -204,16 +214,6 @@ func copyFromSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, o
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"clusterid",
-		"clustername",
-		"namespace",
-		"createdat",
-		"serialized",
 	}
 
 	idx := 0
@@ -240,7 +240,7 @@ func copyFromSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, o
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets"}, copyColsSecrets, inputRows); err != nil {
 		return err
 	}
 
@@ -253,16 +253,16 @@ func copyFromSecrets(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, o
 	return nil
 }
 
+var copyColsSecretsFiles = []string{
+	"secrets_id",
+	"idx",
+	"type",
+	"cert_enddate",
+}
+
 func copyFromSecretsFiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, secretID string, objs ...*storage.SecretDataFile) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"secrets_id",
-		"idx",
-		"type",
-		"cert_enddate",
 	}
 
 	idx := 0
@@ -281,7 +281,7 @@ func copyFromSecretsFiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files"}, copyColsSecretsFiles, inputRows); err != nil {
 		return err
 	}
 
@@ -294,16 +294,16 @@ func copyFromSecretsFiles(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 	return nil
 }
 
+var copyColsSecretsFilesRegistries = []string{
+	"secrets_id",
+	"secrets_files_idx",
+	"idx",
+	"name",
+}
+
 func copyFromSecretsFilesRegistries(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, secretID string, secretFileIdx int, objs ...*storage.ImagePullSecret_Registry) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"secrets_id",
-		"secrets_files_idx",
-		"idx",
-		"name",
 	}
 
 	idx := 0
@@ -322,7 +322,7 @@ func copyFromSecretsFilesRegistries(ctx context.Context, s pgSearch.Deleter, tx 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files_registries"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"secrets_files_registries"}, copyColsSecretsFilesRegistries, inputRows); err != nil {
 		return err
 	}
 

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -137,6 +137,17 @@ func insertIntoServiceAccounts(batch *pgx.Batch, obj *storage.ServiceAccount) er
 	return nil
 }
 
+var copyColsServiceAccounts = []string{
+	"id",
+	"name",
+	"namespace",
+	"clustername",
+	"clusterid",
+	"labels",
+	"annotations",
+	"serialized",
+}
+
 func copyFromServiceAccounts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ServiceAccount) error {
 	if len(objs) == 0 {
 		return nil
@@ -152,17 +163,6 @@ func copyFromServiceAccounts(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"namespace",
-		"clustername",
-		"clusterid",
-		"labels",
-		"annotations",
-		"serialized",
 	}
 
 	idx := 0
@@ -190,7 +190,7 @@ func copyFromServiceAccounts(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_accounts"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_accounts"}, copyColsServiceAccounts, inputRows); err != nil {
 		return err
 	}
 

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoServiceIdentities(batch *pgx.Batch, obj *storage.ServiceIdentity)
 	return nil
 }
 
+var copyColsServiceIdentities = []string{
+	"serialstr",
+	"serialized",
+}
+
 func copyFromServiceIdentities(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.ServiceIdentity) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromServiceIdentities(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"serialstr",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromServiceIdentities(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_identities"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"service_identities"}, copyColsServiceIdentities, inputRows); err != nil {
 		return err
 	}
 

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -115,6 +115,12 @@ func insertIntoSignatureIntegrations(batch *pgx.Batch, obj *storage.SignatureInt
 	return nil
 }
 
+var copyColsSignatureIntegrations = []string{
+	"id",
+	"name",
+	"serialized",
+}
+
 func copyFromSignatureIntegrations(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.SignatureIntegration) error {
 	if len(objs) == 0 {
 		return nil
@@ -130,12 +136,6 @@ func copyFromSignatureIntegrations(ctx context.Context, s pgSearch.Deleter, tx *
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -158,7 +158,7 @@ func copyFromSignatureIntegrations(ctx context.Context, s pgSearch.Deleter, tx *
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"signature_integrations"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"signature_integrations"}, copyColsSignatureIntegrations, inputRows); err != nil {
 		return err
 	}
 

--- a/central/virtualmachine/datastore/internal/store/postgres/store.go
+++ b/central/virtualmachine/datastore/internal/store/postgres/store.go
@@ -135,6 +135,15 @@ func insertIntoVirtualMachines(batch *pgx.Batch, obj *storage.VirtualMachine) er
 	return nil
 }
 
+var copyColsVirtualMachines = []string{
+	"id",
+	"namespace",
+	"name",
+	"clusterid",
+	"clustername",
+	"serialized",
+}
+
 func copyFromVirtualMachines(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.VirtualMachine) error {
 	if len(objs) == 0 {
 		return nil
@@ -150,15 +159,6 @@ func copyFromVirtualMachines(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"namespace",
-		"name",
-		"clusterid",
-		"clustername",
-		"serialized",
 	}
 
 	idx := 0
@@ -184,7 +184,7 @@ func copyFromVirtualMachines(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"virtual_machines"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"virtual_machines"}, copyColsVirtualMachines, inputRows); err != nil {
 		return err
 	}
 

--- a/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnmgmt/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -200,6 +200,29 @@ func insertIntoVulnerabilityRequestsApproversV2(batch *pgx.Batch, obj *storage.A
 	return nil
 }
 
+var copyColsVulnerabilityRequests = []string{
+	"id",
+	"name",
+	"targetstate",
+	"status",
+	"expired",
+	"requestor_name",
+	"createdat",
+	"lastupdated",
+	"scope_imagescope_registry",
+	"scope_imagescope_remote",
+	"scope_imagescope_tag",
+	"requesterv2_id",
+	"requesterv2_name",
+	"deferralreq_expiry_expireson",
+	"deferralreq_expiry_expireswhenfixed",
+	"deferralreq_expiry_expirytype",
+	"cves_cves",
+	"deferralupdate_cves",
+	"falsepositiveupdate_cves",
+	"serialized",
+}
+
 func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.VulnerabilityRequest) error {
 	if len(objs) == 0 {
 		return nil
@@ -215,29 +238,6 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"name",
-		"targetstate",
-		"status",
-		"expired",
-		"requestor_name",
-		"createdat",
-		"lastupdated",
-		"scope_imagescope_registry",
-		"scope_imagescope_remote",
-		"scope_imagescope_tag",
-		"requesterv2_id",
-		"requesterv2_name",
-		"deferralreq_expiry_expireson",
-		"deferralreq_expiry_expireswhenfixed",
-		"deferralreq_expiry_expirytype",
-		"cves_cves",
-		"deferralupdate_cves",
-		"falsepositiveupdate_cves",
-		"serialized",
 	}
 
 	idx := 0
@@ -277,7 +277,7 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests"}, copyColsVulnerabilityRequests, inputRows); err != nil {
 		return err
 	}
 
@@ -296,15 +296,15 @@ func copyFromVulnerabilityRequests(ctx context.Context, s pgSearch.Deleter, tx *
 	return nil
 }
 
+var copyColsVulnerabilityRequestsApprovers = []string{
+	"vulnerability_requests_id",
+	"idx",
+	"name",
+}
+
 func copyFromVulnerabilityRequestsApprovers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, vulnerabilityRequestID string, objs ...*storage.SlimUser) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"vulnerability_requests_id",
-		"idx",
-		"name",
 	}
 
 	idx := 0
@@ -322,22 +322,22 @@ func copyFromVulnerabilityRequestsApprovers(ctx context.Context, s pgSearch.Dele
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers"}, copyColsVulnerabilityRequestsApprovers, inputRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+var copyColsVulnerabilityRequestsComments = []string{
+	"vulnerability_requests_id",
+	"idx",
+	"user_name",
+}
+
 func copyFromVulnerabilityRequestsComments(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, vulnerabilityRequestID string, objs ...*storage.RequestComment) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"vulnerability_requests_id",
-		"idx",
-		"user_name",
 	}
 
 	idx := 0
@@ -355,23 +355,23 @@ func copyFromVulnerabilityRequestsComments(ctx context.Context, s pgSearch.Delet
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_comments"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_comments"}, copyColsVulnerabilityRequestsComments, inputRows); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+var copyColsVulnerabilityRequestsApproversV2 = []string{
+	"vulnerability_requests_id",
+	"idx",
+	"id",
+	"name",
+}
+
 func copyFromVulnerabilityRequestsApproversV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, vulnerabilityRequestID string, objs ...*storage.Approver) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"vulnerability_requests_id",
-		"idx",
-		"id",
-		"name",
 	}
 
 	idx := 0
@@ -390,7 +390,7 @@ func copyFromVulnerabilityRequestsApproversV2(ctx context.Context, s pgSearch.De
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers_v2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"vulnerability_requests_approvers_v2"}, copyColsVulnerabilityRequestsApproversV2, inputRows); err != nil {
 		return err
 	}
 

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -106,6 +106,11 @@ func insertIntoWatchedImages(batch *pgx.Batch, obj *storage.WatchedImage) error 
 	return nil
 }
 
+var copyColsWatchedImages = []string{
+	"name",
+	"serialized",
+}
+
 func copyFromWatchedImages(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.WatchedImage) error {
 	if len(objs) == 0 {
 		return nil
@@ -121,11 +126,6 @@ func copyFromWatchedImages(ctx context.Context, s pgSearch.Deleter, tx *postgres
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"name",
-		"serialized",
 	}
 
 	idx := 0
@@ -147,7 +147,7 @@ func copyFromWatchedImages(ctx context.Context, s pgSearch.Deleter, tx *postgres
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"watched_images"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"watched_images"}, copyColsWatchedImages, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -155,6 +155,24 @@ func insertIntoTestStructsNesteds(batch *pgx.Batch, obj *storage.TestStruct_Nest
 	return nil
 }
 
+var copyColsTestStructs = []string{
+	"key1",
+	"key2",
+	"stringslice",
+	"bool",
+	"uint64",
+	"int64",
+	"float",
+	"labels",
+	"timestamp",
+	"enum",
+	"enums",
+	"string_",
+	"int32slice",
+	"oneofnested_nested",
+	"serialized",
+}
+
 func copyFromTestStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestStruct) error {
 	if len(objs) == 0 {
 		return nil
@@ -170,24 +188,6 @@ func copyFromTestStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"key1",
-		"key2",
-		"stringslice",
-		"bool",
-		"uint64",
-		"int64",
-		"float",
-		"labels",
-		"timestamp",
-		"enum",
-		"enums",
-		"string_",
-		"int32slice",
-		"oneofnested_nested",
-		"serialized",
 	}
 
 	idx := 0
@@ -222,7 +222,7 @@ func copyFromTestStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs"}, copyColsTestStructs, inputRows); err != nil {
 		return err
 	}
 
@@ -235,20 +235,20 @@ func copyFromTestStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	return nil
 }
 
+var copyColsTestStructsNesteds = []string{
+	"test_structs_key1",
+	"idx",
+	"nested",
+	"isnested",
+	"int64",
+	"nested2_nested2",
+	"nested2_isnested",
+	"nested2_int64",
+}
+
 func copyFromTestStructsNesteds(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, testStructKey1 string, objs ...*storage.TestStruct_Nested) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"test_structs_key1",
-		"idx",
-		"nested",
-		"isnested",
-		"int64",
-		"nested2_nested2",
-		"nested2_isnested",
-		"nested2_int64",
 	}
 
 	idx := 0
@@ -271,7 +271,7 @@ func copyFromTestStructsNesteds(ctx context.Context, s pgSearch.Deleter, tx *pos
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs_nesteds"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_structs_nesteds"}, copyColsTestStructsNesteds, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -260,6 +260,12 @@ func {{ template "insertFunctionName" $schema }}(batch *pgx.Batch, obj {{$schema
 {{- define "copyObject"}}
 {{- $schema := .schema }}
 {{- $singlePK := index $schema.PrimaryKeys 0 }}
+var copyCols{{$schema.Table|upperCamelCase}} = []string{
+{{- range $index, $field := $schema.DBColumnFields }}
+    "{{$field.ColumnName|lowerCase}}",
+{{- end }}
+}
+
 func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, {{ range $index, $field := $schema.FieldsReferringToParent }} {{$field.Name}} {{$field.Type}},{{end}} objs ...{{$schema.Type}}) error {
     if len(objs) == 0 {
         return nil
@@ -277,12 +283,6 @@ func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.D
         }
     }
     {{end}}
-
-    copyCols := []string {
-    {{- range $index, $field := $schema.DBColumnFields }}
-        "{{$field.ColumnName|lowerCase}}",
-    {{- end }}
-    }
 
     idx := 0
     inputRows := pgx.CopyFromFunc(func() ([]any, error) {
@@ -304,8 +304,8 @@ func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.D
         }, nil
     })
 
-    if _, err := tx.CopyFrom(ctx, pgx.Identifier{"{{$schema.Table|lowerCase}}"}, copyCols, inputRows); err != nil {
-            return err
+    if _, err := tx.CopyFrom(ctx, pgx.Identifier{"{{$schema.Table|lowerCase}}"}, copyCols{{$schema.Table|upperCamelCase}}, inputRows); err != nil {
+        return err
     }
 
     {{if $schema.Children }}

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -122,6 +122,21 @@ func insertIntoTestSingleKeyStructs(batch *pgx.Batch, obj *storage.TestSingleKey
 	return nil
 }
 
+var copyColsTestSingleKeyStructs = []string{
+	"key",
+	"name",
+	"stringslice",
+	"bool",
+	"uint64",
+	"int64",
+	"float",
+	"labels",
+	"timestamp",
+	"enum",
+	"enums",
+	"serialized",
+}
+
 func copyFromTestSingleKeyStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestSingleKeyStruct) error {
 	if len(objs) == 0 {
 		return nil
@@ -137,21 +152,6 @@ func copyFromTestSingleKeyStructs(ctx context.Context, s pgSearch.Deleter, tx *p
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"key",
-		"name",
-		"stringslice",
-		"bool",
-		"uint64",
-		"int64",
-		"float",
-		"labels",
-		"timestamp",
-		"enum",
-		"enums",
-		"serialized",
 	}
 
 	idx := 0
@@ -183,7 +183,7 @@ func copyFromTestSingleKeyStructs(ctx context.Context, s pgSearch.Deleter, tx *p
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_key_structs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_key_structs"}, copyColsTestSingleKeyStructs, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -110,6 +110,12 @@ func insertIntoTestChild1(batch *pgx.Batch, obj *storage.TestChild1) error {
 	return nil
 }
 
+var copyColsTestChild1 = []string{
+	"id",
+	"val",
+	"serialized",
+}
+
 func copyFromTestChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestChild1) error {
 	if len(objs) == 0 {
 		return nil
@@ -125,12 +131,6 @@ func copyFromTestChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -153,7 +153,7 @@ func copyFromTestChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1"}, copyColsTestChild1, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -112,6 +112,13 @@ func insertIntoTestChild1P4(batch *pgx.Batch, obj *storage.TestChild1P4) error {
 	return nil
 }
 
+var copyColsTestChild1P4 = []string{
+	"id",
+	"parentid",
+	"val",
+	"serialized",
+}
+
 func copyFromTestChild1P4(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestChild1P4) error {
 	if len(objs) == 0 {
 		return nil
@@ -127,13 +134,6 @@ func copyFromTestChild1P4(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -157,7 +157,7 @@ func copyFromTestChild1P4(ctx context.Context, s pgSearch.Deleter, tx *postgres.
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1_p4"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child1_p4"}, copyColsTestChild1P4, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -113,6 +113,14 @@ func insertIntoTestChild2(batch *pgx.Batch, obj *storage.TestChild2) error {
 	return nil
 }
 
+var copyColsTestChild2 = []string{
+	"id",
+	"parentid",
+	"grandparentid",
+	"val",
+	"serialized",
+}
+
 func copyFromTestChild2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestChild2) error {
 	if len(objs) == 0 {
 		return nil
@@ -128,14 +136,6 @@ func copyFromTestChild2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"grandparentid",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -160,7 +160,7 @@ func copyFromTestChild2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_child2"}, copyColsTestChild2, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -112,6 +112,14 @@ func insertIntoTestG2GrandChild1(batch *pgx.Batch, obj *storage.TestG2GrandChild
 	return nil
 }
 
+var copyColsTestG2GrandChild1 = []string{
+	"id",
+	"parentid",
+	"childid",
+	"val",
+	"serialized",
+}
+
 func copyFromTestG2GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestG2GrandChild1) error {
 	if len(objs) == 0 {
 		return nil
@@ -127,14 +135,6 @@ func copyFromTestG2GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"childid",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -159,7 +159,7 @@ func copyFromTestG2GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g2_grand_child1"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g2_grand_child1"}, copyColsTestG2GrandChild1, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -110,6 +110,12 @@ func insertIntoTestG3GrandChild1(batch *pgx.Batch, obj *storage.TestG3GrandChild
 	return nil
 }
 
+var copyColsTestG3GrandChild1 = []string{
+	"id",
+	"val",
+	"serialized",
+}
+
 func copyFromTestG3GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestG3GrandChild1) error {
 	if len(objs) == 0 {
 		return nil
@@ -125,12 +131,6 @@ func copyFromTestG3GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -153,7 +153,7 @@ func copyFromTestG3GrandChild1(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g3_grand_child1"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g3_grand_child1"}, copyColsTestG3GrandChild1, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -110,6 +110,12 @@ func insertIntoTestGGrandChild1(batch *pgx.Batch, obj *storage.TestGGrandChild1)
 	return nil
 }
 
+var copyColsTestGGrandChild1 = []string{
+	"id",
+	"val",
+	"serialized",
+}
+
 func copyFromTestGGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestGGrandChild1) error {
 	if len(objs) == 0 {
 		return nil
@@ -125,12 +131,6 @@ func copyFromTestGGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postg
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -153,7 +153,7 @@ func copyFromTestGGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postg
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g_grand_child1"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_g_grand_child1"}, copyColsTestGGrandChild1, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -112,6 +112,14 @@ func insertIntoTestGrandChild1(batch *pgx.Batch, obj *storage.TestGrandChild1) e
 	return nil
 }
 
+var copyColsTestGrandChild1 = []string{
+	"id",
+	"parentid",
+	"childid",
+	"val",
+	"serialized",
+}
+
 func copyFromTestGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestGrandChild1) error {
 	if len(objs) == 0 {
 		return nil
@@ -127,14 +135,6 @@ func copyFromTestGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"childid",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -159,7 +159,7 @@ func copyFromTestGrandChild1(ctx context.Context, s pgSearch.Deleter, tx *postgr
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grand_child1"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grand_child1"}, copyColsTestGrandChild1, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -163,6 +163,14 @@ func insertIntoTestGrandparentsEmbeddedsEmbedded2(batch *pgx.Batch, obj *storage
 	return nil
 }
 
+var copyColsTestGrandparents = []string{
+	"id",
+	"val",
+	"priority",
+	"riskscore",
+	"serialized",
+}
+
 func copyFromTestGrandparents(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestGrandparent) error {
 	if len(objs) == 0 {
 		return nil
@@ -178,14 +186,6 @@ func copyFromTestGrandparents(ctx context.Context, s pgSearch.Deleter, tx *postg
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"val",
-		"priority",
-		"riskscore",
-		"serialized",
 	}
 
 	idx := 0
@@ -210,7 +210,7 @@ func copyFromTestGrandparents(ctx context.Context, s pgSearch.Deleter, tx *postg
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents"}, copyColsTestGrandparents, inputRows); err != nil {
 		return err
 	}
 
@@ -223,15 +223,15 @@ func copyFromTestGrandparents(ctx context.Context, s pgSearch.Deleter, tx *postg
 	return nil
 }
 
+var copyColsTestGrandparentsEmbeddeds = []string{
+	"test_grandparents_id",
+	"idx",
+	"val",
+}
+
 func copyFromTestGrandparentsEmbeddeds(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, testGrandparentID string, objs ...*storage.TestGrandparent_Embedded) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"test_grandparents_id",
-		"idx",
-		"val",
 	}
 
 	idx := 0
@@ -249,7 +249,7 @@ func copyFromTestGrandparentsEmbeddeds(ctx context.Context, s pgSearch.Deleter, 
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds"}, copyColsTestGrandparentsEmbeddeds, inputRows); err != nil {
 		return err
 	}
 
@@ -262,16 +262,16 @@ func copyFromTestGrandparentsEmbeddeds(ctx context.Context, s pgSearch.Deleter, 
 	return nil
 }
 
+var copyColsTestGrandparentsEmbeddedsEmbedded2 = []string{
+	"test_grandparents_id",
+	"test_grandparents_embeddeds_idx",
+	"idx",
+	"val",
+}
+
 func copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, testGrandparentID string, testGrandparentEmbeddedIdx int, objs ...*storage.TestGrandparent_Embedded_Embedded2) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"test_grandparents_id",
-		"test_grandparents_embeddeds_idx",
-		"idx",
-		"val",
 	}
 
 	idx := 0
@@ -290,7 +290,7 @@ func copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, s pgSearch.
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds_embedded2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_grandparents_embeddeds_embedded2"}, copyColsTestGrandparentsEmbeddedsEmbedded2, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -137,6 +137,14 @@ func insertIntoTestParent1Childrens(batch *pgx.Batch, obj *storage.TestParent1_C
 	return nil
 }
 
+var copyColsTestParent1 = []string{
+	"id",
+	"parentid",
+	"val",
+	"stringslice",
+	"serialized",
+}
+
 func copyFromTestParent1(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestParent1) error {
 	if len(objs) == 0 {
 		return nil
@@ -152,14 +160,6 @@ func copyFromTestParent1(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"val",
-		"stringslice",
-		"serialized",
 	}
 
 	idx := 0
@@ -184,7 +184,7 @@ func copyFromTestParent1(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1"}, copyColsTestParent1, inputRows); err != nil {
 		return err
 	}
 
@@ -197,15 +197,15 @@ func copyFromTestParent1(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 	return nil
 }
 
+var copyColsTestParent1Childrens = []string{
+	"test_parent1_id",
+	"idx",
+	"childid",
+}
+
 func copyFromTestParent1Childrens(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, testParent1ID string, objs ...*storage.TestParent1_Child1Ref) error {
 	if len(objs) == 0 {
 		return nil
-	}
-
-	copyCols := []string{
-		"test_parent1_id",
-		"idx",
-		"childid",
 	}
 
 	idx := 0
@@ -223,7 +223,7 @@ func copyFromTestParent1Childrens(ctx context.Context, s pgSearch.Deleter, tx *p
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1_childrens"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent1_childrens"}, copyColsTestParent1Childrens, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -112,6 +112,13 @@ func insertIntoTestParent2(batch *pgx.Batch, obj *storage.TestParent2) error {
 	return nil
 }
 
+var copyColsTestParent2 = []string{
+	"id",
+	"parentid",
+	"val",
+	"serialized",
+}
+
 func copyFromTestParent2(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestParent2) error {
 	if len(objs) == 0 {
 		return nil
@@ -127,13 +134,6 @@ func copyFromTestParent2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -157,7 +157,7 @@ func copyFromTestParent2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent2"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent2"}, copyColsTestParent2, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -111,6 +111,13 @@ func insertIntoTestParent3(batch *pgx.Batch, obj *storage.TestParent3) error {
 	return nil
 }
 
+var copyColsTestParent3 = []string{
+	"id",
+	"parentid",
+	"val",
+	"serialized",
+}
+
 func copyFromTestParent3(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestParent3) error {
 	if len(objs) == 0 {
 		return nil
@@ -126,13 +133,6 @@ func copyFromTestParent3(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -156,7 +156,7 @@ func copyFromTestParent3(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent3"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent3"}, copyColsTestParent3, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -112,6 +112,13 @@ func insertIntoTestParent4(batch *pgx.Batch, obj *storage.TestParent4) error {
 	return nil
 }
 
+var copyColsTestParent4 = []string{
+	"id",
+	"parentid",
+	"val",
+	"serialized",
+}
+
 func copyFromTestParent4(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestParent4) error {
 	if len(objs) == 0 {
 		return nil
@@ -127,13 +134,6 @@ func copyFromTestParent4(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"parentid",
-		"val",
-		"serialized",
 	}
 
 	idx := 0
@@ -157,7 +157,7 @@ func copyFromTestParent4(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent4"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_parent4"}, copyColsTestParent4, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -111,6 +111,13 @@ func insertIntoTestShortCircuits(batch *pgx.Batch, obj *storage.TestShortCircuit
 	return nil
 }
 
+var copyColsTestShortCircuits = []string{
+	"id",
+	"childid",
+	"g2grandchildid",
+	"serialized",
+}
+
 func copyFromTestShortCircuits(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestShortCircuit) error {
 	if len(objs) == 0 {
 		return nil
@@ -126,13 +133,6 @@ func copyFromTestShortCircuits(ctx context.Context, s pgSearch.Deleter, tx *post
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"id",
-		"childid",
-		"g2grandchildid",
-		"serialized",
 	}
 
 	idx := 0
@@ -156,7 +156,7 @@ func copyFromTestShortCircuits(ctx context.Context, s pgSearch.Deleter, tx *post
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_short_circuits"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_short_circuits"}, copyColsTestShortCircuits, inputRows); err != nil {
 		return err
 	}
 

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/store.go
@@ -122,6 +122,21 @@ func insertIntoTestSingleUUIDKeyStructs(batch *pgx.Batch, obj *storage.TestSingl
 	return nil
 }
 
+var copyColsTestSingleUUIDKeyStructs = []string{
+	"key",
+	"name",
+	"stringslice",
+	"bool",
+	"uint64",
+	"int64",
+	"float",
+	"labels",
+	"timestamp",
+	"enum",
+	"enums",
+	"serialized",
+}
+
 func copyFromTestSingleUUIDKeyStructs(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.TestSingleUUIDKeyStruct) error {
 	if len(objs) == 0 {
 		return nil
@@ -137,21 +152,6 @@ func copyFromTestSingleUUIDKeyStructs(ctx context.Context, s pgSearch.Deleter, t
 		if err := s.DeleteMany(ctx, deletes); err != nil {
 			return err
 		}
-	}
-
-	copyCols := []string{
-		"key",
-		"name",
-		"stringslice",
-		"bool",
-		"uint64",
-		"int64",
-		"float",
-		"labels",
-		"timestamp",
-		"enum",
-		"enums",
-		"serialized",
 	}
 
 	idx := 0
@@ -183,7 +183,7 @@ func copyFromTestSingleUUIDKeyStructs(ctx context.Context, s pgSearch.Deleter, t
 		}, nil
 	})
 
-	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_uuid_key_structs"}, copyCols, inputRows); err != nil {
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"test_single_uuid_key_structs"}, copyColsTestSingleUUIDKeyStructs, inputRows); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The generated store code re-generates the list of column names for a given object type on each call to UpsertMany that triggers the copyFrom path.

The goal here is to save this re-generation for information that is known at generate/compile time and does not need to be re-computed at runtime.

Benchmark tests do not show tangible changes in the number of allocations (neither improvement nor degradation).
On the other hand, the difference here is likely one array of 36 string constants "drowned" in the allocations to create the input rows for each processed alert (the interesting part is when the count of alert exceeds 100).

```
                                    │    old.txt      │    new.txt      │                       |
                                    │      B/op       │      B/op       |        vs base        │
------------------------------------+-----------------+-----------------+-----------------------+
AlertDatabaseOps/UpsertMany/2-12    |  70.02  Ki ± 1% |  70.22  Ki ± 1% | +0.28% (p=0.029 n=10) |
AlertDatabaseOps/UpsertMany/4-12    | 139.8   Ki ± 1% | 140.1   Ki ± 1% |      ~ (p=0.542 n=10) |
AlertDatabaseOps/UpsertMany/8-12    | 279.2   Ki ± 0% | 279.3   Ki ± 1% |      ~ (p=0.853 n=10) |
AlertDatabaseOps/UpsertMany/16-12   | 558.2   Ki ± 1% | 559.7   Ki ± 2% |      ~ (p=0.315 n=10) |
AlertDatabaseOps/UpsertMany/32-12   |   1.109 Mi ± 1% |   1.115 Mi ± 1% |      ~ (p=0.165 n=10) |
AlertDatabaseOps/UpsertMany/64-12   |   2.191 Mi ± 2% |   2.180 Mi ± 3% |      ~ (p=0.529 n=10) |
------------------------------------+-----------------+-----------------+-----------------------+
AlertDatabaseOps/UpsertMany/128-12  |   4.408 Mi ± 1% |   4.441 Mi ± 2% |      ~ (p=0.393 n=10) |
AlertDatabaseOps/UpsertMany/256-12  |   8.837 Mi ± 0% |   8.830 Mi ± 1% |      ~ (p=0.739 n=10) |
AlertDatabaseOps/UpsertMany/512-12  |  17.65  Mi ± 0% |  17.65  Mi ± 1% |      ~ (p=0.853 n=10) |
AlertDatabaseOps/UpsertMany/1024-12 |  35.15  Mi ± 0% |  35.14  Mi ± 0% |      ~ (p=0.971 n=10) |
AlertDatabaseOps/UpsertMany/2048-12 |  70.11  Mi ± 0% |  70.10  Mi ± 0% |      ~ (p=0.912 n=10) |
AlertDatabaseOps/UpsertMany/4096-12 | 140.2   Mi ± 0% | 140.2   Mi ± 0% |      ~ (p=0.436 n=10) |

                                    │    old.txt     │    new.txt     │                       |
                                    │   allocs/op    │   allocs/op    |        vs base        │
------------------------------------+----------------+----------------+-----------------------+
AlertDatabaseOps/UpsertMany/2-12    | 662.0     ± 0% | 662.0     ± 0% |      ~ (p=1.000 n=10) |
AlertDatabaseOps/UpsertMany/4-12    |   1.322 k ± 0% |   1.322 k ± 0% |      ~ (p=0.263 n=10) |
AlertDatabaseOps/UpsertMany/8-12    |   2.643 k ± 0% |   2.642 k ± 0% |      ~ (p=0.234 n=10) |
AlertDatabaseOps/UpsertMany/16-12   |   5.283 k ± 0% |   5.284 k ± 0% |      ~ (p=0.142 n=10) |
AlertDatabaseOps/UpsertMany/32-12   |  10.57  k ± 0% |  10.56  k ± 0% |      ~ (p=0.253 n=10) |
AlertDatabaseOps/UpsertMany/64-12   |  21.13  k ± 0% |  21.13  k ± 0% |      ~ (p=0.955 n=10) |
------------------------------------+----------------+----------------+-----------------------+
AlertDatabaseOps/UpsertMany/128-12  |  42.27  k ± 0% |  42.29  k ± 0% |      ~ (p=0.271 n=10) |
AlertDatabaseOps/UpsertMany/256-12  |  84.62  k ± 0% |  84.60  k ± 0% |      ~ (p=0.342 n=10) |
AlertDatabaseOps/UpsertMany/512-12  | 169.5   k ± 0% | 169.5   k ± 0% |      ~ (p=0.643 n=10) |
AlertDatabaseOps/UpsertMany/1024-12 | 339.2   k ± 0% | 339.3   k ± 0% |      ~ (p=0.912 n=10) |
AlertDatabaseOps/UpsertMany/2048-12 | 678.5   k ± 0% | 678.5   k ± 0% |      ~ (p=0.670 n=10) |
AlertDatabaseOps/UpsertMany/4096-12 |   1.356 M ± 0% |   1.356 M ± 0% |      ~ (p=0.481 n=10) |

```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->
Existing tests (generated store_test.go) should smoke-test that part of the code.

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI (postgres unit test) run
