### PR TITLE
ROX-31308: Delete React and sort named imports in ConfigManagement

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -777,7 +777,6 @@ module.exports = [
             'src/Components/**',
             'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated
-            'src/Containers/ConfigManagement/**',
             'src/Containers/PolicyCategories/**',
             'src/Containers/SystemHealth/**',
             'src/Containers/VulnMgmt/**', // deprecated
@@ -829,7 +828,6 @@ module.exports = [
             'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/ComplianceEnhanced/**',
-            'src/Containers/ConfigManagement/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',
             'src/Containers/Vulnerabilities/VirtualMachineCves/**',

--- a/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import { memo } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/ConfigManagementDashboardPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/ConfigManagementDashboardPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import useCaseLabels from 'messages/useCase';
 import useCaseTypes from 'constants/useCaseTypes';
 import { standardTypes } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/AppMenu.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/AppMenu.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import entityTypes from 'constants/entityTypes';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import pluralize from 'pluralize';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/CISControlsTile.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/CISControlsTile.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import URLService from 'utils/URLService';
 import { useLocation } from 'react-router-dom-v5-compat';
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import ExportButton from 'Components/ExportButton';
 import useCaseTypes from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/PoliciesTile.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/PoliciesTile.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 import { useLocation } from 'react-router-dom-v5-compat';
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/RBACMenu.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/RBACMenu.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import entityTypes from 'constants/entityTypes';
 import pluralize from 'pluralize';
 import entityLabels from 'messages/entity';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import { useContext, useState } from 'react';
 import { Alert } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/Lollipop.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/Lollipop.jsx
@@ -1,13 +1,12 @@
-import React from 'react';
 import {
     FlexibleWidthXYPlot,
+    GradientDefs,
+    HorizontalBarSeries,
+    LabelSeries,
+    MarkSeries,
+    VerticalGridLines,
     XAxis,
     YAxis,
-    VerticalGridLines,
-    HorizontalBarSeries,
-    MarkSeries,
-    LabelSeries,
-    GradientDefs,
 } from 'react-vis';
 import max from 'lodash/max';
 import { useNavigate } from 'react-router-dom-v5-compat';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import URLService from 'utils/URLService';
 import Widget from 'Components/Widget';
 import Sunburst from 'Components/visuals/Sunburst';
@@ -9,7 +9,7 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { Link, useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import max from 'lodash/max';
-import { severityValues, severities } from 'constants/severities';
+import { severities, severityValues } from 'constants/severities';
 import { policySeverityColorMap } from 'constants/severityColors';
 import { severityLabels as policySeverityLabels } from 'messages/common';
 import { policySeverities } from 'types/policy.proto';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link, useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 import Loader from 'Components/Loader';
 import { Link, useLocation } from 'react-router-dom-v5-compat';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityCluster.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityCluster.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -9,7 +9,7 @@ import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
 import BinderTabs from 'Components/BinderTabs';
 import Tab from 'Components/Tab';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
 import getSubListFromEntity from 'utils/getSubListFromEntity';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityControl.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityControl.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';
@@ -12,7 +12,7 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import isGQLLoading from 'utils/gqlLoading';
 import Widget from 'Components/Widget';
 import searchContext from 'Containers/searchContext';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import NodesWithFailedControls from './widgets/NodesWithFailedControls';
 import ConfigManagementListNodes from '../List/ConfigManagementListNodes';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityImage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityImage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -10,7 +10,7 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
 import { entityToColumns } from 'constants/listColumns';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import CVETable from 'Containers/Images/CVETable';
 import searchContext from 'Containers/searchContext';
 import { getDateTime } from 'utils/dateUtils';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNamespace.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNamespace.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -8,7 +8,7 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import RelatedEntity from 'Components/RelatedEntity';
 import Metadata from 'Components/Metadata';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNode.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNode.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import NoResultsMessage from 'Components/NoResultsMessage';
@@ -9,8 +9,8 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntity from 'Components/RelatedEntity';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
-import { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { defaultColumnClassName, defaultHeaderClassName } from 'Components/Table';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import { standardLabels } from 'messages/standards';
 import { CONTROL_FRAGMENT } from 'queries/controls';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityRole.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityRole.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -10,7 +10,7 @@ import Metadata from 'Components/Metadata';
 import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
 import searchContext from 'Containers/searchContext';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySecret.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySecret.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import { gql } from '@apollo/client';
@@ -12,7 +12,7 @@ import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
 import CollapsibleRow from 'Components/CollapsibleRow';
 import Widget from 'Components/Widget';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityServiceAccount.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityServiceAccount.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -8,7 +8,7 @@ import CollapsibleSection from 'Components/CollapsibleSection';
 import RelatedEntity from 'Components/RelatedEntity';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import { getDateTime } from 'utils/dateUtils';
 import getSubListFromEntity from 'utils/getSubListFromEntity';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -8,7 +8,7 @@ import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
 import isGQLLoading from 'utils/gqlLoading';
 import queryService from 'utils/queryService';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 
 import EntityList from '../List/EntityList';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/ConfigManagementEntityDeployment.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/ConfigManagementEntityDeployment.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import Query from 'Components/ThrowingQuery';
@@ -9,7 +9,7 @@ import RelatedEntity from 'Components/RelatedEntity';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
 import Metadata from 'Components/Metadata';
 import { getDateTime } from 'utils/dateUtils';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import getSubListFromEntity from 'utils/getSubListFromEntity';
 import isGQLLoading from 'utils/gqlLoading';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/DeploymentFindings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ViolationsAcrossThisDeployment from 'Containers/Workflow/widgets/ViolationsAcrossThisDeployment';
 import entityTypes from 'constants/entityTypes';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import upperFirst from 'lodash/upperFirst';
 import startCase from 'lodash/startCase';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityTabs.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityTabs.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import entityTypes from 'constants/entityTypes';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/ConfigManagementEntityPolicy.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/ConfigManagementEntityPolicy.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 
@@ -10,7 +10,7 @@ import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverit
 import Widget from 'Components/Widget';
 import Metadata from 'Components/Metadata';
 import RelatedEntityListCount from 'Components/RelatedEntityListCount';
-import { entityComponentPropTypes, entityComponentDefaultProps } from 'constants/entityPageProps';
+import { entityComponentDefaultProps, entityComponentPropTypes } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import { formatLifecycleStages } from 'Containers/Policies/policies.utils';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/DeploymentViolations.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/DeploymentViolations.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/PolicyFindings.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/PolicyFindings.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import entityTypes from 'constants/entityTypes';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ClusterScopedPermissions.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ClusterScopedPermissions.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Widget from 'Components/Widget';
 import NoResultsMessage from 'Components/NoResultsMessage';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import VIOLATIONS from 'queries/violation';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import entityTypes from 'constants/entityTypes';
-import { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';
+import { defaultColumnClassName, defaultHeaderClassName } from 'Components/Table';
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';
 import { sortSeverity } from 'sorters/sorters';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/NamespaceScopedPermissions.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/NamespaceScopedPermissions.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Widget from 'Components/Widget';
 import NoResultsMessage from 'Components/NoResultsMessage';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/NodesWithFailedControls.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/NodesWithFailedControls.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import entityTypes from 'constants/entityTypes';
 import NoResultsMessage from 'Components/NoResultsMessage';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/PermissionCounts.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/PermissionCounts.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const flattenPermissions = (scopedPermissions) => {

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/RulePermissions.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/RulePermissions.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import Widget from 'Components/Widget';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/Rules.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/Rules.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import Widget from 'Components/Widget';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const ScopedPermissions = ({ permissions }) => {
     return permissions.map((datum) => {
         return (

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/TableWidget.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/TableWidget.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import resolvePath from 'object-resolve-path';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListClusters.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListClusters.jsx
@@ -1,16 +1,15 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import { clusterSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListControls.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListControls.jsx
@@ -1,17 +1,17 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import capitalize from 'lodash/capitalize';
 
 import NotApplicableIconText from 'Components/PatternFly/IconText/NotApplicableIconText';
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
-import { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';
+import { defaultColumnClassName, defaultHeaderClassName } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
 import searchContext from 'Containers/searchContext';
 import COMPLIANCE_STATES from 'constants/complianceStates';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import { standardLabels } from 'messages/standards';
 import { LIST_STANDARD_NO_NODES as QUERY } from 'queries/standard';
-import { sortVersion, sortStatus } from 'sorters/sorters';
+import { sortStatus, sortVersion } from 'sorters/sorters';
 import queryService from 'utils/queryService';
 import { getConfigMgmtPathForEntitiesAndId } from '../entities';
 import ListFrontendPaginated from './ListFrontendPaginated';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListDeployments.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListDeployments.jsx
@@ -1,17 +1,17 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
 import searchContext from 'Containers/searchContext';
 import { deploymentSortFields } from 'constants/sortFields';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { DEPLOYMENTS_QUERY } from 'queries/deployment';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { imageSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { IMAGES_QUERY } from 'queries/image';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNamespaces.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNamespaces.jsx
@@ -1,16 +1,16 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
 import searchContext from 'Containers/searchContext';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import { namespaceSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
@@ -1,15 +1,14 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { nodeSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { getDateTime } from 'utils/dateUtils';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListPolicies.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListPolicies.jsx
@@ -1,15 +1,13 @@
-import React from 'react';
-
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import PolicyDisabledIconText from 'Components/PatternFly/IconText/PolicyDisabledIconText';
 import PolicySeverityIconText from 'Components/PatternFly/IconText/PolicySeverityIconText';
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
 import TableCellLink from 'Components/TableCellLink';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import { policySortFields } from 'constants/sortFields';
 import { formatLifecycleStages } from 'Containers/Policies/policies.utils';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { roleSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { K8S_ROLES_QUERY } from 'queries/role';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
@@ -1,15 +1,14 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import uniq from 'lodash/uniq';
 import pluralize from 'pluralize';
 
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { SECRETS_QUERY } from 'queries/secret';
 import { secretSortFields } from 'constants/sortFields';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListServiceAccounts.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListServiceAccounts.jsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { serviceAccountSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { SERVICE_ACCOUNTS_QUERY } from 'queries/serviceAccount';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 
 import {
-    defaultHeaderClassName,
     defaultColumnClassName,
+    defaultHeaderClassName,
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
+import { entityListDefaultprops, entityListPropTypes } from 'constants/entityPageProps';
 import { subjectSortFields } from 'constants/sortFields';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import { SUBJECTS_QUERY } from 'queries/subject';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/EntityList.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/EntityList.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import PageNotFound from 'Components/PageNotFound';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/List.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/List.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat'; // Updated imports
 import pluralize from 'pluralize';
@@ -7,7 +7,7 @@ import resolvePath from 'object-resolve-path';
 import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
 import PageNotFound from 'Components/PageNotFound';
-import { PanelNew, PanelBody, PanelHead, PanelHeadEnd, PanelTitle } from 'Components/Panel';
+import { PanelBody, PanelHead, PanelHeadEnd, PanelNew, PanelTitle } from 'Components/Panel';
 import Table from 'Components/Table';
 import TablePagination from 'Components/TablePagination';
 import URLSearchInput from 'Components/URLSearchInput';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
@@ -7,7 +7,7 @@ import resolvePath from 'object-resolve-path';
 import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
 import PageNotFound from 'Components/PageNotFound';
-import { PanelNew, PanelBody, PanelHead, PanelHeadEnd, PanelTitle } from 'Components/Panel';
+import { PanelBody, PanelHead, PanelHeadEnd, PanelNew, PanelTitle } from 'Components/Panel';
 import Table, { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import TablePagination from 'Components/TablePagination';
 import URLSearchInput from 'Components/URLSearchInput';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useRef, useState } from 'react';
+import { useCallback, useContext, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/utilities/NoEntitiesIconText.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/utilities/NoEntitiesIconText.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Icon } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BackButton.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom-v5-compat';
 import URLService from 'utils/URLService';

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate, Link } from 'react-router-dom-v5-compat';
+import { Link, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import CloseButton from 'Components/CloseButton';
-import { PanelNew, PanelBody, PanelHead, PanelHeadEnd } from 'Components/Panel';
+import { PanelBody, PanelHead, PanelHeadEnd, PanelNew } from 'Components/Panel';
 import searchContext from 'Containers/searchContext';
 import workflowStateContext from 'Containers/workflowStateContext';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';


### PR DESCRIPTION
## Description

Double up to merge ahead of PatternFly 6.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.