### PR TITLE
ROX-31597: Delete ROX_AUTO_LOCK_PROCESS_BASELINES in ui

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationForm.tsx
@@ -11,7 +11,6 @@ import {
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import SelectSingle from 'Components/SelectSingle';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useMetadata from 'hooks/useMetadata';
 import type { ClusterType, CompleteClusterConfig, DynamicClusterConfig } from 'types/cluster.proto';
 import { getVersionedDocs } from 'utils/versioning';
@@ -35,10 +34,6 @@ function DynamicConfigurationForm({
     helmConfig,
     isManagerTypeNonConfigurable,
 }: DynamicConfigurationFormProps) {
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isAutoLockProcessBaselinesEnabled = isFeatureFlagEnabled(
-        'ROX_AUTO_LOCK_PROCESS_BASELINES'
-    );
     const { version } = useMetadata();
 
     const isLoggingSupported = clusterType === 'OPENSHIFT4_CLUSTER';
@@ -193,30 +188,26 @@ function DynamicConfigurationForm({
                     </Alert>
                 )}
             </FormGroup>
-            {isAutoLockProcessBaselinesEnabled && (
-                <FormGroup label="Automatically lock process baselines">
-                    <SelectSingle
-                        id="dynamicConfig.autoLockProcessBaselinesConfig.enabled"
-                        value={
-                            dynamicConfig.autoLockProcessBaselinesConfig?.enabled
-                                ? 'enabled'
-                                : 'disabled'
-                        }
-                        handleSelect={(id, value) => handleChange(id, value === 'enabled')}
-                        isDisabled={isManagerTypeNonConfigurable}
-                        isFullWidth={false}
-                    >
-                        <SelectOption value="enabled">Enabled</SelectOption>
-                        <SelectOption value="disabled">Disabled</SelectOption>
-                    </SelectSingle>
-                    <HelmValueWarning
-                        currentValue={dynamicConfig.autoLockProcessBaselinesConfig?.enabled}
-                        helmValue={
-                            helmConfig?.dynamicConfig?.autoLockProcessBaselinesConfig?.enabled
-                        }
-                    />
-                </FormGroup>
-            )}
+            <FormGroup label="Automatically lock process baselines">
+                <SelectSingle
+                    id="dynamicConfig.autoLockProcessBaselinesConfig.enabled"
+                    value={
+                        dynamicConfig.autoLockProcessBaselinesConfig?.enabled
+                            ? 'enabled'
+                            : 'disabled'
+                    }
+                    handleSelect={(id, value) => handleChange(id, value === 'enabled')}
+                    isDisabled={isManagerTypeNonConfigurable}
+                    isFullWidth={false}
+                >
+                    <SelectOption value="enabled">Enabled</SelectOption>
+                    <SelectOption value="disabled">Disabled</SelectOption>
+                </SelectSingle>
+                <HelmValueWarning
+                    currentValue={dynamicConfig.autoLockProcessBaselinesConfig?.enabled}
+                    helmValue={helmConfig?.dynamicConfig?.autoLockProcessBaselinesConfig?.enabled}
+                />
+            </FormGroup>
         </Form>
     );
 }

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -3,7 +3,6 @@
 // prettier-ignore
 export type FeatureFlagEnvVar =
     | 'ROX_ACTIVE_VULN_MGMT'
-    | 'ROX_AUTO_LOCK_PROCESS_BASELINES'
     | 'ROX_CISA_KEV'
     | 'ROX_CUSTOMIZABLE_PLATFORM_COMPONENTS'
     | 'ROX_EXTERNAL_IPS'


### PR DESCRIPTION
## Description

Review: **hide space** because of indentation change.

Do the simpler deletion while I analyze its more complicated neighbor.

Feature flag was enabled for 4.9 release on 2025-10-06 in #16889

https://github.com/stackrox/stackrox/tree/master/ui/apps/platform#delete-a-feature-flag-from-frontend-code

### Analysis

Find in Files for `ROX_AUTO_LOCK_PROCESS_BASELINES`
* has no results: ui/apps/platform/cypress folder
* has 2 results in 2 files: ui/apps/platform/src folder
    Conditional rendering of **Automatically lock process baselines** select in dynamic configuration form:
    * Because REST API and code has optional chaining, UI code displays **Disabled** in unlikely case that customer turns off the feature flag.
    * For Helm and Operator installation methods, UI is read-only.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central

#### Manual testing

1. Visit /main/clusters click a link, and then scroll down to forms.

    See **Automatically lock process baselines** under **Dynamic configuration**
    <img width="1439" height="898" alt="autoLockProcessBaselinesConfig" src="https://github.com/user-attachments/assets/9bba0542-7529-47d1-aa2c-5a39c38f1ef2" />
