### PR TITLE
ROX-31601: Long running cluster should always have churn

### DIFF
--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -23,7 +23,7 @@ jobs:
     churnDuration: 1000h
     churnDelay: 10m
     churnPercent: 80
-    maxWaitTimeout: 8m
+    maxWaitTimeout: 12m
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false
       pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Sometimes a small number of berserker pods will get stuck in the pending state. Unfortunately kube-buner waits for all pods to be ready, and then waits a set amount of time before applying churn. To solve this issue `maxWaitTimeout` is set to value less than `churnDelay`. 

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

A long running cluster was created.

Went to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml
Clicked on "Run workflow"
Set jv-long-running-cluster-should-always-have-churn as the branch
Set the version to 0.0.53
Clicked on "Run workflow"

Waited for the long running to be deployed and connected to the cluster with real load

```
$ infractl artifacts lrl-0-0-53 --download-dir /tmp/artifacts-lrl-0-0-53
$ export KUBECONFIG=/tmp/artifacts-lrl-0-0-53/kubeconfig 
```

Checked that everything was running Okay.

```
$ ks get pod
NAME                                                      READY   STATUS    RESTARTS   AGE
admission-control-6444847c56-bwk9q                        1/1     Running   0          10m
admission-control-6444847c56-cp5zx                        1/1     Running   0          10m
admission-control-6444847c56-tdr9p                        1/1     Running   0          10m
collector-h4dmr                                           2/2     Running   0          9m49s
collector-j68ws                                           2/2     Running   0          9m49s
collector-j74lm                                           2/2     Running   0          9m54s
collector-vcgnm                                           2/2     Running   0          9m53s
collector-zsplt                                           2/2     Running   0          9m53s
monitoring-7f658fbc74-bjlpv                               2/2     Running   0          10m
sensor-5b9fbc457b-p9g8d                                   1/1     Running   0          9m52s
stackrox-monitoring-alertmanager-0                        2/2     Running   0          10m
stackrox-monitoring-kube-state-metrics-7c77c7d988-m7rxl   1/1     Running   0          10m
```

```
$ kc get ns
NAME                          STATUS   AGE
berserker-1                   Active   8m19s
berserker-2                   Active   2m52s
berserker-3                   Active   2m50s
berserker-4                   Active   2m45s
berserker-5                   Active   2m41s
default                       Active   38m
gke-managed-cim               Active   36m
gke-managed-system            Active   36m
gke-managed-volumepopulator   Active   36m
gmp-public                    Active   36m
gmp-system                    Active   36m
kube-burner                   Active   9m15s
kube-node-lease               Active   38m
kube-public                   Active   38m
kube-system                   Active   38m
stackrox                      Active   11m
```

To trigger the case where berserker pods would be stuck in the pending state, I created 50 pods that did nothing but sleep. This way there would be too many pods for to run, and some of the berserker pods would get stuck in the pending state.

```
$ cat sleep-deployment.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: sleep-deployment
  labels:
    app: sleep
spec:
  replicas: 50
  selector:
    matchLabels:
      app: sleep
  template:
    metadata:
      labels:
        app: sleep
    spec:
      containers:
      - name: sleeper
        image: busybox:latest
        command: ["sleep", "infinity"]
        resources:
          requests:
            memory: "64Mi"
            cpu: "50m"
          limits:
            memory: "128Mi"
            cpu: "100m"
```

This did result in kube-burner pods getting stuck in the pending state.

