### PR TITLE
test(perf): benchmark Alert UpsertMany

### DIFF
--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -100,15 +100,13 @@ func BenchmarkAlertDatabaseOps(b *testing.B) {
 	}
 	for _, batchSize := range batchSizes {
 		curBatch := make([]*storage.Alert, batchSize)
-		for i := 0; i < batchSize; i++ {
+		for i := range batchSize {
 			curBatch[i] = alertBatch[i%len(alertBatch)]
 		}
 		b.Run(fmt.Sprintf("UpsertMany/%d", batchSize), func(ib *testing.B) {
-			ib.StartTimer()
 			for ib.Loop() {
 				assert.NoError(ib, datastore.UpsertAlerts(ctx, curBatch))
 			}
-			ib.StopTimer()
 		})
 	}
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

New benchmark for UpsertMany operations.
The goal was to validate the gains from #17594 

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) ~~is updated **OR**~~ update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) ~~is created and is linked above **OR**~~ is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
<!--
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests
-->

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manually run the benchmark

```
central/alert/datastore $ go test -bench . -tags sql_integration -v -benchmem
[... Unit test output ...]
goos: darwin
goarch: amd64
pkg: github.com/stackrox/rox/central/alert/datastore
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkAlertDatabaseOps
[... other benchmark results ...]
BenchmarkAlertDatabaseOps/UpsertMany/2-12    129       8444423 ns/op        72641 B/op      652 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/4-12    126       9450085 ns/op       143699 B/op     1301 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/8-12    102      10966132 ns/op       288552 B/op     2600 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/16-12    58      19630015 ns/op       570999 B/op     5246 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/32-12    31      39424580 ns/op      1135336 B/op    10460 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/64-12    16      82800704 ns/op      2266851 B/op    20870 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/128-12    7     153732317 ns/op      4482170 B/op    41369 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/256-12    4     306455768 ns/op      8846962 B/op    81715 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/512-12    2     668219706 ns/op     17143036 B/op   158666 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/1024-12   1    1182267493 ns/op     31881624 B/op   297524 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/2048-12   1    2669737128 ns/op     64396296 B/op   596042 allocs/op
BenchmarkAlertDatabaseOps/UpsertMany/4096-12   1    5213174727 ns/op    127927328 B/op  1191928 allocs/op
PASS
```