### PR TITLE
ROX-31530: Delete React and sort named imports in Clusters

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -775,7 +775,6 @@ module.exports = [
         ignores: [
             'cypress/integration/**',
             'src/Components/**',
-            'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/ConfigManagement/**',
             'src/Containers/PolicyCategories/**',
@@ -829,7 +828,6 @@ module.exports = [
         files: ['**/*.{js,jsx,ts,tsx}'],
         ignores: [
             'src/Containers/Audit/**',
-            'src/Containers/Clusters/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/ComplianceEnhanced/**',
             'src/Containers/ConfigManagement/**',

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Button, Flex, FlexItem, Switch, Text, Title } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Flex, FlexItem, Title } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Button, Icon, TextInput, Tooltip, ValidatedOptions } from '@patternfly/react-core';
 import { PlusCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import type { ClusterLabels } from 'services/ClustersService';
 import { getIsValidLabelKey, getIsValidLabelValue } from 'utils/labels';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -25,10 +25,10 @@ import useInterval from 'hooks/useInterval';
 import useMetadata from 'hooks/useMetadata';
 import usePermissions from 'hooks/usePermissions';
 import {
-    fetchClusterWithRetentionInformation,
-    saveCluster,
     downloadClusterYaml,
+    fetchClusterWithRetentionInformation,
     getClusterDefaults,
+    saveCluster,
 } from 'services/ClustersService';
 import type { Cluster, ClusterManagerType } from 'types/cluster.proto';
 import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     DescriptionList,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretTechPreviewAlert.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretTechPreviewAlert.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Alert } from '@patternfly/react-core';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import {
     Breadcrumb,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Bullseye, Button, Divider, PageSection, Spinner } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsRoute.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import qs from 'qs';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/RevokeClusterRegistrationSecretModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import qs from 'qs';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     ClipboardCopy,

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClusterStatusGrid.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterStatusGrid.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Grid, GridItem } from '@patternfly/react-core';
 
 import type { ClusterHealthStatus } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Grid, GridItem } from '@patternfly/react-core';
 
 import type { Cluster } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { MouseEvent, ReactElement } from 'react';
 import {
     ActionsColumn,

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Button,
@@ -33,10 +33,10 @@ import useMetadata from 'hooks/useMetadata';
 import usePermissions from 'hooks/usePermissions';
 import useURLSearch from 'hooks/useURLSearch';
 import {
-    fetchClustersWithRetentionInfo,
     deleteClusters,
-    upgradeClusters,
+    fetchClustersWithRetentionInfo,
     upgradeCluster,
+    upgradeClusters,
 } from 'services/ClustersService';
 import type { Cluster } from 'types/cluster.proto';
 import type { ClusterIdToRetentionInfo } from 'types/clusterService.proto';
@@ -45,12 +45,12 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
 import {
     clustersBasePath,
+    clustersClusterRegistrationSecretsPath,
     clustersDelegatedScanningPath,
     clustersDiscoveredClustersPath,
     clustersInitBundlesPath,
-    clustersSecureClusterPath,
     clustersSecureClusterCrsPath,
-    clustersClusterRegistrationSecretsPath,
+    clustersSecureClusterPath,
 } from 'routePaths';
 
 import ClustersTable from './ClustersTable';

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlPanel.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import {
     DescriptionList,
+    DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    DescriptionListDescription,
     List,
     ListItem,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import type { ClusterHealthStatus } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/AutoUpgradeToggle.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AutoUpgradeToggle.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import { Switch } from '@patternfly/react-core';
 import {
-    isAutoUpgradeSupported,
     getAutoUpgradeConfig,
+    isAutoUpgradeSupported,
     saveAutoUpgradeConfig,
 } from 'services/ClustersService';
 import type { AutoUpgradeConfig } from 'services/ClustersService';

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterDeletion.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterHealthPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterHealthPanel.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import type { ReactElement, ReactNode } from 'react';
-import { Panel, PanelHeader, PanelMain, PanelMainBody, Divider } from '@patternfly/react-core';
+import { Divider, Panel, PanelHeader, PanelMain, PanelMainBody } from '@patternfly/react-core';
 
 type ClusterHealthPanelProps = {
     children: ReactNode;

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterMetadata.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterMetadata.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import {
     DescriptionList,
+    DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    DescriptionListDescription,
 } from '@patternfly/react-core';
 
 import type { ClusterStatus } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterNameWithTypeIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Flex } from '@patternfly/react-core';
 import type { Cluster } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import type { ClusterHealthStatus } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorPanel.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import {
     DescriptionList,
+    DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    DescriptionListDescription,
     List,
     ListItem,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import type { ClusterHealthStatus } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import { healthStatusStylesLegacy } from '../../cluster.helpers';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { differenceInDays } from 'date-fns';
 import { Tooltip } from '@patternfly/react-core';
 
-import { getTime, getDate, getDayOfWeek, getDistanceStrictAsPhrase } from 'utils/dateUtils';
+import { getDate, getDayOfWeek, getDistanceStrictAsPhrase, getTime } from 'utils/dateUtils';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useMetadata from 'hooks/useMetadata';
 import { getVersionedDocs } from 'utils/versioning';

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthLabelWithDelayed.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthLabelWithDelayed.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import { healthStatusLabels } from '../cluster.constants';
-import type { ClusterHealthItemStatus, ClusterHealthItem } from '../clusterTypes';
+import type { ClusterHealthItem, ClusterHealthItemStatus } from '../clusterTypes';
 
 type HealthLabelWithDelayedProps = {
     delayedText: string;

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthStatus.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement, ReactNode } from 'react';
 
 /*

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthStatusNotApplicable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthStatusNotApplicable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 type HealthStatusNotApplicableProps = { testId: string; isList?: boolean };

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmValueWarning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmValueWarning.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerPanel.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import {
     DescriptionList,
+    DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    DescriptionListDescription,
     List,
     ListItem,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { ClusterHealthStatus } from 'types/cluster.proto';
 
 import {

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorPanel.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import {
     DescriptionList,
+    DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    DescriptionListDescription,
 } from '@patternfly/react-core';
 
 import type { ClusterHealthStatus } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import type { ClusterHealthStatus } from 'types/cluster.proto';

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import HealthStatus from './HealthStatus';

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgradePanel.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
 import {
+    Button,
     DescriptionList,
+    DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    DescriptionListDescription,
     Divider,
     Panel,
     PanelHeader,
     PanelMain,
     PanelMainBody,
-    Button,
 } from '@patternfly/react-core';
 import upperFirst from 'lodash/upperFirst';
 

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedRegistriesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement, Ref } from 'react';
 import {
     Button,

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement, Ref } from 'react';
 import {
     Flex,

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/ToggleDelegatedScanning.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormGroup, Radio } from '@patternfly/react-core';
 
 import type { DelegatedRegistryConfigEnabledFor } from 'services/DelegatedRegistryConfigService';

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegateScanningPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
     Alert,
     Breadcrumb,
@@ -18,12 +18,12 @@ import PageTitle from 'Components/PageTitle';
 import usePermissions from 'hooks/usePermissions';
 import { clustersBasePath } from 'routePaths';
 import {
-    fetchDelegatedRegistryConfig,
     fetchDelegatedRegistryClusters,
+    fetchDelegatedRegistryConfig,
 } from 'services/DelegatedRegistryConfigService';
 import type {
-    DelegatedRegistryConfig,
     DelegatedRegistryCluster,
+    DelegatedRegistryConfig,
 } from 'services/DelegatedRegistryConfigService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegatedImageScanningForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/DelegatedImageScanningForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ActionGroup, Alert, Button, Flex, Form, FormGroup } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useFormik } from 'formik';

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredCluster.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { CheckCircleIcon, SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
 import { Icon } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersEmptyState.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersEmptyState.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Bullseye,
     EmptyState,
     EmptyStateBody,
+    EmptyStateHeader,
     EmptyStateIcon,
     Flex,
     Text,
     Title,
-    EmptyStateHeader,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { Tbody, Td, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Tooltip } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.cy.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { noop } from 'lodash';
 
 import ComponentTestProvider from 'test-utils/ComponentTestProvider';

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/DiscoveredClustersToolbar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     Pagination,

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterNames.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterNames.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { SearchInput } from '@patternfly/react-core';
 
 type SearchFilterNamesProps = {

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Divider, SelectOption } from '@patternfly/react-core';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Divider, SelectOption } from '@patternfly/react-core';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';

--- a/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DownloadHelmValues.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { Button, Flex, FlexItem, Text, Title } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Alert,
     Form,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleDescription.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     DescriptionList,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import {
     Breadcrumb,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Bullseye, Button, PageSection, Spinner } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesRoute.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import qs from 'qs';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundlesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/RevokeBundleModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import qs from 'qs';

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingHelmChart.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import {
     ClipboardCopy,

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterUsingOperator.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/NoClustersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import {
@@ -7,14 +7,14 @@ import {
     Button,
     EmptyState,
     EmptyStateBody,
+    EmptyStateFooter,
+    EmptyStateHeader,
     EmptyStateIcon,
     Flex,
     FlexItem,
     PageSection,
     Spinner,
     Text,
-    EmptyStateHeader,
-    EmptyStateFooter,
 } from '@patternfly/react-core';
 import { CloudSecurityIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/StaticConfigurationForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Form,
     FormGroup,

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -1,8 +1,8 @@
 import {
     findUpgradeState,
     formatBuildDate,
-    formatKubernetesVersion,
     formatCloudProvider,
+    formatKubernetesVersion,
     getCredentialExpirationStatus,
     getUpgradeableClusters,
 } from './cluster.helpers';

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { differenceInDays, differenceInMinutes } from 'date-fns';
 import get from 'lodash/get';
 import { DownloadCloud } from 'react-feather';
@@ -7,8 +6,8 @@ import {
     CheckCircleIcon,
     ExclamationCircleIcon,
     ExclamationTriangleIcon,
-    InfoCircleIcon,
     InProgressIcon,
+    InfoCircleIcon,
     MinusCircleIcon,
     ResourcesEmptyIcon,
     UnknownIcon,


### PR DESCRIPTION
## Description

Double up to merge ahead of PatternFly 6.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.