### PR TITLE
ROX-31589: Sort named imports in Components

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -774,7 +774,6 @@ module.exports = [
         files: ['**/*.{js,jsx,ts,tsx}'], // generic configuration
         ignores: [
             'cypress/integration/**',
-            'src/Components/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/PolicyCategories/**',
             'src/Containers/SystemHealth/**',

--- a/ui/apps/platform/src/Components/BinderTabs/Binder.test.tsx
+++ b/ui/apps/platform/src/Components/BinderTabs/Binder.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import BinderTabs from './BinderTabs';

--- a/ui/apps/platform/src/Components/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/CheckboxSelect.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, ReactElement, ReactNode, Ref } from 'react';
-import { Select, MenuToggle, Badge, Flex, FlexItem } from '@patternfly/react-core';
+import { Badge, Flex, FlexItem, MenuToggle, Select } from '@patternfly/react-core';
 import type { MenuToggleElement, SelectOption } from '@patternfly/react-core';
 
 import { ensureString } from 'utils/ensure';

--- a/ui/apps/platform/src/Components/CodeViewer.tsx
+++ b/ui/apps/platform/src/Components/CodeViewer.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState } from 'react';
 import type { CSSProperties, Dispatch, ReactElement, ReactNode, SetStateAction } from 'react';
-import { CodeBlockAction, ClipboardCopyButton, Button, CodeBlock } from '@patternfly/react-core';
+import { Button, ClipboardCopyButton, CodeBlock, CodeBlockAction } from '@patternfly/react-core';
 import { MoonIcon, SunIcon } from '@patternfly/react-icons';
 
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';

--- a/ui/apps/platform/src/Components/CollapsibleRow.jsx
+++ b/ui/apps/platform/src/Components/CollapsibleRow.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { ChevronRight, ChevronDown } from 'react-feather';
+import { ChevronDown, ChevronRight } from 'react-feather';
 
 import CollapsibleAnimatedDiv from 'Components/animations/CollapsibleAnimatedDiv';
 

--- a/ui/apps/platform/src/Components/ColorPicker.jsx
+++ b/ui/apps/platform/src/Components/ColorPicker.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 import { ChromePicker } from 'react-color';
 
