### PR TITLE
ROX-31595: Sort named imports in PolicyCategories and SystemHealth

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -776,8 +776,6 @@ module.exports = [
             'cypress/integration/**',
             'src/Components/**',
             'src/Containers/Compliance/**', // deprecated
-            'src/Containers/PolicyCategories/**',
-            'src/Containers/SystemHealth/**',
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',
             'src/Containers/Vulnerabilities/VulnerablityReporting/**',

--- a/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
@@ -1,16 +1,16 @@
 import type { FormEvent, ReactElement } from 'react';
 import * as yup from 'yup';
 import {
-    Modal,
-    ModalBoxBody,
-    ModalBoxFooter,
     Button,
     Form,
     FormGroup,
-    TextInput,
     FormHelperText,
     HelperText,
     HelperTextItem,
+    Modal,
+    ModalBoxBody,
+    ModalBoxFooter,
+    TextInput,
 } from '@patternfly/react-core';
 import { FormikProvider, useFormik } from 'formik';
 

--- a/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/DeletePolicyCategoryModal.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react';
 import {
+    Button,
+    Flex,
+    FlexItem,
+    List,
+    ListComponent,
+    ListItem,
     Modal,
     ModalBoxBody,
     ModalBoxFooter,
-    Button,
-    List,
-    ListItem,
-    ListComponent,
     OrderType,
-    Flex,
-    FlexItem,
     Panel,
     PanelMain,
     PanelMainBody,
@@ -17,7 +17,7 @@ import {
 
 import { getPolicies } from 'services/PoliciesService';
 import { deletePolicyCategory } from 'services/PolicyCategoriesService';
-import type { PolicyCategory, ListPolicy } from 'types/policy.proto';
+import type { ListPolicy, PolicyCategory } from 'types/policy.proto';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 type DeletePolicyCategoryModalProps = {

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesListSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { PageSection, Divider, Title, Flex, FlexItem, TextInput } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem, PageSection, TextInput, Title } from '@patternfly/react-core';
 
 import type { PolicyCategory } from 'types/policy.proto';
 import PolicyCategoriesList from './PolicyCategoriesList';

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -1,18 +1,18 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
-    PageSection,
+    Alert,
+    AlertActionCloseButton,
+    AlertGroup,
     Bullseye,
-    Spinner,
-    Divider,
     Button,
+    Divider,
     Flex,
+    PageSection,
+    Spinner,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
-    AlertGroup,
-    Alert,
-    AlertActionCloseButton,
 } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
@@ -1,17 +1,17 @@
 import type { FormEvent, ReactElement } from 'react';
 import { FormikProvider, useFormik } from 'formik';
 import {
-    PageSection,
-    Title,
-    Flex,
-    TextInput,
+    ActionGroup,
     Button,
+    Flex,
     Form,
     FormGroup,
-    ActionGroup,
     FormHelperText,
     HelperText,
     HelperTextItem,
+    PageSection,
+    TextInput,
+    Title,
 } from '@patternfly/react-core';
 
 import type { PolicyCategory } from 'types/policy.proto';

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -26,7 +26,7 @@ import {
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getVersionedDocs } from 'utils/versioning';
 
-import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
+import { ErrorIcon, SpinnerIcon, healthIconMap } from '../CardHeaderIcons';
 
 type CertificateCardProps = {
     component: CertExpiryComponent;

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -11,8 +11,8 @@ import {
     TdHealthy,
     TdTotal,
     TdUnavailable,
-    TdUninitialized,
     TdUnhealthy,
+    TdUninitialized,
     TheadClustersHealth,
 } from './ClustersHealthTable';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
@@ -4,7 +4,7 @@ import { CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
 import { clustersBasePath } from 'routePaths';
 
-import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
+import { ErrorIcon, SpinnerIcon, healthIconMap } from '../CardHeaderIcons';
 
 import { getClustersHealthPhrase, getClustersHealthVariant } from './ClustersHealth.utils';
 import type { ClusterStatusCounts } from './ClustersHealth.utils';

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -11,8 +11,8 @@ import {
     TdHealthy,
     TdTotal,
     TdUnavailable,
-    TdUninitialized,
     TdUnhealthy,
+    TdUninitialized,
     TheadClustersHealth,
 } from './ClustersHealthTable';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
@@ -11,8 +11,8 @@ import {
     TdHealthy,
     TdTotal,
     TdUnavailable,
-    TdUninitialized,
     TdUnhealthy,
+    TdUninitialized,
     TheadClustersHealth,
 } from './ClustersHealthTable';
 

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/BackupIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/BackupIntegrationHealthWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import { fetchBackupIntegrationsHealth } from 'services/IntegrationHealthService';

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
@@ -12,7 +12,7 @@ import {
 import pluralize from 'pluralize';
 import IntegrationsHealth from './IntegrationsHealth';
 import type { IntegrationMergedItem } from '../utils/integrations';
-import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
+import { ErrorIcon, SpinnerIcon, healthIconMap } from '../CardHeaderIcons';
 
 type IntegrationHealthWidgetVisualProps = {
     integrationText: string;

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/NotifierIntegrationHealthWidget.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/NotifierIntegrationHealthWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 
 import { fetchNotifierIntegrationsHealth } from 'services/IntegrationHealthService';

--- a/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DeclarativeConfigurationHealth/DeclarativeConfigurationHealthCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,
@@ -9,7 +9,7 @@ import {
     Flex,
     FlexItem,
 } from '@patternfly/react-core';
-import { Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
 import { fetchDeclarativeConfigurationsHealth } from 'services/DeclarativeConfigHealthService';
@@ -17,7 +17,7 @@ import type { DeclarativeConfigHealth } from 'types/declarativeConfigHealth.prot
 import { getDateTime } from 'utils/dateUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
+import { ErrorIcon, SpinnerIcon, healthIconMap } from '../CardHeaderIcons';
 
 type DeclarativeConfigurationHealthCardProps = {
     pollingCount: number;

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
 import {
     Button,
+    Checkbox,
     Chip,
     ChipGroup,
-    Checkbox,
     DatePicker,
     Flex,
     FlexItem,
@@ -17,10 +17,10 @@ import {
     Select,
     SelectList,
     SelectOption,
-    TimePicker,
     TextInputGroup,
     TextInputGroupMain,
     TextInputGroupUtilities,
+    TimePicker,
 } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
@@ -15,7 +15,7 @@ import { fetchVulnerabilityDefinitionsInfo } from 'services/IntegrationHealthSer
 import type { ScannerComponent } from 'services/IntegrationHealthService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
+import { ErrorIcon, SpinnerIcon, healthIconMap } from '../CardHeaderIcons';
 
 const dayInMinutes = 24 * 60;
 


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.