### PR TITLE
ROX-31588: Enable lint rules for consistency in VirtualMachineCves

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -780,7 +780,6 @@ module.exports = [
             'src/Containers/SystemHealth/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',
-            'src/Containers/Vulnerabilities/VirtualMachineCves/**',
             'src/Containers/Vulnerabilities/VulnerablityReporting/**',
             'src/Containers/Vulnerabilities/WorkloadCves/**',
         ],
@@ -803,7 +802,6 @@ module.exports = [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',
-            'src/Containers/Vulnerabilities/VirtualMachineCves/**',
             'src/Containers/Vulnerabilities/VulnerablityReporting/**',
             'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
@@ -831,7 +829,6 @@ module.exports = [
             'src/Containers/ComplianceEnhanced/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',
-            'src/Containers/Vulnerabilities/VirtualMachineCves/**',
             'src/Containers/Vulnerabilities/VulnerablityReporting/**',
             'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, CardBody, Flex, PageSection, Text, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
@@ -1,23 +1,19 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import {
     Flex,
     Pagination,
-    pluralize,
     Skeleton,
     Split,
     SplitItem,
     Title,
+    pluralize,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import DateDistance from 'Components/DateDistance';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import {
-    virtualMachinesClusterSearchFilterConfig,
-    virtualMachinesSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -33,6 +29,10 @@ import {
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
+import {
+    virtualMachinesClusterSearchFilterConfig,
+    virtualMachinesSearchFilterConfig,
+} from '../../searchFilterConfig';
 import { getVirtualMachineEntityPagePath } from '../../utils/searchUtils';
 import { VIRTUAL_MACHINE_SORT_FIELD } from '../../utils/sortFields';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineComponentsTable.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Td, Thead, Tr, Tbody, Th, Table } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import type { CveComponentRow } from '../aggregateUtils';
 import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePackagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePackagesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePage.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import {
-    PageSection,
     Breadcrumb,
-    Divider,
     BreadcrumbItem,
+    Divider,
+    PageSection,
     Skeleton,
     Tab,
     TabContent,
@@ -14,7 +14,6 @@ import {
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import { DEFAULT_VM_PAGE_SIZE } from 'Containers/Vulnerabilities/constants';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -22,6 +21,7 @@ import useURLSort from 'hooks/useURLSort';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import { getVirtualMachine } from 'services/VirtualMachineService';
 
+import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { detailsTabValues } from '../../types';
 import { getOverviewPagePath } from '../../utils/searchUtils';
 import {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { PageSection } from '@patternfly/react-core';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeader.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Flex, Title, LabelGroup, Label, Alert } from '@patternfly/react-core';
+import { Alert, Flex, Label, LabelGroup, Title } from '@patternfly/react-core';
 
 import DeveloperPreviewLabel from 'Components/PatternFly/DeveloperPreviewLabel';
-import { VirtualMachine } from 'services/VirtualMachineService';
+import type { VirtualMachine } from 'services/VirtualMachineService';
 import { getDateTime } from 'utils/dateUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePagePackages.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePagePackages.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import {
     Flex,
     PageSection,
     Pagination,
-    pluralize,
     Skeleton,
     Split,
     SplitItem,
@@ -12,10 +11,10 @@ import {
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
+    pluralize,
 } from '@patternfly/react-core';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import ComponentScannableStatusDropdown from 'Containers/Vulnerabilities/components/ComponentScannableStatusDropdown';
 import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { onURLSearch } from 'Components/CompoundSearchFilter/utils/utils';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
@@ -32,6 +31,7 @@ import {
     applyVirtualMachinePackagesTableSort,
     getVirtualMachinePackagesTableData,
 } from '../aggregateUtils';
+import ComponentScannableStatusDropdown from '../../components/ComponentScannableStatusDropdown';
 import { virtualMachineComponentSearchFilterConfig } from '../../searchFilterConfig';
 import VirtualMachinePackagesTable from './VirtualMachinePackagesTable';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
@@ -1,20 +1,16 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import {
     Flex,
     PageSection,
     Pagination,
-    pluralize,
     Skeleton,
     Split,
     SplitItem,
     Title,
+    pluralize,
 } from '@patternfly/react-core';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
-import {
-    virtualMachineCVESearchFilterConfig,
-    virtualMachineComponentSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
 import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import type { UseUrlSearchReturn } from 'hooks/useURLSearch';
 import type { UseURLSortResult } from 'hooks/useURLSort';
@@ -25,14 +21,18 @@ import { getHasSearchApplied } from 'utils/searchUtils';
 import {
     applyVirtualMachineCveTableFilters,
     applyVirtualMachineCveTableSort,
-    getVirtualMachineCveTableData,
     getVirtualMachineCveSeverityStatusCounts,
+    getVirtualMachineCveTableData,
 } from '../aggregateUtils';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import CvesByStatusSummaryCard from '../../components/CvesByStatusSummaryCard';
 import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import VirtualMachineScanScopeAlert from '../components/VirtualMachineScanScopeAlert';
+import {
+    virtualMachineCVESearchFilterConfig,
+    virtualMachineComponentSearchFilterConfig,
+} from '../../searchFilterConfig';
 import {
     getHiddenSeverities,
     getHiddenStatuses,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineVulnerabilitiesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import CvssFormatted from 'Components/CvssFormatted';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/components/VirtualMachineScanScopeAlert.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/components/VirtualMachineScanScopeAlert.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Alert } from '@patternfly/react-core';
 
 function VirtualMachineScanScopeAlert() {


### PR DESCRIPTION
## Description

Triple up on smaller folder to merge before:
* PatternFly 6 upgrade
* feature work by Brad

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.