-import { Manager, Target, Popper } from 'react-popper';
+import { Manager, Popper, Target } from 'react-popper';
 
 class ColorPickerComponent extends Component {
     static propTypes = {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocomplete.tsx
@@ -1,16 +1,16 @@
 import { useMemo, useRef, useState } from 'react';
 import type { FormEvent, KeyboardEvent, MouseEvent as ReactMouseEvent, Ref } from 'react';
 import {
-    Select,
-    SelectOption,
-    SelectList,
+    Button,
+    Flex,
     MenuToggle,
+    Select,
+    SelectList,
+    SelectOption,
+    Skeleton,
     TextInputGroup,
     TextInputGroupMain,
     TextInputGroupUtilities,
-    Button,
-    Skeleton,
-    Flex,
     debounce,
 } from '@patternfly/react-core';
 import type { MenuToggleElement, SelectOptionProps } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
-import { Select, SelectList, MenuToggle } from '@patternfly/react-core';
+import { MenuToggle, Select, SelectList } from '@patternfly/react-core';
 import type { MenuToggleElement, SelectOption } from '@patternfly/react-core';
 
 export type SimpleSelectProps = {

--- a/ui/apps/platform/src/Components/D3Anchor/D3Anchor.jsx
+++ b/ui/apps/platform/src/Components/D3Anchor/D3Anchor.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { select } from 'd3-selection';
 

--- a/ui/apps/platform/src/Components/DescriptionListItem.tsx
+++ b/ui/apps/platform/src/Components/DescriptionListItem.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement, ReactNode } from 'react';
 import {
+    DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    DescriptionListDescription,
 } from '@patternfly/react-core';
 
 type DescriptionListItemProps = {

--- a/ui/apps/platform/src/Components/DetailedTooltipContent.tsx
+++ b/ui/apps/platform/src/Components/DetailedTooltipContent.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode, CSSProperties } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import { Divider, Text, TextVariants } from '@patternfly/react-core';
 
 export type DetailedTooltipContentProps = {

--- a/ui/apps/platform/src/Components/EmptyStateTemplate/EmptyStateTemplate.tsx
+++ b/ui/apps/platform/src/Components/EmptyStateTemplate/EmptyStateTemplate.tsx
@@ -1,9 +1,9 @@
 import type { ComponentType, PropsWithChildren, ReactElement, ReactNode } from 'react';
 import {
     EmptyState,
-    EmptyStateIcon,
     EmptyStateBody,
     EmptyStateHeader,
+    EmptyStateIcon,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
+++ b/ui/apps/platform/src/Components/NotFoundMessage/NotFoundMessage.tsx
@@ -5,8 +5,8 @@ import {
     Button,
     EmptyState,
     EmptyStateBody,
-    EmptyStateHeader,
     EmptyStateFooter,
+    EmptyStateHeader,
 } from '@patternfly/react-core';
 
 export type NotFoundMessageProps = {

--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationView.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationView.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Button, Flex, FlexItem, Title } from '@patternfly/react-core';
-import { Table, Tbody, Thead, Td, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { isDefaultEmailTemplate } from 'Components/EmailTemplate/EmailTemplate.utils';
 import EmailTemplateModal from 'Components/EmailTemplate/EmailTemplateModal';

--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Button, Flex, FlexItem, TextInput, SelectOption } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, SelectOption, TextInput } from '@patternfly/react-core';
 import type { FormikErrors } from 'formik';
 
 import EmailNotifierModal from 'Components/EmailNotifier/EmailNotifierModal';

--- a/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.jsx
+++ b/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import NextPaginationButton from './NextPaginationButton';
 import PaginationInput from '../PaginationInput';

--- a/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.jsx
+++ b/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import clamp from 'lodash/clamp';

--- a/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.test.jsx
+++ b/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.test.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import PaginationInput from './PaginationInput';
 

--- a/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.jsx
+++ b/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import PaginationInput from '../PaginationInput';
 import PrevPaginationButton from '.';

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -3,11 +3,11 @@ import {
     Badge,
     Button,
     EmptyState,
+    EmptyStateFooter,
+    EmptyStateHeader,
     EmptyStateIcon,
     Flex,
     FormGroup,
-    EmptyStateHeader,
-    EmptyStateFooter,
     Icon,
 } from '@patternfly/react-core';
 import { CubesIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
@@ -8,14 +8,14 @@ import type {
     Ref,
 } from 'react';
 import {
-    Select,
-    SelectOption,
-    SelectGroup,
-    MenuToggle,
     Badge,
     Flex,
     FlexItem,
+    MenuToggle,
+    Select,
+    SelectGroup,
     SelectList,
+    SelectOption,
 } from '@patternfly/react-core';
 import type {
     MenuToggleElement,

--- a/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryPage.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ErrorBoundary/ErrorBoundaryPage.tsx
@@ -1,13 +1,13 @@
 import type { ErrorInfo, ReactElement } from 'react';
 import {
     EmptyState,
+    EmptyStateFooter,
+    EmptyStateHeader,
     EmptyStateIcon,
     Flex,
     FlexItem,
     PageSection,
     Title,
-    EmptyStateHeader,
-    EmptyStateFooter,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Components/PatternFly/FormLabelGroup.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FormLabelGroup.tsx
@@ -7,7 +7,7 @@ import {
     ValidatedOptions,
 } from '@patternfly/react-core';
 import type { FormGroupProps } from '@patternfly/react-core';
-import type { FormikTouched, FormikErrors } from 'formik';
+import type { FormikErrors, FormikTouched } from 'formik';
 import get from 'lodash/get';
 
 export interface FormLabelGroupProps<T> extends FormGroupProps {

--- a/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SearchFilterChips.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import { Button, ChipGroup, Chip, Flex, FlexItem } from '@patternfly/react-core';
+import { Button, Chip, ChipGroup, Flex, FlexItem } from '@patternfly/react-core';
 import type { ToolbarChip } from '@patternfly/react-core';
 import { Globe } from 'react-feather';
 

--- a/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
@@ -11,8 +11,8 @@ import { Icon } from '@patternfly/react-core';
 
 import {
     CRITICAL_SEVERITY_COLOR,
-    LOW_SEVERITY_COLOR,
     IMPORTANT_HIGH_SEVERITY_COLOR,
+    LOW_SEVERITY_COLOR,
     MODERATE_MEDIUM_SEVERITY_COLOR,
     UNKNOWN_SEVERITY_COLOR,
 } from 'constants/severityColors';

--- a/ui/apps/platform/src/Components/PatternFly/WidgetCard.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/WidgetCard.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactElement, ReactNode } from 'react';
-import { Skeleton, Card, CardBody, CardHeader } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Skeleton } from '@patternfly/react-core';
 
 import { defaultChartHeight } from 'utils/chartUtils';
 import { CancelledPromiseError } from 'services/cancellationUtils';

--- a/ui/apps/platform/src/Components/Popper.jsx
+++ b/ui/apps/platform/src/Components/Popper.jsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 
-import { Manager, Target, Popper } from 'react-popper';
+import { Manager, Popper, Target } from 'react-popper';
 
 class CustomPopper extends Component {
     static propTypes = {

--- a/ui/apps/platform/src/Components/ReportJob/ReportJobStatusFilter.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/ReportJobStatusFilter.tsx
@@ -2,7 +2,7 @@ import { SelectList, SelectOption } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 
 import CheckboxSelect from 'Components/CheckboxSelect';
-import { reportJobStatuses, reportJobStatusLabels } from './types';
+import { reportJobStatusLabels, reportJobStatuses } from './types';
 import type { ReportJobStatus } from './types';
 
 function isReportJobStatus(value: string): value is ReportJobStatus {

--- a/ui/apps/platform/src/Components/SearchInput/SearchInput.jsx
+++ b/ui/apps/platform/src/Components/SearchInput/SearchInput.jsx
@@ -4,13 +4,13 @@ import findLastIndex from 'lodash/findLastIndex';
 
 import { Creatable } from 'Components/ReactSelect';
 import {
-    placeholderCreator,
+    MultiValue,
     Option,
     ValueContainer,
-    MultiValue,
-    noOptionsMessage,
     createOptionPosition,
     inputMatchesTopOption,
+    noOptionsMessage,
+    placeholderCreator,
     removeValuesForKey,
 } from 'Components/URLSearchInputWithAutocomplete';
 import searchOptionsToQuery from 'services/searchOptionsToQuery';

--- a/ui/apps/platform/src/Components/SearchInput/SearchInput.test.js
+++ b/ui/apps/platform/src/Components/SearchInput/SearchInput.test.js
@@ -1,4 +1,4 @@
-import { getLastCategoryInSearchOptions, createSearchModifiers } from './SearchInput';
+import { createSearchModifiers, getLastCategoryInSearchOptions } from './SearchInput';
 
 describe('SearchInput', () => {
     describe('getLastCategoryInSearchOptions', () => {

--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -1,5 +1,5 @@
 import type { FocusEventHandler, ReactElement, ReactNode, Ref } from 'react';
-import { Select, MenuToggle, SelectList, MenuFooter } from '@patternfly/react-core';
+import { MenuFooter, MenuToggle, Select, SelectList } from '@patternfly/react-core';
 import type { MenuToggleElement, MenuToggleProps, SelectOptionProps } from '@patternfly/react-core';
 
 import useSelectToggleState from './useSelectToggleState';

--- a/ui/apps/platform/src/Components/TabNav/TabNavSubHeader.tsx
+++ b/ui/apps/platform/src/Components/TabNav/TabNavSubHeader.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import { PageSection, Flex, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { Flex, PageSection, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
 type TabNavSubHeaderProps = {
     description: string;

--- a/ui/apps/platform/src/Components/TablePagination.jsx
+++ b/ui/apps/platform/src/Components/TablePagination.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ChevronLeft, ChevronRight } from 'react-feather';
 import debounce from 'lodash/debounce';

--- a/ui/apps/platform/src/Components/TableStateTemplates/TbodyFullCentered.tsx
+++ b/ui/apps/platform/src/Components/TableStateTemplates/TbodyFullCentered.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 import { Bullseye } from '@patternfly/react-core';
-import { Tbody, Tr, Td } from '@patternfly/react-table';
+import { Tbody, Td, Tr } from '@patternfly/react-table';
 
 export type TbodyFullCenteredProps = {
     colSpan: number;

--- a/ui/apps/platform/src/Components/TableStateTemplates/TbodyUnified.cy.jsx
+++ b/ui/apps/platform/src/Components/TableStateTemplates/TbodyUnified.cy.jsx
@@ -1,6 +1,6 @@
 import ComponentTestProvider from 'test-utils/ComponentTestProvider';
 
-import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import TbodyUnified from './TbodyUnified';
 
 function setup(tableState, otherProps) {

--- a/ui/apps/platform/src/Components/TimelineGraph/Axis/Axis.jsx
+++ b/ui/apps/platform/src/Components/TimelineGraph/Axis/Axis.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { scaleLinear } from 'd3-scale';
-import { axisTop, axisBottom } from 'd3-axis';
+import { axisBottom, axisTop } from 'd3-axis';
 
 import mainViewSelector from 'Components/TimelineGraph/MainView/selectors';
 import { getWidth } from 'utils/d3Utils';

--- a/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ZoomableOverlay/zoomUtils.js
+++ b/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ZoomableOverlay/zoomUtils.js
@@ -1,7 +1,7 @@
 import { select } from 'd3-selection';
 import { zoom as d3Zoom } from 'd3-zoom';
 
-import { getWidth, getHeight } from 'utils/d3Utils';
+import { getHeight, getWidth } from 'utils/d3Utils';
 import mainViewSelector from 'Components/TimelineGraph/MainView/selectors';
 import timelineZoomSelector from 'Components/TimelineGraph/EventsGraph/ZoomableOverlay/selectors';
 

--- a/ui/apps/platform/src/Components/TimelineGraph/MainView/MainView.jsx
+++ b/ui/apps/platform/src/Components/TimelineGraph/MainView/MainView.jsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { getWidth, getHeight } from 'utils/d3Utils';
+import { getHeight, getWidth } from 'utils/d3Utils';
 import Axis, { AXIS_HEIGHT } from '../Axis';
 import EventsGraph from '../EventsGraph';
 

--- a/ui/apps/platform/src/Components/TimelineGraph/Minimap/Minimap.jsx
+++ b/ui/apps/platform/src/Components/TimelineGraph/Minimap/Minimap.jsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import miniMapSelector from 'Components/TimelineGraph/Minimap/selectors';
-import { getWidth, getHeight } from 'utils/d3Utils';
+import { getHeight, getWidth } from 'utils/d3Utils';
 import EventsGraph from 'Components/TimelineGraph/EventsGraph';
 import Axis, { AXIS_HEIGHT } from '../Axis';
 import BrushableOverlay from './BrushableOverlay';

--- a/ui/apps/platform/src/Components/TimelineGraph/Pagination/Pagination.jsx
+++ b/ui/apps/platform/src/Components/TimelineGraph/Pagination/Pagination.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { PaginationInput, PrevPaginationButton, NextPaginationButton } from 'Components/Pagination';
+import { NextPaginationButton, PaginationInput, PrevPaginationButton } from 'Components/Pagination';
 
 const Pagination = ({ currentPage, totalSize, pageSize, onChange }) => {
     return (

--- a/ui/apps/platform/src/Components/TypeaheadSelect/TypeaheadSelect.tsx
+++ b/ui/apps/platform/src/Components/TypeaheadSelect/TypeaheadSelect.tsx
@@ -9,13 +9,13 @@ import type {
     Ref,
 } from 'react';
 import {
-    Select,
-    SelectOption,
+    MenuFooter,
     MenuToggle,
+    Select,
     SelectList,
+    SelectOption,
     TextInputGroup,
     TextInputGroupMain,
-    MenuFooter,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Components/animations/CollapsibleAnimatedDiv.jsx
+++ b/ui/apps/platform/src/Components/animations/CollapsibleAnimatedDiv.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 
 const variants = {
     open: { opacity: 1, height: 'auto' },

--- a/ui/apps/platform/src/Components/animations/SidePanelAnimatedArea.tsx
+++ b/ui/apps/platform/src/Components/animations/SidePanelAnimatedArea.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 
 const variants = {
     open: { x: 0 },

--- a/ui/apps/platform/src/Components/visuals/ArcSingle.jsx
+++ b/ui/apps/platform/src/Components/visuals/ArcSingle.jsx
@@ -1,4 +1,4 @@
-import { XYPlot, ArcSeries, LabelSeries } from 'react-vis';
+import { ArcSeries, LabelSeries, XYPlot } from 'react-vis';
 import PropTypes from 'prop-types';
 
 const RADIUS = 3;

--- a/ui/apps/platform/src/Components/visuals/Sunburst.jsx
+++ b/ui/apps/platform/src/Components/visuals/Sunburst.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { Sunburst as SunburstReactVis, DiscreteColorLegend, LabelSeries } from 'react-vis';
+import { DiscreteColorLegend, LabelSeries, Sunburst as SunburstReactVis } from 'react-vis';
 import PropTypes from 'prop-types';
 import merge from 'deepmerge';
 


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] update lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.