### PR TITLE
ROX-31580: Delete obsolete endpoints in VulnerabilitiesService

### DIFF
--- a/ui/apps/platform/src/services/VulnerabilitiesService.js
+++ b/ui/apps/platform/src/services/VulnerabilitiesService.js
@@ -8,10 +8,8 @@ function getBaseCveUrl(cveType) {
     if (cveType === entityTypes.NODE_CVE) {
         return '/v1/nodecves';
     }
-    if (cveType === entityTypes.IMAGE_CVE) {
-        return '/v1/imagecves';
-    }
-    return '/v1/cves';
+    // VulnMgmgListCves does not render global snooze action for image CVEs.
+    return '';
 }
 
 /**
@@ -24,7 +22,11 @@ function getBaseCveUrl(cveType) {
  */
 export function suppressVulns(cveType, cveNames, duration = '0') {
     const baseUrl = getBaseCveUrl(cveType);
-    return axios.patch(`${baseUrl}/suppress`, { cves: cveNames, duration });
+    return baseUrl
+        ? axios
+              .patch(`${baseUrl}/suppress`, { cves: cveNames, duration })
+              .then((response) => response.data)
+        : Promise.resolve({});
 }
 
 /**
@@ -36,5 +38,7 @@ export function suppressVulns(cveType, cveNames, duration = '0') {
  */
 export function unsuppressVulns(cveType, cveNames) {
     const baseUrl = getBaseCveUrl(cveType);
-    return axios.patch(`${baseUrl}/unsuppress`, { cves: cveNames });
+    return baseUrl
+        ? axios.patch(`${baseUrl}/unsuppress`, { cves: cveNames }).then((response) => response.data)
+        : Promise.resolve({});
 }


### PR DESCRIPTION
## Description

Frontend counterpart to delete `/v1/imagecves` from backend in #17599

Better late than never to delete `/v1/cves` in #6456

### Analysis

VulnMgmgListCves.jsx file does not render action for image CVEs:

```js
    const isLegacySnoozeEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_LEGACY_SNOOZE');

    // Only allow snooze mutations when:
    // Legacy snooze is enabled, and the CVE is a Node or Platform CVE
    const shouldRenderGlobalSnoozeAction =
        isLegacySnoozeEnabled && cveType !== entityTypes.IMAGE_CVE;
```

### Solution

1. Delete obsolete endpoints from `getBaseCveUrl` function.
2. Return resolved empty promise for theoretical unexpected `cveType` argument:
    * `suppressVulns`
    * `unsuppressVulns`
3. Include `.then((response) => response.data)` in chain even for empty response data, otherwise function return leaks the entire response object.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder.
2. `npm run tsc` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.
    * Suppress and then unsuppress a node CVE.
