### PR TITLE
ci: handle process lines with quotes

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -85,6 +85,13 @@ handle_dangling_processes() {
 
     local psline pid ppid
     ps -e -O ppid | while read -r pid ppid psline; do
+        # Example output:
+        #     PID    PPID S TTY          TIME COMMAND
+        #       1       0 S ?        00:00:00 /tmp/entrypoint-wrapper/entrypoint-wrapper /tools/entrypoint
+        # [...]
+        #  179283      25 R ?        00:00:00 ps -e -O ppid
+
+        # trim leading whitespace
         psline="$pid $ppid $psline"
         if [[ "$pid" == "PID" ]]; then
             # Ignoring header


### PR DESCRIPTION
Change handle_dangling_processes() to not fail on process lines with quotes.
Also simplify the extraction+matching of pid and ppid from the psline.

example failure before:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/70917/rehearse-70917-periodic-ci-stackrox-stackrox-master-ocp-4.21-lp-interop-cr-acs-tests-aws/1985719376904458240/build-log.txt
```
INFO: Tue Nov  4 17:55:04 UTC 2025: Process state at exit:
    PID    PPID S TTY          TIME COMMAND
      1       0 S ?        00:00:00 /tmp/entrypoint-wrapper/entrypoint-wrapper /tools/entrypoint
     16       1 S ?        00:00:00 /tools/entrypoint
     24      16 S ?        00:00:00 /bin/real-bash -c #!/bin/bash set -eu #!/bin/bash  function install_yq() {     # Install yq manually if not found in image       echo "Installing yq"       ...  
     25      24 S ?        00:00:00 /bin/real-bash .openshift-ci/dispatch.sh ocp-qa-e2e-tests
   6406       1 Z ?        00:00:00 [real-bash] <defunct>
...
  14460       1 S ?        00:05:03 /usr/lib/jvm/java-17-openjdk-17.0.14.0.7-2.el9.x86_64/bin/java ...
  17245       1 Z ?        00:00:00 [kubectl] <defunct>
  90897       1 Z ?        00:00:00 [kubectl] <defunct>
 179283      25 R ?        00:00:00 ps -e -O ppid
Ignoring ci-operator entrypoint or defunct process: 1 0 S ? 00:00:00 /tmp/entrypoint-wrapper/entrypoint-wrapper /tools/entrypoint
Ignoring ci-operator entrypoint or defunct process: 16 1 S ? 00:00:00 /tools/entrypoint
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
```

example after (fixed):
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/70917/rehearse-70917-periodic-ci-stackrox-stackrox-davdhacs-proc-cleanup-ocp-4.21-lp-interop-cr-acs-tests-aws/1986510208305729536/artifacts/acs-tests-aws/stackrox-qa-e2e/build-log.txt
```
INFO: Thu Nov  6 21:48:35 UTC 2025: Process state at exit:
    PID    PPID S TTY          TIME COMMAND
      1       0 S ?        00:00:00 /tmp/entrypoint-wrapper/entrypoint-wrapper /tools/entrypoint
     18       1 S ?        00:00:00 /tools/entrypoint
     26      18 S ?        00:00:00 /bin/real-bash -c #!/bin/bash set -eu #!/bin/bash  function install_yq() {     # Install yq manually if not found in image       echo "Installing yq"       mkdir -p /tmp/bin || true       export PATH=$PATH:/tmp/bin/       curl -L "https://github.com/mikefarah/yq/rele...
...
Ignoring ci-operator entrypoint or defunct process: 18 1 S ?        00:00:00 /tools/entrypoint
A candidate to kill: 26 18 S ?        00:00:00 /bin/real-bash -c #!/bin/bash set -eu #!/bin/bash  function install_yq() {     # Inst...
Will kill 26
Ignoring self: 27 26 S ?        00:00:00 /bin/real-bash .openshift-ci/dispatch.sh ocp-qa-e2e-tests
...
Ignoring ci-operator entrypoint or defunct process: 17912 1 Z ?        00:00:00 [kubectl] <defunct>
Ignoring ci-operator entrypoint or defunct process: 97967 1 Z ?        00:00:00 [kubectl] <defunct>
Ignoring child: 196160 27 R ?        00:00:00 ps -e -O ppid
```