### PR TITLE
ROX-31549: Add Route-replace rule to pluginGeneric

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -115,6 +115,37 @@ const rules = {
             };
         },
     },
+    'Route-replace': {
+        // Require replace prop for React Router Navigate element.
+        // If landing path of route (that is, address in left navigation)
+        // redirects to first tab as (default) push,
+        // then browser history has an additional entry
+        // and user must click Back two times instead of expected one time.
+        // Rule allows replace={false} for theoretical case where push is intended.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Require replace prop for React Router Navigate element',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (
+                        node.name?.name === 'Navigate' &&
+                        node.attributes.some((attribute) => attribute.name?.name === 'to') &&
+                        !node.attributes.some((attribute) => attribute.name?.name === 'replace')
+                    ) {
+                        context.report({
+                            node,
+                            message: 'Require that React Router Navigate element has replace prop',
+                        });
+                    }
+                },
+            };
+        },
+    },
     'Td-defaultColumns': {
         // Require that Td element has key and title from defaultColumns configuration.
         // That is, if Td element has props for column management:

--- a/ui/apps/platform/src/Components/TabNav/TabNavHeader.tsx
+++ b/ui/apps/platform/src/Components/TabNav/TabNavHeader.tsx
@@ -1,19 +1,16 @@
 import { PageSection, Title } from '@patternfly/react-core';
 
-import PageTitle from 'Components/PageTitle';
 import TabNav from 'Components/TabNav/TabNav';
 
 type TabNavHeaderProps = {
     mainTitle: string;
-    pageTitle: string;
     currentTabTitle: string;
     tabLinks: { title: string; href: string }[];
 };
 
-function TabNavHeader({ mainTitle, pageTitle, currentTabTitle, tabLinks }: TabNavHeaderProps) {
+function TabNavHeader({ mainTitle, currentTabTitle, tabLinks }: TabNavHeaderProps) {
     return (
         <>
-            <PageTitle title={pageTitle} />
             <PageSection variant="light">
                 <Title headingLevel="h1">{mainTitle}</Title>
             </PageSection>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -14,7 +14,7 @@ function AccessControl(): ReactElement {
     return (
         <>
             <Routes>
-                <Route index element={<Navigate to={entityPathSegment.AUTH_PROVIDER} />} />
+                <Route index element={<Navigate to={entityPathSegment.AUTH_PROVIDER} replace />} />
                 <Route
                     path={`${entityPathSegment.AUTH_PROVIDER}/${paramId}`}
                     element={<AuthProviders />}

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTablePage.tsx
@@ -6,6 +6,7 @@ import pluralize from 'pluralize';
 import orderBy from 'lodash/orderBy';
 
 import { policiesBasePath } from 'routePaths';
+import PageTitle from 'Components/PageTitle';
 import TabNavSubHeader from 'Components/TabNav/TabNavSubHeader';
 import {
     deletePolicies,
@@ -206,6 +207,7 @@ function PoliciesTablePage({
 
     return (
         <>
+            <PageTitle title="Policy Management - Policies" />
             <PolicyManagementHeader currentTabTitle="Policies" />
             <Divider component="div" />
             <TabNavSubHeader

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -15,6 +15,7 @@ import {
     AlertActionCloseButton,
 } from '@patternfly/react-core';
 
+import PageTitle from 'Components/PageTitle';
 import usePermissions from 'hooks/usePermissions';
 import useToasts from 'hooks/patternfly/useToasts';
 import type { Toast } from 'hooks/patternfly/useToasts';
@@ -86,6 +87,7 @@ function PolicyCategoriesPage(): ReactElement {
 
     return (
         <>
+            <PageTitle title="Policy management - Policy categories" />
             <PolicyManagementHeader currentTabTitle="Policy categories" />
             <Divider component="div" />
             <PageSection variant="light" className="pf-v5-u-py-0">

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
@@ -16,7 +16,6 @@ function PolicyManagementHeader({ currentTabTitle }: PolicyManagementHeaderProps
             <TabNavHeader
                 currentTabTitle={currentTabTitle}
                 tabLinks={tabLinks}
-                pageTitle="Policy management - Policy categories"
                 mainTitle="Policy management"
             />
         </>

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
@@ -6,7 +6,7 @@ import PolicyCategoriesPage from 'Containers/PolicyCategories/PolicyCategoriesPa
 function PolicyManagementPage() {
     return (
         <Routes>
-            <Route index element={<Navigate to="policies" />} />
+            <Route index element={<Navigate to="policies" replace />} />
             <Route path="policies/:policyId?/:command?" element={<PoliciesPage />} />
             <Route path="policy-categories" element={<PolicyCategoriesPage />} />
         </Routes>


### PR DESCRIPTION
## Description

Follow up discovery of problem in #17557

### Problem

If landing path of route (that is, address in left navigation) redirects to first tab as (default) **push**, then browser history has an additional entry and user must click **back** two times instead of expected one time.

Bonus problem: /main/policy-management/policies has title on browser tab: Policy management - policy categories

### Analysis

Find in Files `<Navigate` has 12 results in 9 files.

Is `Navigate` with or without prop and what about `Route` element?

With `replace` prop:
* CoveragePage.tsx file: `ProfilesRedirectHandler` function
* CoveragesPage.tsx file: `path="*"` prop
* ScanConfigsPage.tsx file: `index` prop
* AuthenticatedRoutes.tsx file: `case` statement
* Body.tsx file:
    * `WorkloadCvesRedirect` function
    * `DeprecatedPoliciesRedirect` function
    * `path="/"` prop
    * `path={mainPath}` prop
* ExceptionRequestsPage.tsx file: `index` prop
* VulnReportingPage.tsx file: `index` prop

Without `replace` prop:
* AccessControl.tsx file: `index` prop
* PolicyManagementPage.tsx file: `index` prop

Bonus analysis: `TabNavNeader` element renders title independent of tab.

### Solution

Use typescript-eslint playground to understand `Navigate` element:
* with `to` prop (to ignore `Navigate` element, if not from React Router)
* without `replace` prop

https://typescript-eslint.io/play/#ts=5.9.3&showAST=es&fileType=.tsx

Bonus solution:
1. Delete `pageTitle` prop from `TabNavHeader` element.
2. Make sure each subroute page renders `PageTitle` element.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. Fix errors.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.

### Manual testing

`npm run start` in ui/apps/platform folder with staging demo as central.

1. Expand **Compliance** and then click **OpenShift Coverage** to visit /main/compliance/coverage

    Redirect to /main/compliance/coverage/profiles/id/checks
    Browser tab: Compliance coverage - Profile clusters

    Independent of changes:
    Browser history: Dashboard
    Click **back** one time.

2. Expand **Platform Configuration** and then click **Access Control** to visit /main/access-control

    Redirect to /main/access-control/auth-providers
    Browser tab: Access Control - Auth providers

    Before changes:
    Browser history: Access Control and then Dashboard
    Click **back** one time: seems to stay on page.
    Click **back** second time: visit /login and see **Go to Dashboard**

    After channges:
    Browser history: Dashboard
    Click **back** one time.

3. Expand **Platform Configuration** and then click **Policy Management** to visit /main/policy-management

    Redirect to /main/policy-management/policies

    Before changes:
    Browser tab: Policy management - policy categories
    Browser history: Policy Management and then Dashboard
    Click **back** one time: seems to stay on page.
    Click **back** second time: blank page

    After channges:
    Browser tab: Policy management - Policies
    Browser history: Dashboard
    Click **back** one time.

    Also verify solution to bonus problem