### PR TITLE
chore(ui): Allow running multiple single Cypress test files via npm

### DIFF
--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -37,11 +37,25 @@ export CYPRESS_SPEC_PATTERN='cypress/integration/**/*.test.{js,ts}'
 export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
 
 if [ "$2" == "--spec" ]; then
-    if [ $# -ne 3 ]; then
-        echo "usage: npm run cypress-spec <spec-file>"
+    if [ $# -lt 3 ]; then
+        echo "usage: npm run cypress-spec <spec-file> [<spec-file> ...]"
         exit 1
     fi
-    cypress run --spec "cypress/integration/$3"
+    # Collect all spec arguments (everything after --spec)
+    shift 2  # Remove script name and --spec
+    all_specs="$*"
+
+    # Support multiple comma-separated spec files by prefixing each individually
+    IFS=',' read -ra specs <<< "$all_specs"
+    prefixed_specs=()
+    for spec in "${specs[@]}"; do
+        # Trim whitespace from each spec
+        spec=$(echo "$spec" | xargs)
+        prefixed_specs+=("cypress/integration/$spec")
+    done
+    # Join with commas for Cypress
+    spec_list=$(IFS=,; echo "${prefixed_specs[*]}")
+    cypress run --spec "$spec_list"
 else
     DEBUG="cypress*" NO_COLOR=1 cypress "$@" 2> /dev/null
 fi


### PR DESCRIPTION
## Description

Allows `npm run cypress-spec` to specify multiple individual files.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
`$ npm run cypress-spec -- access.test.js,auth.test.js`

```
====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  access.test.js                            47ms       16        -        -       16        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  auth.test.js                              21ms        4        -        -        4        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                         68ms       20        -        -       20        -
```