### PR TITLE
ROX-31566: indicator migration faster

### DIFF
--- a/migrator/migrations/m_212_to_m_213_add_container_start_column_to_indicators/migration_impl.go
+++ b/migrator/migrations/m_212_to_m_213_add_container_start_column_to_indicators/migration_impl.go
@@ -41,7 +41,7 @@ func migrate(database *types.Databases) error {
 	}
 
 	var clusters []string
-	if err := db.Model(&updatedSchema.Clusters{}).Pluck("id", &clusters).Error; err != nil {
+	if err := db.Order("id").Model(&updatedSchema.Clusters{}).Pluck("id", &clusters).Error; err != nil {
 		return err
 	}
 	log.Infof("clusters found: %v", clusters)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Drop the indexes and re-add them to see if it improves the migration performance.

This method appears to drop the time required for the migration by a third compared to #17094.  About 14 minutes in this one compared to 20 minutes in #17094.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Running migration of 10M in about 14 minutes

```
Migrator: 2025/11/04 19:48:09.760957 log.go:18: Info: Found DB at version 212, which is less than what we expect (213). Running migrations...
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:48:10.046435 migration_impl.go:47: Info: clusters found: [1ee52fdf-87de-4cec-b5d7-a5bcefdecdbd caaaaaaa-bbbb-4011-0000-333333333333 caaaaaaa-bbbb-4011-0000-111111111111 2902a528-8ae7-4936-86e7-1ccdc4c21afc b12f2627-4077-4017-8512-0f7da4b51860 032b0ee6-fb03-4d7f-b49d-571520bc880f 7d4404a6-5dfe-472c-871e-dd53c790ead3 be78fb19-df6e-4526-af53-9300d27f8eab caaaaaaa-bbbb-4011-0000-222222222222 55986ed4-f2a2-4c73-a9ec-6ebfcebb16e1 89a8e9cc-e494-4a29-aba9-e76397aeb681]
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:48:19.845151 migration_impl.go:88: Info: Processing 1ee52fdf-87de-4cec-b5d7-a5bcefdecdbd with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:49:44.955994 migration_impl.go:98: Info: Populated container start time for 1500000 process indicators in cluster 1ee52fdf-87de-4cec-b5d7-a5bcefdecdbd
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:50:02.162195 migration_impl.go:88: Info: Processing caaaaaaa-bbbb-4011-0000-333333333333 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:51:27.544801 migration_impl.go:98: Info: Populated container start time for 1500000 process indicators in cluster caaaaaaa-bbbb-4011-0000-333333333333
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:51:45.497376 migration_impl.go:88: Info: Processing caaaaaaa-bbbb-4011-0000-111111111111 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:53:26.640116 migration_impl.go:98: Info: Populated container start time for 1500000 process indicators in cluster caaaaaaa-bbbb-4011-0000-111111111111
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:53:26.642744 migration_impl.go:88: Info: Processing 2902a528-8ae7-4936-86e7-1ccdc4c21afc with 0 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:53:26.642847 migration_impl.go:98: Info: Populated container start time for 0 process indicators in cluster 2902a528-8ae7-4936-86e7-1ccdc4c21afc
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:53:45.854559 migration_impl.go:88: Info: Processing b12f2627-4077-4017-8512-0f7da4b51860 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:55:15.408899 migration_impl.go:98: Info: Populated container start time for 1500000 process indicators in cluster b12f2627-4077-4017-8512-0f7da4b51860
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:55:15.411379 migration_impl.go:88: Info: Processing 032b0ee6-fb03-4d7f-b49d-571520bc880f with 0 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:55:15.411478 migration_impl.go:98: Info: Populated container start time for 0 process indicators in cluster 032b0ee6-fb03-4d7f-b49d-571520bc880f
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:55:15.413649 migration_impl.go:88: Info: Processing 7d4404a6-5dfe-472c-871e-dd53c790ead3 with 0 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:55:15.413742 migration_impl.go:98: Info: Populated container start time for 0 process indicators in cluster 7d4404a6-5dfe-472c-871e-dd53c790ead3
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:55:16.178832 migration_impl.go:88: Info: Processing be78fb19-df6e-4526-af53-9300d27f8eab with 359000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:55:35.329230 migration_impl.go:98: Info: Populated container start time for 359000 process indicators in cluster be78fb19-df6e-4526-af53-9300d27f8eab
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:56:10.999458 migration_impl.go:88: Info: Processing caaaaaaa-bbbb-4011-0000-222222222222 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:57:32.010141 migration_impl.go:98: Info: Populated container start time for 1500000 process indicators in cluster caaaaaaa-bbbb-4011-0000-222222222222
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:58:03.267582 migration_impl.go:88: Info: Processing 55986ed4-f2a2-4c73-a9ec-6ebfcebb16e1 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:59:20.219105 migration_impl.go:98: Info: Populated container start time for 1500000 process indicators in cluster 55986ed4-f2a2-4c73-a9ec-6ebfcebb16e1
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 19:59:42.401799 migration_impl.go:88: Info: Processing 89a8e9cc-e494-4a29-aba9-e76397aeb681 with 1500000 indicators
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 20:01:04.132491 migration_impl.go:98: Info: Populated container start time for 1500000 process indicators in cluster 89a8e9cc-e494-4a29-aba9-e76397aeb681
migrations/m_212_to_m_213_add_container_start_column_to_indicators: 2025/11/04 20:02:59.067423 migration_impl.go:71: Info: Process Indicators migrated
Migrator: 2025/11/04 20:02:59.088660 log.go:18: Info: Successfully updated DB from version 212 to 213
```