### PR TITLE
ROX-31695: fix logger name accumulation in SensorCAHashExtension

### DIFF
--- a/operator/internal/securedcluster/extensions/sensor_ca_hash.go
+++ b/operator/internal/securedcluster/extensions/sensor_ca_hash.go
@@ -22,9 +22,9 @@ import (
 
 // SensorCAHashExtension is an extension that computes and caches the CA hash for Secured Clusters,
 // enabling declarative rollout restarts when the CA changes.
-func SensorCAHashExtension(client ctrlClient.Client, direct ctrlClient.Reader, logger logr.Logger, renderCache *rendercache.RenderCache) extensions.ReconcileExtension {
+func SensorCAHashExtension(client ctrlClient.Client, direct ctrlClient.Reader, renderCache *rendercache.RenderCache) extensions.ReconcileExtension {
 	return func(ctx context.Context, obj *unstructured.Unstructured, statusUpdater func(statusFunc extensions.UpdateStatusFunc), log logr.Logger) error {
-		logger = logger.WithName("sensor-ca-hash")
+		log = log.WithName("sensor-ca-hash")
 
 		// Clean up render cache entry if CR is being deleted.
 		if obj.GetDeletionTimestamp() != nil {
@@ -39,7 +39,7 @@ func SensorCAHashExtension(client ctrlClient.Client, direct ctrlClient.Reader, l
 
 		// Runtime TLS secrets are not stored atomically, check if they are consistent.
 		if fromRuntimeSecret {
-			secretsConsistent, err := verifyAllTLSSecretsMatchCA(ctx, client, direct, obj.GetNamespace(), sensorHash, logger)
+			secretsConsistent, err := verifyAllTLSSecretsMatchCA(ctx, client, direct, obj.GetNamespace(), sensorHash, log)
 			if err != nil {
 				return err
 			}

--- a/operator/internal/securedcluster/extensions/sensor_ca_hash_test.go
+++ b/operator/internal/securedcluster/extensions/sensor_ca_hash_test.go
@@ -68,7 +68,7 @@ func TestSensorCAHashExtension_CertificatePriority(t *testing.T) {
 			sc := createTestSecuredCluster()
 			scUnstructured := toUnstructured(t, sc)
 
-			extension := SensorCAHashExtension(client, client, logr.Discard(), renderCache)
+			extension := SensorCAHashExtension(client, client, renderCache)
 			err := extension(context.Background(), scUnstructured, nil, logr.Discard())
 
 			if tt.expectError {
@@ -130,7 +130,7 @@ func TestSensorCAHashExtension_ConsistencyCheck(t *testing.T) {
 			sc := createTestSecuredCluster()
 			scUnstructured := toUnstructured(t, sc)
 
-			extension := SensorCAHashExtension(client, client, logr.Discard(), renderCache)
+			extension := SensorCAHashExtension(client, client, renderCache)
 			err := extension(context.Background(), scUnstructured, nil, logr.Discard())
 
 			if tt.expectError {
@@ -152,7 +152,7 @@ func TestSensorCAHashExtension_DeletionCleanup(t *testing.T) {
 	sc := createTestSecuredCluster()
 	scUnstructured := toUnstructured(t, sc)
 
-	extension := SensorCAHashExtension(client, client, logr.Discard(), renderCache)
+	extension := SensorCAHashExtension(client, client, renderCache)
 
 	err := extension(context.Background(), scUnstructured, nil, logr.Discard())
 	require.NoError(t, err)

--- a/operator/internal/securedcluster/reconciler/reconciler.go
+++ b/operator/internal/securedcluster/reconciler/reconciler.go
@@ -43,7 +43,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 		pkgReconciler.WithPreExtension(commonExtensions.ReconcileProductVersionStatusExtension(version.GetMainVersion())),
 		pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerDBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())),
 		pkgReconciler.WithPreExtension(extensions.ReconcileLocalScannerV4DBPasswordExtension(mgr.GetClient(), mgr.GetAPIReader())),
-		pkgReconciler.WithPreExtension(extensions.SensorCAHashExtension(mgr.GetClient(), mgr.GetAPIReader(), mgr.GetLogger(), renderCache)),
+		pkgReconciler.WithPreExtension(extensions.SensorCAHashExtension(mgr.GetClient(), mgr.GetAPIReader(), renderCache)),
 	}
 
 	opts := make([]pkgReconciler.Option, 0, len(otherPreExtensions)+8)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR fixes a bug in the logging on `SensorCAHashExtension` where each time the extension runs, `sensor-ca-hash` is appended to the name of the logger, growing indefinitely (causing a leak and hard to read operator logs).

E.g.:
```
2025-11-07T11:15:49+01:00	INFO	sensor-ca-hash.sensor-ca-hash.sensor-ca-hash.sensor-ca-hash.sensor-ca-hash.sensor-ca-hash.sensor-ca-hash.sensor-ca-hash.sensor-ca-hash.sensor-ca-hash	Secret not found	{"secret": "tls-cert-sensor"}
```
instead of:
```
2025-11-07T11:15:49+01:00	INFO	sensor-ca-hash	Secret not found	{"secret": "tls-cert-sensor"}
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Verified manually that the logs are now OK.