### PR TITLE
ROX-31591: Enable lint rules in Vulnerabilities components

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -776,7 +776,6 @@ module.exports = [
             'cypress/integration/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/components/**',
             'src/Containers/Vulnerabilities/WorkloadCves/**',
         ],
 
@@ -797,7 +796,6 @@ module.exports = [
         ignores: [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/components/**',
             'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
         ],
@@ -821,7 +819,6 @@ module.exports = [
         ignores: [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/components/**',
             'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
         ],

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvancedFiltersToolbar.tsx
@@ -1,22 +1,21 @@
-import React, { ReactNode } from 'react';
-import { Toolbar, ToolbarGroup, ToolbarContent } from '@patternfly/react-core';
+import type { ReactElement, ReactNode } from 'react';
+import { Toolbar, ToolbarContent, ToolbarGroup } from '@patternfly/react-core';
 import { uniq } from 'lodash';
 
-import CompoundSearchFilter, {
-    CompoundSearchFilterProps,
-} from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import type { CompoundSearchFilterProps } from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils/utils';
 import SearchFilterChips, { FilterChip } from 'Components/PatternFly/SearchFilterChips';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { getHasSearchApplied, searchValueAsArray } from 'utils/searchUtils';
 
-import { DefaultFilters } from '../types';
+import type { DefaultFilters } from '../types';
 import {
-    cveStatusClusterFixableDescriptor,
-    cveStatusFixableDescriptor,
     cveSeverityFilterDescriptor,
     cveSnoozedDescriptor,
+    cveStatusClusterFixableDescriptor,
+    cveStatusFixableDescriptor,
 } from '../filterChipDescriptor';
 import CVESeverityDropdown from './CVESeverityDropdown';
 import CVEStatusDropdown from './CVEStatusDropdown';
@@ -70,7 +69,7 @@ function AdvancedFiltersToolbar({
     defaultSearchFilterEntity,
     additionalContextFilter,
     children,
-}: AdvancedFiltersToolbarProps) {
+}: AdvancedFiltersToolbarProps): ReactElement {
     const baseDescriptors = makeFilterChipDescriptors(searchFilterConfig);
 
     const severityDescriptors = includeCveSeverityFilters

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvisoryLinkOrText.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/AdvisoryLinkOrText.tsx
@@ -1,7 +1,7 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
-import { Advisory } from 'types/cve.proto';
+import type { Advisory } from 'types/cve.proto';
 
 // https://access.redhat.com/security/updates/advisory
 // Red Hat publishes three types of errata:

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/BySeveritySummaryCard.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { Card, CardBody, CardTitle, Flex, Grid, GridItem, Text } from '@patternfly/react-core';
 
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 
-import { VulnerabilitySeverity } from 'types/cve.proto';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 
 const severitiesDescendingCriticality = [

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTd.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { Td } from '@patternfly/react-table';
 
-import useMap from 'hooks/useMap';
+import type useMap from 'hooks/useMap';
 
 export type CVESelectionTdProps<T extends { cve: string }> = {
     selectedCves: ReturnType<typeof useMap<string, T>>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESelectionTh.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { Th } from '@patternfly/react-table';
 
-import useMap from 'hooks/useMap';
+import type useMap from 'hooks/useMap';
 
 export type CVESelectionThProps<T extends { cve: string }> = {
     selectedCves: ReturnType<typeof useMap<string, T>>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESeverityDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVESeverityDropdown.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
 import { searchValueAsArray } from 'utils/searchUtils';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 type CVESeverityDropdownProps = {
     searchFilter: SearchFilter;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CVEStatusDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CVEStatusDropdown.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
 import { searchValueAsArray } from 'utils/searchUtils';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 type CVEStatusDropdownProps<FilterField> = {
     filterField: FilterField;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ComponentScannableStatusDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ComponentScannableStatusDropdown.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { SelectOption } from '@patternfly/react-core';
 
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
 import { searchValueAsArray } from 'utils/searchUtils';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 type ComponentScannableStatusDropdownProps = {
     searchFilter: SearchFilter;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.cy.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FeatureFlagsProvider } from 'providers/FeatureFlagProvider';
 import CvePageHeader from './CvePageHeader';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import type { ReactNode } from 'react';
-import { Flex, LabelGroup, Label, Text, Title, List, ListItem } from '@patternfly/react-core';
+import { Flex, Label, LabelGroup, List, ListItem, Text, Title } from '@patternfly/react-core';
 import uniqBy from 'lodash/uniqBy';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { CveBaseInfo } from 'types/cve.proto';
+import type { CveBaseInfo } from 'types/cve.proto';
 import { getDateTime } from 'utils/dateUtils';
 
 import {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvesByStatusSummaryCard.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
 import {
     Card,
-    CardTitle,
     CardBody,
+    CardTitle,
     Flex,
     Grid,
     GridItem,
-    pluralize,
     Text,
+    pluralize,
 } from '@patternfly/react-core';
 import { MinusIcon, WrenchIcon } from '@patternfly/react-icons';
 import { gql } from '@apollo/client';
 import sumBy from 'lodash/sumBy';
 
-import { FixableStatus } from '../types';
+import type { FixableStatus } from '../types';
 
 export type ResourceCountByCveSeverityAndStatus = {
     critical: { total: number; fixable: number };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/EntityTypeToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/EntityTypeToggleGroup.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import { ToggleGroup, ToggleGroupItem, pluralize } from '@patternfly/react-core';
 
 import useURLStringUnion from 'hooks/useURLStringUnion';
-import { NonEmptyArray } from 'utils/type.utils';
-import { EntityTab } from '../types';
+import type { NonEmptyArray } from 'utils/type.utils';
+import type { EntityTab } from '../types';
 
 type EntityTypeToggleGroupProps<EntityTabType extends EntityTab> = {
     className?: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CompletedExceptionRequestModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Button,
     ClipboardCopy,
@@ -14,10 +13,12 @@ import {
 import differenceInCalendarDays from 'date-fns/difference_in_calendar_days';
 
 import {
-    BaseVulnerabilityException,
-    VulnerabilityDeferralException,
     isDeferralException,
     isFalsePositiveException,
+} from 'services/VulnerabilityExceptionService';
+import type {
+    BaseVulnerabilityException,
+    VulnerabilityDeferralException,
 } from 'services/VulnerabilityExceptionService';
 import { getDate } from 'utils/dateUtils';
 import { ensureExhaustive } from 'utils/type.utils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/CveSelections.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { Link, generatePath } from 'react-router-dom-v5-compat';
-import { Flex, List, ListItem, Text, Button, FlexItem, Alert } from '@patternfly/react-core';
+import { Alert, Button, Flex, FlexItem, List, ListItem, Text } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestForm.tsx
@@ -1,21 +1,23 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
     Button,
     Flex,
-    FormGroup,
     Form,
-    Tabs,
+    FormGroup,
     Tab,
-    TextArea,
-    Text,
     TabContent,
+    Tabs,
+    Text,
+    TextArea,
 } from '@patternfly/react-core';
-import { FormikHelpers, useFormik } from 'formik';
-import * as yup from 'yup';
+import { useFormik } from 'formik';
+import type { FormikHelpers } from 'formik';
+import type * as yup from 'yup';
 
-import { ScopeContext, ExceptionValues } from './utils';
+import type { ExceptionValues, ScopeContext } from './utils';
 import ExceptionScopeField, { ALL } from './ExceptionScopeField';
-import CveSelections, { CveSelectionsProps } from './CveSelections';
+import CveSelections from './CveSelections';
+import type { CveSelectionsProps } from './CveSelections';
 import ExpiryField from './ExpiryField';
 
 function getDefaultValues(cves: string[], scopeContext: ScopeContext): ExceptionValues {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestModal.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
 import { Alert, Modal, ModalBoxBody, pluralize } from '@patternfly/react-core';
-import { FormikHelpers } from 'formik';
+import type { FormikHelpers } from 'formik';
 import dateFns from 'date-fns';
 
 import {
-    UpdateVulnerabilityExceptionRequest,
-    VulnerabilityException,
     createDeferralVulnerabilityException,
     createFalsePositiveVulnerabilityException,
     updateVulnerabilityException,
+} from 'services/VulnerabilityExceptionService';
+import type {
+    UpdateVulnerabilityExceptionRequest,
+    VulnerabilityException,
 } from 'services/VulnerabilityExceptionService';
 import useRestMutation from 'hooks/useRestMutation';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -16,17 +17,16 @@ import useAnalytics, {
     WORKLOAD_CVE_DEFERRAL_EXCEPTION_REQUESTED,
     WORKLOAD_CVE_FALSE_POSITIVE_EXCEPTION_REQUESTED,
 } from 'hooks/useAnalytics';
-import { CveExceptionRequestType } from '../../types';
+import type { CveExceptionRequestType } from '../../types';
 import {
-    DeferralValues,
-    FalsePositiveValues,
-    ScopeContext,
     deferralValidationSchema,
     falsePositiveValidationSchema,
     formValuesToDeferralRequest,
     formValuesToFalsePositiveRequest,
 } from './utils';
-import ExceptionRequestForm, { ExceptionRequestFormProps } from './ExceptionRequestForm';
+import type { DeferralValues, FalsePositiveValues, ScopeContext } from './utils';
+import ExceptionRequestForm from './ExceptionRequestForm';
+import type { ExceptionRequestFormProps } from './ExceptionRequestForm';
 
 function normalizeExpiryForAnalytics(
     expiry: DeferralValues['expiry']

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionScopeField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionScopeField.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
 import {
     FormGroup,
-    FormGroupProps,
     FormHelperText,
     HelperText,
     HelperTextItem,
     Radio,
 } from '@patternfly/react-core';
+import type { FormGroupProps } from '@patternfly/react-core';
 
-import { useFormik } from 'formik';
-import { DeferralValues, ScopeContext } from './utils';
+import type { useFormik } from 'formik';
+import type { DeferralValues, ScopeContext } from './utils';
 
 export const ALL = '.*';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExpiryField.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExpiryField.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import {
     Bullseye,
     DatePicker,
+    Flex,
     FormGroup,
     FormHelperText,
-    Flex,
     HelperText,
     HelperTextItem,
     Radio,
@@ -12,13 +11,14 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { addDays } from 'date-fns';
-import { useFormik } from 'formik';
+import type { useFormik } from 'formik';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import useRestQuery from 'hooks/useRestQuery';
 import { fetchVulnerabilitiesExceptionConfig } from 'services/ExceptionConfigService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { DeferralValues, futureDateValidator } from './utils';
+import { futureDateValidator } from './utils';
+import type { DeferralValues } from './utils';
 
 /**
  * Returns the date portion of an ISO date string

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/utils.ts
@@ -1,7 +1,7 @@
 import { addDays, isAfter } from 'date-fns';
 import * as yup from 'yup';
 
-import {
+import type {
     CreateDeferVulnerabilityExceptionRequest,
     CreateFalsePositiveVulnerabilityExceptionRequest,
     VulnerabilityExceptionScope,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExpandableLabelSection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExpandableLabelSection.tsx
@@ -1,13 +1,14 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import {
-    ExpandableSection,
     Badge,
-    Flex,
     DataList,
     DataListCell,
     DataListItem,
     DataListItemCells,
     DataListItemRow,
+    ExpandableSection,
+    Flex,
 } from '@patternfly/react-core';
 
 export type ExpandableLabelSectionProps = {
@@ -21,7 +22,7 @@ export type ExpandableLabelSectionProps = {
 function ExpandableLabelSection({ toggleText, labels }: ExpandableLabelSectionProps) {
     const [isExpanded, setIsExpanded] = useState(false);
 
-    const onToggle = (_event: React.MouseEvent, isExpanded: boolean) => {
+    const onToggle = (_event: ReactMouseEvent, isExpanded: boolean) => {
         setIsExpanded(isExpanded);
     };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/FixedByVersion.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/FixedByVersion.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex } from '@patternfly/react-core';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Alert,
     Button,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/HeaderLoadingSkeleton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, Skeleton } from '@patternfly/react-core';
 
 export type HeaderLoadingSkeletonProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Label, Tooltip } from '@patternfly/react-core';
 
 const tooltip =

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/PartialCVEDataAlert.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/PartialCVEDataAlert.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Alert } from '@patternfly/react-core';
 
 function PartialCVEDataAlert() {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/PendingExceptionLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/PendingExceptionLabel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link } from 'react-router-dom-v5-compat';
 import { Label, Popover } from '@patternfly/react-core';
 import { OutlinedClockIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SeverityCountLabels.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import { Flex, Label, Tooltip, capitalize } from '@patternfly/react-core';
 import { EllipsisHIcon } from '@patternfly/react-icons';
 
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import { noViolationsClassName, noViolationsColor } from 'constants/severityColors';
 
-import { VulnerabilitySeverityLabel } from '../types';
+import type { VulnerabilitySeverityLabel } from '../types';
 
 import './SeverityCountLabels.css';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozeCvesModal/SnoozeCvesModal.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { Alert, Modal, Text, Button, Flex, Form, Radio, FormGroup } from '@patternfly/react-core';
-import { FormikHelpers, useFormik } from 'formik';
+import { Alert, Button, Flex, Form, FormGroup, Modal, Radio, Text } from '@patternfly/react-core';
+import { useFormik } from 'formik';
+import type { FormikHelpers } from 'formik';
 
 import { durations, snoozeDurations } from 'constants/timeWindows';
 import useRestMutation from 'hooks/useRestMutation';
 import { suppressVulns, unsuppressVulns } from 'services/VulnerabilitiesService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { ValueOf } from 'utils/type.utils';
-import { SnoozeAction, SnoozeableCveType } from './useSnoozeCveModal';
+import type { ValueOf } from 'utils/type.utils';
+import type { SnoozeAction, SnoozeableCveType } from './useSnoozeCveModal';
 
 const durationOptions = ['DAY', 'WEEK', 'MONTH', 'UNSET'] as const;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.cy.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import SnoozedCveToggleButton from './SnoozedCveToggleButton';
 
 function Wrapper({ startingSearchFilter = {}, snoozedCveCount }) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SnoozedCveToggleButton.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { Button } from '@patternfly/react-core';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 export type SnoozedCveToggleButtonProps = {
     searchFilter: SearchFilter;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.cy.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SummaryCard, SummaryCardLayout } from './SummaryCardLayout';
 
 describe(Cypress.spec.relative, () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/SummaryCardLayout.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Alert, Gallery, GalleryItem, Skeleton } from '@patternfly/react-core';
 
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-const LoadingContext = React.createContext<{ isLoading: boolean }>({
+const LoadingContext = createContext<{ isLoading: boolean }>({
     isLoading: false,
 });
 
 export type SummaryCardProps<T> = {
     data: T;
     loadingText: string;
-    renderer: ({ data }: { data: NonNullable<T> }) => React.ReactNode;
+    renderer: ({ data }: { data: NonNullable<T> }) => ReactNode;
 };
 
 /**
@@ -18,7 +19,7 @@ export type SummaryCardProps<T> = {
  * from the parent context and render a skeleton if the data is not yet available.
  */
 export function SummaryCard<T>({ loadingText, renderer, data }: SummaryCardProps<T>) {
-    const { isLoading } = React.useContext(LoadingContext);
+    const { isLoading } = useContext(LoadingContext);
     return (
         <GalleryItem>
             {isLoading || !data ? (
@@ -38,7 +39,7 @@ const fullWidth = '100%';
 export type SummaryCardLayoutProps = {
     error: unknown;
     isLoading: boolean;
-    children: React.ReactNode;
+    children: ReactNode;
     errorAlertTitle?: string;
 };
 
@@ -51,7 +52,7 @@ export function SummaryCardLayout({
     isLoading,
     children,
     errorAlertTitle = 'There was an error loading the summary data for this entity',
-}: SummaryCardLayoutProps) {
+}: SummaryCardLayoutProps): ReactElement {
     return (
         <LoadingContext.Provider value={{ isLoading }}>
             <div className="pf-v5-u-background-color-100 pf-v5-u-p-lg">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/TableEntityToolbar.tsx
@@ -1,14 +1,14 @@
-import React, { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     Divider,
-    Toolbar,
-    ToolbarItem,
-    ToolbarContent,
     Pagination,
+    Toolbar,
+    ToolbarContent,
     ToolbarGroup,
+    ToolbarItem,
 } from '@patternfly/react-core';
 
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 
@@ -27,7 +27,7 @@ export type TableEntityToolbarProps = {
      * Any additional children to be rendered in the toolbar.
      *  These will be rendered between the entityToggleGroup and the pagination.
      */
-    children?: React.ReactNode;
+    children?: ReactNode;
 };
 
 /**
@@ -40,7 +40,7 @@ function TableEntityToolbar({
     tableRowCount,
     isFiltered,
     children,
-}: TableEntityToolbarProps) {
+}: TableEntityToolbarProps): ReactElement {
     const { page, perPage, setPage, setPerPage } = pagination;
     return (
         <>


### PR DESCRIPTION
## Description

Triple up on smaller folder to merge before PatternFly 6 upgrade.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.