### PR TITLE
fix(VM): remove codes.Internal from retryable gRPC errors

### DIFF
--- a/compliance/virtualmachines/relay/relay.go
+++ b/compliance/virtualmachines/relay/relay.go
@@ -239,9 +239,7 @@ func isRetryableGRPCError(err error) bool {
 	}
 	code := grpcErr.Code()
 	switch code {
-	case codes.DeadlineExceeded:
-		return !errors.Is(err, context.Canceled)
-	case codes.Unavailable, codes.ResourceExhausted, codes.Internal:
+	case codes.DeadlineExceeded, codes.Unavailable, codes.ResourceExhausted:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Description

Remove codes.Internal from the list of retryable gRPC errors in VM relay.

Internal errors indicate server-side bugs or corrupted state that are unlikely to resolve on retry. Retrying these errors can mask underlying issues and delay proper error handling.

This change aligns the retry logic with best practices: only retry errors that are genuinely transient (DeadlineExceeded, Unavailable, ResourceExhausted).

Also remove special handling of `DeadlineExceeded`, since a gRPC error should not wrap `context.Canceled`:

```go
case codes.DeadlineExceeded:
		return !errors.Is(err, context.Canceled)
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)