### PR TITLE
ROX-31675: Delete ROX_VULNERABILITY_VIEW_BASED_REPORTS in ui

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -1,7 +1,6 @@
 import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import PageTitle from 'Components/PageTitle';
 import {
     vulnerabilityConfigurationReportsPath,
@@ -22,9 +21,6 @@ const tabs = [
 ];
 
 function VulnReportingLayout() {
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isViewBasedReportsEnabled = isFeatureFlagEnabled('ROX_VULNERABILITY_VIEW_BASED_REPORTS');
-
     const location = useLocation();
     const navigate = useNavigate();
 
@@ -37,30 +33,25 @@ function VulnReportingLayout() {
     return (
         <>
             <PageTitle title="Vulnerability reporting" />
-            <PageSection
-                variant="light"
-                className={`${!isViewBasedReportsEnabled && 'pf-v5-u-pb-0'}`}
-            >
+            <PageSection variant="light">
                 <Title headingLevel="h1">Vulnerability reporting</Title>
             </PageSection>
-            {isViewBasedReportsEnabled && (
-                <PageSection
-                    variant="light"
-                    padding={{ default: 'noPadding' }}
-                    className="pf-v5-u-pl-lg pf-v5-u-background-color-100"
-                >
-                    <Tabs activeKey={activeTabIndex} onSelect={onTabSelect}>
-                        {tabs.map((tab, index) => (
-                            <Tab
-                                key={tab.id}
-                                eventKey={index}
-                                title={tab.title}
-                                tabContentId={`${tab.id}-tab-content`}
-                            />
-                        ))}
-                    </Tabs>
-                </PageSection>
-            )}
+            <PageSection
+                variant="light"
+                padding={{ default: 'noPadding' }}
+                className="pf-v5-u-pl-lg pf-v5-u-background-color-100"
+            >
+                <Tabs activeKey={activeTabIndex} onSelect={onTabSelect}>
+                    {tabs.map((tab, index) => (
+                        <Tab
+                            key={tab.id}
+                            eventKey={index}
+                            title={tab.title}
+                            tabContentId={`${tab.id}-tab-content`}
+                        />
+                    ))}
+                </Tabs>
+            </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>
                 <Outlet />
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -20,7 +20,6 @@ import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import type { VulnerabilityState } from 'types/cve.proto';
 
@@ -77,9 +76,7 @@ function DeploymentPage({ showVulnerabilityStateTabs, vulnerabilityState }: Depl
     // Report-specific functionality
     const { hasReadAccess } = usePermissions();
     const hasWorkflowAdminAccess = hasReadAccess('WorkflowAdministration');
-    const { isFeatureFlagEnabled } = useFeatureFlags();
     const isViewBasedReportsEnabled =
-        isFeatureFlagEnabled('ROX_VULNERABILITY_VIEW_BASED_REPORTS') &&
         hasWorkflowAdminAccess &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -31,7 +31,6 @@ import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 import usePermissions from 'hooks/usePermissions';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import type { VulnerabilityState } from 'types/cve.proto';
 
@@ -135,9 +134,7 @@ function ImagePage({
     const [sbomTargetImage, setSbomTargetImage] = useState<string>();
 
     // Report-specific functionality
-    const { isFeatureFlagEnabled } = useFeatureFlags();
     const isViewBasedReportsEnabled =
-        isFeatureFlagEnabled('ROX_VULNERABILITY_VIEW_BASED_REPORTS') &&
         hasWorkflowAdminAccess &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -305,10 +305,8 @@ function WorkloadCvesOverviewPage() {
 
     // Report-specific state management
     const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
-    const isViewBasedReportsEnabled = isFeatureFlagEnabled('ROX_VULNERABILITY_VIEW_BASED_REPORTS');
 
-    const isOnDemandReportsVisible =
-        isViewBasedReportsEnabled &&
+    const isViewBasedReportsEnabled =
         hasWorkflowAdminAccess &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
@@ -409,7 +407,7 @@ function WorkloadCvesOverviewPage() {
                                 onEntityTabChange={onEntityTabChange}
                                 activeEntityTabKey={activeEntityTabKey}
                                 additionalToolbarItems={
-                                    isOnDemandReportsVisible && (
+                                    isViewBasedReportsEnabled && (
                                         <CreateReportDropdown
                                             onSelect={() => {
                                                 setIsCreateViewBasedReportModalOpen(true);
@@ -503,7 +501,7 @@ function WorkloadCvesOverviewPage() {
                     }}
                     onWatchedImagesChange={onWatchedImagesChange}
                 />
-                {isOnDemandReportsVisible && (
+                {isViewBasedReportsEnabled && (
                     <CreateViewBasedReportModal
                         isOpen={isCreateViewBasedReportModalOpen}
                         setIsOpen={setIsCreateViewBasedReportModalOpen}

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -12,5 +12,4 @@ export type FeatureFlagEnvVar =
     | 'ROX_SCANNER_V4'
     | 'ROX_VIRTUAL_MACHINES'
     | 'ROX_VULN_MGMT_LEGACY_SNOOZE'
-    | 'ROX_VULNERABILITY_VIEW_BASED_REPORTS'
     ;


### PR DESCRIPTION
## Description

**Review**: hide space because of indentation changes.

Squeeze in between tech investment contributions for VulnerabilityReporting and WorkloadCves folders.

Feature flag was enabled for 4.9 release on 2025-10-07 in #17157

https://github.com/stackrox/stackrox/tree/master/ui/apps/platform#delete-a-feature-flag-from-frontend-code

### Analysis

Find in Files `ROX_VULNERABILITY_VIEW_BASED_REPORTS`
* no results: ui/apps/platform/cypress
* 5 results in 5 files: ui/apps/platform/src

Find in Files `isViewBasedReportsEnabled`
1. VulnReportingLayout.tsx file:
    * padding if **not** enabled
    * tabs
2. DeploymentPage.tsx file:
    * `isViewBasedReportsEnabled`
3. ImagePage.tsx file:
    * `isViewBasedReportsEnabled`
4. WorkloadCvesOverviewPage.tsx file:
    * `isOnDemandReportsVisible` replace leftover name

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration

    Before and after change, see **Report configurations** and **View-based reports** tabs.

2. Visit /main/vulnerabilities/user-workloads

    Before and after change, see **Create report** dropdown.

3. Visit /main/vulnerabilities/user-workloads click **Images** toggle, and then click an image link.

    Before and after change, see **Create report** dropdown.

4. Visit /main/vulnerabilities/user-workloads click **Deployments** toggle, and then click an image link.

    Before and after change, see **Create report** dropdown.