### PR TITLE
ROX-31638: Sort named imports in cypress

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -20,15 +20,15 @@ import {
     clickRowActionMenuItemInTable,
     groupsAlias,
     groupsBatchAliasForPOST,
+    inviteNewGroupsBatch,
     rolesAlias,
     saveCreatedAuthProvider,
     saveUpdatedAuthProvider,
-    inviteNewGroupsBatch,
     visitAccessControlEntities,
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
-import { selectors, accessModalSelectors } from './accessControl.selectors';
+import { accessModalSelectors, selectors } from './accessControl.selectors';
 
 describe('Access Control Auth providers', () => {
     withAuth();

--- a/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.helpers.js
@@ -1,8 +1,8 @@
 import { visitFromLeftNavExpandable } from '../../helpers/nav';
 import {
+    interactAndWaitForResponses,
     interceptRequests,
     waitForResponses,
-    interactAndWaitForResponses,
 } from '../../helpers/request';
 import { visit } from '../../helpers/visit';
 

--- a/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/delegatedScanning.test.js
@@ -4,11 +4,11 @@ import { getInputByLabel } from '../../helpers/formHelpers';
 import { visitWithStaticResponseForPermissions } from '../../helpers/visit';
 
 import {
+    clustersPath,
+    delegatedScanningPath,
+    // saveDelegatedRegistryConfig,
     visitClusters,
     visitDelegateScanning,
-    // saveDelegatedRegistryConfig,
-    delegatedScanningPath,
-    clustersPath,
 } from './Clusters.helpers';
 
 // There is some overlap between tests for Certificate Expiration and Health Status.

--- a/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
+++ b/ui/apps/platform/cypress/integration/compliance-enhanced/complianceEnhancedScanConfigs.test.js
@@ -9,9 +9,9 @@ import {
 import { navigateWizardNext } from '../../helpers/wizard';
 
 import {
-    visitComplianceEnhancedSchedulesFromLeftNav,
-    visitComplianceEnhancedScanConfigs,
     complianceEnhancedScanConfigsPath,
+    visitComplianceEnhancedScanConfigs,
+    visitComplianceEnhancedSchedulesFromLeftNav,
 } from './ComplianceEnhanced.helpers';
 
 function interceptAndMockComplianceIntegrations(callback) {

--- a/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
@@ -11,8 +11,8 @@ import {
     verifyWidgetLinkToTableFromSidePanel,
     verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementDashboard,
-    visitConfigurationManagementEntityInSidePanel,
     visitConfigurationManagementEntitiesWithSearch,
+    visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
 const entitiesKey = 'controls';

--- a/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
@@ -1,16 +1,16 @@
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    visitConfigurationManagementEntityInSidePanel,
-    navigateToSingleEntityPage,
     hasCountWidgetsFor,
     hasTabsFor,
     interactAndWaitForConfigurationManagementScan,
+    navigateToSingleEntityPage,
     verifyTableLinkToSidePanelTable,
     verifyWidgetLinkToTableFromSidePanel,
     verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementDashboard,
     visitConfigurationManagementEntities,
+    visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 import { selectors } from './ConfigurationManagement.selectors';
 

--- a/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
@@ -3,8 +3,8 @@ import withAuth from '../../helpers/basicAuth';
 import {
     clickEntityTableRowThatHasLinkInColumn,
     clickOnCountWidget,
-    clickOnSingularEntityWidgetInSidePanel,
     clickOnSingleEntityInTable,
+    clickOnSingularEntityWidgetInSidePanel,
     hasCountWidgetsFor,
     hasRelatedEntityFor,
     hasTabsFor,

--- a/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
@@ -5,8 +5,8 @@ import { triggerScan } from '../compliance/Compliance.helpers';
 import {
     clickEntityTableRowThatHasLinkInColumn,
     clickOnCountWidget,
-    clickOnSingularEntityWidgetInSidePanel,
     clickOnSingleEntityInTable,
+    clickOnSingularEntityWidgetInSidePanel,
     hasCountWidgetsFor,
     hasRelatedEntityFor,
     hasTabsFor,

--- a/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
@@ -2,8 +2,8 @@ import withAuth from '../../helpers/basicAuth';
 
 import {
     hasCountWidgetsFor,
-    hasTabsFor,
     hasRelatedEntityFor,
+    hasTabsFor,
     navigateToSingleEntityPage,
     verifyWidgetLinkToTableFromSidePanel,
     verifyWidgetLinkToTableFromSinglePage,

--- a/ui/apps/platform/cypress/integration/configmanagement/serviceaccount.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/serviceaccount.test.js
@@ -1,11 +1,11 @@
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    clickOnSingularEntityWidgetInSidePanel,
     clickOnSingleEntityInTable,
+    clickOnSingularEntityWidgetInSidePanel,
     hasCountWidgetsFor,
-    hasTabsFor,
     hasRelatedEntityFor,
+    hasTabsFor,
     navigateToSingleEntityPage,
     verifyWidgetLinkToTableFromSidePanel,
     verifyWidgetLinkToTableFromSinglePage,

--- a/ui/apps/platform/cypress/integration/integrations/apiTokens.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/apiTokens.test.js
@@ -1,8 +1,8 @@
 import withAuth from '../../helpers/basicAuth';
 import {
+    generateNameWithDate,
     getHelperElementByLabel,
     getInputByLabel,
-    generateNameWithDate,
     getSelectButtonByLabel,
     getSelectOption,
 } from '../../helpers/formHelpers';

--- a/ui/apps/platform/cypress/integration/integrations/externalBackups.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/externalBackups.test.js
@@ -11,9 +11,9 @@ import {
     deleteIntegrationInTable,
     saveCreatedIntegrationInForm,
     testIntegrationInFormWithStoredCredentials,
+    visitIntegrationsAndVerifyNotFoundWithStaticResponseForCapabilities,
     visitIntegrationsTable,
     visitIntegrationsWithStaticResponseForCapabilities,
-    visitIntegrationsAndVerifyNotFoundWithStaticResponseForCapabilities,
 } from './integrations.helpers';
 import { selectors } from './integrations.selectors';
 

--- a/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
@@ -1,9 +1,9 @@
 import withAuth from '../../helpers/basicAuth';
 import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
+    generateNameWithDate,
     getHelperElementByLabel,
     getInputByLabel,
-    generateNameWithDate,
     getToggleGroupItem,
 } from '../../helpers/formHelpers';
 

--- a/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/notifiers.test.js
@@ -11,8 +11,8 @@ import {
     clickCreateNewIntegrationInTable,
     deleteIntegrationInTable,
     saveCreatedIntegrationInForm,
-    testIntegrationInFormWithoutStoredCredentials,
     testIntegrationInFormWithStoredCredentials,
+    testIntegrationInFormWithoutStoredCredentials,
     visitIntegrationsTable,
 } from './integrations.helpers';
 import { selectors } from './integrations.selectors';

--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -1,11 +1,11 @@
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    visitNetworkGraph,
     checkNetworkGraphEmptyState,
     selectCluster,
-    selectNamespace,
     selectDeployment,
+    selectNamespace,
+    visitNetworkGraph,
 } from './networkGraph.helpers';
 import { networkGraphSelectors } from './networkGraph.selectors';
 

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -2,14 +2,14 @@ import withAuth from '../../helpers/basicAuth';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
 import {
-    visitNetworkGraph,
-    visitNetworkGraphFromLeftNav,
     checkNetworkGraphEmptyState,
     selectCluster,
-    selectNamespace,
     selectDeployment,
     selectFilter,
+    selectNamespace,
     updateAndCloseCidrModal,
+    visitNetworkGraph,
+    visitNetworkGraphFromLeftNav,
 } from './networkGraph.helpers';
 import { networkGraphSelectors } from './networkGraph.selectors';
 

--- a/ui/apps/platform/cypress/integration/policies/importPolicy.test.js
+++ b/ui/apps/platform/cypress/integration/policies/importPolicy.test.js
@@ -1,7 +1,7 @@
 import * as api from '../../constants/apiEndpoints';
 import { selectors } from '../../constants/PoliciesPage';
 import withAuth from '../../helpers/basicAuth';
-import { doPolicyRowAction, visitPolicies, importPolicyFromFixture } from '../../helpers/policies';
+import { doPolicyRowAction, importPolicyFromFixture, visitPolicies } from '../../helpers/policies';
 
 describe('Import policy', () => {
     withAuth();

--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3-dnd.test.js
@@ -3,11 +3,11 @@ import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
 import DndSimulatorDataTransfer from '../../helpers/dndSimulatorDataTransfer';
 import {
-    visitPolicies,
+    cloneFirstPolicyFromTable,
     doPolicyRowAction,
     editFirstPolicyFromTable,
-    cloneFirstPolicyFromTable,
     goToStep3,
+    visitPolicies,
 } from '../../helpers/policies';
 import { hasFeatureFlag } from '../../helpers/features';
 

--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -2,11 +2,11 @@ import { selectors } from '../../constants/PoliciesPage';
 import * as api from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
 import {
-    visitPolicies,
+    cloneFirstPolicyFromTable,
     doPolicyRowAction,
     editFirstPolicyFromTable,
-    cloneFirstPolicyFromTable,
     goToStep3,
+    visitPolicies,
 } from '../../helpers/policies';
 import { closeModalByButton } from '../../helpers/modal';
 import { hasFeatureFlag } from '../../helpers/features';

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -8,12 +8,12 @@ import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
 import {
     clickTab,
-    deploymentswithprocessinfoAlias,
     deploymentscountAlias,
-    visitRiskDeployments,
-    visitRiskDeploymentsWithSearchQuery,
+    deploymentswithprocessinfoAlias,
     viewRiskDeploymentByName,
     viewRiskDeploymentInNetworkGraph,
+    visitRiskDeployments,
+    visitRiskDeploymentsWithSearchQuery,
 } from './Risk.helpers';
 import { selectors as RiskPageSelectors } from './Risk.selectors';
 

--- a/ui/apps/platform/cypress/integration/systemHealth/certificateHealthCards.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/certificateHealthCards.test.js
@@ -1,7 +1,7 @@
 import withAuth from '../../helpers/basicAuth';
 import {
-    credentialForCentralExpiryAlias,
     credentialForCentralDbExpiryAlias,
+    credentialForCentralExpiryAlias,
     credentialForScannerExpiryAlias,
     setClock,
     visitSystemHealth,

--- a/ui/apps/platform/cypress/integration/systemHealth/declarativeConfiguration.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/declarativeConfiguration.test.js
@@ -1,7 +1,7 @@
 import withAuth from '../../helpers/basicAuth';
 import {
-    visitSystemHealthWithStaticResponseForCapabilities,
     integrationHealthDeclarativeConfigsAlias,
+    visitSystemHealthWithStaticResponseForCapabilities,
 } from '../../helpers/systemHealth';
 
 describe('System Health Declarative Configuration', () => {

--- a/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
+++ b/ui/apps/platform/cypress/integration/violations/Violations.helpers.js
@@ -1,4 +1,4 @@
-import { visitFromLeftNav, visitFromHorizontalNav } from '../../helpers/nav';
+import { visitFromHorizontalNav, visitFromLeftNav } from '../../helpers/nav';
 import { interactAndWaitForResponses } from '../../helpers/request';
 import { visit } from '../../helpers/visit';
 import { readFileFromDownloads } from '../../helpers/file';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approveRequestFlow.test.ts
@@ -1,6 +1,6 @@
 import withAuth from '../../../helpers/basicAuth';
 import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
-import { deferAndVisitRequestDetails, approveRequest } from './ExceptionManagement.helpers';
+import { approveRequest, deferAndVisitRequestDetails } from './ExceptionManagement.helpers';
 
 const deferralProps = {
     comment: 'Defer me',

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
@@ -6,9 +6,9 @@ import {
     visitWorkloadCveOverview,
 } from '../workloadCves/WorkloadCves.helpers';
 import {
+    approveRequest,
     deferAndVisitRequestDetails,
     visitApprovedDeferralsTab,
-    approveRequest,
 } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
 import { selectors as workloadSelectors } from '../workloadCves/WorkloadCves.selectors';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
@@ -6,9 +6,9 @@ import {
     visitWorkloadCveOverview,
 } from '../workloadCves/WorkloadCves.helpers';
 import {
+    approveRequest,
     markFalsePositiveAndVisitRequestDetails,
     visitApprovedFalsePositivesTab,
-    approveRequest,
 } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
 import { selectors as workloadSelectors } from '../workloadCves/WorkloadCves.selectors';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/cancelRequestFlow.test.ts
@@ -1,10 +1,10 @@
 import withAuth from '../../../helpers/basicAuth';
 import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
 import {
+    approveRequest,
     deferAndVisitRequestDetails,
     markFalsePositiveAndVisitRequestDetails,
     visitPendingRequestsTab,
-    approveRequest,
 } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/pendingRequestsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/pendingRequestsTable.test.ts
@@ -3,10 +3,10 @@ import {
     cancelAllCveExceptions,
     fillAndSubmitExceptionForm,
     selectSingleCveForException,
+    typeAndEnterCustomSearchFilterValue,
     verifyExceptionConfirmationDetails,
     verifySelectedCvesInModal,
     visitWorkloadCveOverview,
-    typeAndEnterCustomSearchFilterValue,
 } from '../workloadCves/WorkloadCves.helpers';
 import { visitPendingRequestsTab } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
@@ -26,8 +26,8 @@ import {
 } from '../workloadCves/WorkloadCves.helpers';
 import {
     getNodeMetadataOpname,
-    getNodeVulnerabilitiesOpname,
     getNodeVulnSummaryOpname,
+    getNodeVulnerabilitiesOpname,
     routeMatcherMapForNodePage,
     routeMatcherMapForNodes,
     visitFirstNodeFromOverviewPage,

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -1,8 +1,8 @@
 import { addDays, format } from 'date-fns';
 import { getDescriptionListGroup } from '../../../helpers/formHelpers';
 import {
-    interactAndWaitForResponses,
     getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
 } from '../../../helpers/request';
 import { visit } from '../../../helpers/visit';
 import { selectors } from './WorkloadCves.selectors';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
@@ -3,9 +3,9 @@ import { verifyColumnManagement } from '../../../helpers/tableHelpers';
 import {
     applyLocalSeverityFilters,
     selectEntityTab,
-    visitWorkloadCveOverview,
-    typeAndEnterSearchFilterValue,
     typeAndEnterCustomSearchFilterValue,
+    typeAndEnterSearchFilterValue,
+    visitWorkloadCveOverview,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
@@ -16,8 +16,8 @@ import {
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 import {
     applyLocalSeverityFilters,
-    typeAndEnterSearchFilterValue,
     selectEntityTab,
+    typeAndEnterSearchFilterValue,
     visitWorkloadCveOverview,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/namespaceView.test.js
@@ -2,8 +2,8 @@ import withAuth from '../../../helpers/basicAuth';
 
 import {
     interactAndWaitForDeploymentList,
-    visitWorkloadCveOverview,
     visitNamespaceView,
+    visitWorkloadCveOverview,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/watchedImagesFlow.test.js
@@ -1,12 +1,12 @@
 import withAuth from '../../../helpers/basicAuth';
 import {
-    visitWorkloadCveOverview,
     selectEntityTab,
-    unwatchAllImages,
     selectUnwatchedImageTextFromTable,
-    watchImageFlowFromModal,
-    unwatchImageFromModal,
     typeAndSelectCustomSearchFilterValue,
+    unwatchAllImages,
+    unwatchImageFromModal,
+    visitWorkloadCveOverview,
+    watchImageFlowFromModal,
 } from './WorkloadCves.helpers';
 import { selectors } from './WorkloadCves.selectors';
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -5,8 +5,8 @@ import { graphql } from '../../../constants/apiEndpoints';
 import {
     applyDefaultFilters,
     applyLocalSeverityFilters,
-    interactAndWaitForImageList,
     interactAndWaitForDeploymentList,
+    interactAndWaitForImageList,
     selectEntityTab,
     visitWorkloadCveOverview,
 } from './WorkloadCves.helpers';
@@ -18,11 +18,11 @@ import {
     verifyColumnManagement,
 } from '../../../helpers/tableHelpers';
 import {
-    getRouteMatcherMapForGraphQL,
     expectRequestedSort,
-    interceptAndWatchRequests,
-    interceptAndOverridePermissions,
+    getRouteMatcherMapForGraphQL,
     interceptAndOverrideFeatureFlags,
+    interceptAndOverridePermissions,
+    interceptAndWatchRequests,
 } from '../../../helpers/request';
 
 const visitFromMoreViewsDropdown = visitFromHorizontalNavExpandable('More Views');

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -773,7 +773,6 @@ module.exports = [
     {
         files: ['**/*.{js,jsx,ts,tsx}'], // generic configuration
         ignores: [
-            'cypress/integration/**',
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Vulnerabilities/components/**',


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

### Problem

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.
    One manual fix because of a comment.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.