```
$ kc get pod --all-namespaces | grep Pending
berserker-4       connection-load-5-696wv                                   0/1     Pending             0          74s
berserker-4       connection-load-5-mljv5                                   0/1     Pending             0          73s
berserker-4       connection-load-5-mq727                                   0/1     Pending             0          74s
berserker-4       connection-load-5-rbq57                                   0/1     Pending             0          73s
berserker-4       connection-load-5-rpcw4                                   0/1     Pending             0          75s
berserker-4       endpoint-load-4-66x5d                                     0/1     Pending             0          75s
berserker-4       endpoint-load-4-6lrzr                                     0/1     Pending             0          73s
berserker-4       endpoint-load-4-f9c74                                     0/1     Pending             0          74s
berserker-4       endpoint-load-4-gfh7l                                     0/1     Pending             0          73s
berserker-4       endpoint-load-4-sgnjn                                     0/1     Pending             0          74s
berserker-5       connection-load-2-5lscg                                   0/1     Pending             0          76s
berserker-5       connection-load-2-xcmq8                                   0/1     Pending             0          76s
berserker-5       endpoint-load-4-xwlws                                     0/1     Pending             0          76s
berserker-5       process-load-1-7d7tq                                      0/1     Pending             0          77s
berserker-5       process-load-2-cnvc9                                      0/1     Pending             0          75s
berserker-5       process-load-2-mtsx6                                      0/1     Pending             0          76s
berserker-5       process-load-2-nmrs7                                      0/1     Pending             0          75s
```

However, it did not prevent churn.

```
$ kc get ns
NAME                          STATUS   AGE
berserker-1                   Active   22s
berserker-2                   Active   19s
berserker-3                   Active   14s
berserker-4                   Active   8s
berserker-5                   Active   29m
default                       Active   3h48m
gke-managed-cim               Active   3h47m
gke-managed-system            Active   3h46m
gke-managed-volumepopulator   Active   3h46m
gmp-public                    Active   3h46m
gmp-system                    Active   3h46m
kube-burner                   Active   3h19m
kube-node-lease               Active   3h48m
kube-public                   Active   3h49m
kube-system                   Active   3h49m
stackrox                      Active   3h21m
```

The young age of the berserker namespaces compared to the other namespaces shows that they are being churned.


The control was also tested. The above steps were repeated except instead of specifying this branch, the main branch was used. The extra pods that sleep were not deployed right away, but much later.

Deploying the extra pods resulted in pods getting stuck in pending.
```
$ kc get pod --all-namespaces | grep Pending
berserker-3       connection-load-2-bl89z                                   0/1     Pending   0          64m
berserker-3       connection-load-3-vfwmr                                   0/1     Pending   0          64m
berserker-3       connection-load-5-d5gh5                                   0/1     Pending   0          64m
berserker-3       endpoint-load-1-79vkj                                     0/1     Pending   0          64m
berserker-3       endpoint-load-4-m9plf                                     0/1     Pending   0          64m
berserker-3       process-load-6-t9762                                      0/1     Pending   0          64m
berserker-4       connection-load-2-c4xrc                                   0/1     Pending   0          64m
berserker-4       connection-load-2-k4d9v                                   0/1     Pending   0          64m
berserker-4       connection-load-2-qnshk                                   0/1     Pending   0          64m
berserker-4       connection-load-2-smxcs                                   0/1     Pending   0          64m
berserker-4       connection-load-3-c6p2b                                   0/1     Pending   0          64m
berserker-4       connection-load-3-gqvng                                   0/1     Pending   0          64m
berserker-4       connection-load-4-cnbfd                                   0/1     Pending   0          64m
berserker-4       connection-load-4-kk5rs                                   0/1     Pending   0          64m
berserker-4       connection-load-4-qjkkp                                   0/1     Pending   0          64m
berserker-4       connection-load-5-swpx2                                   0/1     Pending   0          64m
berserker-4       connection-load-5-wqfbb                                   0/1     Pending   0          64m
```

and the churn stopping.

```
$ kc get ns
NAME                          STATUS   AGE
berserker-1                   Active   62m
berserker-2                   Active   62m
berserker-3                   Active   62m
berserker-4                   Active   62m
berserker-5                   Active   77m
default                       Active   3h22m
gke-managed-cim               Active   3h20m
gke-managed-system            Active   3h19m
gke-managed-volumepopulator   Active   3h19m
gmp-public                    Active   3h19m
gmp-system                    Active   3h19m
kube-burner                   Active   173m
kube-node-lease               Active   3h22m
kube-public                   Active   3h22m
kube-system                   Active   3h22m
stackrox                      Active   175m
```

The berserker namespaces are over an hour old even though they should last for only 10 minutes.